### PR TITLE
Fix regression in `Socket::shutdown()` when having `_noShutdown` set

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -218,10 +218,10 @@ public:
     /// TODO: Support separate read/write shutdown.
     virtual void shutdown()
     {
-        setClosed();
         if (!_noShutdown)
         {
             LOG_TRC("Socket shutdown RDWR. " << *this);
+            setClosed();
             if constexpr (!Util::isMobileApp())
                 ::shutdown(_fd, SHUT_RDWR);
             else


### PR DESCRIPTION
Change-Id: I57d46e0428905137e05d34dad450fea1d6a0f127

* Resolves: #9833
* Target version: master 

### Summary
Regression injected with commit 0579ee81c709865ea420c2d70dcc443bdf69de1a of PR https://github.com/CollaboraOnline/online/pull/9916

Original behavior was to do nothing in Socket::shutdown(), while the commit in question did setClosed() leading to an eventual socket close within SocketPoll::poll().

The latter causes an error within system ::ppoll().

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

