### PR TITLE
Option to hide server signature in HTTP response

### DIFF
--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -47,6 +47,7 @@ namespace
 std::thread TimeoutThread;
 std::mutex TimeoutThreadMutex;
 std::condition_variable TimeoutConditionVariable;
+bool CppunitTesting = false;
 
 } // namespace
 
@@ -352,6 +353,16 @@ void UnitBase::rememberInstance(UnitType type, UnitBase* instance)
         assert(false);
         break;
     }
+}
+
+void UnitBase::setCppunitTesting(bool cppunitTesting)
+{
+    CppunitTesting = cppunitTesting;
+}
+
+bool UnitBase::isCppunitTesting()
+{
+    return CppunitTesting;
 }
 
 int UnitBase::uninit()

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -145,6 +145,9 @@ public:
     /// Returns 0 on success.
     static int uninit();
 
+    static void setCppunitTesting(bool cppunitTesting);
+    static bool isCppunitTesting();
+
     /// Do we have a unit test library hooking things & loaded
     static bool isUnitTesting()
     {

--- a/configure.ac
+++ b/configure.ac
@@ -421,6 +421,7 @@ bundle_msg="using uglified bundled JS and CSS"
 LOK_LOG_ASSERTIONS=0
 log_asserts_msg="disabled"
 SSL_VERIFY="true"
+SERVER_SIGNATURE="false"
 
 # a reasonable default
 NUM_PRESPAWN_CHILDREN=4
@@ -440,6 +441,7 @@ if test "$enable_debug" = "yes"; then
    BROWSER_LOGGING="true"
    debug_msg="low security debugging mode"
    SSL_VERIFY="false"
+   SERVER_SIGNATURE="true"
 
    # helps attaching to the right process
    NUM_PRESPAWN_CHILDREN=1
@@ -526,6 +528,8 @@ AC_MSG_CHECKING([if ssl verification is enabled by default])
 AC_MSG_RESULT([$SSL_VERIFY])
 AC_DEFINE_UNQUOTED([SSL_VERIFY],["$SSL_VERIFY"],[Default SSL Verification mode])
 AC_SUBST(SSL_VERIFY)
+
+AC_SUBST(SERVER_SIGNATURE)
 
 dnl check for a file at a path with an env-var with a given suffix
 AC_DEFUN([CHK_FILE_VAR], dnl env-var, suffix, file-to-match, msg

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -226,6 +226,7 @@
       <macro_security_level desc="Level of Macro security. 1 (Medium) Confirmation required before executing macros from untrusted sources. 0 (Low, not recommended) All macros will be executed without confirmation." type="int" default="1">1</macro_security_level>
       <enable_websocket_urp desc="Should we enable URP (UNO remote protocol) communication over the websocket. This allows full control of the Kit child server to anyone with access to the websocket including executing macros without confirmation or running arbitrary shell commands in the jail." type="bool" default="false">false</enable_websocket_urp>
       <enable_metrics_unauthenticated desc="When enabled, the /cool/getMetrics endpoint will not require authentication." type="bool" default="false">false</enable_metrics_unauthenticated>
+      <server_signature desc="Whether to send server signature in HTTP response headers" type="bool" default="@SERVER_SIGNATURE@">@SERVER_SIGNATURE@</server_signature>
     </security>
 
     <certificates>

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -55,6 +55,8 @@
 #include <Log.hpp>
 #include <Watchdog.hpp>
 #include <wasm/base64.hpp>
+#include <common/ConfigUtil.hpp>
+#include <common/Unit.hpp>
 
 // Bug in pre C++17 where static constexpr must be defined. Fixed in C++17.
 constexpr std::chrono::microseconds SocketPoll::DefaultPollTimeoutMicroS;
@@ -1732,7 +1734,13 @@ namespace http
 {
 std::string getAgentString() { return "COOLWSD HTTP Agent " + Util::getCoolVersion(); }
 
-std::string getServerString() { return "COOLWSD HTTP Server " + Util::getCoolVersion(); }
+std::string getServerString()
+{
+    if (!UnitBase::isCppunitTesting())
+        if (config::getBool("security.server_signature", false))
+            return "COOLWSD HTTP Server " + Util::getCoolVersion();
+    return "COOLWSD HTTP Server";
+}
 }
 
 extern "C" {

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -108,6 +108,7 @@ public:
             = new Poco::Net::Context(Poco::Net::Context::CLIENT_USE, sslParams);
         Poco::Net::SSLManager::instance().initializeClient(nullptr, std::move(invalidCertHandler), std::move(sslContext));
 #endif
+        UnitBase::setCppunitTesting(true);
     }
 
     ~HttpRequestTests()

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2084,6 +2084,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
         { "security.seccomp", "true" },
         { "security.jwt_expiry_secs", "1800" },
         { "security.enable_metrics_unauthenticated", "false" },
+        { "security.server_signature", "false" },
         { "certificates.database_path", "" },
         { "server_name", "" },
         { "ssl.ca_file_path", COOLWSD_CONFIGDIR "/ca-chain.cert.pem" },


### PR DESCRIPTION
Hiding the server signature reduces the likelihood of targeted attacks by making it harder for attackers to identify the server's configuration.

In built-in default configuration security.server_signature is set to false. It is also set to false in coolwsd.xml packaged with production builds. HTTP response header is like:
    Server: COOLWSD HTTP Server
In debug mode security.server_signature is set to true in coolwsd.xml. HTTP response header is like:
    Server: COOLWSD HTTP Server 24.04.9.1


Change-Id: Ie23c2dbc1514e46e2942f558ada2e27d0f108bea
