### PR TITLE
Implement MaxConnection Limit (2)

### DIFF
--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -39,8 +39,8 @@ public:
     /// WebSocketHandler ping interval in us (18s default), i.e. duration until next ping. Zero disables instrument.
     std::chrono::microseconds wsPingInterval;
 
-    /// Maximum number of concurrent TCP connections. Zero disables instrument.
-    size_t maxTCPConnections;
+    /// Maximum number of concurrent external TCP connections. Zero disables instrument.
+    size_t maxExtConnections;
 };
 extern DefaultValues Defaults;
 

--- a/net/ServerSocket.hpp
+++ b/net/ServerSocket.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "NetUtil.hpp"
 #include "memory"
 
 #include "Socket.hpp"
@@ -108,9 +109,13 @@ public:
                 const std::string msg = "Failed to accept. (errno: ";
                 throw std::runtime_error(msg + std::strerror(errno) + ')');
             }
-
-            LOG_TRC("Accepted client #" << clientSocket->getFD());
-            _clientPoller.insertNewSocket(std::move(clientSocket));
+            const size_t extConnCount = StreamSocket::getExternalConnectionCount();
+            if( 0 == net::Defaults.maxExtConnections || extConnCount <= net::Defaults.maxExtConnections )
+            {
+                LOG_TRC("Accepted client #" << clientSocket->getFD());
+                _clientPoller.insertNewSocket(std::move(clientSocket));
+            } else
+                LOG_WRN("Limiter rejected extConn[" << extConnCount << "/" << net::Defaults.maxExtConnections << "]: " << *clientSocket);
         }
     }
 

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -15,7 +15,6 @@
 #include "TraceEvent.hpp"
 #include "Util.hpp"
 
-#include <atomic>
 #include <chrono>
 #include <cstring>
 #include <cctype>
@@ -66,29 +65,10 @@ std::atomic<bool> Socket::InhibitThreadChecks(false);
 
 std::unique_ptr<Watchdog> SocketPoll::PollWatchdog;
 
-std::mutex SocketPoll::StatsMutex;
-std::atomic<size_t> SocketPoll::StatsConnectionCount(0);
-
 net::DefaultValues net::Defaults = { .inactivityTimeout = std::chrono::seconds(3600),
                                      .wsPingAvgTimeout = std::chrono::seconds(12),
                                      .wsPingInterval = std::chrono::seconds(18),
                                      .maxTCPConnections = 200000 /* arbitrary value to be resolved */ };
-
-size_t SocketPoll::StatsConnectionMod(size_t added, size_t removed) {
-    if( added == 0 && removed == 0 ) {
-        return GetStatsConnectionCount();
-    }
-    size_t res, pre;
-    {
-        std::lock_guard<std::mutex> lock(StatsMutex);
-        pre = GetStatsConnectionCount();
-        res = pre + added; // overflow impossible due to MAX_CONNECTIONS
-        res -= removed; // underflow impossible due to MAX_CONNECTIONS
-        StatsConnectionCount.store(res, std::memory_order_seq_cst);
-    }
-    LOG_DBG("SocketPoll::ConnectionCount: " << pre << " +" << added << " -" << removed << " = " << res);
-    return res;
-}
 
 #define SOCKET_ABSTRACT_UNIX_NAME "0coolwsd-"
 
@@ -320,8 +300,6 @@ namespace {
 
 SocketPoll::SocketPoll(std::string threadName)
     : _name(std::move(threadName)),
-      _limitedConnections( false ),
-      _connectionLimit( 0 ),
       _pollStartIndex(0),
       _stop(false),
       _threadStarted(0),
@@ -523,8 +501,6 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
     // The events to poll on change each spin of the loop.
     setupPollFds(now, timeoutMaxMicroS);
     const size_t size = _pollSockets.size();
-    size_t itemsAdded = 0;
-    size_t itemsErased = 0;
 
     // disable watchdog - it's good to sleep
     disableWatchdog();
@@ -577,29 +553,7 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
         std::vector<CallbackFn> invoke;
         {
             std::lock_guard<std::mutex> lock(_mutex);
-            const size_t newConnCount = _newSockets.size();
-            const size_t globCount = GetStatsConnectionCount();
 
-            if( _limitedConnections &&
-                _connectionLimit > 0 &&
-                globCount + newConnCount > _connectionLimit)
-            {
-                // For now we simply drop new connections
-                const size_t overhead = globCount + newConnCount - _connectionLimit;
-                for(size_t i=0; i<overhead; ++i)
-                {
-                    std::shared_ptr<Socket>& socket = _newSockets.back(); // oldest
-                    assert(socket);
-
-                    LOG_WRN("Limiter: #" << socket->getFD() << ": Removing "
-                             << (i+1) << " / " << overhead << " new socket of (pre "
-                             << globCount << " + new " << newConnCount << ") / max " << _connectionLimit
-                             << " from " << _name);
-
-                    socket->resetThreadOwner();
-                    _newSockets.pop_back();
-                }
-            }
             if (!_newSockets.empty())
             {
                 LOGA_TRC(Socket, "Inserting " << _newSockets.size() << " new sockets after the existing "
@@ -611,8 +565,6 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
 
                 // Copy the new sockets over and clear.
                 _pollSockets.insert(_pollSockets.end(), _newSockets.begin(), _newSockets.end());
-
-                itemsAdded += _newSockets.size();
 
                 _newSockets.clear();
             }
@@ -647,15 +599,10 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
         }
     }
 
-    if (itemsAdded != _pollSockets.size() - size)
+    if (_pollSockets.size() != size)
     {
-        // unexpected
-        LOG_WRN("PollSocket container size has changed from " << size
-            << " + " << itemsAdded << " to " << _pollSockets.size());
-    } else if (itemsAdded > 0)
-    {
-        LOG_TRC("PollSocket container size increased from " << size
-            << " + " << itemsAdded << " to " << _pollSockets.size());
+        LOG_TRC("PollSocket container size has changed from " << size << " to "
+                                                              << _pollSockets.size());
     }
 
     // If we had sockets to process.
@@ -672,6 +619,7 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
         if (_pollStartIndex > size - 1)
             _pollStartIndex = 0;
 
+        size_t itemsErased = 0;
         size_t i = _pollStartIndex;
         for (std::size_t j = 0; j < size; ++j)
         {
@@ -731,35 +679,15 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
 
         if (itemsErased)
         {
-            const size_t itemsErasedPre = itemsErased;
-            itemsErased = 0; // correcting itemsErased
+            LOG_TRC("Scanning to removing " << itemsErased << " defunct sockets from "
+                    << _pollSockets.size() << " sockets");
 
             _pollSockets.erase(
                 std::remove_if(_pollSockets.begin(), _pollSockets.end(),
-                               [&itemsErased](const std::shared_ptr<Socket>& s) -> bool
-                               {
-                                   if (!s)
-                                   {
-                                       ++itemsErased;
-                                       return true;
-                                   }
-                                   else
-                                   {
-                                       return false;
-                                   }
-                               }),
+                    [](const std::shared_ptr<Socket>& s)->bool
+                    { return !s; }),
                 _pollSockets.end());
-
-            LOG_TRC("Removed " << itemsErased
-                    << "(" << itemsErasedPre << ") defunct sockets from "
-                    << _pollSockets.size() << " sockets");
         }
-    }
-    if( _limitedConnections )
-    {
-        // Perform bookkeeping if required
-        // New connections might be dropped if exceeding limits, see _newSockets above.
-        StatsConnectionMod(itemsAdded, itemsErased);
     }
 
     return rc;
@@ -868,11 +796,9 @@ void SocketPoll::createWakeups()
 void SocketPoll::removeSockets()
 {
     LOG_DBG("Removing all " << _pollSockets.size() + _newSockets.size()
-                            << " sockets from SocketPoll thread " << _name
-                            << " of " << GetStatsConnectionCount() << " total poll sockets");
+                            << " sockets from SocketPoll thread " << _name);
     ASSERT_CORRECT_SOCKET_THREAD(this);
 
-    size_t removedPollSockets = 0;
     while (!_pollSockets.empty())
     {
         const std::shared_ptr<Socket>& socket = _pollSockets.back();
@@ -883,10 +809,6 @@ void SocketPoll::removeSockets()
         socket->resetThreadOwner();
 
         _pollSockets.pop_back();
-        ++removedPollSockets;
-    }
-    if( _limitedConnections ) {
-        StatsConnectionMod(0, removedPollSockets);
     }
 
     while (!_newSockets.empty())
@@ -1154,9 +1076,7 @@ void SocketPoll::dumpState(std::ostream& os) const
     const auto pollSockets = _pollSockets;
 
     os << "\n  SocketPoll [" << name() << "] with " << pollSockets.size() << " socket"
-       << (pollSockets.size() == 1 ? "" : "s")
-       << " of " << GetStatsConnectionCount()
-       << " total - wakeup rfd: " << _wakeup[0]
+       << (pollSockets.size() == 1 ? "" : "s") << " - wakeup rfd: " << _wakeup[0]
        << " wfd: " << _wakeup[1] << '\n';
     const auto callbacks = _newCallbacks.size();
     if (callbacks > 0)

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -65,10 +65,12 @@ std::atomic<bool> Socket::InhibitThreadChecks(false);
 
 std::unique_ptr<Watchdog> SocketPoll::PollWatchdog;
 
+std::atomic<size_t> StreamSocket::ExternalConnectionCount = 0;
+
 net::DefaultValues net::Defaults = { .inactivityTimeout = std::chrono::seconds(3600),
                                      .wsPingAvgTimeout = std::chrono::seconds(12),
                                      .wsPingInterval = std::chrono::seconds(18),
-                                     .maxTCPConnections = 200000 /* arbitrary value to be resolved */ };
+                                     .maxExtConnections = 200000 /* arbitrary value to be resolved */ };
 
 #define SOCKET_ABSTRACT_UNIX_NAME "0coolwsd-"
 
@@ -1189,8 +1191,7 @@ std::shared_ptr<Socket> ServerSocket::accept()
             _socket->setClientAddress(addrstr, clientInfo.sin6_port);
 
             LOG_TRC("Accepted socket #" << _socket->getFD() << " has family "
-                                        << clientInfo.sin6_family << " address "
-                                        << _socket->clientAddress());
+                                        << clientInfo.sin6_family << ", " << *_socket);
 #else
             std::shared_ptr<Socket> _socket = createSocketFromAccept(rc, Socket::Type::Unix);
 #endif

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -819,15 +819,6 @@ public:
     /// Global wakeup - signal safe: wakeup all socket polls.
     static void wakeupWorld();
 
-    /// Enable connection accounting and limiter
-    /// Internally we allow one extra connection for the WS upgrade
-    /// @param connectionLimit socket connection limit
-    void setLimiter(size_t connectionLimit)
-    {
-        _limitedConnections = true;
-        _connectionLimit = connectionLimit > 0 ? connectionLimit + 1 : 0;
-    }
-
     /// Insert a new socket to be polled.
     /// A socket is removed when it is closed, readIncomingData
     /// returns false, or when removeSockets is called (which is
@@ -1000,8 +991,6 @@ private:
 
     /// Debug name used for logging.
     const std::string _name;
-    bool _limitedConnections;
-    size_t _connectionLimit;
 
     /// main-loop wakeup pipe
     int _wakeup[2];
@@ -1028,13 +1017,6 @@ private:
     /// Time-stamp for profiling
     int _ownerThreadId;
     std::atomic<uint64_t> _watchdogTime;
-
-    static std::mutex StatsMutex;
-    static std::atomic<size_t> StatsConnectionCount; // total of all _pollSockets (excluding _newSockets)
-    static size_t StatsConnectionMod(size_t added, size_t removed); // safe add-sub of StatsConnectionCount
-
-public:
-    static int64_t GetStatsConnectionCount() { return StatsConnectionCount.load(std::memory_order_seq_cst); }
 };
 
 /// A SocketPoll that will stop polling and

--- a/test/UnitTimeoutBase.hpp
+++ b/test/UnitTimeoutBase.hpp
@@ -204,6 +204,8 @@ inline UnitBase::TestResult UnitTimeoutBase1::testHttp(const size_t connectionLi
     sessions.clear();
     TST_LOG("Clearing Poller: " << testname);
     socketPollers.clear();
+    // TCP Connection Count: Just an estimation, no locking on server side
+    TST_LOG("TCP Connection Count: " << testname << ", " << StreamSocket::getExternalConnectionCount() << " / " << net::Defaults.maxExtConnections);
     TST_LOG("Ending Test: " << testname);
     return TestResult::Ok;
 }
@@ -302,6 +304,8 @@ inline UnitBase::TestResult UnitTimeoutBase1::testWSPing(const size_t connection
     sessions.clear();
     TST_LOG("Clearing Poller: " << testname);
     socketPollers.clear();
+    // TCP Connection Count: Just an estimation, no locking on server side
+    TST_LOG("TCP Connection Count: " << testname << ", " << StreamSocket::getExternalConnectionCount() << " / " << net::Defaults.maxExtConnections);
     TST_LOG("Ending Test: " << testname);
     return TestResult::Ok;
 }
@@ -397,6 +401,8 @@ inline UnitBase::TestResult UnitTimeoutBase1::testWSDChatPing(const size_t conne
     sessions.clear();
     TST_LOG("Clearing Poller: " << testname);
     socketPollers.clear();
+    // TCP Connection Count: Just an estimation, no locking on server side
+    TST_LOG("TCP Connection Count: " << testname << ", " << StreamSocket::getExternalConnectionCount() << " / " << net::Defaults.maxExtConnections);
     TST_LOG("Ending Test: " << testname);
     return TestResult::Ok;
 }

--- a/test/UnitTimeoutConnections.cpp
+++ b/test/UnitTimeoutConnections.cpp
@@ -34,7 +34,7 @@ class UnitTimeoutConnections : public UnitTimeoutBase1
 {
     void configure(Poco::Util::LayeredConfiguration& /* config */) override
     {
-        net::Defaults.maxTCPConnections = ConnectionLimit;
+        net::Defaults.maxExtConnections = ConnectionLimit;
     }
 
 public:

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2935,7 +2935,6 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
 #endif
 
     WebServerPoll = std::make_unique<TerminatingPoll>("websrv_poll");
-    WebServerPoll->setLimiter( net::Defaults.maxTCPConnections );
 
 #if !MOBILEAPP
     net::AsyncDNS::startAsyncDNS();

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2762,7 +2762,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
         LOG_DBG("net::Defaults: WSPing[timeout "
                 << net::Defaults.wsPingAvgTimeout << ", interval " << net::Defaults.wsPingInterval
                 << "], Socket[inactivityTimeout " << net::Defaults.inactivityTimeout
-                << ", maxTCPConnections " << net::Defaults.maxTCPConnections << "]");
+                << ", maxExtConnections " << net::Defaults.maxExtConnections << "]");
     }
 
 #if !MOBILEAPP

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -139,7 +139,6 @@ public:
         TerminatingPoll(threadName),
         _docBroker(docBroker)
     {
-        setLimiter( net::Defaults.maxTCPConnections );
     }
 
     void pollingThread() override


### PR DESCRIPTION
* Resolves: #9833  refining PR #9916, partially replacing PR #10355
* Target version: master 

This PR is on top of #10366 !

### Summary

Reimplementation of commit 80246f7ac1140257d14162504d3550909d6ba681 (post revert).

Adding external TCP connection limit to server-side TCP IPv4/IPv6 Sockets
- Counted at StreamSocket ctor
  - Only limits TCP connections for server-side IPv4 or IPv6 TCP connections.
- Rejected at ServerSocker::handlePoll
  - If exceeding net::Defaults.maxExtConnections, socket object and hence connection is dropped
    
### TODO
- revise net::Defaults.maxTCPConnections to match actual system settings
  - earmarked for subsequent PR

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

