### PR TITLE
fix: paste happens in document instead of combobox input

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -581,6 +581,9 @@ L.Clipboard = L.Class.extend({
 		if ($('.w2ui-input').is(':focus'))
 			return true;
 
+		if ($('input.ui-combobox-content').is(':focus'))
+			return true;
+
 		if (this._map.uiManager.isAnyDialogOpen()
 			&& !this.isCopyPasteDialogReadyForCopy()
 			&& !this.isPasteSpecialDialogOpen())


### PR DESCRIPTION
- now text is pasted in combobox input for example fonts, addressinput filed instead of in the document

Change-Id: Idb2ffa1e6a77d8b14fe43a71e2ed728d4d31a959
