### PR TITLE
ContextMenu: add a css class to entries

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -317,9 +317,13 @@ L.Control.ContextMenu = L.Control.extend({
 					itemName = _UNO(item.command, docType, true);
 				}
 
+				var toSnakeCase = function (text) {
+					return text.replace(/[ _]/gi, '-').replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+				};
+
 				contextMenu[item.command] = {
 					// Using 'click' and <a href='#' is vital for copy/paste security context.
-					name: (window.mode.isMobile() ? _(itemName) : '<a href="#" class="context-menu-link">' +  _(itemName) + '</a'),
+					name: (window.mode.isMobile() ? _(itemName) : '<a href="#" class="context-menu-link ' + toSnakeCase(commandName) + '">' + _(itemName) + '</a'),
 					isHtmlName: true,
 				};
 


### PR DESCRIPTION
Change-Id: I71ce81efcbbb0c6a57d808d5f5d0e691567dfad5

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Context menu entries will now get a class corresponding to the uno
command name associated, in a snake-case format.

I.e InsertAnnotation => insert-annotation

This allows to change style individual context menu entry or even remove them.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

