### PR TITLE
Don't show spreadsheet-toolbar in other docType

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -166,7 +166,7 @@ m4_ifelse(MOBILEAPP,[true],
       </div>
     </div>
 
-    <div id="spreadsheet-toolbar"></div>
+    <div id="spreadsheet-toolbar" class="hidden"></div>
 
     <div id="mobile-edit-button">
       <div id="mobile-edit-button-image"></div>

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -356,6 +356,8 @@ L.Control.UIManager = L.Control.extend({
 			this.sheetsBar = JSDialog.SheetsBar(this.map, isDesktop || window.mode.isTablet());
 
 			let formulabarRow = document.getElementById('formulabar-row');
+			let spreadsheetToolbar = document.getElementById('spreadsheet-toolbar');
+			spreadsheetToolbar.classList.remove('hidden');
 			formulabarRow.classList.remove('hidden');
 			this.map.formulabar = JSDialog.FormulaBar(this.map);
 			this.map.addressInputField = JSDialog.AddressInputField(this.map);


### PR DESCRIPTION
The #spreadsheet-toolbar element shows up in every doc type at
the loading time. This means that the user sees a flash at the bottom
and if the integrator has customized COOL via CSS var etc the color of
the bar or its border color then that flash stands out even more.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ie325bfb841f5aff2a1cdc9711610fa747b6e1d7b
