### PR TITLE
Misc Improvements

### DIFF
--- a/common/CoolMount.cpp
+++ b/common/CoolMount.cpp
@@ -310,6 +310,7 @@ int domount(int argc, const char* const* argv)
         {
             // Now we need to set read-only and other flags with a remount.
             unsigned long mountflags = (MS_BIND | MS_REMOUNT | MS_NODEV | MS_NOSUID | MS_RDONLY);
+            const char* fstype = "none";
 
             /* a) In the linux namespace mount case an additional MS_NOATIME, etc. will result in
                EPERM on remounting something hosted in a toplevel [rel]atime mount. man 2 mount
@@ -322,7 +323,7 @@ int domount(int argc, const char* const* argv)
                where the closest match is:  "mount options=(ro,remount,bind,nodev,nosuid)"
                so additional 'MS_SILENT' or 'MS_REC' flags cause the remount to be denied
             */
-            int retval = MOUNT(source, target, nullptr, mountflags, nullptr);
+            int retval = MOUNT(source, target, fstype, mountflags, nullptr);
             if (retval)
             {
                 fprintf(stderr, "%s: mount failed remount [%s] readonly: %s.\n", program, target,
@@ -330,7 +331,7 @@ int domount(int argc, const char* const* argv)
                 return EX_SOFTWARE;
             }
 
-            retval = MOUNT(source, target, nullptr, (MS_UNBINDABLE | MS_REC), nullptr);
+            retval = MOUNT(source, target, fstype, (MS_UNBINDABLE | MS_REC), nullptr);
             if (retval)
             {
                 fprintf(stderr, "%s: mount failed make [%s] private: %s.\n", program, target,

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -425,11 +425,6 @@ void UnitBase::initialize()
     socketPoll()->startThread();
 }
 
-bool UnitBase::isUnitTesting()
-{
-    return DlHandle;
-}
-
 void UnitBase::setTimeout(std::chrono::milliseconds timeoutMilliSeconds)
 {
     assert(!TimeoutThread.joinable() && "setTimeout must be called before starting a test");

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -148,7 +148,14 @@ public:
     static int uninit();
 
     /// Do we have a unit test library hooking things & loaded
-    static bool isUnitTesting();
+    static bool isUnitTesting()
+    {
+#ifdef ENABLE_DEBUG
+        return DlHandle;
+#else
+        return false; // In non-debug builds unit-tests cannot be run. See test/run_unit.sh.
+#endif
+    }
 
     /// Tweak the return value from the process.
     virtual void returnValue(int& /* retValue */);

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -115,6 +115,10 @@ namespace Util
         {
         }
 
+        /// Returns the start-time.
+        std::chrono::steady_clock::time_point startTime() const { return _startTime; }
+
+        /// Resets the start-time to now.
         void restart() { _startTime = std::chrono::steady_clock::now(); }
 
         /// Returns the time that has elapsed since starting, in the units required.
@@ -127,9 +131,12 @@ namespace Util
         }
 
         /// Returns true iff at least the given amount of time has elapsed.
-        template <typename T> bool elapsed(T duration) const
+        template <typename T>
+        bool
+        elapsed(T duration,
+                std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now()) const
         {
-            return elapsed<std::chrono::nanoseconds>() >= duration;
+            return elapsed<std::chrono::nanoseconds>(now) >= duration;
         }
 
     private:

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1175,7 +1175,7 @@ void SocketPoll::dumpState(std::ostream& os) const
     os << "\t    fd\tevents\trbuffered\twbuffered\trtotal\twtotal\tclientaddress\n";
     for (const std::shared_ptr<Socket>& socket : pollSockets)
         socket->dumpState(os);
-    os << "\n  Done [" << name() << ']';
+    os << "\n  Done [" << name() << "]\n";
 }
 
 /// Returns true on success only.

--- a/tools/Replay.hpp
+++ b/tools/Replay.hpp
@@ -562,8 +562,9 @@ public:
 
             sendMessage("tileprocessed tile=" + desc.generateID());
             std::cerr << _logPre << "Sent tileprocessed tile= " + desc.generateID() << "\n";
-        } if (tokens.equals(0, "error:")) {
-
+        }
+        else if (tokens.equals(0, "error:"))
+        {
             bool reconnect = false;
             if (firstLine == "error: cmd=load kind=docunloading")
             {

--- a/tools/Replay.hpp
+++ b/tools/Replay.hpp
@@ -382,17 +382,16 @@ class StressSocketHandler : public WebSocketHandler
     std::chrono::steady_clock::time_point _lastTile;
 
 public:
-    StressSocketHandler(SocketPoll &poll, /* bad style */
-                        const std::shared_ptr<Stats> stats,
-                        const std::string &uri, const std::string &trace,
-                        const int delayMs = 0) :
-        WebSocketHandler(true, true),
-        _poll(poll),
-        _reader(trace),
-        _connecting(true),
-        _uri(uri),
-        _trace(trace),
-        _stats(stats)
+    StressSocketHandler(SocketPoll& poll, /* bad style */
+                        const std::shared_ptr<Stats>& stats, const std::string& uri,
+                        const std::string& trace, const int delayMs = 0)
+        : WebSocketHandler(true, true)
+        , _poll(poll)
+        , _reader(trace)
+        , _connecting(true)
+        , _uri(uri)
+        , _trace(trace)
+        , _stats(stats)
     {
         assert(_stats && "stats must be provided");
 

--- a/tools/Stress.cpp
+++ b/tools/Stress.cpp
@@ -91,11 +91,11 @@ int Stress::main(const std::vector<std::string>& args)
 
     const std::chrono::microseconds PollTimeoutMicroS = net::Defaults::get().SocketPollTimeout;
 
-    std::string server = args[0];
+    const std::string& server = args[0];
 
     if (!strncmp(server.c_str(), "http", 4))
     {
-        std::cerr << "Server should be wss:// or ws:// URL not " << server << "\n";
+        std::cerr << "Server should be wss:// or ws:// URL, not " << server << '\n';
         return -1;
     }
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -60,7 +60,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <queue>
 #include <regex>
 #include <sstream>
 #include <string>
@@ -68,22 +67,9 @@
 
 #if !MOBILEAPP
 
-#include <Poco/Net/Context.h>
-#include <Poco/Net/HTTPRequest.h>
-#include <Poco/Net/HTTPResponse.h>
-#include <Poco/Net/IPAddress.h>
-#include <Poco/Net/MessageHeader.h>
-#include <Poco/Net/NameValueCollection.h>
-#include <Poco/Net/Net.h>
-#include <Poco/Net/NetException.h>
-#include <Poco/Net/PartHandler.h>
-#include <Poco/Net/SocketAddress.h>
-#include <Poco/Net/AcceptCertificateHandler.h>
-#include <Poco/Net/Context.h>
-#include <Poco/Net/KeyConsoleHandler.h>
+#if ENABLE_SSL
 #include <Poco/Net/SSLManager.h>
-
-using Poco::Net::PartHandler;
+#endif
 
 #include <cerrno>
 #include <stdexcept>
@@ -97,15 +83,10 @@ using Poco::Net::PartHandler;
 
 #endif
 
-#include <Poco/DateTimeFormatter.h>
 #include <Poco/DirectoryIterator.h>
 #include <Poco/Exception.h>
 #include <Poco/File.h>
-#include <Poco/FileStream.h>
-#include <Poco/MemoryStream.h>
-#include <Poco/Net/HostEntry.h>
 #include <Poco/Path.h>
-#include <Poco/TemporaryFile.h>
 #include <Poco/URI.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Poco/Util/HelpFormatter.h>
@@ -116,7 +97,6 @@ using Poco::Net::PartHandler;
 #include <Poco/Util/ServerApplication.h>
 #include <Poco/Util/XMLConfiguration.h>
 
-#include "ClientSession.hpp"
 #include <ClientRequestDispatcher.hpp>
 #include <Common.hpp>
 #include <Clipboard.hpp>
@@ -137,18 +117,15 @@ using Poco::Net::PartHandler;
 #if ENABLE_SSL
 #  include <SslSocket.hpp>
 #endif
-#include "Storage.hpp"
 #include <wsd/wopi/StorageConnectionManager.hpp>
-#include "TraceFile.hpp"
+#include <wsd/TraceFile.hpp>
 #include <Unit.hpp>
 #include <Util.hpp>
 #include <common/ConfigUtil.hpp>
-#include <common/TraceEvent.hpp>
 
 #include <common/SigUtil.hpp>
 #include <net/AsyncDNS.hpp>
 
-#include <RequestVettingStation.hpp>
 #include <ServerSocket.hpp>
 
 #if MOBILEAPP

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1087,7 +1087,11 @@ COOLWSD::COOLWSD()
 
 COOLWSD::~COOLWSD()
 {
-    UnitWSD::get().setWSD(nullptr);
+    if (UnitBase::isUnitTesting())
+    {
+        // We won't have a valid UnitWSD::get() when not testing.
+        UnitWSD::get().setWSD(nullptr);
+    }
 }
 
 #if !MOBILEAPP

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -147,25 +147,8 @@
 #endif
 #endif
 
-using namespace COOLProtocol;
-
-using Poco::DirectoryIterator;
-using Poco::Exception;
-using Poco::File;
-using Poco::Path;
-using Poco::URI;
-using Poco::Net::HTTPRequest;
-using Poco::Net::HTTPResponse;
-using Poco::Net::MessageHeader;
-using Poco::Net::NameValueCollection;
-using Poco::Util::Application;
-using Poco::Util::HelpFormatter;
 using Poco::Util::LayeredConfiguration;
-using Poco::Util::MissingOptionException;
 using Poco::Util::Option;
-using Poco::Util::OptionSet;
-using Poco::Util::ServerApplication;
-using Poco::Util::XMLConfiguration;
 
 /// Port for external clients to connect to
 int ClientPortNumber = 0;
@@ -1637,7 +1620,7 @@ public:
                 COOLWSD::BuyProductUrl = buyProductUri.toString();
             }
         }
-        catch(const Poco::Exception& exc)
+        catch (const std::exception& exc)
         {
             LOG_ERR("handleOptions: Exception " << exc.what());
         }
@@ -2003,14 +1986,15 @@ void COOLWSD::setupChildRoot(const bool UseMountNamespaces)
 
 #endif
 
-void COOLWSD::innerInitialize(Application& self)
+void COOLWSD::innerInitialize(Poco::Util::Application& self)
 {
     if (!Util::isMobileApp() && geteuid() == 0 && CheckCoolUser)
     {
         throw std::runtime_error("Do not run as root. Please run as cool user.");
     }
 
-    Util::setApplicationPath(Poco::Path(Application::instance().commandPath()).parent().toString());
+    Util::setApplicationPath(
+        Poco::Path(Poco::Util::Application::instance().commandPath()).parent().toString());
 
     StartTime = std::chrono::steady_clock::now();
 
@@ -2210,7 +2194,7 @@ void COOLWSD::innerInitialize(Application& self)
     // Load default configuration files, with name independent
     // of Poco's view of app-name, from local file if present.
     Poco::Path configPath("coolwsd.xml");
-    if (Application::findFile(configPath))
+    if (Poco::Util::Application::findFile(configPath))
         loadConfiguration(configPath.toString(), PRIO_DEFAULT);
     else
     {
@@ -2219,17 +2203,19 @@ void COOLWSD::innerInitialize(Application& self)
     }
 
     // Load extra ("plug-in") configuration files, if present
-    File dir(ConfigDir);
+    Poco::File dir(ConfigDir);
     if (dir.exists() && dir.isDirectory())
     {
-        for (auto configFileIterator = DirectoryIterator(dir); configFileIterator != DirectoryIterator(); ++configFileIterator)
+        const Poco::DirectoryIterator end;
+        for (Poco::DirectoryIterator configFileIterator(dir); configFileIterator != end;
+             ++configFileIterator)
         {
             // Only accept configuration files ending in .xml
             const std::string configFile = configFileIterator.path().getFileName();
             if (configFile.length() > 4 && strcasecmp(configFile.substr(configFile.length() - 4).data(), ".xml") == 0)
             {
                 const std::string fullFileName = dir.path() + "/" + configFile;
-                PluginConfigurations.insert(new XMLConfiguration(fullFileName));
+                PluginConfigurations.insert(new Poco::Util::XMLConfiguration(fullFileName));
             }
         }
     }
@@ -2549,14 +2535,14 @@ void COOLWSD::innerInitialize(Application& self)
     if (SysTemplate.empty())
     {
         LOG_FTL("Missing sys_template_path config entry.");
-        throw MissingOptionException("systemplate");
+        throw Poco::Util::MissingOptionException("systemplate");
     }
 
     ChildRoot = getPathFromConfig("child_root_path");
     if (ChildRoot.empty())
     {
         LOG_FTL("Missing child_root_path config entry.");
-        throw MissingOptionException("childroot");
+        throw Poco::Util::MissingOptionException("childroot");
     }
     else
     {
@@ -3108,7 +3094,7 @@ void COOLWSD::dumpOutgoingTrace(const std::string& id, const std::string& sessio
     }
 }
 
-void COOLWSD::defineOptions(OptionSet& optionSet)
+void COOLWSD::defineOptions(Poco::Util::OptionSet& optionSet)
 {
     if constexpr (Util::isMobileApp())
         return;
@@ -3320,7 +3306,7 @@ void COOLWSD::initializeEnvOptions()
 
 void COOLWSD::displayHelp()
 {
-    HelpFormatter helpFormatter(options());
+    Poco::Util::HelpFormatter helpFormatter(options());
     helpFormatter.setCommand(commandName());
     helpFormatter.setUsage("OPTIONS");
     helpFormatter.setHeader("Collabora Online WebSocket server.");
@@ -3532,7 +3518,8 @@ bool COOLWSD::createForKit()
     std::unique_lock<std::mutex> newChildrenLock(NewChildrenMutex);
 
     StringVector args;
-    std::string parentPath = Path(Application::instance().commandPath()).parent().toString();
+    std::string parentPath =
+        Poco::Path(Poco::Util::Application::instance().commandPath()).parent().toString();
 
 #if STRACE_COOLFORKIT
     // if you want to use this, you need to sudo setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/strace
@@ -4395,7 +4382,7 @@ int COOLWSD::innerMain()
     if (LoTemplate.empty())
     {
         LOG_FTL("Missing --lo-template-path option");
-        throw MissingOptionException("lotemplate");
+        throw Poco::Util::MissingOptionException("lotemplate");
     }
 
     if (FileServerRoot.empty())

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1796,7 +1796,7 @@ bool ClientRequestDispatcher::handleClientProxyRequest(const Poco::Net::HTTPRequ
     const std::string url = requestDetails.getLegacyDocumentURI();
 
     LOG_INF("URL [" << url << "] for Proxy request.");
-    const auto uriPublic = RequestDetails::sanitizeURI(url);
+    auto uriPublic = RequestDetails::sanitizeURI(url);
     const auto docKey = RequestDetails::getDocKey(uriPublic);
     const std::string fileId = Uri::getFilenameFromURL(docKey);
     Util::mapAnonymized(fileId, fileId); // Identity mapping, since fileId is already obfuscated

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -600,8 +600,10 @@ void ClientRequestDispatcher::onConnect(const std::shared_ptr<StreamSocket>& soc
     LOG_TRC("Connected to ClientRequestDispatcher");
 }
 
-void launchAsyncCheckFileInfo(const std::string& id, const FileServerRequestHandler::ResourceAccessDetails& accessDetails,
-                              std::unordered_map<std::string, std::shared_ptr<RequestVettingStation>>& requestVettingStations)
+void launchAsyncCheckFileInfo(
+    const std::string& id, const FileServerRequestHandler::ResourceAccessDetails& accessDetails,
+    std::unordered_map<std::string, std::shared_ptr<RequestVettingStation>>& requestVettingStations,
+    const std::size_t highWatermark)
 {
     const std::string requestKey = RequestDetails::getRequestKey(
         accessDetails.wopiSrc(), accessDetails.accessToken());
@@ -619,6 +621,12 @@ void launchAsyncCheckFileInfo(const std::string& id, const FileServerRequestHand
     if (requestVettingStations.find(requestKey) != requestVettingStations.end())
     {
         LOG_TRC("Found RVS under key: " << requestKey << ", nothing to do");
+    }
+    else if (requestVettingStations.size() >= highWatermark)
+    {
+        LOG_WRN("RequestVettingStations in flight ("
+                << requestVettingStations.size() << ") hit the high-watermark (" << highWatermark
+                << "); suppressing ahead-of-time CheckFileInfo");
     }
     else
     {
@@ -712,7 +720,8 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
                         mapAccessDetails.at("wopiSrc"),
                         mapAccessDetails.at("accessToken"),
                         mapAccessDetails.at("permission"));
-                    launchAsyncCheckFileInfo(_id, accessDetails, RequestVettingStations);
+                    launchAsyncCheckFileInfo(_id, accessDetails, RequestVettingStations,
+                                             RvsHighWatermark);
                 }
             }
         }
@@ -766,7 +775,8 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
                             Uri::decode(accessDetails.wopiSrc()),
                         "Expected identical WOPISrc in the request as in cool.html");
 
-                    launchAsyncCheckFileInfo(_id, accessDetails, RequestVettingStations);
+                    launchAsyncCheckFileInfo(_id, accessDetails, RequestVettingStations,
+                                             RvsHighWatermark);
                 }
                 servedSync = true;
             }

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -11,8 +11,6 @@
 
 #include <config.h>
 
-#include <ClientRequestDispatcher.hpp>
-
 #if ENABLE_FEATURE_LOCK
 #include "CommandControl.hpp"
 #endif
@@ -21,7 +19,6 @@
 #include <COOLWSD.hpp>
 #include <ClientSession.hpp>
 #include <ConfigUtil.hpp>
-#include <wsd/DocumentBroker.hpp>
 #include <Exceptions.hpp>
 #include <FileServer.hpp>
 #include <HttpRequest.hpp>
@@ -34,6 +31,9 @@
 #include <Util.hpp>
 #include <net/AsyncDNS.hpp>
 #include <net/HttpHelper.hpp>
+#include <wsd/ClientRequestDispatcher.hpp>
+#include <wsd/DocumentBroker.hpp>
+#include <wsd/RequestVettingStation.hpp>
 #if !MOBILEAPP
 #include <wsd/SpecialBrokers.hpp>
 #include <HostUtil.hpp>
@@ -54,12 +54,15 @@
 #include <Poco/SAX/InputSource.h>
 #include <Poco/StreamCopier.h>
 
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
 std::map<std::string, std::string> ClientRequestDispatcher::StaticFileContentCache;
+
+std::size_t ClientRequestDispatcher::NextRvsCleanupSize = RvsLowWatermark;
 std::unordered_map<std::string, std::shared_ptr<RequestVettingStation>>
     ClientRequestDispatcher::RequestVettingStations;
 
@@ -704,6 +707,8 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
             else if (!socket->isLocal())
                 throw BadRequestException("ProxyPrefix request from non-local socket");
         }
+
+        CleanupRequestVettingStations();
 
         // Routing
         const bool isUnitTesting = UnitWSD::isUnitTesting();
@@ -2049,6 +2054,30 @@ std::string ClientRequestDispatcher::getDiscoveryXML()
     writer.writeNode(ostrXML, docXML);
     return ostrXML.str();
 #endif
+}
+
+void ClientRequestDispatcher::CleanupRequestVettingStations()
+{
+    if (RequestVettingStations.size() >= NextRvsCleanupSize)
+    {
+        LOG_DBG("Cleaning up RequestVettingStations ("
+                << RequestVettingStations.size()
+                << ") with NextRvsCleanupSize: " << NextRvsCleanupSize);
+
+        const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+        std::erase_if(RequestVettingStations,
+                      [now](const auto& pair) { return pair.second->aged(RvsMaxAge, now); });
+
+        // Clean up next when we grow by 10%.
+        NextRvsCleanupSize =
+            std::min(RvsHighWatermark - 1,
+                     std::max(RvsLowWatermark + 1,
+                              static_cast<std::size_t>(RequestVettingStations.size() * 1.1)));
+
+        LOG_DBG("Cleaned up RequestVettingStations ("
+                << RequestVettingStations.size()
+                << ") with NextRvsCleanupSize: " << NextRvsCleanupSize);
+    }
 }
 
 #if !MOBILEAPP

--- a/wsd/ClientRequestDispatcher.hpp
+++ b/wsd/ClientRequestDispatcher.hpp
@@ -114,6 +114,9 @@ private:
     /// Process the discovery.xml file and return as string.
     static std::string getDiscoveryXML();
 
+    /// Keeps RVS instances in check.
+    void CleanupRequestVettingStations();
+
 private:
     // The socket that owns us (we can't own it).
     std::weak_ptr<StreamSocket> _socket;
@@ -131,9 +134,19 @@ private:
     /// WS is created and as long as it is connected.
     std::shared_ptr<RequestVettingStation> _rvs;
 
+    /// The minimum number of RVS instances in flight to trigger cleanup.
+    static constexpr std::size_t RvsLowWatermark = 1 * 1024;
+
     /// The absolute maximum number of RVS instances in flight.
     /// Note: exceeding this means we will not do parallel CheckFileInfo, ahead of loading.
-    static constexpr std::size_t RvsHighWatermark = 10 * 1024;
+    static constexpr std::size_t RvsHighWatermark = (10 * RvsLowWatermark) - 1;
+
+    /// Any RVS instance, in RequestVettingStations, older than this will be purged.
+    static constexpr std::chrono::seconds RvsMaxAge = std::chrono::seconds(60);
+
+    /// The expected size of RVS to trigger the next cleanup.
+    /// This is to avoid excessive cleanup attempts.
+    static std::size_t NextRvsCleanupSize;
 
     /// External requests are first vetted before allocating DocBroker and Kit process.
     /// This is a map of the request URI to the RequestVettingStation for vetting.

--- a/wsd/ClientRequestDispatcher.hpp
+++ b/wsd/ClientRequestDispatcher.hpp
@@ -131,8 +131,15 @@ private:
     /// WS is created and as long as it is connected.
     std::shared_ptr<RequestVettingStation> _rvs;
 
+    /// The absolute maximum number of RVS instances in flight.
+    /// Note: exceeding this means we will not do parallel CheckFileInfo, ahead of loading.
+    static constexpr std::size_t RvsHighWatermark = 10 * 1024;
+
     /// External requests are first vetted before allocating DocBroker and Kit process.
     /// This is a map of the request URI to the RequestVettingStation for vetting.
+    /// This is a temporary storage until we get the WS upgrade. If we don't, we purge.
+    /// Note: this is accessed exclusively from websrv_poll, through
+    /// handleIncomingMessage and handleClientWsUpgrade. Do *not* access in the ctor/dtor!
     static std::unordered_map<std::string, std::shared_ptr<RequestVettingStation>>
         RequestVettingStations;
 

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -38,6 +38,7 @@
 #include <common/TraceEvent.hpp>
 #include <common/Util.hpp>
 #include <common/CommandControl.hpp>
+#include <wsd/TileDesc.hpp>
 #include <net/HttpHelper.hpp>
 
 using namespace COOLProtocol;
@@ -2603,22 +2604,24 @@ void ClientSession::enqueueSendMessage(const std::shared_ptr<Message>& data)
     LOG_CHECK_RET(docBroker && "Null DocumentBroker instance", );
     docBroker->ASSERT_CORRECT_THREAD();
 
-    std::unique_ptr<TileDesc> tile;
+    TileWireId wireId = 0;
+    bool haveWireId = false;
     if (data->firstTokenMatches("tile:") ||
         data->firstTokenMatches("delta:"))
     {
         // Avoid sending tile or delta if it has the same wireID as the
         // previously sent tile
-        tile = std::make_unique<TileDesc>(TileDesc::parse(data->firstLine()));
+        wireId = TileDesc::parse(data->firstLine()).getWireId();
+        haveWireId = true;
     }
 
     LOG_TRC("Enqueueing client message " << data->id());
-    std::size_t sizeBefore = _senderQueue.size();
-    std::size_t newSize = _senderQueue.enqueue(data);
+    const std::size_t sizeBefore = _senderQueue.size();
+    const std::size_t newSize = _senderQueue.enqueue(data);
 
     // Track sent tile
-    if (tile && sizeBefore != newSize)
-        addTileOnFly(tile->getWireId());
+    if (haveWireId && sizeBefore != newSize)
+        addTileOnFly(wireId);
 }
 
 void ClientSession::addTileOnFly(TileWireId wireId)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -147,6 +147,10 @@ public:
     {
         // Delegate to the docBroker.
         _docBroker.pollThread();
+
+        // We are done; let's clean up. (Is it excessive to be impatient?)
+        LOG_TRC("Waking up world after finishing DocBroker poll");
+        SocketPoll::wakeupWorld();
     }
 };
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -135,7 +135,11 @@ public:
             _urpFromKit->shutdown();
         if (_urpToKit)
             _urpToKit->shutdown();
-        ::close(_smapsFD);
+        if (_smapsFD != -1)
+        {
+            ::close(_smapsFD);
+            _smapsFD = -1;
+        }
     }
 
     const ChildProcess& operator=(ChildProcess&& other) = delete;

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -13,6 +13,7 @@
 
 #include "RequestDetails.hpp"
 #include <Storage.hpp>
+#include "Util.hpp"
 #include "WebSocketHandler.hpp"
 
 #include <Poco/URI.h>
@@ -66,6 +67,14 @@ public:
                        const std::shared_ptr<StreamSocket>& socket, unsigned mobileAppDocId,
                        SocketDisposition& disposition);
 
+    /// Returns true iff we are older than the given age.
+    template <typename T>
+    bool aged(T minAge,
+              std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now()) const
+    {
+        return _birthday.elapsed<T>(minAge, now);
+    }
+
 private:
     bool createDocBroker(const std::string& docKey, const std::string& url,
                          const Poco::URI& uriPublic);
@@ -87,6 +96,7 @@ private:
     std::unique_ptr<CheckFileInfo> _checkFileInfo;
 #endif // !MOBILEAPP
 
+    Util::Stopwatch _birthday;
     std::shared_ptr<TerminatingPoll> _poll;
     std::string _id;
     std::shared_ptr<WebSocketHandler> _ws;


### PR DESCRIPTION
Commit logs explain what these do. There are several cleanups, some perf improvements, some valgrind check fixes, and cleaning up RequestVettingStation instances (and capping them).

- wsd: use 'none' mount(2) fstype
- wsd: cosmetics
- wsd: avoid calling close(2) on invalid FD
- wsd: avoid unnecessary argument copying
- wsd: else-if mutually-exclusive condition
- wsd: test: protect against uninitialized unit-test
- wsd: avoid unnecessary TileDesc allocation
- wsd: include cleanup in COOLWSD.cpp
- wsd: reduce excessive 'using' keyword in COOLWSD.cpp
- wsd: remove const to move URI
- wsd: missing new-line in SocketPoll::dumpState
- wsd: cap in-flight RequestVettingStations
- wsd: StopWatch improvements
- wsd: track the age of RequestVettingStation instances
- wsd: clean up lingering RequestVettingStations
- wsd: trigger DocBroker cleaning up after exiting the poll
