### PR TITLE
include climits for INT_MAX

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -22,6 +22,7 @@
 #include <cassert>
 #include <cerrno>
 #include <chrono>
+#include <climits>
 #include <cstdlib>
 #include <cstring>
 #include <functional>


### PR DESCRIPTION
./net/Socket.hpp: In member function ‘int StreamSocket::getSendBufferCapacity() const’: ./net/Socket.hpp:1429:20: error: ‘INT_MAX’ was not declared in this scope
 1429 |             return INT_MAX; // We want to always send a single record in one go
      |                    ^~~~~~~
./net/Socket.hpp:1429:20: note: ‘INT_MAX’ is defined in header ‘<climits>’; did you forget to ‘#include <climits>’?


Change-Id: I94a8b9cc578a9a59eaa74351965f49fea43c36e6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

