### PR TITLE
cool#9992 doc sign: move sign key/cert init from doc init to sign dispatch

### DIFF
--- a/common/JsonUtil.hpp
+++ b/common/JsonUtil.hpp
@@ -267,6 +267,15 @@ inline std::map<std::string, std::string> jsonToMap(const std::string& jsonStrin
     return map;
 }
 
+template <typename T>
+Poco::JSON::Object::Ptr makePropertyValue(const std::string& type, const T& val)
+{
+    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object();
+    obj->set("type", type);
+    obj->set("value", val);
+    return obj;
+}
+
 } // end namespace JsonUtil
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -155,6 +155,7 @@ private:
     bool dialogEvent(const StringVector& tokens);
     bool completeFunction(const StringVector& tokens);
     bool unoCommand(const StringVector& tokens);
+    bool unoSignatureCommand();
     bool selectText(const StringVector& tokens, const LokEventTargetEnum target);
     bool selectGraphic(const StringVector& tokens);
     bool renderNextSlideLayer(const unsigned width, const unsigned height, bool& done);

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -115,6 +115,7 @@ using Poco::Path;
 #endif
 
 using namespace COOLProtocol;
+using JsonUtil::makePropertyValue;
 
 extern "C" { void dump_kit_state(void); /* easy for gdb */ }
 
@@ -2147,17 +2148,6 @@ bool Document::forwardToChild(const std::string& prefix, const std::vector<char>
     return false;
 }
 
-namespace {
-template <typename T>
-Object::Ptr makePropertyValue(const std::string& type, const T& val)
-{
-    Object::Ptr obj = new Object();
-    obj->set("type", type);
-    obj->set("value", val);
-    return obj;
-}
-}
-
 /* static */ std::string Document::makeRenderParams(const std::string& renderOpts, const std::string& userName,
                                                     const std::string& spellOnline, const std::string& theme,
                                                     const std::string& backgroundTheme,
@@ -2204,18 +2194,6 @@ Object::Ptr makePropertyValue(const std::string& type, const T& val)
     }
 
     // Extract settings relevant as view options from userPrivateInfo.
-    std::string signatureCert;
-    JsonUtil::findJSONValue(userPrivateInfoObj, "SignatureCert", signatureCert);
-    if (!signatureCert.empty())
-    {
-        renderOptsObj->set(".uno:SignatureCert", makePropertyValue("string", signatureCert));
-    }
-    std::string signatureKey;
-    JsonUtil::findJSONValue(userPrivateInfoObj, "SignatureKey", signatureKey);
-    if (!signatureKey.empty())
-    {
-        renderOptsObj->set(".uno:SignatureKey", makePropertyValue("string", signatureKey));
-    }
     std::string signatureCa;
     JsonUtil::findJSONValue(userPrivateInfoObj, "SignatureCa", signatureCa);
     if (!signatureCa.empty())


### PR DESCRIPTION
core.git commit d48264d51891d81f77fcfd77766e1d34ec17412b (cool#9992 lok
doc sign: allow late-init of the sign cert, 2024-10-22) allows sending
the sign key/cert only when actually signing.

Also commit 7998ba53a533be83ce8fed60cabc44b6457543c4 (fix uno:Signature
cypress test, etc., 2024-10-23) already started to annotate
.uno:Signature with sign parameters.

Complete this move by:

1) Extracting the .uno:Signature handling code to a separate function,
   since ChildSession::_handleInput() is large enough already.

2) Poco::Dynamic::Var::extract() can throw an exception if the user
   private info is not an object (but is e.g. a list), guard against
   that.

3) Stop sending the sign cert/key in Document::makeRenderParams().

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I426c0dc8b028eb874f0baf6b99f5c803ad8078d7
