### PR TITLE
calc: fix: autocomplete formula edge case 

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1796,8 +1796,9 @@ L.CanvasTileLayer = L.Layer.extend({
 					break;
 				}
 			}
+
 			if (index === -1)
-				index = minLength;
+				index = newFormula.length-1;
 
 			// newFormulaDiffIndex have index of last added character in formula
 			// It is used during Formula Autocomplete to find partial remaining text


### PR DESCRIPTION
- Fixes the following case:
1. Create 3 Named Ranges: testrange1, testrange111, testrange11111
2. Try to autocomplete `=SUM(test`
3. Autocomplete `test` with `testrange1`
4. Now popup will show up because there are `testrange111`, `testrange1111` which can be autocompleted if you select one of those it will autocomplete with `testrange1range111` which is not correct


Change-Id: I81cf0f8f3ebf23e275561f16301ac775e7d00a9f