### PR TITLE
Fix: Prevent slide deletion when using Delete/Backspace in Hex color input with dialog open

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -426,7 +426,10 @@ L.Map.Keyboard = L.Handler.extend({
 					if (app.file.fileBasedView)
 						this._map._docLayer._checkSelectedPart();
 				}
-				else if (this._map.isEditMode() && !app.file.fileBasedView) {
+				else if (this._map.isEditMode() && !app.file.fileBasedView &&
+						this._map.jsdialog &&
+						!this._map.jsdialog.hasDialogOpened()
+				) {
 					this._map.deletePage(this._map._docLayer._selectedPart);
 				}
 				ev.preventDefault();


### PR DESCRIPTION
- To reproduce the issue:

1. Open the attached .odp file
2. Go the second or third slide
3. Open the slide Properties dialog. Layout > Slide Properties
4. Open the Color Tab and try to delete the Hex color text.


- Problem: 
    - If we change HEX color of any slide property, then by default if deletes the current selected slide.
    - which should not be happening if focus is inside dialog

- Solution: 
    - Added a check which will prevent the deletion if dialog is in open state

Change-Id: I9e090fd44e6ffedeb8097d7564d8aeadc57b2eb9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

