### PR TITLE
CustomProperties dialog: set a default height

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2231,8 +2231,9 @@ kbd,
 	margin: 0;
 }
 
-#DocumentPropertiesDialog #customprops .jsdialog.ui-scrollwindow {
-	max-height: min-content;
+#DocumentPropertiesDialog #customprops #CustomInfoPage > .jsdialog.ui-scrollwindow:not(.formulabar) {
+	height: 540px;
+	max-height: none;
 }
 
 #ServerAuditDialog #ServerAuditDialog-mainbox {


### PR DESCRIPTION
Change-Id: I83daefea86fbfc86c996c2d015ff1cef5c245900


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Set an appropriate initial size for the CustomProperties scrolledWindow.

This is to improve the appearance of this dialog that degraded after https://github.com/CollaboraOnline/online/pull/9914

Before:
![image](https://github.com/user-attachments/assets/c49d46c4-cbba-4b5e-b8f3-06d241b9f872)

After:
![image](https://github.com/user-attachments/assets/ca05b2b3-f9e2-4b30-a803-c1eaad11059e)

