### PR TITLE
ConfigUtil Refactoring (Part II)

### DIFF
--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -124,13 +124,4 @@ bool has(const std::string& key)
     return Config ? Config->has(key) : false;
 }
 
-bool isSupportKeyEnabled()
-{
-#if ENABLE_SUPPORT_KEY
-    return true;
-#else
-    return false;
-#endif
-}
-
 } // namespace ConfigUtil

--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -26,10 +26,21 @@ namespace ConfigUtil
 static Poco::AutoPtr<Poco::Util::XMLConfiguration> XmlConfig;
 static const Poco::Util::AbstractConfiguration* Config{ 0 };
 
+#if ENABLE_SSL
+RuntimeConstant<bool> SslEnabled;
+RuntimeConstant<bool> SslTermination;
+#endif
+
 void initialize(const Poco::Util::AbstractConfiguration* config)
 {
+    assert(config && "Cannot initialize with invalid config instance");
     assert(!Config && "Config is already initialized.");
     Config = config;
+
+#if ENABLE_SSL
+    SslEnabled.set(getBool("ssl.enable", true));
+    SslTermination.set(getBool("ssl.termination", false));
+#endif
 }
 
 void initialize(const std::string& xml)
@@ -111,15 +122,6 @@ bool has(const std::string& key)
 {
     assert(Config && "Config is not initialized.");
     return Config ? Config->has(key) : false;
-}
-
-bool isSslEnabled()
-{
-#if ENABLE_SSL
-    return !Util::isFuzzing() && getBool("ssl.enable", true);
-#else
-    return false;
-#endif
 }
 
 bool isSupportKeyEnabled()

--- a/common/ConfigUtil.hpp
+++ b/common/ConfigUtil.hpp
@@ -70,6 +70,11 @@ public:
     }
 };
 
+#if ENABLE_SSL
+extern RuntimeConstant<bool> SslEnabled;
+extern RuntimeConstant<bool> SslTermination;
+#endif
+
 /// Initialize the config from an XML string.
 void initialize(const std::string& xml);
 
@@ -95,7 +100,29 @@ bool getBool(const std::string& key, const bool def);
 int getInt(const std::string& key, const int def);
 
 /// Return true if SSL is enabled in the config and no fuzzing is enabled.
-bool isSslEnabled();
+inline bool isSslEnabled()
+{
+#if defined(ENABLE_SSL) && ENABLE_SSL
+#if ENABLE_DEBUG
+    // Unit-tests enable/disable SSL at will.
+    return !Util::isFuzzing() && getBool("ssl.enable", true);
+#else
+    return !Util::isFuzzing() && SslEnabled.get();
+#endif
+#else
+    return false;
+#endif
+}
+
+/// Returns true if SSL Termination is enabled in the config and no fuzzing is enabled.
+inline bool isSSLTermination()
+{
+#if defined(ENABLE_SSL) && ENABLE_SSL
+    return !Util::isFuzzing() && SslTermination.get();
+#else
+    return false;
+#endif
+}
 
 /// Return true if build is support key enabled (ENABLE_SUPPORT_KEY is defined)
 bool isSupportKeyEnabled();

--- a/common/ConfigUtil.hpp
+++ b/common/ConfigUtil.hpp
@@ -27,6 +27,44 @@
 
 namespace ConfigUtil
 {
+/// A logical constant that is allowed to initialize
+/// exactly once and checks usage before initialization.
+template <typename T> class RuntimeConstant
+{
+    T _value;
+    std::atomic<bool> _initialized;
+
+public:
+    RuntimeConstant()
+        : _value()
+        , _initialized(false)
+    {
+    }
+
+    /// Use a compile-time const instead.
+    RuntimeConstant(const T& value) = delete;
+
+    const T& get()
+    {
+        assert(_initialized);
+
+        if (_initialized)
+        {
+            return _value;
+        }
+
+        throw std::runtime_error("RuntimeConstant instance read before being initialized.");
+    }
+
+    void set(const T& value)
+    {
+        assert(!_initialized);
+
+        _initialized = true;
+        _value = value;
+    }
+};
+
 /// Initialize the config from an XML string.
 void initialize(const std::string& xml);
 

--- a/common/ConfigUtil.hpp
+++ b/common/ConfigUtil.hpp
@@ -125,7 +125,14 @@ inline bool isSSLTermination()
 }
 
 /// Return true if build is support key enabled (ENABLE_SUPPORT_KEY is defined)
-bool isSupportKeyEnabled();
+inline constexpr bool isSupportKeyEnabled()
+{
+#ifdef ENABLE_SUPPORT_KEY
+    return ENABLE_SUPPORT_KEY;
+#else
+    return false;
+#endif
+}
 
 class ConfigValueGetter
 {

--- a/common/ConfigUtil.hpp
+++ b/common/ConfigUtil.hpp
@@ -48,12 +48,17 @@ public:
     {
         assert(_initialized);
 
+        // Don't incur a high cost in release builds.
+#if ENABLE_DEBUG
         if (_initialized)
         {
             return _value;
         }
 
         throw std::runtime_error("RuntimeConstant instance read before being initialized.");
+#else // ENABLE_DEBUG
+        return _value;
+#endif // !ENABLE_DEBUG
     }
 
     void set(const T& value)

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1264,43 +1264,6 @@ int main(int argc, char**argv)
         std::set<std::string> _denied;
     };
 
-    /// A logical constant that is allowed to initialize
-    /// exactly once and checks usage before initialization.
-    template <typename T>
-    class RuntimeConstant
-    {
-        T _value;
-        std::atomic<bool> _initialized;
-
-    public:
-        RuntimeConstant()
-            : _value()
-            , _initialized(false)
-        {
-        }
-
-        /// Use a compile-time const instead.
-        RuntimeConstant(const T& value) = delete;
-
-        const T& get()
-        {
-            if (_initialized)
-            {
-                return _value;
-            }
-
-            throw std::runtime_error("RuntimeConstant instance read before being initialized.");
-        }
-
-        void set(const T& value)
-        {
-            assert(!_initialized);
-
-            _initialized = true;
-            _value = value;
-        }
-    };
-
     /// Simple backtrace capture
     /// Use case, e.g. streaming up to 20 frames to log: `LOG_TRC( Util::Backtrace::get(20) );`
     /// Enabled for !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -599,7 +599,7 @@ inline std::string getLaunchBase(bool asAdmin = false)
 {
     std::ostringstream oss;
     oss << "    ";
-    oss << ((COOLWSD::isSSLEnabled() || COOLWSD::isSSLTermination()) ? "https://" : "http://");
+    oss << ((ConfigUtil::isSslEnabled() || COOLWSD::isSSLTermination()) ? "https://" : "http://");
 
     if (asAdmin)
     {
@@ -2115,7 +2115,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
         { "per_view.idle_timeout_secs", "900" },
         { "per_view.out_of_focus_timeout_secs", "300" },
         { "per_view.custom_os_info", "" },
-        { "per_view.min_saved_message_timeout_secs", "0" },
+        { "per_view.min_saved_message_timeout_secs", "0"},
         { "security.capabilities", "true" },
         { "security.seccomp", "true" },
         { "security.jwt_expiry_secs", "1800" },
@@ -2548,7 +2548,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
 
     IsProxyPrefixEnabled = ConfigUtil::getConfigValue<bool>(conf, "net.proxy_prefix", false);
 
-    LOG_INF("SSL support: SSL is " << (COOLWSD::isSSLEnabled() ? "enabled." : "disabled."));
+    LOG_INF("SSL support: SSL is " << (ConfigUtil::isSslEnabled() ? "enabled." : "disabled."));
     LOG_INF("SSL support: termination is " << (COOLWSD::isSSLTermination() ? "enabled." : "disabled."));
 
     std::string allowedLanguages(config().getString("allowed_languages"));
@@ -2636,7 +2636,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
     }
 
     // Fixup some config entries to match out decisions/overrides.
-    KitXmlConfig->setBool("ssl.enable", isSSLEnabled());
+    KitXmlConfig->setBool("ssl.enable", ConfigUtil::isSslEnabled());
     KitXmlConfig->setBool("ssl.termination", isSSLTermination());
 
     // We don't pass the config via command-line
@@ -3074,7 +3074,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
 void COOLWSD::initializeSSL()
 {
 #if ENABLE_SSL
-    if (!COOLWSD::isSSLEnabled())
+    if (!ConfigUtil::isSslEnabled())
         return;
 
     const std::string ssl_cert_file_path = ConfigUtil::getPathFromConfig("ssl.cert_file_path");
@@ -4128,9 +4128,9 @@ public:
 
         os << "COOLWSDServer: " << version << " - " << hash << " state dumping"
 #if !MOBILEAPP
-           << "\n  Kit version: " << COOLWSD::LOKitVersion
-           << "\n  Ports: server " << ClientPortNumber << " prisoner " << MasterLocation
-           << "\n  SSL: " << (COOLWSD::isSSLEnabled() ? "https" : "http")
+           << "\n  Kit version: " << COOLWSD::LOKitVersion << "\n  Ports: server "
+           << ClientPortNumber << " prisoner " << MasterLocation
+           << "\n  SSL: " << (ConfigUtil::isSslEnabled() ? "https" : "http")
            << "\n  SSL-Termination: " << (COOLWSD::isSSLTermination() ? "yes" : "no")
            << "\n  Security " << (COOLWSD::NoCapsForKit ? "no" : "") << " chroot, "
            << (COOLWSD::NoSeccomp ? "no" : "") << " api lockdown"
@@ -4299,7 +4299,7 @@ private:
         }
 
 #if ENABLE_SSL
-        if (COOLWSD::isSSLEnabled())
+        if (ConfigUtil::isSslEnabled())
             factory = std::make_shared<SslSocketFactory>();
         else
 #endif
@@ -4875,7 +4875,7 @@ void COOLWSD::cleanup()
 
 #if ENABLE_SSL
         // Finally, we no longer need SSL.
-        if (COOLWSD::isSSLEnabled())
+        if (ConfigUtil::isSslEnabled())
         {
             Poco::Net::uninitializeSSL();
             Poco::Crypto::uninitializeCrypto();

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -599,7 +599,8 @@ inline std::string getLaunchBase(bool asAdmin = false)
 {
     std::ostringstream oss;
     oss << "    ";
-    oss << ((ConfigUtil::isSslEnabled() || COOLWSD::isSSLTermination()) ? "https://" : "http://");
+    oss << ((ConfigUtil::isSslEnabled() || ConfigUtil::isSSLTermination()) ? "https://"
+                                                                           : "http://");
 
     if (asAdmin)
     {
@@ -2549,7 +2550,8 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
     IsProxyPrefixEnabled = ConfigUtil::getConfigValue<bool>(conf, "net.proxy_prefix", false);
 
     LOG_INF("SSL support: SSL is " << (ConfigUtil::isSslEnabled() ? "enabled." : "disabled."));
-    LOG_INF("SSL support: termination is " << (COOLWSD::isSSLTermination() ? "enabled." : "disabled."));
+    LOG_INF("SSL support: termination is "
+            << (ConfigUtil::isSSLTermination() ? "enabled." : "disabled."));
 
     std::string allowedLanguages(config().getString("allowed_languages"));
     // Core <= 7.0.
@@ -2637,7 +2639,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
 
     // Fixup some config entries to match out decisions/overrides.
     KitXmlConfig->setBool("ssl.enable", ConfigUtil::isSslEnabled());
-    KitXmlConfig->setBool("ssl.termination", isSSLTermination());
+    KitXmlConfig->setBool("ssl.termination", ConfigUtil::isSSLTermination());
 
     // We don't pass the config via command-line
     // to avoid dealing with escaping and other traps.
@@ -4131,7 +4133,7 @@ public:
            << "\n  Kit version: " << COOLWSD::LOKitVersion << "\n  Ports: server "
            << ClientPortNumber << " prisoner " << MasterLocation
            << "\n  SSL: " << (ConfigUtil::isSslEnabled() ? "https" : "http")
-           << "\n  SSL-Termination: " << (COOLWSD::isSSLTermination() ? "yes" : "no")
+           << "\n  SSL-Termination: " << (ConfigUtil::isSSLTermination() ? "yes" : "no")
            << "\n  Security " << (COOLWSD::NoCapsForKit ? "no" : "") << " chroot, "
            << (COOLWSD::NoSeccomp ? "no" : "") << " api lockdown"
            << "\n  Admin: " << (COOLWSD::AdminEnabled ? "enabled" : "disabled")

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3331,6 +3331,8 @@ void COOLWSD::handleOption(const std::string& optionName,
 #endif
 }
 
+#if !MOBILEAPP
+
 void COOLWSD::initializeEnvOptions()
 {
     int n = 0;
@@ -3372,8 +3374,6 @@ void COOLWSD::initializeEnvOptions()
     if ((optionValue = std::getenv("dictionaries")) != nullptr) _overrideSettings["allowed_languages"] = optionValue;
     if ((optionValue = std::getenv("remoteconfigurl")) != nullptr) _overrideSettings["remote_config.remote_url"] = optionValue;
 }
-
-#if !MOBILEAPP
 
 void COOLWSD::displayHelp()
 {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -697,8 +697,8 @@ bool COOLWSD::CheckCoolUser = true;
 bool COOLWSD::CleanupOnly = false; ///< If we should cleanup and exit.
 bool COOLWSD::IsProxyPrefixEnabled = false;
 #if ENABLE_SSL
-Util::RuntimeConstant<bool> COOLWSD::SSLEnabled;
-Util::RuntimeConstant<bool> COOLWSD::SSLTermination;
+ConfigUtil::RuntimeConstant<bool> COOLWSD::SSLEnabled;
+ConfigUtil::RuntimeConstant<bool> COOLWSD::SSLTermination;
 #endif
 unsigned COOLWSD::MaxConnections;
 unsigned COOLWSD::MaxDocuments;

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -357,23 +357,9 @@ public:
         return HardwareResourceWarning;
     }
 
-    static bool isSSLEnabled()
-    {
-#if ENABLE_SSL
-        return !Util::isFuzzing() && COOLWSD::SSLEnabled.get();
-#else
-        return false;
-#endif
-    }
+    static bool isSSLEnabled() { return ConfigUtil::isSslEnabled(); }
 
-    static bool isSSLTermination()
-    {
-#if ENABLE_SSL
-        return !Util::isFuzzing() && COOLWSD::SSLTermination.get();
-#else
-        return false;
-#endif
-    }
+    static bool isSSLTermination() { return ConfigUtil::isSSLTermination(); }
 
     static std::shared_ptr<TerminatingPoll> getWebServerPoll();
 
@@ -483,11 +469,6 @@ protected:
     static void cleanup();
 
 private:
-#if ENABLE_SSL
-    static ConfigUtil::RuntimeConstant<bool> SSLEnabled;
-    static ConfigUtil::RuntimeConstant<bool> SSLTermination;
-#endif
-
 #if !MOBILEAPP
     void processFetchUpdate(SocketPoll& poll);
     static void setupChildRoot(const bool UseMountNamespaces);

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -11,6 +11,11 @@
 
 #pragma once
 
+#include <common/ConfigUtil.hpp>
+#include <common/FileUtil.hpp>
+#include <common/Util.hpp>
+#include <net/WebSocketHandler.hpp>
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
@@ -28,11 +33,6 @@
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Poco/Util/OptionSet.h>
 #include <Poco/Util/ServerApplication.h>
-
-#include "Util.hpp"
-#include "FileUtil.hpp"
-#include "WebSocketHandler.hpp"
-#include "QuarantineUtil.hpp"
 
 class ChildProcess;
 class TraceFileWriter;
@@ -484,8 +484,8 @@ protected:
 
 private:
 #if ENABLE_SSL
-    static Util::RuntimeConstant<bool> SSLEnabled;
-    static Util::RuntimeConstant<bool> SSLTermination;
+    static ConfigUtil::RuntimeConstant<bool> SSLEnabled;
+    static ConfigUtil::RuntimeConstant<bool> SSLTermination;
 #endif
 
 #if !MOBILEAPP

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -357,8 +357,6 @@ public:
         return HardwareResourceWarning;
     }
 
-    static bool isSSLEnabled() { return ConfigUtil::isSslEnabled(); }
-
     static bool isSSLTermination() { return ConfigUtil::isSSLTermination(); }
 
     static std::shared_ptr<TerminatingPoll> getWebServerPoll();

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -460,7 +460,6 @@ protected:
 
     void defineOptions(Poco::Util::OptionSet& options) override;
     void handleOption(const std::string& name, const std::string& value) override;
-    void initializeEnvOptions();
     int main(const std::vector<std::string>& args) override;
 
     /// Handle various global static destructors.
@@ -470,7 +469,9 @@ private:
 #if !MOBILEAPP
     void processFetchUpdate(SocketPoll& poll);
     static void setupChildRoot(const bool UseMountNamespaces);
-#endif
+    void initializeEnvOptions();
+#endif // !MOBILEAPP
+
     void initializeSSL();
     void displayHelp();
 

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1064,7 +1064,7 @@ bool ClientRequestDispatcher::handleWopiDiscoveryRequest(
     std::string xml = getFileContent("discovery.xml");
     std::string srvUrl =
 #if ENABLE_SSL
-        ((ConfigUtil::isSslEnabled() || COOLWSD::isSSLTermination()) ? "https://" : "http://")
+        ((ConfigUtil::isSslEnabled() || ConfigUtil::isSSLTermination()) ? "https://" : "http://")
 #else
         "http://"
 #endif

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -654,7 +654,7 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
     }
 
 #if !MOBILEAPP
-    if (!COOLWSD::isSSLEnabled() && socket->sniffSSL())
+    if (!ConfigUtil::isSslEnabled() && socket->sniffSSL())
     {
         LOG_ERR("Looks like SSL/TLS traffic on plain http port");
         HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
@@ -1064,7 +1064,7 @@ bool ClientRequestDispatcher::handleWopiDiscoveryRequest(
     std::string xml = getFileContent("discovery.xml");
     std::string srvUrl =
 #if ENABLE_SSL
-        ((COOLWSD::isSSLEnabled() || COOLWSD::isSSLTermination()) ? "https://" : "http://")
+        ((ConfigUtil::isSslEnabled() || COOLWSD::isSSLTermination()) ? "https://" : "http://")
 #else
         "http://"
 #endif

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1571,7 +1571,7 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
     httpResponse.add("Content-Security-Policy", csp.generate());
 
     // Setup HTTP Public key pinning
-    if ((ConfigUtil::isSslEnabled() || COOLWSD::isSSLTermination()) &&
+    if ((ConfigUtil::isSslEnabled() || ConfigUtil::isSSLTermination()) &&
         config.getBool("ssl.hpkp[@enable]", false))
     {
         size_t i = 0;

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -307,7 +307,7 @@ bool FileServerRequestHandler::authenticateAdmin(const Poco::Net::HTTPBasicCrede
     Poco::Net::HTTPCookie cookie("jwt", jwtToken);
     // bundlify appears to add an extra /dist -> dist/dist/admin
     cookie.setPath(COOLWSD::ServiceRoot + "/browser/dist/");
-    cookie.setSecure(COOLWSD::isSSLEnabled());
+    cookie.setSecure(ConfigUtil::isSslEnabled());
     response.header().addCookie(cookie.toString());
 
     return true;
@@ -1571,7 +1571,8 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
     httpResponse.add("Content-Security-Policy", csp.generate());
 
     // Setup HTTP Public key pinning
-    if ((COOLWSD::isSSLEnabled() || COOLWSD::isSSLTermination()) && config.getBool("ssl.hpkp[@enable]", false))
+    if ((ConfigUtil::isSslEnabled() || COOLWSD::isSSLTermination()) &&
+        config.getBool("ssl.hpkp[@enable]", false))
     {
         size_t i = 0;
         std::string pinPath = "ssl.hpkp.pins.pin[" + std::to_string(i) + ']';

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -172,7 +172,7 @@ public:
     {
         // HSTS hardening. Disabled in debug builds.
 #if !ENABLE_DEBUG
-        if (ConfigUtil::isSslEnabled() || COOLWSD::isSSLTermination())
+        if (ConfigUtil::isSslEnabled() || ConfigUtil::isSSLTermination())
         {
             if (ConfigUtil::getConfigValue<bool>("ssl.sts.enabled", false))
             {

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -172,7 +172,7 @@ public:
     {
         // HSTS hardening. Disabled in debug builds.
 #if !ENABLE_DEBUG
-        if (COOLWSD::isSSLEnabled() || COOLWSD::isSSLTermination())
+        if (ConfigUtil::isSslEnabled() || COOLWSD::isSSLTermination())
         {
             if (ConfigUtil::getConfigValue<bool>("ssl.sts.enabled", false))
             {

--- a/wsd/ServerURL.hpp
+++ b/wsd/ServerURL.hpp
@@ -42,7 +42,7 @@ public:
         // The user can override the ServerRoot with a new prefix.
         _pathPlus = COOLWSD::ServiceRoot;
 
-        _ssl = (ConfigUtil::isSslEnabled() || COOLWSD::isSSLTermination());
+        _ssl = (ConfigUtil::isSslEnabled() || ConfigUtil::isSSLTermination());
         _websocket = true;
         _schemeAuthority = COOLWSD::ServerName.empty() ? host : COOLWSD::ServerName;
 

--- a/wsd/ServerURL.hpp
+++ b/wsd/ServerURL.hpp
@@ -42,7 +42,7 @@ public:
         // The user can override the ServerRoot with a new prefix.
         _pathPlus = COOLWSD::ServiceRoot;
 
-        _ssl = (COOLWSD::isSSLEnabled() || COOLWSD::isSSLTermination());
+        _ssl = (ConfigUtil::isSslEnabled() || COOLWSD::isSSLTermination());
         _websocket = true;
         _schemeAuthority = COOLWSD::ServerName.empty() ? host : COOLWSD::ServerName;
 

--- a/wsd/wopi/StorageConnectionManager.cpp
+++ b/wsd/wopi/StorageConnectionManager.cpp
@@ -129,7 +129,7 @@ StorageConnectionManager::getHttpSession(const Poco::URI& uri, std::chrono::seco
         // We decoupled the Wopi communication from client communication because
         // the Wopi communication must have an independent policy.
         // So, we will use here only Storage settings.
-        useSSL = SSLEnabled || COOLWSD::isSSLTermination();
+        useSSL = SSLEnabled || ConfigUtil::isSSLTermination();
     }
 
     const auto protocol =

--- a/wsd/wopi/StorageConnectionManager.cpp
+++ b/wsd/wopi/StorageConnectionManager.cpp
@@ -181,7 +181,7 @@ void StorageConnectionManager::initialize()
 
     if (SSLEnabled || SSLAsScheme)
     {
-        if (COOLWSD::isSSLEnabled())
+        if (ConfigUtil::isSslEnabled())
         {
             sslClientParams.certificateFile = ConfigUtil::getPathFromConfigWithFallback(
                 "storage.ssl.cert_file_path", "ssl.cert_file_path");

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -278,7 +278,7 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo, Poco::JSON::Ob
 
     // Update the scheme to https if ssl or ssl termination is on
     if (_postMessageOrigin.starts_with("http://") &&
-        (ConfigUtil::isSslEnabled() || COOLWSD::isSSLTermination()))
+        (ConfigUtil::isSslEnabled() || ConfigUtil::isSSLTermination()))
     {
         _postMessageOrigin.replace(0, 4, "https");
         LOG_DBG("Updating PostMessageOrigin scheme to HTTPS. Updated origin is now ["

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -278,7 +278,7 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo, Poco::JSON::Ob
 
     // Update the scheme to https if ssl or ssl termination is on
     if (_postMessageOrigin.starts_with("http://") &&
-        (COOLWSD::isSSLEnabled() || COOLWSD::isSSLTermination()))
+        (ConfigUtil::isSslEnabled() || COOLWSD::isSSLTermination()))
     {
         _postMessageOrigin.replace(0, 4, "https");
         LOG_DBG("Updating PostMessageOrigin scheme to HTTPS. Updated origin is now ["


### PR DESCRIPTION
Non-functional refactoring of config helpers and migration from COOLWSD.?pp into ConfigUtil.?pp.
This is part 2, and includes part 1 patches (from #10324).

- wsd: config: consistent namespace name with convention
- wsd: config: move config helpers to ConfigUtil
- wsd: config: move RuntimeConstant to ConfigUtil
- wsd: config: check RuntimeConst in debug mode only
- wsd: config: move SSLEnabled and SSLTermination to ConfigUtil
- wsd: config: COOLWSD::isSSLEnabled() -> ConfigUtil::isSslEnabled()
- wsd: config: COOLWSD::isSSLTermination() -> ConfigUtil::isSSLTermination()
- wsd: config: inline ConfigUtil::isSupportKeyEnabled()
