### PR TITLE
Better log message for unexpected css vars

### DIFF
--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -399,15 +399,21 @@ std::string FileServerRequestHandler::cssVarsToStyle(const std::string& cssVars)
     StringVector tokens(StringVector::tokenize(cssVars, ';'));
     for (const auto& token : tokens)
     {
+        if (tokens.getParam(token).find('=') == std::string::npos)
+        {
+            LOG_WRN("Skipping the token [" << tokens.getParam(token) << "] since it does not have '='");
+            continue;
+        }
+
         StringVector keyValue(StringVector::tokenize(tokens.getParam(token), '='));
         if (keyValue.size() < 2)
         {
-            LOG_ERR("Skipping the token [" << tokens.getParam(token) << "] since it does not have '='");
+            LOG_WRN("Skipping the token [" << tokens.getParam(token) << "] since the value is not set");
             continue;
         }
         else if (keyValue.size() > 2)
         {
-            LOG_ERR("Skipping the token [" << tokens.getParam(token) << "] since it has more than one '=' pair");
+            LOG_WRN("Skipping the token [" << tokens.getParam(token) << "] since it has more than one '=' pair");
             continue;
         }
 


### PR DESCRIPTION
I've seen for example:
```
ERR  Skipping the token [--nc-light-color-primary-default=] since it does not have '='| wsd/FileServerUtil.cpp:405 
ERR  Skipping the token [--nc-dark-color-primary-default=] since it does not have '='| wsd/FileServerUtil.cpp:405

```
The tokens had '=', so the message was misleading. On the other hand, if we report these as errors, the users may think it's something serious. Better to report them as warnings.


Change-Id: I9f9a31c49ca171f44d52cec9be42ff2953f1b9f4

