### PR TITLE
Fix TypeError in _syncTilePanePos

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3903,7 +3903,7 @@ L.CanvasTileLayer = L.Layer.extend({
 	},
 
 	_syncTilePanePos: function () {
-		var tilePane = this._container.parentElement;
+		var tilePane = this._container ? this._container.parentElement : null;
 		if (tilePane) {
 			var mapPanePos = this._map._getMapPanePos();
 			L.DomUtil.setPosition(tilePane, new L.Point(-mapPanePos.x , -mapPanePos.y));


### PR DESCRIPTION
Blind fix for:
`bundle.js:19150 Uncaught TypeError: Cannot read properties of null (reading 'parentElement')`