### PR TITLE
Fix: checkbox position not good in mobile view

### DIFF
--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -854,7 +854,7 @@ div#mobile-wizard-content .spinfieldcontainer .spinfieldimage.disabled {
 #mobile-wizard input[type='checkbox']{
 	width: var(--btn-size);
 	height: var(--btn-size);
-	margin: 10px 20px 10px 0px !important;
+	margin: 10px 10px 10px auto !important;
 	float: right;
 	-webkit-appearance: none;
 	-moz-appearance: none;


### PR DESCRIPTION
- Adjusted the margin value for checkbox in mobile view
- styling should be same as we have for 'radio button'

Before: 

![image](https://github.com/user-attachments/assets/fae1a952-bef8-41e3-a159-6d9264f27182)

After:

![image](https://github.com/user-attachments/assets/1dae7d82-d2a8-49f4-8b99-9722be2cef92)

Change-Id: I2d8697269b73a018cbf5976b794cd9a0f7418de9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

