### PR TITLE
net::Defaults: Revert and re-apply revised code

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <map>

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -17,7 +17,6 @@
 
 #include <common/StateEnum.hpp>
 #include "Util.hpp"
-#include "NetUtil.hpp"
 #include "net/Socket.hpp"
 #include <Poco/Exception.h>
 
@@ -420,9 +419,6 @@ public:
 
     /// Manipulate and modify the configuration before any usage.
     virtual void configure(Poco::Util::LayeredConfiguration& /* config */) {}
-
-    /// Manipulate and modify the net::Defaults for before any usage.
-    virtual void configNet(net::Defaults& /* defaults */) {}
 
     /// Main-loop reached, time for testing.
     /// Invoked from coolwsd's main thread.

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -68,7 +68,6 @@
 #include <common/JsonUtil.hpp>
 #include "KitHelper.hpp"
 #include "Kit.hpp"
-#include <NetUtil.hpp>
 #include <Protocol.hpp>
 #include <Log.hpp>
 #include <Png.hpp>
@@ -2928,7 +2927,7 @@ void documentViewCallback(const int type, const char* payload, void* data)
 int pollCallback(void* pData, int timeoutUs)
 {
     if (timeoutUs < 0)
-        timeoutUs = net::Defaults::get().SocketPollTimeout.count();
+        timeoutUs = SocketPoll::DefaultPollTimeoutMicroS.count();
 #ifndef IOS
     if (!pData)
         return 0;

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1201,9 +1201,9 @@ public:
     }
 
     /// Returns the default timeout.
-    static std::chrono::milliseconds getDefaultTimeout()
+    static constexpr std::chrono::milliseconds getDefaultTimeout()
     {
-        return std::chrono::duration_cast<std::chrono::milliseconds>( net::Defaults::get().HTTPTimeout );
+        return std::chrono::seconds(30);
     }
 
     /// Returns the current protocol scheme.

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include <chrono>
 #include <functional>
 #include <string>
 #include <memory>
@@ -28,43 +27,6 @@ struct sockaddr;
 
 namespace net
 {
-
-class Defaults
-{
-public:
-    /// WebSocketHandler ping timeout in us (2s default). Zero disables metric.
-    std::chrono::microseconds WSPingTimeout;
-    /// WebSocketHandler ping period in us (3s default), i.e. duration until next ping. Zero disables metric.
-    std::chrono::microseconds WSPingPeriod;
-    /// http::Session timeout in us (30s default). Zero disables metric.
-    std::chrono::microseconds HTTPTimeout;
-
-    /// Maximum total connections (9999 or MAX_CONNECTIONS). Zero disables metric.
-    size_t MaxConnections;
-
-    /// Socket poll timeout in us (64s), useful to increase for debugging.
-    std::chrono::microseconds SocketPollTimeout;
-
-private:
-    Defaults()
-        : WSPingTimeout(std::chrono::microseconds(2000000))
-        , WSPingPeriod(std::chrono::microseconds(3000000))
-        , HTTPTimeout(std::chrono::microseconds(30000000))
-        , MaxConnections(9999)
-        , SocketPollTimeout(std::chrono::microseconds(64000000))
-    {
-    }
-
-public:
-    Defaults(const Defaults&) = delete;
-    Defaults(Defaults&&) = delete;
-
-    static Defaults& get()
-    {
-        static Defaults def;
-        return def;
-    }
-};
 
 class HostEntry
 {

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <string>
 #include <memory>
@@ -27,6 +28,21 @@ struct sockaddr;
 
 namespace net
 {
+
+class DefaultValues
+{
+public:
+    /// StreamSocket inactivity timeout in us (3600s default). Zero disables instrument.
+    std::chrono::microseconds inactivityTimeout;
+    /// WebSocketHandler average ping timeout in us (12s default). Zero disables instrument.
+    std::chrono::microseconds wsPingAvgTimeout;
+    /// WebSocketHandler ping interval in us (18s default), i.e. duration until next ping. Zero disables instrument.
+    std::chrono::microseconds wsPingInterval;
+
+    /// Maximum number of concurrent TCP connections. Zero disables instrument.
+    size_t maxTCPConnections;
+};
+extern DefaultValues Defaults;
 
 class HostEntry
 {

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -715,8 +715,6 @@ public:
 
     /// Default poll time - useful to increase for debugging.
     static constexpr std::chrono::microseconds DefaultPollTimeoutMicroS = std::chrono::seconds(64);
-    static constexpr std::chrono::microseconds DefaultInactivityimeoutMicroS = std::chrono::seconds(3600);
-    static constexpr size_t DefaultMaxTCPConnections = 200000; // arbitrary value to be resolved
     static std::atomic<bool> InhibitThreadChecks;
 
     /// Stop the polling thread.

--- a/test/UnitPerf.cpp
+++ b/test/UnitPerf.cpp
@@ -57,8 +57,6 @@ void UnitPerf::testPerf(std::string testType, std::string fileType, std::string 
     stats = std::make_shared<Stats>();
     stats->setTypeOfTest(std::move(testType));
 
-    const std::chrono::microseconds PollTimeoutMicroS = net::Defaults::get().SocketPollTimeout;
-
     TerminatingPoll poll("performance test");
 
     std::string docName = "empty." + fileType;
@@ -74,7 +72,7 @@ void UnitPerf::testPerf(std::string testType, std::string fileType, std::string 
         stats);
 
     do {
-        poll.poll(PollTimeoutMicroS);
+        poll.poll(TerminatingPoll::DefaultPollTimeoutMicroS);
     } while (poll.continuePolling() && poll.getSocketCount() > 0);
 
     stats->dump();

--- a/test/UnitTimeoutConnections.cpp
+++ b/test/UnitTimeoutConnections.cpp
@@ -34,8 +34,7 @@ class UnitTimeoutConnections : public UnitTimeoutBase1
 {
     void configure(Poco::Util::LayeredConfiguration& /* config */) override
     {
-        // to be resolved!
-        // defaults.MaxConnections = ConnectionLimit;
+        net::Defaults.maxTCPConnections = ConnectionLimit;
     }
 
 public:
@@ -49,24 +48,20 @@ public:
 
 void UnitTimeoutConnections::invokeWSDTest()
 {
-    // to be resolved!
-    if( false )
-    {
-        UnitBase::TestResult result = TestResult::Ok;
+    UnitBase::TestResult result = TestResult::Ok;
 
-        result = testHttp(ConnectionLimit, ConnectionCount);
-        if (result != TestResult::Ok)
-            exitTest(result);
+    result = testHttp(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
 
-        result = testWSPing(ConnectionLimit, ConnectionCount);
-        if (result != TestResult::Ok)
-            exitTest(result);
+    result = testWSPing(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
 
-        result = testWSDChatPing(ConnectionLimit, ConnectionCount);
-        if (result != TestResult::Ok)
-            exitTest(result);
+    result = testWSDChatPing(ConnectionLimit, ConnectionCount);
+    if (result != TestResult::Ok)
+        exitTest(result);
 
-    }
     exitTest(TestResult::Ok);
 }
 

--- a/test/UnitTimeoutConnections.cpp
+++ b/test/UnitTimeoutConnections.cpp
@@ -32,14 +32,10 @@ static constexpr size_t ConnectionCount = 9;
 /// Base test suite class for connection limit (limited) using HTTP and WS sessions.
 class UnitTimeoutConnections : public UnitTimeoutBase1
 {
-    void configNet(net::Defaults& defaults) override
+    void configure(Poco::Util::LayeredConfiguration& /* config */) override
     {
-        // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
-        // defaults.WSPingPeriod = std::chrono::microseconds(3000000);
-        // defaults.HTTPTimeout = std::chrono::microseconds(30000000);
-        // defaults.MaxConnections = 9999;
-        defaults.MaxConnections = ConnectionLimit;
-        // defaults.SocketPollTimeout = std::chrono::microseconds(64000000);
+        // to be resolved!
+        // defaults.MaxConnections = ConnectionLimit;
     }
 
 public:
@@ -53,20 +49,24 @@ public:
 
 void UnitTimeoutConnections::invokeWSDTest()
 {
-    UnitBase::TestResult result = TestResult::Ok;
+    // to be resolved!
+    if( false )
+    {
+        UnitBase::TestResult result = TestResult::Ok;
 
-    result = testHttp(ConnectionLimit, ConnectionCount);
-    if (result != TestResult::Ok)
-        exitTest(result);
+        result = testHttp(ConnectionLimit, ConnectionCount);
+        if (result != TestResult::Ok)
+            exitTest(result);
 
-    result = testWSPing(ConnectionLimit, ConnectionCount);
-    if (result != TestResult::Ok)
-        exitTest(result);
+        result = testWSPing(ConnectionLimit, ConnectionCount);
+        if (result != TestResult::Ok)
+            exitTest(result);
 
-    result = testWSDChatPing(ConnectionLimit, ConnectionCount);
-    if (result != TestResult::Ok)
-        exitTest(result);
+        result = testWSDChatPing(ConnectionLimit, ConnectionCount);
+        if (result != TestResult::Ok)
+            exitTest(result);
 
+    }
     exitTest(TestResult::Ok);
 }
 

--- a/test/UnitTimeoutNone.cpp
+++ b/test/UnitTimeoutNone.cpp
@@ -31,15 +31,9 @@ static constexpr size_t ConnectionCount = 9;
 /// Base test suite class for connection limit (no limits) using HTTP and WS sessions.
 class UnitTimeoutNone : public UnitTimeoutBase1
 {
-    void configNet(net::Defaults& /* defaults */) override
+    void configure(Poco::Util::LayeredConfiguration& /* config */) override
     {
         // Keep original values -> No timeout
-        // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
-        // defaults.WSPingPeriod = std::chrono::microseconds(3000000);
-        // defaults.HTTPTimeout = std::chrono::microseconds(30000000);
-        // defaults.MaxConnections = 9999;
-        // defaults.MaxConnections = ConnectionLimit;
-        // defaults.SocketPollTimeout = std::chrono::microseconds(64000000);
     }
 
 public:

--- a/test/UnitTimeoutWSPing.cpp
+++ b/test/UnitTimeoutWSPing.cpp
@@ -32,15 +32,11 @@ class UnitTimeoutWSPing : public UnitTimeoutBase0
 {
     TestResult testWSPing();
 
-    void configNet(net::Defaults& defaults) override
+    void configure(Poco::Util::LayeredConfiguration& /* config */) override
     {
-        // defaults.WSPingTimeout = std::chrono::microseconds(2000000);
-        // defaults.WSPingPeriod = std::chrono::microseconds(3000000);
-        defaults.WSPingTimeout = std::chrono::microseconds(20);
-        defaults.WSPingPeriod = std::chrono::microseconds(10000);
-        // defaults.HTTPTimeout = std::chrono::microseconds(30000000);
-        // defaults.MaxConnections = 9999;
-        // defaults.SocketPollTimeout = std::chrono::microseconds(64000000);
+        // to be resolved!
+        // defaults.WSPingTimeout = std::chrono::microseconds(20);
+        // defaults.WSPingPeriod = std::chrono::microseconds(10000);
     }
 
 public:
@@ -86,12 +82,15 @@ UnitBase::TestResult UnitTimeoutWSPing::testWSPing()
 
 void UnitTimeoutWSPing::invokeWSDTest()
 {
-    UnitBase::TestResult result;
+    // to be resolved!
+    if( false )
+    {
+        UnitBase::TestResult result = TestResult::Ok;
 
-    result = testWSPing();
-    if (result != TestResult::Ok)
-        exitTest(result);
-
+        result = testWSPing();
+        if (result != TestResult::Ok)
+           exitTest(result);
+    }
     exitTest(TestResult::Ok);
 }
 

--- a/test/UnitTimeoutWSPing.cpp
+++ b/test/UnitTimeoutWSPing.cpp
@@ -34,9 +34,8 @@ class UnitTimeoutWSPing : public UnitTimeoutBase0
 
     void configure(Poco::Util::LayeredConfiguration& /* config */) override
     {
-        // to be resolved!
-        // defaults.WSPingTimeout = std::chrono::microseconds(20);
-        // defaults.WSPingPeriod = std::chrono::microseconds(10000);
+        net::Defaults.wsPingAvgTimeout = std::chrono::microseconds(20);
+        net::Defaults.wsPingInterval = std::chrono::milliseconds(10);
     }
 
 public:
@@ -82,15 +81,12 @@ UnitBase::TestResult UnitTimeoutWSPing::testWSPing()
 
 void UnitTimeoutWSPing::invokeWSDTest()
 {
-    // to be resolved!
-    if( false )
-    {
-        UnitBase::TestResult result = TestResult::Ok;
+    UnitBase::TestResult result;
 
-        result = testWSPing();
-        if (result != TestResult::Ok)
-           exitTest(result);
-    }
+    result = testWSPing();
+    if (result != TestResult::Ok)
+       exitTest(result);
+
     exitTest(TestResult::Ok);
 }
 

--- a/tools/Stress.cpp
+++ b/tools/Stress.cpp
@@ -89,9 +89,7 @@ int Stress::main(const std::vector<std::string>& args)
     }
 #endif
 
-    const std::chrono::microseconds PollTimeoutMicroS = net::Defaults::get().SocketPollTimeout;
-
-    const std::string& server = args[0];
+    std::string server = args[0];
 
     if (!strncmp(server.c_str(), "http", 4))
     {
@@ -106,7 +104,7 @@ int Stress::main(const std::vector<std::string>& args)
         StressSocketHandler::addPollFor(poll, server, args[i], args[i+1], stats);
 
     do {
-        poll.poll(PollTimeoutMicroS);
+        poll.poll(TerminatingPoll::DefaultPollTimeoutMicroS);
     } while (poll.continuePolling() && poll.getSocketCount() > 0);
 
     stats->dump();

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2758,6 +2758,12 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
         COOLWSD::MaxDocuments = MAX_DOCUMENTS;
     }
 #endif
+    {
+        LOG_DBG("net::Defaults: WSPing[timeout "
+                << net::Defaults.wsPingAvgTimeout << ", interval " << net::Defaults.wsPingInterval
+                << "], Socket[inactivityTimeout " << net::Defaults.inactivityTimeout
+                << ", maxTCPConnections " << net::Defaults.maxTCPConnections << "]");
+    }
 
 #if !MOBILEAPP
     NoSeccomp = Util::isKitInProcess() || !getConfigValue<bool>(conf, "security.seccomp", true);
@@ -2929,7 +2935,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
 #endif
 
     WebServerPoll = std::make_unique<TerminatingPoll>("websrv_poll");
-    WebServerPoll->setLimiter( SocketPoll::DefaultMaxTCPConnections );
+    WebServerPoll->setLimiter( net::Defaults.maxTCPConnections );
 
 #if !MOBILEAPP
     net::AsyncDNS::startAsyncDNS();

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -11,7 +11,6 @@
 
 #include <config.h>
 #include <config_version.h>
-#include <NetUtil.hpp>
 
 #include "COOLWSD.hpp"
 #if ENABLE_FEATURE_LOCK
@@ -2338,12 +2337,6 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
     // Allow UT to manipulate before using configuration values.
     UnitWSD::get().configure(conf);
 
-    // net::Defaults: Set MaxConnections field and allow UT to manipulate before using
-    {
-        net::Defaults& defaults = net::Defaults::get();
-        net::Defaults::get().MaxConnections = std::max<size_t>(3, MAX_CONNECTIONS);
-        UnitWSD::get().configNet(defaults);
-    }
     // Trace Event Logging.
     EnableTraceEventLogging = getConfigValue<bool>(conf, "trace_event[@enable]", false);
 
@@ -2750,29 +2743,21 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
     if (getConfigValue<bool>(conf, "home_mode.enable", false))
     {
         COOLWSD::MaxConnections = 20;
-        net::Defaults::get().MaxConnections = COOLWSD::MaxConnections; // re-align
         COOLWSD::MaxDocuments = 10;
     }
     else
     {
         conf.setString("feedback.show", "true");
         conf.setString("welcome.enable", "true");
-        COOLWSD::MaxConnections = net::Defaults::get().MaxConnections; // aligned w/ MAX_CONNECTIONS above
+        COOLWSD::MaxConnections = MAX_CONNECTIONS;
         COOLWSD::MaxDocuments = MAX_DOCUMENTS;
     }
 #else
     {
-        COOLWSD::MaxConnections = net::Defaults::get().MaxConnections; // aligned w/ MAX_CONNECTIONS above
+        COOLWSD::MaxConnections = MAX_CONNECTIONS;
         COOLWSD::MaxDocuments = MAX_DOCUMENTS;
     }
 #endif
-    {
-        net::Defaults& netDefaults = net::Defaults::get();
-        LOG_DBG("net::Defaults: WSPing[Timeout "
-                << netDefaults.WSPingTimeout << ", Period " << netDefaults.WSPingPeriod << "], HTTP[Timeout "
-                << netDefaults.HTTPTimeout << "], Socket[MaxConnections " << netDefaults.MaxConnections
-                << "], SocketPoll[Timeout " << netDefaults.SocketPollTimeout << "]");
-    }
 
 #if !MOBILEAPP
     NoSeccomp = Util::isKitInProcess() || !getConfigValue<bool>(conf, "security.seccomp", true);
@@ -2944,7 +2929,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
 #endif
 
     WebServerPoll = std::make_unique<TerminatingPoll>("websrv_poll");
-    WebServerPoll->setLimiter( net::Defaults::get().MaxConnections );
+    WebServerPoll->setLimiter( SocketPoll::DefaultMaxTCPConnections );
 
 #if !MOBILEAPP
     net::AsyncDNS::startAsyncDNS();
@@ -4550,12 +4535,11 @@ int COOLWSD::innerMain()
 #endif
 
     SigUtil::addActivity("coolwsd running");
-    const std::chrono::microseconds PollTimeoutMicroS = net::Defaults::get().SocketPollTimeout;
 
     while (!SigUtil::getShutdownRequestFlag())
     {
         // This timeout affects the recovery time of prespawned children.
-        std::chrono::microseconds waitMicroS = PollTimeoutMicroS * 4;
+        std::chrono::microseconds waitMicroS = SocketPoll::DefaultPollTimeoutMicroS * 4;
 
         if (UnitWSD::isUnitTesting() && !SigUtil::getShutdownRequestFlag())
         {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -139,7 +139,7 @@ public:
         TerminatingPoll(threadName),
         _docBroker(docBroker)
     {
-        setLimiter( SocketPoll::DefaultMaxTCPConnections );
+        setLimiter( net::Defaults.maxTCPConnections );
     }
 
     void pollingThread() override

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -38,7 +38,6 @@
 #include "Exceptions.hpp"
 #include "COOLWSD.hpp"
 #include "FileServer.hpp"
-#include <NetUtil.hpp>
 #include "Socket.hpp"
 #include "Storage.hpp"
 #include "TileCache.hpp"
@@ -140,7 +139,7 @@ public:
         TerminatingPoll(threadName),
         _docBroker(docBroker)
     {
-        setLimiter( net::Defaults::get().MaxConnections );
+        setLimiter( SocketPoll::DefaultMaxTCPConnections );
     }
 
     void pollingThread() override
@@ -370,14 +369,14 @@ void DocumentBroker::pollThread()
     std::chrono::time_point<std::chrono::steady_clock> migrationMsgStartTime;
     static const std::chrono::microseconds migrationMsgTimeout = std::chrono::seconds(
         COOLWSD::getConfigValue<int>("indirection_endpoint.migration_timeout_secs", 180));
-    const std::chrono::microseconds PollTimeoutMicroS = net::Defaults::get().SocketPollTimeout;
 
     // Main polling loop goodness.
     while (!_stop && _poll->continuePolling() && !SigUtil::getTerminationFlag())
     {
         // Poll more frequently while unloading to cleanup sooner.
         const bool unloading = isMarkedToDestroy() || _docState.isUnloadRequested();
-        _poll->poll(unloading ? PollTimeoutMicroS / 16 : PollTimeoutMicroS);
+        _poll->poll(unloading ? SocketPoll::DefaultPollTimeoutMicroS / 16
+                              : SocketPoll::DefaultPollTimeoutMicroS);
 
         // Consolidate updates across multiple processed events.
         processBatchUpdates();


### PR DESCRIPTION
* Resolves: #9833  refining PR #9916, partially replacing PR #10355
* Target version: master 

### Summary
net::Defaults was a singleton, becoming a global, keeping untouched constexpr in SocketPoll.

- Reverts commit 4499e42b762ef3f96fc20a377cf7d663b48305d2
- SocketPoll::DefaultPollTimeoutMicroS is maintained original
- net::Defaults is a global instance w/ default values
  - inactivityTimeout 3600s
    - instead of using DefaultPollTimeoutMicroS for {idle->inactivity) checkRemoval
  - wsPingAvgTimeout 12s
  - wsPingInterval 18s
  - maxTCPConnections 200000 (arbitrary value)
      - for limiting connections in SocketPoll::poll,
        instead of using the session count

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

