### PR TITLE
sidebar btns: Use the correct css var for btn image size

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -351,8 +351,8 @@
 	background-repeat: no-repeat;
 }
 .unospan-optionstoolboxdown .unobutton > img {
-	width: var(--btn-size);
-	height: var(--btn-size);
+	width: var(--btn-img-size);
+	height: var(--btn-img-size);
 }
 #closebuttonwrapper {
 	order: 99;


### PR DESCRIPTION
it's an image within a button. Otherwise the icons will appear huge.


Change-Id: I3a7e74c53aa6b1f4a0a1b2bd2f3120be0a9b1c55


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

