### PR TITLE
calc: scroll fix convert pixels to twips

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -253,8 +253,8 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		var isCalcRTL = this._map._docLayer.isCalcRTL();
 		lastCellPixel = isCalcRTL ? lastCellPixel.getBottomRight() : lastCellPixel.getBottomLeft();
 		var lastCellTwips = this._corePixelsToTwips(lastCellPixel);
-		var mapSizeTwips = this._corePixelsToTwips(this._map.getSize());
-		var mapPosTwips = this._corePixelsToTwips(this._map._getTopLeftPoint());
+		var mapSizeTwips = this._pixelsToTwips(this._map.getSize());
+		var mapPosTwips = this._pixelsToTwips(this._map._getTopLeftPoint());
 
 		// margin outside data area we allow to scroll
 		// has to be bigger on mobile to allow scroll


### PR DESCRIPTION
map size and position are given in browser pixels and not core pixels.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I7dacb8324df822dc9673b64b7f34596c4fe82871
