### PR TITLE
Misc Refactoring

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -186,10 +186,19 @@ namespace Util
         }
     }
 
+    /// Encode an ID into the given stream.
+    std::ostringstream& encodeId(std::ostringstream& oss, const std::uint64_t number,
+                                 const int padding)
+    {
+        oss << std::hex << std::setw(padding) << std::setfill('0') << number;
+        return oss;
+    }
+
+    /// Encode an ID into a string.
     std::string encodeId(const std::uint64_t number, const int padding)
     {
         std::ostringstream oss;
-        oss << std::hex << std::setw(padding) << std::setfill('0') << number;
+        encodeId(oss, number, padding);
         return oss.str();
     }
 

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -186,31 +186,6 @@ namespace Util
         }
     }
 
-    /// Encode an ID into the given stream.
-    std::ostringstream& encodeId(std::ostringstream& oss, const std::uint64_t number,
-                                 const int padding)
-    {
-        oss << std::hex << std::setw(padding) << std::setfill('0') << number;
-        return oss;
-    }
-
-    /// Encode an ID into a string.
-    std::string encodeId(const std::uint64_t number, const int padding)
-    {
-        std::ostringstream oss;
-        encodeId(oss, number, padding);
-        return oss.str();
-    }
-
-    std::uint64_t decodeId(const std::string& str)
-    {
-        std::uint64_t id = 0;
-        std::stringstream ss;
-        ss << std::hex << str;
-        ss >> id;
-        return id;
-    }
-
     bool windowingAvailable()
     {
         return std::getenv("DISPLAY") != nullptr;

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -431,12 +431,6 @@ namespace Util
         return json;
     }
 
-    std::string UniqueId()
-    {
-        static std::atomic_int counter(0);
-        return std::to_string(getpid()) + '/' + std::to_string(counter++);
-    }
-
     bool isValidURIScheme(const std::string& scheme)
     {
         if (scheme.empty())

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -500,7 +500,7 @@ namespace Util
 
     std::string getVersionJSON(bool enableExperimental, const std::string& timezone);
 
-    inline unsigned short hexFromByte(unsigned char byte)
+    inline constexpr unsigned short hexFromByte(unsigned char byte)
     {
         constexpr auto hex = "0123456789ABCDEF";
         return (hex[byte >> 4] << 8) | hex[byte & 0xf];

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1478,7 +1478,14 @@ int main(int argc, char**argv)
      */
     bool isFuzzing();
 
-    constexpr bool isMobileApp() { return MOBILEAPP; }
+    constexpr bool isMobileApp()
+    {
+#ifdef MOBILEAPP
+        return MOBILEAPP;
+#else
+        return false;
+#endif
+    }
 
     void setKitInProcess(bool value);
     bool isKitInProcess();

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -443,9 +443,6 @@ namespace Util
 
     std::string getVersionJSON(bool enableExperimental, const std::string& timezone);
 
-    /// Return a string that is unique across processes and calls.
-    std::string UniqueId();
-
     inline unsigned short hexFromByte(unsigned char byte)
     {
         constexpr auto hex = "0123456789ABCDEF";

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1467,8 +1467,8 @@ bool Document::forkToSave(const std::function<void()> &childSave, int viewId)
 
         // sort out thread local variables to get logging right from
         // as early as possible.
-        Util::setThreadName("kitbgsv_" + Util::encodeId(_mobileAppDocId, 3) +
-                            "_" + Util::encodeId(numSaves, 3));
+        Util::setThreadName("kitbgsv_" + Util::encodeId(_mobileAppDocId, 3) + '_' +
+                            Util::encodeId(numSaves, 3));
         _isBgSaveProcess = true;
 
         SigUtil::addActivity("forked background save process: " +

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -205,7 +205,7 @@ public:
     constexpr uint64_t bytesRcvd() const { return _bytesRcvd; }
 
     /// Get input/output statistics on this stream
-    constexpr void getIOStats(uint64_t &sent, uint64_t &recv) const
+    void getIOStats(uint64_t& sent, uint64_t& recv) const
     {
         sent = _bytesSent;
         recv = _bytesRcvd;
@@ -430,9 +430,9 @@ protected:
     inline void logPrefix(std::ostream& os) const { os << '#' << _fd << ": "; }
 
     /// Adds `len` sent bytes to statistic
-    constexpr void notifyBytesSent(uint64_t len) { _bytesSent += len; }
+    void notifyBytesSent(uint64_t len) { _bytesSent += len; }
     /// Adds `len` received bytes to statistic
-    constexpr void notifyBytesRcvd(uint64_t len) { _bytesRcvd += len; }
+    void notifyBytesRcvd(uint64_t len) { _bytesRcvd += len; }
 
     /// avoid doing a shutdown before close
     void setNoShutdown() { _noShutdown = true; }

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -518,7 +518,7 @@ void TileCacheTests::testUnresponsiveClient()
     std::ostringstream oss;
     for (int i = 0; i < 1000; ++i)
     {
-        oss << Util::encodeId(Util::rng::getNext(), 6);
+        Util::encodeId(oss, Util::rng::getNext(), 6);
     }
 
     const std::string documentContents = oss.str();

--- a/test/UnitLargePaste.cpp
+++ b/test/UnitLargePaste.cpp
@@ -55,7 +55,7 @@ void UnitLargePaste::invokeWSDTest()
     std::ostringstream oss;
     for (int i = 0; i < 1000; ++i)
     {
-        oss << Util::encodeId(Util::rng::getNext(), 6);
+        Util::encodeId(oss, Util::rng::getNext(), 6);
     }
 
     const std::string documentContents = oss.str();

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -987,7 +987,6 @@ bool ClientSession::_handleInput(const char *buffer, int length)
     {
         if (tokens.size() > 1 && (isDocumentOwner() || !isReadOnly()))
         {
-            std::string sessionId = Util::encodeId(std::stoi(tokens[1]), 4);
             docBroker->broadcastMessage(firstLine);
             docBroker->removeSession(client_from_this());
         }


### PR DESCRIPTION
- wsd: constexpr function's return type 'void' is not a literal type
- wsd: better Util::isMobileApp()
- wsd: Util::encodeId() now supports streaming
- wsd: remove unused Util::UniqueId()
- wsd: inline and optimize Util::encodeId()
- wsd: hexFromByte can be constexpr
- wsd: optimize encodeId
