### PR TITLE
Presenter Console: Add background and text color

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -11,10 +11,12 @@
 	--color-text-darker: #c0bfbc;  /* hover */
 	--color-text-lighter: #fff; /* secondard text, disabled */
 	--color-status-badge: #d6d6d6;
+	--color-slideshow: #d6d6d6;
 
 	--color-main-background: #121212;
 	--color-background-dark: #1E1E1E;  /* select */
 	--color-background-darker: #000;  /* todo: apply to pressed (active), li:hover(top menu on classic mode)*/
+	--color-background-slideshow: #171717;
 	--color-background-lighter: #262626; /* hover, toolbar, dialog, disabled */
 	--color-overlay: #1c5fa814;
 	--color-background-tabs-group: #303030;

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -12,10 +12,12 @@
 	--color-text-darker: #000;  /* hover */
 	--color-text-lighter: #696969; /* secondard text, disabled */
 	--color-status-badge: #616161;
+	--color-slideshow: #A8A8A8;
 
 	--color-main-background: #F8F9FA;
 	--color-background-dark: #e8e8e8;  /* select */
 	--color-background-darker: #c0bfbc;  /* todo: apply to pressed (active), li:hover(top menu on classic mode)*/
+	--color-background-slideshow: #1a1a1a;
 	--color-background-lighter: #fff; /* hover, toolbar, dialog, disabled */
 	--color-overlay: #1c5fa814;
 	--color-background-tabs-group: #f1f1f1;

--- a/browser/src/slideshow/PresenterConsole.js
+++ b/browser/src/slideshow/PresenterConsole.js
@@ -138,6 +138,15 @@ class PresenterConsole {
 		this._proxyPresenter.document.body.style.minWidth = '100vw';
 
 		let elem = this._proxyPresenter.document.querySelector('#main-content');
+		let slideShowBGColor = window
+			.getComputedStyle(document.documentElement)
+			.getPropertyValue('--color-background-slideshow');
+		let slideShowColor = window
+			.getComputedStyle(document.documentElement)
+			.getPropertyValue('--color-slideshow');
+
+		elem.style.backgroundColor = slideShowBGColor;
+		elem.style.color = slideShowColor;
 		elem.style.display = 'flex';
 		elem.style.flexDirection = 'row';
 		elem.style.flexWrap = 'wrap';


### PR DESCRIPTION
Both for light and dark mode. In here I opted to use a dark tint on both and later on - depending on the user feedback - we can switch so something lighter for the light mode


Change-Id: I31eed3b0bac327ac3db365f6fdf79405537058bb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

