### PR TITLE
StreamSocket::checkRemoval: Signal shutdown only if appropriate

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -211,8 +211,10 @@ public:
         recv = _bytesRcvd;
     }
 
-    /// Checks whether socket is due for forced removal, e.g. by internal timeout or small throughput. Method will shutdown connection and socket on forced removal.
-    /// Returns true in case of forced removal, caller shall stop processing
+    /// Checks whether socket is due for forced removal, e.g. by internal timeout or small throughput.
+    /// Method either shutdown connection and socket immediately for forced removal,
+    /// signals a pending shutdown or keeping the socket alive.
+    /// Returns `true` if isClosed(), i.e. immediately socket shutdown and set for removal.
     virtual bool checkRemoval(std::chrono::steady_clock::time_point /* now */) { return false; }
 
     /// Shutdown the socket.


### PR DESCRIPTION
Change-Id: I4e3ba962880b77017443236bc33b03ed20dcdd34

* Resolves: #9833 refining PR #9916
* Target version: master 

### Summary
Signal shutdown only if appropriate, allowing to drain bytes instead of hard disconnect. Only in case of SigUtil::getTerminationFlag(), we force disconnection.

SocketPoll::poll() hence checks isClosed() after checkRemoval() for forced Socket removal. A pending signaled shutdown may occure via handlePoll() after processing more I/O data.

Further, remove useless setClosed() in checkRemoval() after asserting !isOpen().

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

