### PR TITLE
cypress: remove unused executeCopyFromContextMenu

### DIFF
--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -136,28 +136,6 @@ function closeMobileWizard() {
 	cy.log('<< closeMobileWizard - end');
 }
 
-function executeCopyFromContextMenu(XPos, YPos) {
-	cy.log('>> executeCopyFromContextMenu - start');
-	cy.log('Param - XPos: ' + XPos);
-	cy.log('Param - YPos: ' + YPos);
-
-	longPressOnDocument(XPos, YPos);
-
-	// Execute copy
-	cy.cGet('body').contains('.menu-entry-with-icon', 'Copy')
-		.click();
-
-	// Close warning about clipboard operations
-	cy.cGet('.vex-dialog-buttons .button-primary')
-		.click();
-
-	// Wait until it's closed
-	cy.cGet('.vex-overlay')
-		.should('not.exist');
-
-	cy.log('<< executeCopyFromContextMenu - end');
-}
-
 function openInsertionWizard() {
 	cy.log('>> openInsertionWizard - start');
 
@@ -397,7 +375,6 @@ module.exports.selectAnnotationMenuItem = selectAnnotationMenuItem;
 module.exports.closeHamburgerMenu = closeHamburgerMenu;
 module.exports.openMobileWizard = openMobileWizard;
 module.exports.closeMobileWizard = closeMobileWizard;
-module.exports.executeCopyFromContextMenu = executeCopyFromContextMenu;
 module.exports.openInsertionWizard = openInsertionWizard;
 module.exports.closeInsertionWizard = closeInsertionWizard;
 module.exports.selectFromColorPalette = selectFromColorPalette;


### PR DESCRIPTION
It would not work anyway, because vex dialogs are not used any more.


Change-Id: I6bdd1d5b72823106d064b18dafc7802cd8518e9f
