### PR TITLE
Backport: clang: fix unknown uint32_t error

### DIFF
--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace SigUtil


### PR DESCRIPTION
fix build with clang 15 after commit e4b51310e268aa05ad83ea6ed79e92885b783eb6 wsd: header cleanup

In file included from common/SigUtil.cpp:14:
./common/SigUtil.hpp:117:50: error: unknown type name 'uint32_t'
    extern "C" { typedef void (*SigChildHandler)(uint32_t); }
                                                 ^


Change-Id: I42020a2049e69693160eb92f49e7c89f5ba94a96


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

