### PR TITLE
private/ash/co 24.04

### DIFF
--- a/common/CoolMount.cpp
+++ b/common/CoolMount.cpp
@@ -310,6 +310,7 @@ int domount(int argc, const char* const* argv)
         {
             // Now we need to set read-only and other flags with a remount.
             unsigned long mountflags = (MS_BIND | MS_REMOUNT | MS_NODEV | MS_NOSUID | MS_RDONLY);
+            const char* fstype = "none";
 
             /* a) In the linux namespace mount case an additional MS_NOATIME, etc. will result in
                EPERM on remounting something hosted in a toplevel [rel]atime mount. man 2 mount
@@ -322,7 +323,7 @@ int domount(int argc, const char* const* argv)
                where the closest match is:  "mount options=(ro,remount,bind,nodev,nosuid)"
                so additional 'MS_SILENT' or 'MS_REC' flags cause the remount to be denied
             */
-            int retval = MOUNT(source, target, nullptr, mountflags, nullptr);
+            int retval = MOUNT(source, target, fstype, mountflags, nullptr);
             if (retval)
             {
                 fprintf(stderr, "%s: mount failed remount [%s] readonly: %s.\n", program, target,
@@ -330,7 +331,7 @@ int domount(int argc, const char* const* argv)
                 return EX_SOFTWARE;
             }
 
-            retval = MOUNT(source, target, nullptr, (MS_UNBINDABLE | MS_REC), nullptr);
+            retval = MOUNT(source, target, fstype, (MS_UNBINDABLE | MS_REC), nullptr);
             if (retval)
             {
                 fprintf(stderr, "%s: mount failed make [%s] private: %s.\n", program, target,

--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -520,7 +520,7 @@ namespace FileUtil
     {
         assert(!path.empty());
 
-        if (!Util::isMobileApp())
+        if constexpr (!Util::isMobileApp())
         {
             bool hookResult = true;
             if (UnitBase::get().filterCheckDiskSpace(path, hookResult))

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -14,16 +14,17 @@
 #include "FileUtil.hpp"
 #include "JailUtil.hpp"
 
+#include <fcntl.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sysexits.h>
-#include <fcntl.h>
 #include <unistd.h>
 #ifdef __linux__
 #include <sys/sysmacros.h>
 #endif
 
+#include <csignal>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -361,7 +362,7 @@ void cleanupJails(const std::string& root)
                 try {
                     int pid = std::stoi(pidStr);
                     LOG_TRC("Checking pid for jail " << pid << " " << root);
-                    if (pid != getpid() && kill(pid, 0) == 0)
+                    if (pid != getpid() && ::kill(pid, 0) == 0)
                     {
                         LOG_TRC("Skipping cleaning jails directory for running coolwsd with pid " << pid);
                         skip = true;

--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -283,8 +283,6 @@ namespace Log
         inline std::size_t size() const { return _tlb.size(); }
         inline std::size_t available() const { return _tlb.available(); }
 
-        inline void flush() { _tlb.flush(); }
-
         inline void buffer(const char* data, std::size_t size) { _tlb.buffer(data, size); }
 
         template <std::size_t N> inline void buffer(const char (&data)[N])
@@ -298,6 +296,8 @@ namespace Log
         ~BufferedConsoleChannel() { flush(); }
 
         void close() override { flush(); }
+
+        static inline void flush() { _tlb.flush(); }
 
         void log(const Poco::Message& msg) override
         {
@@ -700,7 +700,13 @@ namespace Log
 
         Poco::Logger::shutdown();
 
-        // Flush
+        flush();
+    }
+
+    void flush()
+    {
+        BufferedConsoleChannel::flush();
+
         fflush(stdout);
         fflush(stderr);
     }

--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -601,7 +601,7 @@ namespace Log
         Static.setName(name);
         std::ostringstream oss;
         oss << Static.getName();
-        if (!Util::isMobileApp())
+        if constexpr (!Util::isMobileApp())
             oss << '-' << std::setw(5) << std::setfill('0') << getpid();
         Static.setId(oss.str());
 
@@ -689,7 +689,7 @@ namespace Log
 
     void shutdown()
     {
-        if (Util::isMobileApp())
+        if constexpr (Util::isMobileApp())
             return;
         if (!Util::isKitInProcess())
             assert(ThreadLocalBufferCount <= 1 &&

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -74,6 +74,8 @@ namespace Log
     /// Shutdown and release the logging system.
     void shutdown();
 
+    void flush();
+
     /// Cleanup state after forking
     void postFork();
 

--- a/common/Png.hpp
+++ b/common/Png.hpp
@@ -182,7 +182,7 @@ inline bool impl_encodeSubBufferToPNG(unsigned char* pixmap, size_t startX, size
         return false;
     }
 
-    if (Util::isMobileApp())
+    if constexpr (Util::isMobileApp())
         png_set_compression_level(png_ptr, Z_BEST_SPEED);
     else
     {

--- a/common/Protocol.hpp
+++ b/common/Protocol.hpp
@@ -256,7 +256,10 @@ namespace COOLProtocol
         {
             // By default, all uno commands are modifying, unless we are certain they don't.
             return !tokens.equals(1, ".uno:SidebarHide") && !tokens.equals(1, ".uno:SidebarShow") &&
-                   !tokens.equals(1, ".uno:Copy") && !tokens.equals(1, ".uno:Save");
+                   !tokens.equals(1, ".uno:Copy") && !tokens.equals(1, ".uno:Save") &&
+                   !tokens.startsWith(1, ".uno:ToolbarMode") && // ToolbarMode?Mode...
+                   !tokens.equals(1, ".uno:InvertBackground") &&
+                   !tokens.equals(1, ".uno:ChangeTheme");
         }
 
         return false;

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -27,24 +27,25 @@ using namespace COOLProtocol;
 
 using Poco::Exception;
 
-Session::Session(const std::shared_ptr<ProtocolHandlerInterface> &protocol,
-                 const std::string& name, const std::string& id, bool readOnly) :
-    MessageHandlerInterface(protocol),
-    _id(id),
-    _name(name),
-    _disconnected(false),
-    _isActive(true),
-    _lastActivityTime(std::chrono::steady_clock::now()),
-    _isCloseFrame(false),
-    _isWritable(!readOnly),
-    _isReadOnly(readOnly),
-    _isAllowChangeComments(false),
-    _haveDocPassword(false),
-    _isDocPasswordProtected(false),
-    _isAdminUser(std::nullopt),
-    _watermarkOpacity(0.2),
-    _accessibilityState(false),
-    _disableVerifyHost(false)
+Session::Session(const std::shared_ptr<ProtocolHandlerInterface>& protocol, const std::string& name,
+                 const std::string& id, bool readOnly)
+    : MessageHandlerInterface(protocol)
+    , _id(id)
+    , _name(name)
+    , _disconnected(false)
+    , _isActive(true)
+    , _lastActivityTime(std::chrono::steady_clock::now())
+    , _isCloseFrame(false)
+    , _writePermission(!readOnly)
+    , _isWritable(!readOnly)
+    , _isReadOnly(readOnly)
+    , _isAllowChangeComments(false)
+    , _haveDocPassword(false)
+    , _isDocPasswordProtected(false)
+    , _isAdminUser(std::nullopt)
+    , _watermarkOpacity(0.2)
+    , _accessibilityState(false)
+    , _disableVerifyHost(false)
 {
 }
 
@@ -318,11 +319,13 @@ void Session::getIOStats(uint64_t &sent, uint64_t &recv)
 
 void Session::dumpState(std::ostream& os)
 {
-    os << "\n\t\tid: " << _id
+    os << std::boolalpha
+       << "\n\t\tid: " << _id
        << "\n\t\tname: " << _name
        << "\n\t\tdisconnected: " << _disconnected
        << "\n\t\tisActive: " << _isActive
        << "\n\t\tisCloseFrame: " << _isCloseFrame
+       << "\n\t\twritePermission: " << _writePermission
        << "\n\t\tisWritable: " << _isWritable
        << "\n\t\tisReadOnly: " << _isReadOnly
        << "\n\t\tisAllowChangeComments: " << _isAllowChangeComments

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -82,7 +82,17 @@ public:
     bool isDisconnected() const { return _disconnected; }
 
     /// Sets the permission to write to storage (for a given document).
-    void setWritePermission(bool write) { _writePermission = write; }
+    /// If set to false, will setWritable(false).
+    void setWritePermission(bool write)
+    {
+        _writePermission = write;
+        if (!write)
+        {
+            // Disable writing.
+            setWritable(false);
+        }
+    }
+
     /// Gets the permission to write to storage (for a given document).
     bool getWritePermission() const { return _writePermission; }
 

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -81,6 +81,11 @@ public:
     const std::string& getName() const { return _name; }
     bool isDisconnected() const { return _disconnected; }
 
+    /// Sets the permission to write to storage (for a given document).
+    void setWritePermission(bool write) { _writePermission = write; }
+    /// Gets the permission to write to storage (for a given document).
+    bool getWritePermission() const { return _writePermission; }
+
     /// Controls whether writing in the Storage is enabled in this session.
     /// If set to false, will setReadOnly(true) and setAllowChangeComments(false).
     void setWritable(bool writable)
@@ -100,7 +105,7 @@ public:
     virtual void setReadOnly(bool readonly) { _isReadOnly = readonly; }
     bool isReadOnly() const { return _isReadOnly; }
 
-    /// Controls whether commenting is enabled in this session
+    /// Controls whether commenting is enabled in this session.
     void setAllowChangeComments(bool allow) { _isAllowChangeComments = allow; }
     bool isAllowChangeComments() const { return _isAllowChangeComments; }
 
@@ -308,10 +313,15 @@ private:
     // Whether websocket received close frame.  Closing Handshake
     std::atomic<bool> _isCloseFrame;
 
-    /// Whether the session can write in storage.
+    /// Whether the session has write permission in storage, as received from WOPI or URL parameters.
+    /// This doesn't change once set.
+    bool _writePermission;
+
+    /// Whether the session can write in storage. May be disabled on error (e.g. low storage).
+    /// Note: A read-only document may still be writable (if _isAllowChangeComments is true), f.e. PDF.
     bool _isWritable;
 
-    /// Whether the session can edit the document.
+    /// Whether the session can edit the document. Disabled when we fail to lock, for example.
     bool _isReadOnly;
 
     /// Whether the session can add/change comments.

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -93,7 +93,7 @@ void setTerminationFlag()
     // Set the forced-termination flag.
     RunStateFlag = RunState::Terminate;
 
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
     {
         // And wake-up the thread.
         SocketPoll::wakeupWorld();

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -61,12 +61,10 @@ enum class RunState : char
 
 /// Single flag to control the current run state.
 static std::atomic<RunState> RunStateFlag(RunState::Run);
+#endif // IOS
 
-#if !MOBILEAPP
 static std::atomic<bool> DumpGlobalState(false);
 static std::atomic<bool> ForwardSigUsr2Flag(false); //< Flags to forward SIG_USR2 to children.
-#endif
-#endif
 
 static std::atomic<size_t> ActivityStringIndex = 0;
 static std::string ActivityHeader;
@@ -114,26 +112,28 @@ void requestShutdown()
 
     void checkDumpGlobalState([[maybe_unused]] GlobalDumpStateFn dumpState)
     {
-#if !MOBILEAPP
-        assert(dumpState && "Invalid callback for checkDumpGlobalState");
-        if (DumpGlobalState)
+        if constexpr (!Util::isMobileApp())
         {
-            DumpGlobalState = false;
-            dumpState();
+            assert(dumpState && "Invalid callback for checkDumpGlobalState");
+            if (DumpGlobalState)
+            {
+                DumpGlobalState = false;
+                dumpState();
+            }
         }
-#endif
     }
 
     void checkForwardSigUsr2([[maybe_unused]] ForwardSigUsr2Fn forwardSigUsr2)
     {
-#if !MOBILEAPP
-        assert(forwardSigUsr2 && "Invalid callback for checkForwardSigUsr2");
-        if (ForwardSigUsr2Flag)
+        if constexpr (!Util::isMobileApp())
         {
-            ForwardSigUsr2Flag = false;
-            forwardSigUsr2();
+            assert(forwardSigUsr2 && "Invalid callback for checkForwardSigUsr2");
+            if (ForwardSigUsr2Flag)
+            {
+                ForwardSigUsr2Flag = false;
+                forwardSigUsr2();
+            }
         }
-#endif
     }
 
     void setActivityHeader(const std::string &message)

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -11,9 +11,6 @@
 
 #pragma once
 
-#include <atomic>
-#include <mutex>
-#include <signal.h>
 #include <string>
 
 namespace SigUtil

--- a/common/StringVector.hpp
+++ b/common/StringVector.hpp
@@ -264,7 +264,7 @@ public:
         }
 
         const StringToken& token = _tokens[index];
-        return _string.compare(token._index, token._length, string) == 0;
+        return std::string_view(_string.data() + token._index, token._length) == string;
     }
 
     /// Compares the nth token with string.
@@ -276,7 +276,10 @@ public:
         }
 
         const StringToken& token = _tokens[index];
-        return _string.compare(token._index, token._length, string, N - 1) == 0;
+        constexpr auto len = N - 1; // we don't want to compare the '\0'
+        return token._length == len &&
+               std::string_view(_string.data() + token._index, token._length) ==
+                   std::string_view(string, len);
     }
 
     // Checks if the token text at index starts with the given string

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -421,11 +421,6 @@ void UnitBase::initialize()
     socketPoll()->startThread();
 }
 
-bool UnitBase::isUnitTesting()
-{
-    return DlHandle;
-}
-
 void UnitBase::setTimeout(std::chrono::milliseconds timeoutMilliSeconds)
 {
     assert(!TimeoutThread.joinable() && "setTimeout must be called before starting a test");

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -9,17 +9,17 @@
 
 #include "Unit.hpp"
 
-#include <iostream>
 #include <cassert>
 #include <condition_variable>
+#include <csignal>
 #include <dlfcn.h>
-#include <fstream>
+#include <iostream>
 #include <mutex>
 #include <sstream>
 #include <sysexits.h>
 #include <thread>
+#include <unistd.h>
 
-#include "JsonUtil.hpp"
 #include <Poco/Util/LayeredConfiguration.h>
 #include <Poco/Util/Application.h>
 
@@ -27,10 +27,10 @@
 #include "Util.hpp"
 #include <test/testlog.hpp>
 
+#include <common/JsonUtil.hpp>
+#include <common/Message.hpp>
 #include <common/SigUtil.hpp>
 #include <common/StringVector.hpp>
-#include <common/Message.hpp>
-#include <unistd.h>
 
 UnitKit *GlobalKit = nullptr;
 UnitWSD *GlobalWSD = nullptr;

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -56,7 +56,7 @@ bool EnableExperimental = false;
 UnitBase** UnitBase::linkAndCreateUnit([[maybe_unused]] UnitType type,
                                        [[maybe_unused]] const std::string& unitLibPath)
 {
-    if (Util::isMobileApp())
+    if constexpr (Util::isMobileApp())
         return nullptr;
     DlHandle = dlopen(unitLibPath.c_str(), RTLD_GLOBAL|RTLD_NOW);
     if (!DlHandle)
@@ -206,7 +206,7 @@ void UnitBase::selfTest()
 
 bool UnitBase::init([[maybe_unused]] UnitType type, [[maybe_unused]] const std::string& unitLibPath)
 {
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
         LOG_ASSERT(!get(type));
     else
     {
@@ -722,7 +722,7 @@ void UnitWSD::onExitTest(TestResult result, const std::string&)
         if (result != TestResult::Ok && !GlobalTestOptions.getKeepgoing())
         {
             LOG_TST("Failing fast per options, even though there are more tests");
-            if (!Util::isMobileApp())
+            if constexpr (!Util::isMobileApp())
             {
                 LOG_TST("Setting TerminationFlag as the Test Suite failed");
                 SigUtil::setTerminationFlag(); // and wake-up world.
@@ -741,7 +741,7 @@ void UnitWSD::onExitTest(TestResult result, const std::string&)
                                  << " was the last test. Finishing "
                                  << (GlobalResult == TestResult::Ok ? "SUCCESS" : "FAILED"));
 
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
     {
         LOG_TST("Setting TerminationFlag as there are no more tests");
         SigUtil::setTerminationFlag(); // and wake-up world.
@@ -776,7 +776,7 @@ void UnitKit::onExitTest(TestResult, const std::string&)
     //                              << " was the last test. Finishing "
     //                              << (GlobalResult == TestResult::Ok ? "SUCCESS" : "FAILED"));
 
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
     {
         // LOG_TST("Setting TerminationFlag as there are no more tests");
         SigUtil::setTerminationFlag(); // and wake-up world.

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -147,7 +147,14 @@ public:
     static int uninit();
 
     /// Do we have a unit test library hooking things & loaded
-    static bool isUnitTesting();
+    static bool isUnitTesting()
+    {
+#ifdef ENABLE_DEBUG
+        return DlHandle;
+#else
+        return false; // In non-debug builds unit-tests cannot be run. See test/run_unit.sh.
+#endif
+    }
 
     /// Tweak the return value from the process.
     virtual void returnValue(int& /* retValue */);

--- a/common/Util-desktop.cpp
+++ b/common/Util-desktop.cpp
@@ -30,8 +30,6 @@
 
 namespace Util
 {
-bool isMobileApp() { return false; }
-
 DirectoryCounter::DirectoryCounter(const char* procPath)
     : _tasks(opendir(procPath))
 {
@@ -459,6 +457,6 @@ std::chrono::microseconds SysStopwatch::elapsedTime() const
     return std::chrono::microseconds(totalUs);
 }
 
-}
+} // namespace Util
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/Util-mobile.cpp
+++ b/common/Util-mobile.cpp
@@ -13,8 +13,6 @@
 
 namespace Util
 {
-bool isMobileApp() { return true; }
-
 /// No-op implementation of desktop only functions
 DirectoryCounter::DirectoryCounter(const char* procPath) { (void)_tasks; }
 DirectoryCounter::~DirectoryCounter() {}
@@ -39,4 +37,4 @@ std::string getLinuxVersion() { return "unknown"; }
 
 void alertAllUsers(const std::string&) {}
 void alertAllUsers(const std::string&, const std::string&) {}
-}
+} // namespace Util

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -113,6 +113,10 @@ namespace Util
         {
         }
 
+        /// Returns the start-time.
+        std::chrono::steady_clock::time_point startTime() const { return _startTime; }
+
+        /// Resets the start-time to now.
         void restart() { _startTime = std::chrono::steady_clock::now(); }
 
         /// Returns the time that has elapsed since starting, in the units required.
@@ -125,9 +129,12 @@ namespace Util
         }
 
         /// Returns true iff at least the given amount of time has elapsed.
-        template <typename T> bool elapsed(T duration) const
+        template <typename T>
+        bool
+        elapsed(T duration,
+                std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now()) const
         {
-            return elapsed<std::chrono::nanoseconds>() >= duration;
+            return elapsed<std::chrono::nanoseconds>(now) >= duration;
         }
 
     private:

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1369,7 +1369,7 @@ int main(int argc, char**argv)
      */
     bool isFuzzing();
 
-    bool isMobileApp();
+    constexpr bool isMobileApp() { return MOBILEAPP; }
 
     void setKitInProcess(bool value);
     bool isKitInProcess();

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -955,7 +955,7 @@ bool ChildSession::loadDocument(const StringVector& tokens)
             return false;
         }
 
-        if (!Util::isMobileApp())
+        if constexpr (!Util::isMobileApp())
             renameForUpload(url);
     }
 
@@ -1305,7 +1305,7 @@ bool ChildSession::downloadAs(const StringVector& tokens)
         jailDoc = jailDoc.substr(0, jailDoc.find(JAILED_DOCUMENT_ROOT)) + JAILED_DOCUMENT_ROOT;
     }
 
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
         consistencyCheckJail();
 
     // The file is removed upon downloading.
@@ -1630,7 +1630,7 @@ bool ChildSession::insertFile(const StringVector& tokens)
 {
     std::string name, type, data;
 
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
     {
         if (tokens.size() != 3 || !getTokenString(tokens[1], "name", name) ||
             !getTokenString(tokens[2], "type", type))
@@ -1657,7 +1657,7 @@ bool ChildSession::insertFile(const StringVector& tokens)
     {
         std::string url;
 
-        if (!Util::isMobileApp())
+        if constexpr (!Util::isMobileApp())
         {
             if (type == "graphic" || type == "selectbackground")
             {
@@ -2704,7 +2704,7 @@ bool ChildSession::saveAs(const StringVector& tokens)
         // url is already encoded
         encodedURL = url;
 
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
         consistencyCheckJail();
 
     std::string encodedWopiFilename;
@@ -3325,7 +3325,7 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
 
         if (!commandName.isEmpty() && commandName.toString() == ".uno:Save")
         {
-            if (!Util::isMobileApp())
+            if constexpr (!Util::isMobileApp())
             {
                 consistencyCheckJail();
 
@@ -3525,7 +3525,7 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         sendTextFrame("printranges: " + payload);
         break;
     case LOK_CALLBACK_FONTS_MISSING:
-        if (!Util::isMobileApp())
+        if constexpr (!Util::isMobileApp())
         {
             // This environment variable is always set in COOLWSD::innerInitialize().
             static std::string fontsMissingHandling = std::string(std::getenv("FONTS_MISSING_HANDLING"));

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -188,7 +188,7 @@ protected:
 
     void onDisconnect() override
     {
-        if (Util::isMobileApp())
+        if constexpr (Util::isMobileApp())
             return;
         LOG_ERR("ForKit connection lost without exit arriving from wsd. Setting TerminationFlag");
         SigUtil::setTerminationFlag();

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2494,8 +2494,14 @@ void Document::dumpState(std::ostream& oss)
         << "\n\tduringLoad: " << _duringLoad
         << "\n\tmodified: " << name(_modified)
         << "\n\tbgSaveProc: " << _isBgSaveProcess
-        << "\n\tbgSaveDisabled: "<< _isBgSaveDisabled
-        << "\n";
+        << "\n\tbgSaveDisabled: "<< _isBgSaveDisabled;
+
+    std::string smap;
+    if (const ssize_t size = FileUtil::readFile("/proc/self/smaps_rollup", smap); size <= 0)
+        oss << "\n  smaps_rollup: <unavailable>";
+    else
+        oss << "\n  smaps_rollup: " << smap;
+    oss << '\n';
 
     // dumpState:
     // TODO: _websocketHandler - but this is an odd one.
@@ -2507,7 +2513,7 @@ void Document::dumpState(std::ostream& oss)
             << " editorId: " << it.second->getDoc()->getEditorId()
             << " mobileAppDocId: " << it.second->getDoc()->getMobileAppDocId();
     }
-    oss << "\n";
+    oss << '\n';
 
     _deltaPool.dumpState(oss);
     _sessions.dumpState(oss);
@@ -2522,7 +2528,7 @@ void Document::dumpState(std::ostream& oss)
         oss << "\n\t\tviewId: " << it.first
             << " last update time(ms): " << ms;
     }
-    oss << "\n";
+    oss << '\n';
 
     oss << "\tspeedCount:";
     for (const auto &it : _speedCount)
@@ -2543,14 +2549,14 @@ void Document::dumpState(std::ostream& oss)
             << " readOnly: " << it.second.isReadOnly()
             << " connected: " << it.second.isConnected();
     }
-    oss << "\n";
+    oss << '\n';
 
     char *pState = nullptr;
     _loKit->dumpState("", &pState);
     oss << "lok state:\n";
     if (pState)
         oss << pState;
-    oss << "\n";
+    oss << '\n';
 }
 
 #if !defined BUILDING_TESTS && !MOBILEAPP && !LIBFUZZER

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1804,7 +1804,7 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
     const bool accessibilityState = session->getAccessibilityState();
     const std::string& userTimezone = session->getTimezone();
 
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
         consistencyCheckFileExists(uri);
 
     std::string options;
@@ -2340,13 +2340,13 @@ void Document::drainQueue()
     catch (const std::exception& exc)
     {
         LOG_FTL("drainQueue: Exception: " << exc.what());
-        if (!Util::isMobileApp())
+        if constexpr (!Util::isMobileApp())
             flushAndExit(EX_SOFTWARE);
     }
     catch (...)
     {
         LOG_FTL("drainQueue: Unknown exception");
-        if (!Util::isMobileApp())
+        if constexpr (!Util::isMobileApp())
             flushAndExit(EX_SOFTWARE);
     }
 }
@@ -2809,7 +2809,7 @@ int KitSocketPoll::kitPoll(int timeoutMicroS)
     if (_document)
         _document->trimAfterInactivity();
 
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
     {
         flushTraceEventRecordings();
 

--- a/kit/KitWebSocket.cpp
+++ b/kit/KitWebSocket.cpp
@@ -99,7 +99,7 @@ void KitWebSocketHandler::handleMessage(const std::vector<char>& data)
 
     else if (tokens.equals(0, "exit"))
     {
-        if (!Util::isMobileApp())
+        if constexpr (!Util::isMobileApp())
         {
             LOG_INF("Terminating immediately due to parent 'exit' command.");
             flushTraceEventRecordings();
@@ -187,7 +187,7 @@ void KitWebSocketHandler::onDisconnect()
         return;
     }
 
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
     {
         //FIXME: We could try to recover.
         LOG_ERR("Kit for DocBroker ["

--- a/kit/SetupKitEnvironment.hpp
+++ b/kit/SetupKitEnvironment.hpp
@@ -39,7 +39,7 @@ inline void setupKitEnvironment(const std::string& userInterface)
     ::setenv("CONFIGURATION_LAYERS", layers.c_str(),
              1 /* override */);
 
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
     {
         // No-caps tracing can spawn eg. glxinfo & other oddness.
         unsetenv("DISPLAY");

--- a/net/FakeSocket.hpp
+++ b/net/FakeSocket.hpp
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "Util.hpp"
+
 #if MOBILEAPP
 
 #include <string>
@@ -54,6 +56,85 @@ int fakeSocketClose(int fd);
 
 void fakeSocketDumpState();
 
-#endif // MOBILEAPP
+#else
+
+inline void fakeSocketSetLoggingCallback(void (*)(const std::string&))
+{
+    assert(Util::isMobileApp() && "Never used in non-mobile builds");
+}
+
+inline int fakeSocketSocket()
+{
+    assert(Util::isMobileApp() && "Never used in non-mobile builds");
+    return -1;
+}
+
+inline int fakeSocketPipe2(int[2])
+{
+    assert(Util::isMobileApp() && "Never used in non-mobile builds");
+    return -1;
+}
+
+inline int fakeSocketPoll(struct pollfd*, int, int)
+{
+    assert(Util::isMobileApp() && "Never used in non-mobile builds");
+    return -1;
+}
+
+inline int fakeSocketListen(int)
+{
+    assert(Util::isMobileApp() && "Never used in non-mobile builds");
+    return -1;
+}
+
+inline int fakeSocketConnect(int, int)
+{
+    assert(Util::isMobileApp() && "Never used in non-mobile builds");
+    return -1;
+}
+
+inline int fakeSocketAccept4(int)
+{
+    assert(Util::isMobileApp() && "Never used in non-mobile builds");
+    return -1;
+}
+
+inline int fakeSocketPeer(int)
+{
+    assert(Util::isMobileApp() && "Never used in non-mobile builds");
+    return -1;
+}
+
+inline ssize_t fakeSocketAvailableDataLength(int)
+{
+    assert(Util::isMobileApp() && "Never used in non-mobile builds");
+    return -1;
+}
+
+inline ssize_t fakeSocketRead(int, void*, size_t)
+{
+    assert(Util::isMobileApp() && "Never used in non-mobile builds");
+    return -1;
+}
+
+inline ssize_t fakeSocketWrite(int, const void*, size_t)
+{
+    assert(Util::isMobileApp() && "Never used in non-mobile builds");
+    return -1;
+}
+
+inline int fakeSocketShutdown(int)
+{
+    assert(Util::isMobileApp() && "Never used in non-mobile builds");
+    return -1;
+}
+
+inline int fakeSocketClose(int)
+{
+    assert(Util::isMobileApp() && "Never used in non-mobile builds");
+    return -1;
+}
+
+#endif // !MOBILEAPP
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1004,7 +1004,7 @@ void SocketPoll::dumpState(std::ostream& os) const
     os << "\t    fd\tevents\trbuffered\twbuffered\trtotal\twtotal\tclientaddress\n";
     for (const std::shared_ptr<Socket>& socket : pollSockets)
         socket->dumpState(os);
-    os << "\n  Done [" << name() << ']';
+    os << "\n  Done [" << name() << "]\n";
 }
 
 /// Returns true on success only.

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -930,7 +930,10 @@ void WebSocketHandler::dumpState(std::ostream& os, const std::string& /*indent*/
         Util::dumpHex(os, _wsPayload, "\t\tws queued payload:\n", "\t\t");
     os << '\n';
     if (_msgHandler)
+    {
+        os << "msgHandler:\n";
         _msgHandler->dumpState(os);
+    }
 }
 
 void StreamSocket::dumpState(std::ostream& os)
@@ -992,16 +995,16 @@ void SocketPoll::dumpState(std::ostream& os) const
     // FIXME: NOT thread-safe! _pollSockets is modified from the polling thread!
     const auto pollSockets = _pollSockets;
 
-    os << "\n  SocketPoll:";
-    os << "\n    Poll [" << name() << "] with " << pollSockets.size() << " socket"
+    os << "\n  SocketPoll [" << name() << "] with " << pollSockets.size() << " socket"
        << (pollSockets.size() == 1 ? "" : "s") << " - wakeup rfd: " << _wakeup[0]
        << " wfd: " << _wakeup[1] << '\n';
     const auto callbacks = _newCallbacks.size();
     if (callbacks > 0)
         os << "\tcallbacks: " << callbacks << '\n';
     os << "\t    fd\tevents\trbuffered\twbuffered\trtotal\twtotal\tclientaddress\n";
-    for (const auto& i : pollSockets)
-        i->dumpState(os);
+    for (const std::shared_ptr<Socket>& socket : pollSockets)
+        socket->dumpState(os);
+    os << "\n  Done [" << name() << ']';
 }
 
 /// Returns true on success only.

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -632,7 +632,7 @@ public:
     {
         LOG_DBG("Stopping SocketPoll thread " << _name);
         _stop = true;
-        if (!Util::isMobileApp())
+        if constexpr (!Util::isMobileApp())
         {
             // We don't want to risk some callbacks in _newCallbacks being invoked when we start
             // running a thread for this SocketPoll again.
@@ -1304,7 +1304,7 @@ public:
     /// buffer for an optimal transmission.
     int getSendBufferCapacity() const
     {
-        if (Util::isMobileApp())
+        if constexpr (Util::isMobileApp())
             return INT_MAX; // We want to always send a single record in one go
         const int capacity = getSendBufferSize();
         return std::max<int>(0, capacity - _outBuffer.size());

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -205,7 +205,7 @@ protected:
                      << static_cast<unsigned>(statusCode) << ", message: " << statusMessage);
             _shuttingDown = true;
 
-            if (!Util::isMobileApp())
+            if constexpr (!Util::isMobileApp())
             {
                 const size_t len = statusMessage.size();
                 std::vector<char> buf(2 + len);
@@ -536,7 +536,7 @@ protected:
     {
         std::shared_ptr<StreamSocket> socket = _socket.lock();
 
-        if (Util::isMobileApp())
+        if constexpr (Util::isMobileApp())
         {
             // No separate "upgrade" is going on
             if (socket && !socket->isWebSocket())

--- a/test/UnitProxy.cpp
+++ b/test/UnitProxy.cpp
@@ -35,7 +35,7 @@ public:
           _poll("proxy-poll"),
           _sentRequest(false)
     {
-        setTimeout(std::chrono::seconds(5));
+        setTimeout(std::chrono::seconds(10));
     }
 
     void invokeWSDTest() override
@@ -46,10 +46,11 @@ public:
 
         auto httpSession = http::Session::create(helpers::getTestServerURI());
 
-        httpSession->setTimeout(std::chrono::seconds(5));
+        httpSession->setTimeout(std::chrono::seconds(9));
 
         TST_LOG("Attempt proxy URL fetch");
 
+        // Request from rating.collaboraonline.com.
         _req = http::Request("/browser/a90f83c/foo/remote/static/lokit-extra-img.svg");
 
         httpSession->setConnectFailHandler([this]() {

--- a/test/UnitQuarantine.cpp
+++ b/test/UnitQuarantine.cpp
@@ -155,12 +155,22 @@ public:
         LOG_TST("Testing " << toString(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
-        LOK_ASSERT_EQUAL_MESSAGE("Expect only documentconflict errors",
-                                 std::string("error: cmd=storage kind=savefailed"), message);
+        if (getCountCheckFileInfo() == 1)
+        {
+            LOK_ASSERT_EQUAL_MESSAGE("Expect only savefailed errors on first upload",
+                                     std::string("error: cmd=storage kind=savefailed"), message);
+        }
+        else
+        {
+            // Once the first upload fails, we issue CheckFileInfo, which detects the conflict.
+            LOK_ASSERT_EQUAL_MESSAGE(
+                "Expect only documentconflict errors after the second CheckFileInfo",
+                std::string("error: cmd=storage kind=documentconflict"), message);
 
-        // Close the document.
-        LOG_TST("Closing the document");
-        WSD_CMD("closedocument");
+            // Close the document.
+            LOG_TST("Closing the document");
+            WSD_CMD("closedocument");
+        }
 
         return true;
     }

--- a/test/UnitQuarantine.cpp
+++ b/test/UnitQuarantine.cpp
@@ -78,6 +78,7 @@ public:
             // With always_save_on_exit=true and limit_store_failures=LimitStoreFailures,
             // we expect exactly two PutFile requests per document.
             setExpectedPutFile(LimitStoreFailures);
+            setExpectedCheckFileInfo(2); // Conflict recovery requires second CFI.
         }
     }
 

--- a/test/UnitWOPICrashModified.cpp
+++ b/test/UnitWOPICrashModified.cpp
@@ -17,6 +17,8 @@
 #include <Util.hpp>
 #include <lokassert.hpp>
 
+#include <csignal>
+
 /// Test crashing a document after modifications.
 class UnitWOPICrashModified : public WopiTestServer
 {

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -105,6 +105,144 @@ public:
     }
 };
 
-UnitBase* unit_create_wsd(void) { return new UnitWOPIDocumentConflict(); }
+/// Simulate an upload timeout that precipitates a "conflict."
+/// When the upload times out (i.e. takes longer than *we* expected),
+/// there are really two outcomes: 1) the upload eventually was
+/// successful (this case), and the document has been updated in storage,
+/// or, 2) the upload fails (for whatever reason), and the
+/// document is not updated in storage. Either way, since we timed out, we
+/// never know the result. In case #1, the modified timestamp in
+/// storage would have changed, and any subsequent upload will fail,
+/// since the timestamp that we will send with subsequent uploads,
+/// which represents the expected last-modify date/time, will be invalid.
+/// This test simulates this particular scenario and verifies that
+/// we are able to recover gracefully from it.
+class UnitConflictAfterTimeoutSuccess : public WopiTestServer
+{
+    STATE_ENUM(Phase, Load, WaitLoadStatus, WaitModifiedStatus, WaitUploaded, WaitDestroy)
+    _phase;
+
+    std::atomic_int _uploadAttemptCount;
+
+    static constexpr int ConnectionTimeoutSeconds = 1;
+
+public:
+    UnitConflictAfterTimeoutSuccess()
+        : WopiTestServer("UnitConflictAfterTimeoutSuccess")
+        , _phase(Phase::Load)
+        , _uploadAttemptCount(0)
+    {
+    }
+
+    void configure(Poco::Util::LayeredConfiguration& config) override
+    {
+        WopiTestServer::configure(config);
+
+        // We intentionally fail uploading twice, so need at least 3 tries.
+        config.setUInt("per_document.limit_store_failures", 3);
+        config.setBool("per_document.always_save_on_exit", false);
+        config.setUInt("net.connection_timeout_secs", ConnectionTimeoutSeconds); // Timeout quickly.
+        config.setUInt("per_document.min_time_between_uploads_ms", 100); // Short retry interval.
+    }
+
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        ++_uploadAttemptCount;
+        LOG_TST("PutFile: " << _uploadAttemptCount << ", Phase: " << name(_phase));
+
+        const std::string wopiTimestamp = request.get("X-COOL-WOPI-Timestamp", std::string());
+        LOK_ASSERT_MESSAGE("Unexpected forced upload", !wopiTimestamp.empty());
+
+        if (_uploadAttemptCount == 1)
+        {
+            // First attempt, timeout.
+            LOG_TST("PutFile: sleeping");
+            sleep(ConnectionTimeoutSeconds + 1);
+        }
+
+        // Success.
+        LOG_TST("PutFile: returning success");
+        return nullptr;
+    }
+
+    /// The document is loaded.
+    bool onDocumentLoaded(const std::string& message) override
+    {
+        LOG_TST("Got: [" << message << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
+
+        TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
+        WSD_CMD("key type=input char=97 key=0");
+        WSD_CMD("key type=up char=0 key=512");
+
+        return true;
+    }
+
+    /// The document is modified. Save it.
+    bool onDocumentModified(const std::string& message) override
+    {
+        LOG_TST("Got: [" << message << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
+
+        TRANSITION_STATE(_phase, Phase::WaitUploaded);
+        WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0");
+
+        return true;
+    }
+
+    void onDocumentUploaded(bool success) override
+    {
+        LOG_TST("Uploaded: " << (success ? "success" : "failure"));
+        LOK_ASSERT_STATE(_phase, Phase::WaitUploaded);
+        LOK_ASSERT_EQUAL_MESSAGE("Expected the first upload to fail", _uploadAttemptCount == 1,
+                                 !success);
+
+        if (success)
+        {
+            // We are done!
+            TRANSITION_STATE(_phase, Phase::WaitDestroy);
+
+            WSD_CMD("closedocument");
+        }
+    }
+
+    // Wait for clean unloading.
+    void onDocBrokerDestroy(const std::string& docKey) override
+    {
+        LOG_TST("Destroyed dockey [" << docKey << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitDestroy);
+
+        passTest("Document uploaded on closing as expected.");
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
+
+                LOG_TST("Load: initWebsocket.");
+                initWebsocket("/wopi/files/0?access_token=anything");
+
+                WSD_CMD("load url=" + getWopiSrc());
+                break;
+            }
+            case Phase::WaitLoadStatus:
+            case Phase::WaitModifiedStatus:
+            case Phase::WaitUploaded:
+            case Phase::WaitDestroy:
+                break;
+        }
+    }
+};
+
+UnitBase** unit_create_wsd_multi(void)
+{
+    return new UnitBase*[3]{ new UnitWOPIDocumentConflict(), new UnitConflictAfterTimeoutSuccess(),
+                             nullptr };
+}
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -13,6 +13,7 @@
 
 #include "WOPIUploadConflictCommon.hpp"
 
+#include <ctime>
 #include <string>
 #include <memory>
 
@@ -109,7 +110,7 @@ public:
 /// When the upload times out (i.e. takes longer than *we* expected),
 /// there are really two outcomes: 1) the upload eventually was
 /// successful (this case), and the document has been updated in storage,
-/// or, 2) the upload fails (for whatever reason), and the
+/// or, 2) the upload fails (UnitConflictAfterTimeoutFailure), and the
 /// document is not updated in storage. Either way, since we timed out, we
 /// never know the result. In case #1, the modified timestamp in
 /// storage would have changed, and any subsequent upload will fail,
@@ -239,10 +240,173 @@ public:
     }
 };
 
+/// Simulate an upload timeout that precipitates a "conflict."
+/// When the upload times out (i.e. takes longer than *we* expected),
+/// there are really two outcomes: 1) the upload eventually was
+/// successful (UnitConflictAfterTimeoutSuccess), and the document
+/// has been updated in storage, or, 2) the upload fails (this case),
+/// and the document is not updated in storage. Either way, since we
+/// timed out, we never know the result. In case #1, the modified
+/// timestamp in storage would have changed, and any subsequent upload
+/// will fail, since the timestamp that we will send with subsequent uploads,
+/// which represents the expected last-modify date/time, will be invalid.
+/// This test simulates this particular scenario and verifies that
+/// we are able to recover gracefully from it.
+class UnitConflictAfterTimeoutFailure : public WopiTestServer
+{
+    STATE_ENUM(Phase, Load, WaitLoadStatus, WaitModifiedStatus, WaitUploaded, WaitDestroy)
+    _phase;
+
+    std::atomic_int _uploadAttemptCount;
+
+    static constexpr int ConnectionTimeoutSeconds = 1;
+
+public:
+    UnitConflictAfterTimeoutFailure()
+        : WopiTestServer("UnitConflictAfterTimeoutFailure")
+        , _phase(Phase::Load)
+        , _uploadAttemptCount(0)
+    {
+    }
+
+    void configure(Poco::Util::LayeredConfiguration& config) override
+    {
+        WopiTestServer::configure(config);
+
+        // We intentionally fail uploading twice, so need at least 3 tries.
+        config.setUInt("per_document.limit_store_failures", 3);
+        config.setBool("per_document.always_save_on_exit", false);
+        config.setUInt("net.connection_timeout_secs", ConnectionTimeoutSeconds); // Timeout quickly.
+        config.setUInt("per_document.min_time_between_uploads_ms", 100); // Short retry interval.
+    }
+
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        LOG_TST("PutFile: " << _uploadAttemptCount << ", Phase: " << name(_phase));
+
+        const std::string wopiTimestamp = request.get("X-COOL-WOPI-Timestamp", std::string());
+        LOK_ASSERT_MESSAGE("Unexpected forced upload", !wopiTimestamp.empty());
+
+        // First attempt, timeout.
+        LOG_TST("PutFile: sleeping");
+        sleep(ConnectionTimeoutSeconds); // Connection timeout.
+        usleep(300'000); // Go over, to be certain we timed-out the upload.
+        // Don't sleep for 2 x ConnectionTimeoutSeconds, as the
+        // CheckFileInfo request may timeout, since we're stuck here.
+
+        // Simulate a conflict. Make the size different, otherwise
+        // we can't yet detect same-size changes.
+        // We do this after the first upload attempt (which will timeout)
+        // because otherwise we would've not reached here and returned
+        // 'conflict' sooner, in WopiTestServer::handleWopiUpload().
+        LOG_TST("Simulating conflict in storage");
+        setFileContent("Modified data in storage");
+
+        // Fail.
+        LOG_TST("PutFile: returning a bogus failure");
+        return std::make_unique<http::Response>(http::StatusCode::InternalServerError);
+    }
+
+    /// The document is loaded.
+    bool onDocumentLoaded(const std::string& message) override
+    {
+        LOG_TST("Got: [" << message << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
+
+        TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
+        WSD_CMD("key type=input char=97 key=0");
+        WSD_CMD("key type=up char=0 key=512");
+
+        return true;
+    }
+
+    /// The document is modified. Save it.
+    bool onDocumentModified(const std::string& message) override
+    {
+        LOG_TST("Got: [" << message << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
+
+        TRANSITION_STATE(_phase, Phase::WaitUploaded);
+        WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0");
+
+        return true;
+    }
+
+    void onDocumentUploaded(bool success) override
+    {
+        LOG_TST("Uploaded #" << _uploadAttemptCount << ": " << (success ? "success" : "failure"));
+        LOK_ASSERT_STATE(_phase, Phase::WaitUploaded);
+        LOK_ASSERT_MESSAGE("Expected Phase::WaitUploaded or Phase::WaitDestroy",
+                           _phase == Phase::WaitUploaded || _phase == Phase::WaitDestroy);
+        // LOK_ASSERT_EQUAL_MESSAGE("Expected the first upload to fail", _uploadAttemptCount == 1,
+        //                          !success);
+    }
+
+    bool onDocumentError(const std::string& message) override
+    {
+        LOG_TST("Testing " << name(_phase) << ": [" << message << ']');
+        // LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
+
+        ++_uploadAttemptCount;
+        LOG_TST("uploadAttemptCount: " << _uploadAttemptCount);
+        if (_uploadAttemptCount == 1)
+        {
+            LOK_ASSERT_EQUAL_MESSAGE("Expect only documentconflict errors",
+                                     std::string("error: cmd=storage kind=savefailed"), message);
+        }
+        else
+        {
+            LOK_ASSERT_EQUAL_MESSAGE("Expect only documentconflict errors",
+                                     std::string("error: cmd=storage kind=documentconflict"),
+                                     message);
+
+            // We are done!
+            TRANSITION_STATE(_phase, Phase::WaitDestroy);
+
+            LOG_TST("Discarding own changes via closedocument");
+            WSD_CMD("closedocument");
+        }
+
+        return true;
+    }
+
+    // Wait for clean unloading.
+    void onDocBrokerDestroy(const std::string& docKey) override
+    {
+        LOG_TST("Destroyed dockey [" << docKey << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitDestroy);
+
+        passTest("Document uploaded on closing as expected.");
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
+
+                LOG_TST("Load: initWebsocket.");
+                initWebsocket("/wopi/files/0?access_token=anything");
+
+                WSD_CMD("load url=" + getWopiSrc());
+                break;
+            }
+            case Phase::WaitLoadStatus:
+            case Phase::WaitModifiedStatus:
+            case Phase::WaitUploaded:
+            case Phase::WaitDestroy:
+                break;
+        }
+    }
+};
+
 UnitBase** unit_create_wsd_multi(void)
 {
-    return new UnitBase*[3]{ new UnitWOPIDocumentConflict(), new UnitConflictAfterTimeoutSuccess(),
-                             nullptr };
+    return new UnitBase*[4]{ new UnitWOPIDocumentConflict(), new UnitConflictAfterTimeoutSuccess(),
+                             new UnitConflictAfterTimeoutFailure(), nullptr };
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/WOPIUploadConflictCommon.hpp
+++ b/test/WOPIUploadConflictCommon.hpp
@@ -121,24 +121,29 @@ public:
         setExpectedGetFile(1); // All the tests GetFile once.
         setExpectedPutRelative(0); // No renaming in these tests.
 
-        if (_scenario == Scenario::VerifyOverwrite)
+        switch (_scenario)
         {
-            // By default, we don't upload when verifying (unless always_save_on_exit is set).
-            setExpectedPutFile(0);
-        }
-        else if (_scenario == Scenario::Disconnect || _scenario == Scenario::SaveDiscard ||
-                 _scenario == Scenario::CloseDiscard)
-        {
-            // When there is no client connected, there is no way
-            // to decide how to resolve the conflict externally.
-            // So we quarantine and let it be.
-            // Similarly, when the client decides to discard changes.
-            setExpectedPutFile(1);
-        }
-        else
-        {
-            // With conflicts, we typically do two PutFile requests.
-            setExpectedPutFile(2);
+            case Scenario::Disconnect:
+            {
+                // When there is no client connected, there is no way
+                // to decide how to resolve the conflict externally.
+                // So we quarantine and let it be.
+                setExpectedPutFile(1);
+            }
+            break;
+            case Scenario::SaveDiscard:
+                setExpectedPutFile(1); // The client discards their changes; don't upload.
+                break;
+            case Scenario::CloseDiscard:
+                setExpectedPutFile(1); // The client discards their changes; don't upload.
+                break;
+            case Scenario::SaveOverwrite:
+                setExpectedPutFile(2); // Upload a second time to force client's changes.
+                break;
+            case Scenario::VerifyOverwrite:
+                // By default, we don't upload when verifying (unless always_save_on_exit is set).
+                setExpectedPutFile(0);
+                break;
         }
     }
 

--- a/test/WOPIUploadConflictCommon.hpp
+++ b/test/WOPIUploadConflictCommon.hpp
@@ -307,6 +307,13 @@ public:
         // LOK_ASSERT_EQUAL(getExpectedPutFile(), getCountPutFile()); //FIXME: unreliable for some tests.
 
         LOG_TST("===== Finished " << name(_scenario) << " test scenario =====");
+
+        if (_scenario != Scenario::VerifyOverwrite)
+        {
+            // Restart the next scenario, unless we are at the last one.
+            TRANSITION_STATE(_phase, Phase::Load);
+        }
+
         switch (_scenario)
         {
             case Scenario::Disconnect:
@@ -325,8 +332,6 @@ public:
                 passTest("Finished all test scenarios without issues");
                 break;
         }
-
-        TRANSITION_STATE(_phase, Phase::Load);
     }
 
     void invokeWSDTest() override

--- a/test/WopiProofTests.cpp
+++ b/test/WopiProofTests.cpp
@@ -157,7 +157,7 @@ void WopiProofTests::testOurProof()
     LOK_ASSERT_EQUAL(pairs[2].first, std::string("X-WOPI-ProofOld"));
     std::string proofOld = pairs[2].second;
 
-    int64_t ticks = std::stoll(timestamp.c_str(), nullptr, 10);
+    int64_t ticks = std::stoll(timestamp, nullptr, 10);
     verifySignature(access_token, uri, ticks, modulus, exponent, proof, testname);
     verifySignature(access_token, uri, ticks, modulus, exponent, proofOld, testname);
 
@@ -175,7 +175,7 @@ void WopiProofTests::testOurProof()
     LOK_ASSERT_EQUAL(pairs[2].first, std::string("X-WOPI-ProofOld"));
     proofOld = pairs[2].second;
 
-    ticks = std::stoll(timestamp.c_str(), nullptr, 10);
+    ticks = std::stoll(timestamp, nullptr, 10);
     verifySignature(access_token, uri, ticks, modulus, exponent, proof, testname);
     verifySignature(access_token, uri, ticks, modulus, exponent, proofOld, testname);
 }

--- a/tools/Replay.hpp
+++ b/tools/Replay.hpp
@@ -562,8 +562,9 @@ public:
 
             sendMessage("tileprocessed tile=" + desc.generateID());
             std::cerr << _logPre << "Sent tileprocessed tile= " + desc.generateID() << "\n";
-        } if (tokens.equals(0, "error:")) {
-
+        }
+        else if (tokens.equals(0, "error:"))
+        {
             bool reconnect = false;
             if (firstLine == "error: cmd=load kind=docunloading")
             {

--- a/tools/Replay.hpp
+++ b/tools/Replay.hpp
@@ -382,17 +382,16 @@ class StressSocketHandler : public WebSocketHandler
     std::chrono::steady_clock::time_point _lastTile;
 
 public:
-    StressSocketHandler(SocketPoll &poll, /* bad style */
-                        const std::shared_ptr<Stats> stats,
-                        const std::string &uri, const std::string &trace,
-                        const int delayMs = 0) :
-        WebSocketHandler(true, true),
-        _poll(poll),
-        _reader(trace),
-        _connecting(true),
-        _uri(uri),
-        _trace(trace),
-        _stats(stats)
+    StressSocketHandler(SocketPoll& poll, /* bad style */
+                        const std::shared_ptr<Stats>& stats, const std::string& uri,
+                        const std::string& trace, const int delayMs = 0)
+        : WebSocketHandler(true, true)
+        , _poll(poll)
+        , _reader(trace)
+        , _connecting(true)
+        , _uri(uri)
+        , _trace(trace)
+        , _stats(stats)
     {
         assert(_stats && "stats must be provided");
 

--- a/tools/Stress.cpp
+++ b/tools/Stress.cpp
@@ -89,11 +89,11 @@ int Stress::main(const std::vector<std::string>& args)
     }
 #endif
 
-    std::string server = args[0];
+    const std::string& server = args[0];
 
     if (!strncmp(server.c_str(), "http", 4))
     {
-        std::cerr << "Server should be wss:// or ws:// URL not " << server << "\n";
+        std::cerr << "Server should be wss:// or ws:// URL, not " << server << '\n';
         return -1;
     }
 

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -13,6 +13,7 @@
 
 #include <chrono>
 #include <iomanip>
+#include <sstream>
 #include <string>
 #include <sys/poll.h>
 #include <unistd.h>
@@ -693,6 +694,17 @@ void Admin::pollingThread()
                 _pendingConnects.erase(_pendingConnects.begin());
                 connectToMonitorSync(rec.getUri());
             }
+        }
+
+        bool dumpMetrics = true;
+        if (_dumpMetrics.compare_exchange_strong(dumpMetrics, false))
+        {
+            std::ostringstream oss;
+            oss << "Admin Metrics:\n";
+            getMetrics(oss);
+            const std::string str = oss.str();
+            fprintf(stderr, "%s\n", str.c_str());
+            LOG_TRC(str);
         }
 
         // Handle websockets & other work.

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -173,6 +173,9 @@ public:
 
     void getMetrics(std::ostringstream &metrics);
 
+    /// Will dump the metrics in the log and stderr from the Admin SocketPoll.
+    static void dumpMetrics() { instance()._dumpMetrics = true; }
+
     // delete entry from _monitorSocket map
     void deleteMonitorSocket(const std::string &uriWithoutParam);
 
@@ -225,6 +228,9 @@ private:
     uint64_t _lastSentCount;
     uint64_t _lastRecvCount;
     std::string _forkitLogLevel;
+
+    /// When set, the metrics will be dumped into the log and stderr.
+    std::atomic_bool _dumpMetrics;
 
     struct MonitorConnectRecord
     {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -59,7 +59,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <queue>
 #include <regex>
 #include <sstream>
 #include <string>
@@ -67,22 +66,9 @@
 
 #if !MOBILEAPP
 
-#include <Poco/Net/Context.h>
-#include <Poco/Net/HTTPRequest.h>
-#include <Poco/Net/HTTPResponse.h>
-#include <Poco/Net/IPAddress.h>
-#include <Poco/Net/MessageHeader.h>
-#include <Poco/Net/NameValueCollection.h>
-#include <Poco/Net/Net.h>
-#include <Poco/Net/NetException.h>
-#include <Poco/Net/PartHandler.h>
-#include <Poco/Net/SocketAddress.h>
-#include <Poco/Net/AcceptCertificateHandler.h>
-#include <Poco/Net/Context.h>
-#include <Poco/Net/KeyConsoleHandler.h>
+#if ENABLE_SSL
 #include <Poco/Net/SSLManager.h>
-
-using Poco::Net::PartHandler;
+#endif
 
 #include <cerrno>
 #include <stdexcept>
@@ -96,15 +82,10 @@ using Poco::Net::PartHandler;
 
 #endif
 
-#include <Poco/DateTimeFormatter.h>
 #include <Poco/DirectoryIterator.h>
 #include <Poco/Exception.h>
 #include <Poco/File.h>
-#include <Poco/FileStream.h>
-#include <Poco/MemoryStream.h>
-#include <Poco/Net/HostEntry.h>
 #include <Poco/Path.h>
-#include <Poco/TemporaryFile.h>
 #include <Poco/URI.h>
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Poco/Util/HelpFormatter.h>
@@ -115,7 +96,6 @@ using Poco::Net::PartHandler;
 #include <Poco/Util/ServerApplication.h>
 #include <Poco/Util/XMLConfiguration.h>
 
-#include "ClientSession.hpp"
 #include <ClientRequestDispatcher.hpp>
 #include <Common.hpp>
 #include <Clipboard.hpp>
@@ -136,18 +116,15 @@ using Poco::Net::PartHandler;
 #if ENABLE_SSL
 #  include <SslSocket.hpp>
 #endif
-#include "Storage.hpp"
 #include <wsd/wopi/StorageConnectionManager.hpp>
-#include "TraceFile.hpp"
+#include <wsd/TraceFile.hpp>
 #include <Unit.hpp>
 #include <Util.hpp>
 #include <common/ConfigUtil.hpp>
-#include <common/TraceEvent.hpp>
 
 #include <common/SigUtil.hpp>
 #include <net/AsyncDNS.hpp>
 
-#include <RequestVettingStation.hpp>
 #include <ServerSocket.hpp>
 
 #if MOBILEAPP

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1086,7 +1086,11 @@ COOLWSD::COOLWSD()
 
 COOLWSD::~COOLWSD()
 {
-    UnitWSD::get().setWSD(nullptr);
+    if (UnitBase::isUnitTesting())
+    {
+        // We won't have a valid UnitWSD::get() when not testing.
+        UnitWSD::get().setWSD(nullptr);
+    }
 }
 
 #if !MOBILEAPP

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4104,6 +4104,12 @@ public:
            << "\n  UserInterface: " << COOLWSD::UserInterface
             ;
 
+        std::string smap;
+        if (const ssize_t size = FileUtil::readFile("/proc/self/smaps_rollup", smap); size <= 0)
+            os << "\n  smaps_rollup: <unavailable>";
+        else
+            os << "\n  smaps_rollup: " << smap;
+
 #if !MOBILEAPP
         if (FetchHttpSession)
         {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -351,7 +351,7 @@ void COOLWSD::appendAllowedAliasGroups(LayeredConfiguration& conf, std::vector<s
 /// connected to any document.
 void COOLWSD::alertAllUsersInternal(const std::string& msg)
 {
-    if (Util::isMobileApp())
+    if constexpr (Util::isMobileApp())
         return;
     std::lock_guard<std::mutex> docBrokersLock(DocBrokersMutex);
 
@@ -370,7 +370,7 @@ void COOLWSD::alertAllUsersInternal(const std::string& msg)
 
 void COOLWSD::alertUserInternal(const std::string& dockey, const std::string& msg)
 {
-    if (Util::isMobileApp())
+    if constexpr (Util::isMobileApp())
         return;
     std::lock_guard<std::mutex> docBrokersLock(DocBrokersMutex);
 
@@ -3102,7 +3102,7 @@ void COOLWSD::dumpOutgoingTrace(const std::string& id, const std::string& sessio
 
 void COOLWSD::defineOptions(OptionSet& optionSet)
 {
-    if (Util::isMobileApp())
+    if constexpr (Util::isMobileApp())
         return;
     ServerApplication::defineOptions(optionSet);
 
@@ -3860,7 +3860,7 @@ private:
 
             auto child = std::make_shared<ChildProcess>(pid, jailId, socket, request);
 
-            if (!Util::isMobileApp())
+            if constexpr (!Util::isMobileApp())
                 UnitWSD::get().newChild(child);
 
             _pid = pid;

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4960,6 +4960,10 @@ void dump_state()
     const std::string msg = oss.str();
     fprintf(stderr, "%s\n", msg.c_str());
     LOG_TRC(msg);
+
+#if !MOBILEAPP
+    Admin::dumpMetrics();
+#endif
 }
 
 void lslr_childroot()

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -382,7 +382,7 @@ public:
     {
         std::string lowerCaseExtension = extension;
         std::transform(lowerCaseExtension.begin(), lowerCaseExtension.end(), lowerCaseExtension.begin(), ::tolower);
-        if (Util::isMobileApp())
+        if constexpr (Util::isMobileApp())
         {
             if (lowerCaseExtension == "pdf")
                 return true; // true for only pdf - it is not editable

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1795,7 +1795,7 @@ bool ClientRequestDispatcher::handleClientProxyRequest(const Poco::Net::HTTPRequ
     const std::string url = requestDetails.getLegacyDocumentURI();
 
     LOG_INF("URL [" << url << "] for Proxy request.");
-    const auto uriPublic = RequestDetails::sanitizeURI(url);
+    auto uriPublic = RequestDetails::sanitizeURI(url);
     const auto docKey = RequestDetails::getDocKey(uriPublic);
     const std::string fileId = Uri::getFilenameFromURL(docKey);
     Util::mapAnonymized(fileId, fileId); // Identity mapping, since fileId is already obfuscated

--- a/wsd/ClientRequestDispatcher.hpp
+++ b/wsd/ClientRequestDispatcher.hpp
@@ -128,8 +128,15 @@ private:
     /// WS is created and as long as it is connected.
     std::shared_ptr<RequestVettingStation> _rvs;
 
+    /// The absolute maximum number of RVS instances in flight.
+    /// Note: exceeding this means we will not do parallel CheckFileInfo, ahead of loading.
+    static constexpr std::size_t RvsHighWatermark = 10 * 1024;
+
     /// External requests are first vetted before allocating DocBroker and Kit process.
     /// This is a map of the request URI to the RequestVettingStation for vetting.
+    /// This is a temporary storage until we get the WS upgrade. If we don't, we purge.
+    /// Note: this is accessed exclusively from websrv_poll, through
+    /// handleIncomingMessage and handleClientWsUpgrade. Do *not* access in the ctor/dtor!
     static std::unordered_map<std::string, std::shared_ptr<RequestVettingStation>>
         RequestVettingStations;
 

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2266,11 +2266,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                 }
             }
 
-            // A view loaded.
-            if (UnitWSD::isUnitTesting())
-            {
-                UnitWSD::get().onDocBrokerViewLoaded(docBroker->getDocKey(), client_from_this());
-            }
+            docBroker->onViewLoaded(client_from_this());
 
 #if !MOBILEAPP
             Admin::instance().setViewLoadDuration(

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -650,7 +650,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         if (COOLWSD::EnableTraceEventLogging)
             sendTextFrame("enabletraceeventlogging yes");
 
-        if (!Util::isMobileApp())
+        if constexpr (!Util::isMobileApp())
         {
             // If it is not mobile, it must be Linux (for now).
             std::string osVersionInfo(COOLWSD::getConfigValue<std::string>("per_view.custom_os_info", ""));
@@ -1826,7 +1826,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
 
     const bool isConvertTo = static_cast<bool>(_saveAsSocket);
 
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
         COOLWSD::dumpOutgoingTrace(docBroker->getJailId(), getId(), firstLine);
 
     const auto& tokens = payload->tokens();

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -38,10 +38,7 @@
 #include <common/TraceEvent.hpp>
 #include <common/Util.hpp>
 #include <common/CommandControl.hpp>
-
-#if !MOBILEAPP
 #include <net/HttpHelper.hpp>
-#endif
 
 using namespace COOLProtocol;
 
@@ -232,7 +229,7 @@ std::string ClientSession::createPublicURI(const std::string& subPath, const std
 #if !MOBILEAPP
     if (!COOLWSD::RouteToken.empty())
         meta += "&RouteToken=" + COOLWSD::RouteToken;
-#endif
+#endif // !MOBILEAPP
 
     if (!encode)
         return meta;
@@ -270,9 +267,8 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
             return; // the getclipboard already completed.
         if (type == DocumentBroker::CLIP_REQUEST_SET)
         {
-#if !MOBILEAPP
-            HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
-#endif
+            if constexpr (!Util::isMobileApp())
+                HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
         }
         else // will be handled during shutdown
         {
@@ -418,9 +414,8 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
         }
         else
         {
-#if !MOBILEAPP
-            HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
-#endif
+            if constexpr (!Util::isMobileApp())
+                HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
         }
     }
 }

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -38,6 +38,7 @@
 #include <common/TraceEvent.hpp>
 #include <common/Util.hpp>
 #include <common/CommandControl.hpp>
+#include <wsd/TileDesc.hpp>
 #include <net/HttpHelper.hpp>
 
 using namespace COOLProtocol;
@@ -2612,22 +2613,24 @@ void ClientSession::enqueueSendMessage(const std::shared_ptr<Message>& data)
     LOG_CHECK_RET(docBroker && "Null DocumentBroker instance", );
     docBroker->ASSERT_CORRECT_THREAD();
 
-    std::unique_ptr<TileDesc> tile;
+    TileWireId wireId = 0;
+    bool haveWireId = false;
     if (data->firstTokenMatches("tile:") ||
         data->firstTokenMatches("delta:"))
     {
         // Avoid sending tile or delta if it has the same wireID as the
         // previously sent tile
-        tile = std::make_unique<TileDesc>(TileDesc::parse(data->firstLine()));
+        wireId = TileDesc::parse(data->firstLine()).getWireId();
+        haveWireId = true;
     }
 
     LOG_TRC("Enqueueing client message " << data->id());
-    std::size_t sizeBefore = _senderQueue.size();
-    std::size_t newSize = _senderQueue.enqueue(data);
+    const std::size_t sizeBefore = _senderQueue.size();
+    const std::size_t newSize = _senderQueue.enqueue(data);
 
     // Track sent tile
-    if (tile && sizeBefore != newSize)
-        addTileOnFly(tile->getWireId());
+    if (haveWireId && sizeBefore != newSize)
+        addTileOnFly(wireId);
 }
 
 void ClientSession::addTileOnFly(TileWireId wireId)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1687,6 +1687,7 @@ bool DocumentBroker::updateStorageLockStateAsync(const std::shared_ptr<ClientSes
             case StorageBase::LockUpdateResult::Status::OK:
                 LOG_DBG((requestedLock == StorageBase::LockState::LOCK ? "Locked" : "Unlocked")
                         << " docKey [" << _docKey << "] successfully");
+                _lockCtx->setState(requestedLock);
                 return;
                 break;
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2410,7 +2410,16 @@ void DocumentBroker::handleUploadToStorageResponse(const StorageBase::UploadResu
     {
         return handleUploadToStorageSuccessful(uploadResult);
     }
-    else if (uploadResult.getResult() == StorageBase::UploadResult::Result::TOO_LARGE)
+
+    handleUploadToStorageFailed(uploadResult);
+}
+
+void DocumentBroker::handleUploadToStorageFailed(const StorageBase::UploadResult& uploadResult)
+{
+    assert(uploadResult.getResult() != StorageBase::UploadResult::Result::OK &&
+           "Expected upload failure");
+
+    if (uploadResult.getResult() == StorageBase::UploadResult::Result::TOO_LARGE)
     {
         LOG_WRN("Got Entitity Too Large while uploading docKey ["
                 << _docKey << "] to URI [" << _uploadRequest->uriAnonym()

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -198,7 +198,7 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
     assert(!_docKey.empty());
     assert(!COOLWSD::ChildRoot.empty());
 
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
         assert(_mobileAppDocId == 0 && "Unexpected to have mobileAppDocId in the non-mobile build");
 #ifdef IOS
     assert(_mobileAppDocId > 0 && "Unexpected to have no mobileAppDocId in the iOS build");
@@ -223,7 +223,7 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
 
 void DocumentBroker::setupPriorities()
 {
-    if (Util::isMobileApp())
+    if constexpr (Util::isMobileApp())
         return;
     if (_type == ChildType::Batch)
     {
@@ -998,7 +998,7 @@ bool DocumentBroker::download(
                     // message for "view file extension" document types
                     session->sendFileMode(session->isReadOnly(), session->isAllowChangeComments());
                 }
-                else if (Util::isMobileApp())
+                else if constexpr (Util::isMobileApp())
                 {
                     // Fix issue #5887 by assuming that documents are writable on iOS and Android
                     // The iOS and Android app saves directly to local disk so, other than for

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -179,7 +179,7 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
     , _cursorWidth(0)
     , _cursorHeight(0)
     , _poll(
-          std::make_unique<DocumentBrokerPoll>("doc" SHARED_DOC_THREADNAME_SUFFIX + _docId, *this))
+          std::make_shared<DocumentBrokerPoll>("doc" SHARED_DOC_THREADNAME_SUFFIX + _docId, *this))
     , _stop(false)
     , _lockCtx(std::make_unique<LockContext>())
     , _tileVersion(0)
@@ -189,7 +189,8 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
     , _mobileAppDocId(mobileAppDocId)
     , _alwaysSaveOnExit(COOLWSD::getConfigValue<bool>("per_document.always_save_on_exit", false))
     , _backgroundAutoSave(COOLWSD::getConfigValue<bool>("per_document.background_autosave", true))
-    , _backgroundManualSave(COOLWSD::getConfigValue<bool>("per_document.background_manualsave", true))
+    , _backgroundManualSave(
+          COOLWSD::getConfigValue<bool>("per_document.background_manualsave", true))
 #if !MOBILEAPP
     , _admin(Admin::instance())
 #endif

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2625,6 +2625,22 @@ void DocumentBroker::onViewLoaded(const std::shared_ptr<ClientSession>& session)
     //TODO: Take the WOPI lock, if necessary.
 }
 
+std::shared_ptr<ClientSession> DocumentBroker::getFirstAuthorizedSession() const
+{
+    ASSERT_CORRECT_THREAD();
+
+    for (const auto& sessionIt : _sessions)
+    {
+        const auto& session = sessionIt.second;
+        if (!session->getAuthorization().isExpired())
+        {
+            return session;
+        }
+    }
+
+    return std::shared_ptr<ClientSession>();
+}
+
 std::shared_ptr<ClientSession> DocumentBroker::getWriteableSession() const
 {
     ASSERT_CORRECT_THREAD();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1543,37 +1543,6 @@ void DocumentBroker::endRenameFileCommand()
     endActivity();
 }
 
-bool DocumentBroker::lockDocumentInStorage(const Authorization& auth, std::string& error)
-{
-    assert(_lockCtx && "Expected an initialized LockContext");
-    assert(_lockCtx->supportsLocks() && "Expected to have lock support");
-    assert(!_lockCtx->isLocked() && "Expected not to have locked already");
-
-    const StorageBase::LockUpdateResult result = _storage->updateLockState(
-        auth, *_lockCtx, StorageBase::LockState::LOCK, _currentStorageAttrs);
-    error = result.getReason();
-
-    switch (result.getStatus())
-    {
-        case StorageBase::LockUpdateResult::Status::UNSUPPORTED:
-            LOG_DBG("Locks on docKey [" << _docKey << "] are unsupported");
-            return true; // Not an error.
-            break;
-        case StorageBase::LockUpdateResult::Status::OK:
-            LOG_DBG("Locked docKey [" << _docKey << "] successfully");
-            return true;
-            break;
-        case StorageBase::LockUpdateResult::Status::UNAUTHORIZED:
-            LOG_ERR("Failed to lock docKey [" << _docKey << "]. Invalid or expired access token");
-            break;
-        case StorageBase::LockUpdateResult::Status::FAILED:
-            LOG_ERR("Failed to lock docKey [" << _docKey << "] with reason: " << error);
-            break;
-    }
-
-    return false;
-}
-
 bool DocumentBroker::updateStorageLockState(ClientSession& session, StorageBase::LockState lock,
                                             std::string& error)
 {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2614,6 +2614,17 @@ void DocumentBroker::setInteractive(bool value)
     }
 }
 
+void DocumentBroker::onViewLoaded(const std::shared_ptr<ClientSession>& session)
+{
+    // A view loaded.
+    if (UnitWSD::isUnitTesting())
+    {
+        UnitWSD::get().onDocBrokerViewLoaded(getDocKey(), session);
+    }
+
+    //TODO: Take the WOPI lock, if necessary.
+}
+
 std::shared_ptr<ClientSession> DocumentBroker::getWriteableSession() const
 {
     ASSERT_CORRECT_THREAD();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -145,6 +145,10 @@ public:
     {
         // Delegate to the docBroker.
         _docBroker.pollThread();
+
+        // We are done; let's clean up. (Is it excessive to be impatient?)
+        LOG_TRC("Waking up world after finishing DocBroker poll");
+        SocketPoll::wakeupWorld();
     }
 };
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -616,6 +616,9 @@ private:
     /// Note that if there is no loaded and writable session, the first will be returned.
     std::shared_ptr<ClientSession> getWriteableSession() const;
 
+    /// Get the first session that has a valid authorization.
+    std::shared_ptr<ClientSession> getFirstAuthorizedSession() const;
+
     void refreshLock();
 
     /// Downloads the document ahead-of-time.

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -652,7 +652,7 @@ private:
     bool processPlugins(std::string& localPath);
 
     /// Start an asynchronous CheckFileInfo request.
-    void checkFileInfo(const Poco::URI& uri, int redirectLimit);
+    void checkFileInfo(const std::shared_ptr<ClientSession>& uri, int redirectLimit);
 
 #endif // !MOBILEAPP
 
@@ -1516,6 +1516,7 @@ private:
                    Conflict, //< The document is conflicted in storaged.
                    Save, //< The document is being saved, manually or auto-save.
                    Upload, //< The document is being uploaded to storage.
+                   SyncFileTimestamp, //< Need to CheckFileInfo and get the modified timestamp.
 #if !MOBILEAPP && !WASMAPP
                    SwitchingToOffline, //< The document will switch to Offline mode.
                    SwitchingToOnline, //< The document will switch to Online mode.
@@ -1670,8 +1671,10 @@ private:
     /// For now we can only have one at a time.
     std::unique_ptr<UploadRequest> _uploadRequest;
 
+#if !MOBILEAPP
     /// The current CheckFileInfo request, if any.
     std::unique_ptr<CheckFileInfo> _checkFileInfo;
+#endif
 
     /// Manage uploading to Storage.
     StorageManager _storageManager;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1696,7 +1696,7 @@ private:
     int _cursorPosY;
     int _cursorWidth;
     int _cursorHeight;
-    std::unique_ptr<DocumentBrokerPoll> _poll;
+    std::shared_ptr<DocumentBrokerPoll> _poll;
     std::atomic<bool> _stop;
     std::string _closeReason;
     std::unique_ptr<LockContext> _lockCtx;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -45,6 +45,7 @@
 
 // Forwards.
 class PrisonerRequestDispatcher;
+class CheckFileInfo;
 class DocumentBroker;
 class LockContext;
 class TileCache;
@@ -649,7 +650,11 @@ private:
 
     /// Process the configured plugins, if any, after downloading the document file.
     bool processPlugins(std::string& localPath);
-#endif //!MOBILEAPP
+
+    /// Start an asynchronous CheckFileInfo request.
+    void checkFileInfo(const Poco::URI& uri, int redirectLimit);
+
+#endif // !MOBILEAPP
 
     bool isLoaded() const { return _docState.hadLoaded(); }
     bool isInteractive() const { return _docState.isInteractive(); }
@@ -1664,6 +1669,9 @@ private:
     /// The current upload request, if any.
     /// For now we can only have one at a time.
     std::unique_ptr<UploadRequest> _uploadRequest;
+
+    /// The current CheckFileInfo request, if any.
+    std::unique_ptr<CheckFileInfo> _checkFileInfo;
 
     /// Manage uploading to Storage.
     StorageManager _storageManager;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -771,6 +771,9 @@ private:
     /// Handles the completion of successful uploading to storage.
     void handleUploadToStorageSuccessful(const StorageBase::UploadResult& uploadResult);
 
+    /// Handles the completion of failed uploading to storage.
+    void handleUploadToStorageFailed(const StorageBase::UploadResult& uploadResult);
+
     /// Sends the .uno:Save command to LoKit.
     bool sendUnoSave(const std::shared_ptr<ClientSession>& session, bool dontTerminateEdit = true,
                      bool dontSaveIfUnmodified = true, bool isAutosave = false, bool finalWrite = false,

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -663,9 +663,6 @@ private:
     bool updateStorageLockStateAsync(const std::shared_ptr<ClientSession>& session,
                                      StorageBase::LockState lock, std::string& error);
 
-    /// Take the lock before loading the first session, if we know we can edit.
-    bool lockDocumentInStorage(const Authorization& auth, std::string& error);
-
     std::size_t getIdleTimeSecs() const
     {
         const auto duration = (std::chrono::steady_clock::now() - _lastActivityTime);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -768,6 +768,9 @@ private:
     /// Handles the completion of uploading to storage, both success and failure cases.
     void handleUploadToStorageResponse(const StorageBase::UploadResult& uploadResult);
 
+    /// Handles the completion of successful uploading to storage.
+    void handleUploadToStorageSuccessful(const StorageBase::UploadResult& uploadResult);
+
     /// Sends the .uno:Save command to LoKit.
     bool sendUnoSave(const std::shared_ptr<ClientSession>& session, bool dontTerminateEdit = true,
                      bool dontSaveIfUnmodified = true, bool isAutosave = false, bool finalWrite = false,

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -132,7 +132,11 @@ public:
             _urpFromKit->shutdown();
         if (_urpToKit)
             _urpToKit->shutdown();
-        ::close(_smapsFD);
+        if (_smapsFD != -1)
+        {
+            ::close(_smapsFD);
+            _smapsFD = -1;
+        }
     }
 
     const ChildProcess& operator=(ChildProcess&& other) = delete;

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -363,6 +363,9 @@ public:
     /// Notify that the document has dialogs before load
     virtual void setInteractive(bool value);
 
+    /// Called when a new view is loaded.
+    void onViewLoaded(const std::shared_ptr<ClientSession>& session);
+
     /// If not yet locked, try to lock
     bool attemptLock(ClientSession& session, std::string& failReason);
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -651,8 +651,7 @@ private:
     bool isInteractive() const { return _docState.isInteractive(); }
 
     /// Before downloading the document, we lock if the document is loaded for editing.
-    void lockIfEditing(const std::shared_ptr<ClientSession>& session, const Poco::URI& uriPublic,
-                       bool userCanWrite);
+    void lockIfEditing(const std::shared_ptr<ClientSession>& session);
 
     /// Updates the document's lock in storage to either locked or unlocked.
     /// Returns true iff the operation was successful.

--- a/wsd/RequestDetails.cpp
+++ b/wsd/RequestDetails.cpp
@@ -74,7 +74,7 @@ RequestDetails::RequestDetails(Poco::Net::HTTPRequest &request, const std::strin
     _isWebSocket = it != request.end() && Util::iequal(it->second, "websocket");
     _closeConnection = !request.getKeepAlive(); // HTTP/1.1: closeConnection true w/ "Connection: close" only!
     // request.getHost fires an exception on mobile.
-    if (!Util::isMobileApp())
+    if constexpr (!Util::isMobileApp())
         _hostUntrusted = request.getHost();
 
     processURI();

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -13,6 +13,7 @@
 
 #include "RequestDetails.hpp"
 #include <Storage.hpp>
+#include "Util.hpp"
 #include "WebSocketHandler.hpp"
 
 #include <Poco/URI.h>
@@ -66,6 +67,14 @@ public:
                        const std::shared_ptr<StreamSocket>& socket, unsigned mobileAppDocId,
                        SocketDisposition& disposition);
 
+    /// Returns true iff we are older than the given age.
+    template <typename T>
+    bool aged(T minAge,
+              std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now()) const
+    {
+        return _birthday.elapsed<T>(minAge, now);
+    }
+
 private:
     bool createDocBroker(const std::string& docKey, const std::string& url,
                          const Poco::URI& uriPublic);
@@ -87,6 +96,7 @@ private:
     std::unique_ptr<CheckFileInfo> _checkFileInfo;
 #endif // !MOBILEAPP
 
+    Util::Stopwatch _birthday;
     std::shared_ptr<TerminatingPoll> _poll;
     std::string _id;
     std::shared_ptr<WebSocketHandler> _ws;

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -392,7 +392,7 @@ std::size_t LocalStorage::uploadLocalFileToStorageAsync(
 
 void LockContext::initSupportsLocks()
 {
-    if (Util::isMobileApp())
+    if constexpr (Util::isMobileApp())
         _supportsLocks = false;
     else
     {

--- a/wsd/wopi/CheckFileInfo.hpp
+++ b/wsd/wopi/CheckFileInfo.hpp
@@ -11,8 +11,6 @@
 
 #pragma once
 
-#include <chrono>
-#include <condition_variable>
 #if MOBILEAPP
 #error This file should be excluded from Mobile App builds
 #endif // MOBILEAPP

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -1072,10 +1072,10 @@ WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
                     << wopiLog << ". Cannot upload file to WOPI storage uri [" << details.uriAnonym
                     << "]: " << responseString);
             result.setResult(StorageBase::UploadResult::Result::FAILED);
+            result.setReason(responseString);
 
             // If we cannot be sure whether we up-loaded successfully eg. we got
-            // a timeout then be tolerant of subsequent timestamp mismatch problems
-            setLastModifiedTimeUnSafe();
+            // a timeout then try to recover in DocBroker.
         }
     }
     catch (const Poco::Exception& pexc)

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -484,7 +484,7 @@ void WopiStorage::updateLockStateAsync(const Authorization& auth, LockContext& l
     httpHeader.setContentLength(0);
 
     http::Session::FinishedCallback finishedCallback =
-        [this, startTime, lockCtx, lock, wopiLog, uriAnonym, asyncLockStateCallback,
+        [this, startTime, lock, wopiLog, uriAnonym, asyncLockStateCallback,
          profileZone =
              std::move(profileZone)](const std::shared_ptr<http::Session>& httpSession) mutable
     {
@@ -508,7 +508,6 @@ void WopiStorage::updateLockStateAsync(const Authorization& auth, LockContext& l
 
         if (httpResponse->statusLine().statusCode() == http::StatusCode::OK)
         {
-            lockCtx.setState(lock);
             return asyncLockStateCallback(
                 AsyncLockUpdate(AsyncLockUpdate::State::Complete,
                                 LockUpdateResult(LockUpdateResult::Status::OK, lock)));


### PR DESCRIPTION
- wsd: restore performance regression due to isMobileApp
- wsd: remove ifdef MOBILEAPP
- wsd: remove ifdef MOBILEAPP
- wsd: header cleanup
- wsd: avoid unnecessary temporary strings
- wsd: support reading unknown-sized files
- wsd: dump the smaps summary on USR1
- wsd: dump the Prometheus metrics with USR1
- wsd: minor non-functional improvements to Delta
- wsd: test: better Rename test
- wsd: refactor the handling of successful upload
- wsd: refactor the handling of failed upload
- wsd: end renaming upon upload failure
- wsd: make DocumentBrokerPoll a shared_ptr
- wsd: capture the original storage write Permission
- wsd: setWritePermission on each loaded session
- wsd: add DocumentBroker::onViewLoaded
- wsd: test: better setExpectedPutFile in UploadConflictCommon
- wsd: test: extend the timeouts in UnitProxy
- wsd: log: support on-deman flushing own buffer
- wsd: mark the dump-state better
- wsd: add getFirstAuthorizedSession to DocBroker
- wsd: test: better scenario transition in WOPIUploadConflictCommon
- wsd: test: add idle-timeout unlock test
- wsd: non-modifying uno commands
- wsd: strict equals comparison in StringVector
- wsd: logging and cosmetics
- wsd: correctly set the lock state
- wsd: unlock before unloading
- wsd: lock only after successful loading
- wsd: remove unused lock helper and dead code
- wsd: use 'none' mount(2) fstype
- wsd: cosmetics
- wsd: avoid calling close(2) on invalid FD
- wsd: avoid unnecessary argument copying
- wsd: else-if mutually-exclusive condition
- wsd: test: protect against uninitialized unit-test
- wsd: avoid unnecessary TileDesc allocation
- wsd: include cleanup in COOLWSD.cpp
- wsd: reduce excessive 'using' keyword in COOLWSD.cpp
- wsd: remove const to move URI
- wsd: missing new-line in SocketPoll::dumpState
- wsd: cap in-flight RequestVettingStations
- wsd: StopWatch improvements
- wsd: track the age of RequestVettingStation instances
- wsd: clean up lingering RequestVettingStations
- wsd: trigger DocBroker cleaning up after exiting the poll
- wsd: add async CheckFileInfo to recover from failed upload
- wsd: recover from failed upload
- wsd: test: recover from upload timeout
- wsd: test: fix UnitQuarantine
- wsd: test: fixup tests
- wsd: test: add UnitConflictAfterTimeoutFailure
