### PR TITLE
lock getWakeupsArray for reading

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -760,6 +760,7 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
 
 void SocketPoll::wakeupWorld()
 {
+    std::lock_guard<std::mutex> lock(getPollWakeupsMutex());
     for (const auto& fd : getWakeupsArray())
         wakeup(fd);
 }


### PR DESCRIPTION
We lock this elsewhere when writing. Seems odd that we don't lock when reading.

Address Sanitizer reports:

```
READ of size 4 at 0x60300016be38 thread T7 (docbroker_001)
    #0 0x1ab5b94 in SocketPoll::wakeupWorld() builddir/online/net/Socket.cpp:764:16
    #1 0x14cc7e9 in DocumentBroker::DocumentBrokerPoll::pollingThread() builddir/online/wsd/DocumentBroker.cpp:153:9
    #2 0x1a9beae in SocketPoll::pollingThreadEntry() builddir/online/net/Socket.cpp:477:9
    #3 0x1b6fb24 in void std::__invoke_impl<void, void (SocketPoll::*)(), SocketPoll*>(std::__invoke_memfun_deref, void (SocketPoll::*&&)(), SocketPoll*&&) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:74:14
    #4 0x1b6f694 in std::__invoke_result<void (SocketPoll::*)(), SocketPoll*>::type std::__invoke<void (SocketPoll::*)(), SocketPoll*>(void (SocketPoll::*&&)(), SocketPoll*&&) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:96:14
    #5 0x1b6f575 in void std::thread::_Invoker<std::tuple<void (SocketPoll::*)(), SocketPoll*>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/std_thread.h:258:13
    #6 0x1b6f3af in std::thread::_Invoker<std::tuple<void (SocketPoll::*)(), SocketPoll*>>::operator()() /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/std_thread.h:265:11
    #7 0x1b6ec62 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (SocketPoll::*)(), SocketPoll*>>>::_M_run() /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/std_thread.h:210:13
    #8 0x7f0fde21bac2  (/usr/lib64/libstdc++.so.6+0xdcac2)
    #9 0x7f0fddfd76e9 in start_thread (/lib64/libpthread.so.0+0xa6e9)
    #10 0x7f0fddcc149e in clone (/lib64/libc.so.6+0x11849e)
0x60300016be38 is located 24 bytes inside of 32-byte region [0x60300016be20,0x60300016be40) freed by thread T3 (remotefontconfi) here:
    #0 0xac9a98 in operator delete(void*, unsigned long) llvm-llvmorg-12.0.1.src/compiler-rt/lib/asan/asan_new_delete.cpp:172:3
    #1 0xbf49ad in std::__new_allocator<int>::deallocate(int*, unsigned long) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/new_allocator.h:158:2
    #2 0xbf494d in std::allocator<int>::deallocate(int*, unsigned long) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/allocator.h:200:25
    #3 0xbf494d in std::allocator_traits<std::allocator<int>>::deallocate(std::allocator<int>&, int*, unsigned long) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/alloc_traits.h:496:13
    #4 0xbf4874 in std::_Vector_base<int, std::allocator<int>>::_M_deallocate(int*, unsigned long) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/stl_vector.h:387:4
    #5 0x19d624b in void std::vector<int, std::allocator<int>>::_M_realloc_insert<int const&>(__gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int>>>, int const&) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/vector.tcc:513:7
    #6 0x19b95bd in std::vector<int, std::allocator<int>>::push_back(int const&) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/stl_vector.h:1287:4
    #7 0x1a922fe in SocketPoll::createWakeups() builddir/online/net/Socket.cpp:857:23
    #8 0x1a90dd2 in SocketPoll::SocketPoll(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>) builddir/online/net/Socket.cpp:336:5
    #9 0xf62703 in TerminatingPoll::TerminatingPoll(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) builddir/online/./net/Socket.hpp:1046:9
    #10 0xf5e4fa in http::Session::syncRequest(http::Request const&) builddir/online/./net/HttpRequest.hpp:1284:25
    #11 0xf58d58 in RemoteJSONPoll::pollingThread() builddir/online/wsd/COOLWSD.cpp:1139:38
    #12 0x1a9beae in SocketPoll::pollingThreadEntry() builddir/online/net/Socket.cpp:477:9
    #13 0x1b6fb24 in void std::__invoke_impl<void, void (SocketPoll::*)(), SocketPoll*>(std::__invoke_memfun_deref, void (SocketPoll::*&&)(), SocketPoll*&&) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:74:14
    #14 0x1b6f694 in std::__invoke_result<void (SocketPoll::*)(), SocketPoll*>::type std::__invoke<void (SocketPoll::*)(), SocketPoll*>(void (SocketPoll::*&&)(), SocketPoll*&&) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:96:14
    #15 0x1b6f575 in void std::thread::_Invoker<std::tuple<void (SocketPoll::*)(), SocketPoll*>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/std_thread.h:258:13
    #16 0x1b6f3af in std::thread::_Invoker<std::tuple<void (SocketPoll::*)(), SocketPoll*>>::operator()() /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/std_thread.h:265:11
    #17 0x1b6ec62 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (SocketPoll::*)(), SocketPoll*>>>::_M_run() /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/std_thread.h:210:13
    #18 0x7f0fde21bac2  (/usr/lib64/libstdc++.so.6+0xdcac2)
previously allocated by thread T0 here:
    #0 0xac8b98 in operator new(unsigned long) llvm-llvmorg-12.0.1.src/compiler-rt/lib/asan/asan_new_delete.cpp:99:3
    #1 0xccfd04 in std::__new_allocator<int>::allocate(unsigned long, void const*) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/new_allocator.h:137:27
    #2 0xccfc31 in std::allocator<int>::allocate(unsigned long) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/allocator.h:188:32
    #3 0xccfc31 in std::allocator_traits<std::allocator<int>>::allocate(std::allocator<int>&, unsigned long) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/alloc_traits.h:464:20
    #4 0xccf4ec in std::_Vector_base<int, std::allocator<int>>::_M_allocate(unsigned long) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/stl_vector.h:378:20
    #5 0x19d5c65 in void std::vector<int, std::allocator<int>>::_M_realloc_insert<int const&>(__gnu_cxx::__normal_iterator<int*, std::vector<int, std::allocator<int>>>, int const&) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/vector.tcc:453:33
    #6 0x19b95bd in std::vector<int, std::allocator<int>>::push_back(int const&) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/stl_vector.h:1287:4
    #7 0x1a922fe in SocketPoll::createWakeups() builddir/online/net/Socket.cpp:857:23
    #8 0x1a90dd2 in SocketPoll::SocketPoll(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>) builddir/online/net/Socket.cpp:336:5
    #9 0xf57119 in RemoteJSONPoll::RemoteJSONPoll(Poco::Util::LayeredConfiguration&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) builddir/online/wsd/COOLWSD.cpp:1071:11
    #10 0xef24ce in RemoteConfigPoll::RemoteConfigPoll(Poco::Util::LayeredConfiguration&) builddir/online/wsd/COOLWSD.cpp:1203:9
    #11 0xe94fef in COOLWSD::innerMain() builddir/online/wsd/COOLWSD.cpp:4351:22
    #12 0xea9736 in COOLWSD::main(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&) builddir/online/wsd/COOLWSD.cpp:4837:23
    #13 0x1bf84d6 in Poco::Util::Application::run() /home/collabora/src/poco-1.12.5p2-all/Util/src/Application.cpp:362:12
    #14 0x1c0a125 in Poco::Util::ServerApplication::run() /home/collabora/src/poco-1.12.5p2-all/Util/src/ServerApplication.cpp:95:25
    #15 0x1c0a25d in Poco::Util::ServerApplication::run(int, char**) /home/collabora/src/poco-1.12.5p2-all/Util/src/ServerApplication.cpp:585:12
    #16 0xeae5ce in main builddir/online/wsd/COOLWSD.cpp:5023:20
    #17 0x7f0fddbde24c in __libc_start_main (/lib64/libc.so.6+0x3524c)
Thread T7 (docbroker_001) created by T5 (websrv_poll) here:
    #0 0xa10662 in __interceptor_pthread_create llvm-llvmorg-12.0.1.src/compiler-rt/lib/asan/asan_interceptors.cpp:205:3
    #1 0x7f0fde21be3b in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) (/usr/lib64/libstdc++.so.6+0xdce3b)
    #2 0x1a97dee in SocketPoll::startThread() builddir/online/net/Socket.cpp:411:23
    #3 0x1ab4f13 in SocketDisposition::execute() builddir/online/net/Socket.cpp:1060:22
    #4 0x1ab1525 in SocketPoll::poll(long) builddir/online/net/Socket.cpp:708:29
    #5 0xb668e2 in SocketPoll::poll(std::chrono::duration<long, std::ratio<1l, 1000000l>>) builddir/online/./net/Socket.hpp:777:61
    #6 0xf09d67 in SocketPoll::pollingThread() builddir/online/./net/Socket.hpp:950:13
    #7 0x1a9beae in SocketPoll::pollingThreadEntry() builddir/online/net/Socket.cpp:477:9
    #8 0x1b6fb24 in void std::__invoke_impl<void, void (SocketPoll::*)(), SocketPoll*>(std::__invoke_memfun_deref, void (SocketPoll::*&&)(), SocketPoll*&&) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:74:14
    #9 0x1b6f694 in std::__invoke_result<void (SocketPoll::*)(), SocketPoll*>::type std::__invoke<void (SocketPoll::*)(), SocketPoll*>(void (SocketPoll::*&&)(), SocketPoll*&&) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:96:14
    #10 0x1b6f575 in void std::thread::_Invoker<std::tuple<void (SocketPoll::*)(), SocketPoll*>>::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/std_thread.h:258:13
    #11 0x1b6f3af in std::thread::_Invoker<std::tuple<void (SocketPoll::*)(), SocketPoll*>>::operator()() /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/std_thread.h:265:11
    #12 0x1b6ec62 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (SocketPoll::*)(), SocketPoll*>>>::_M_run() /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/std_thread.h:210:13
    #13 0x7f0fde21bac2  (/usr/lib64/libstdc++.so.6+0xdcac2)
Thread T5 (websrv_poll) created by T0 here:
    #0 0xa10662 in __interceptor_pthread_create llvm-llvmorg-12.0.1.src/compiler-rt/lib/asan/asan_interceptors.cpp:205:3
    #1 0x7f0fde21be3b in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) (/usr/lib64/libstdc++.so.6+0xdce3b)
    #2 0x1a97dee in SocketPoll::startThread() builddir/online/net/Socket.cpp:411:23
    #3 0xef5b24 in COOLWSDServer::start() builddir/online/wsd/COOLWSD.cpp:4033:24
    #4 0xe9d04c in COOLWSD::innerMain() builddir/online/wsd/COOLWSD.cpp:4483:13
    #5 0xea9736 in COOLWSD::main(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&) builddir/online/wsd/COOLWSD.cpp:4837:23
    #6 0x1bf84d6 in Poco::Util::Application::run() /home/collabora/src/poco-1.12.5p2-all/Util/src/Application.cpp:362:12
    #7 0x1c0a125 in Poco::Util::ServerApplication::run() /home/collabora/src/poco-1.12.5p2-all/Util/src/ServerApplication.cpp:95:25
    #8 0x1c0a25d in Poco::Util::ServerApplication::run(int, char**) /home/collabora/src/poco-1.12.5p2-all/Util/src/ServerApplication.cpp:585:12
    #9 0xeae5ce in main builddir/online/wsd/COOLWSD.cpp:5023:20
    #10 0x7f0fddbde24c in __libc_start_main (/lib64/libc.so.6+0x3524c)
Thread T3 (remotefontconfi) created by T0 here:
    #0 0xa10662 in __interceptor_pthread_create llvm-llvmorg-12.0.1.src/compiler-rt/lib/asan/asan_interceptors.cpp:205:3
    #1 0x7f0fde21be3b in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) (/usr/lib64/libstdc++.so.6+0xdce3b)
    #2 0x1a97dee in SocketPoll::startThread() builddir/online/net/Socket.cpp:411:23
    #3 0xef3dbb in RemoteJSONPoll::start() builddir/online/wsd/COOLWSD.cpp:1104:9
    #4 0xe9c767 in COOLWSD::innerMain() builddir/online/wsd/COOLWSD.cpp:4471:33
    #5 0xea9736 in COOLWSD::main(std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>> const&) builddir/online/wsd/COOLWSD.cpp:4837:23
    #6 0x1bf84d6 in Poco::Util::Application::run() /home/collabora/src/poco-1.12.5p2-all/Util/src/Application.cpp:362:12
    #7 0x1c0a125 in Poco::Util::ServerApplication::run() /home/collabora/src/poco-1.12.5p2-all/Util/src/ServerApplication.cpp:95:25
    #8 0x1c0a25d in Poco::Util::ServerApplication::run(int, char**) /home/collabora/src/poco-1.12.5p2-all/Util/src/ServerApplication.cpp:585:12
    #9 0xeae5ce in main builddir/online/wsd/COOLWSD.cpp:5023:20
    #10 0x7f0fddbde24c in __libc_start_main (/lib64/libc.so.6+0x3524c)
```

Change-Id: I5aad074ffa06408ff7055046a5ba6d8674aec31d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

