### PR TITLE
Kit versions: log version on start, and also check for known badness.

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3517,6 +3517,23 @@ void lokit_main(
 
             SigUtil::setVersionInfo(versionString);
 
+            LOG_INF("Kit core version is " << versionString);
+
+            // Extend the list on new releases
+            static const char *denyVersions[] = {
+                "\"22.05\"", "\"23.05\""
+            };
+            for (auto const &deny: denyVersions)
+            {
+                if (Util::findSubArray(versionString.c_str(), versionString.length(),
+                                       deny, strlen(deny)) >= 0)
+                {
+                    LOG_FTL("Mis-matching, obsolete core version, "
+                            "please update your packages: " << versionString);
+                    Util::forcedExit(EX_SOFTWARE);
+                }
+            }
+
             // Add some parameters we want to pass to the client. Could not figure out how to get
             // the configuration parameters from COOLWSD.cpp's initialize() or coolwsd.xml here, so
             // oh well, just have the value hardcoded in KitHelper.hpp. It isn't really useful to


### PR DESCRIPTION
The combination of a year+ old core, and a modern coolforkit can initialize and startup, but then fails subsequently in hard to diagnose ways, so look for badness and log it early.


Change-Id: I9b9c94997afcc8faa8174b7339483f832ec87dd6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

