### PR TITLE
user following: update on cursor invalidation

### DIFF
--- a/browser/src/docstatefunctions.js
+++ b/browser/src/docstatefunctions.js
@@ -134,6 +134,36 @@ app.isFollowingEditor = function () {
 	return app.following.mode === 'editor';
 };
 
+app.updateFollowingUsers = function () {
+	var isCellCursorVisible = app.calc.cellCursorVisible;
+	var isTextCursorVisible = app.file.textCursor.visible;
+	if (isCellCursorVisible || isTextCursorVisible) {
+		if (isCellCursorVisible)
+			var cursorPos = app.map._docLayer._twipsToLatLng({
+				x: app.calc.cellCursorRectangle.x2,
+				y: app.calc.cellCursorRectangle.y2,
+			});
+		else
+			cursorPos = app.map._docLayer._twipsToLatLng({
+				x: app.file.textCursor.rectangle.x2,
+				y: app.file.textCursor.rectangle.y2,
+			});
+		var cursorPositionInView = app.map._docLayer._isLatLngInView(cursorPos);
+		if (
+			parseInt(app.getFollowedViewId()) ===
+				parseInt(app.map._docLayer._viewId) &&
+			!cursorPositionInView
+		) {
+			app.setFollowingOff();
+		} else if (
+			parseInt(app.getFollowedViewId()) === -1 &&
+			cursorPositionInView
+		) {
+			app.setFollowingUser(parseInt(app.map._docLayer._viewId));
+		}
+	}
+};
+
 app.calc.isRTL = function () {
 	if (!app.map._docLayer || !app.map._docLayer._lastStatusJSON) return false;
 

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1000,21 +1000,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._move();
 		this._moveInProgress = false;
 		this._moveTileRequests = [];
-
-		var isCellCursorVisible = app.calc.cellCursorVisible;
-		var isTextCursorVisible = app.file.textCursor.visible;
-		if (isCellCursorVisible || isTextCursorVisible) {
-			if (isCellCursorVisible)
-				var cursorPos = this._map._docLayer._twipsToLatLng({ x: app.calc.cellCursorRectangle.x2, y: app.calc.cellCursorRectangle.y2 });
-			else
-				cursorPos = this._map._docLayer._twipsToLatLng({ x: app.file.textCursor.rectangle.x2, y: app.file.textCursor.rectangle.y2 });
-			var cursorPositionInView = this._isLatLngInView(cursorPos);
-			if (parseInt(app.getFollowedViewId()) === parseInt(this._viewId) && !cursorPositionInView) {
-				app.setFollowingOff();
-			} else if (parseInt(app.getFollowedViewId()) === -1 && cursorPositionInView) {
-				app.setFollowingUser(parseInt(this._viewId));
-			}
-		}
+		app.updateFollowingUsers();
 	},
 
 	_requestNewTiles: function () {
@@ -3030,9 +3016,11 @@ L.CanvasTileLayer = L.Layer.extend({
 				' buttons=' + buttons + ' modifier=' + modifier);
 
 
-		if (type === 'buttondown') {
+		if (type === 'buttondown')
 			this._clearSearchResults();
-		}
+
+		if (this._map && this._map._docLayer && (type === 'buttondown' || type === 'buttonup'))
+			app.setFollowingUser(this._map._docLayer._getViewId());
 	},
 
 	// Given a character code and a UNO keycode, send a "key" message to coolwsd.


### PR DESCRIPTION
so we don't skip cases when there is no scrolling using eg. mouse. this fixes problem in writer:
1. open long, multi page document
2. search for word which exists on every page
3. search using "next" button until you scroll to other page - works
4. scroll using mouse to the top
5. click before first word to put cursors there
6. click multiple times "next" button

result: cursor no longer shown when going to next page
expected: following the cursor all the time