### PR TITLE
Use WSD-config or system's maximum concurrent TCP connections for net::Defaults.maxTCPConnections

### DIFF
--- a/common/ConfigUtil.hpp
+++ b/common/ConfigUtil.hpp
@@ -171,6 +171,7 @@ public:
 
     void operator()(int& value) { value = _config.getInt(_name); }
     void operator()(unsigned int& value) { value = _config.getUInt(_name); }
+    void operator()(int64_t& value) { value = _config.getInt64(_name); }
     void operator()(uint64_t& value) { value = _config.getUInt64(_name); }
     void operator()(bool& value) { value = _config.getBool(_name); }
     void operator()(std::string& value) { value = _config.getString(_name); }

--- a/common/Util-mobile.cpp
+++ b/common/Util-mobile.cpp
@@ -21,7 +21,8 @@ int spawnProcess(const std::string& cmd, const StringVector& args) { return 0; }
 
 std::string getHumanizedBytes(unsigned long nBytes) { return std::string(); }
 size_t getTotalSystemMemoryKb() { return 0; }
-std::size_t getFromFile(const char* path) { return 0; }
+size_t getMaxConcurrentTCPConnections() { return 0; }
+std::size_t getFromFile(const char* /*path*/, const size_t /*defaultValue*/) { return 0; }
 std::size_t getCGroupMemLimit() { return 0; }
 std::size_t getCGroupMemSoftLimit() { return 0; }
 size_t getMemoryUsagePSS(const pid_t pid) { return 0; }

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -333,8 +333,12 @@ namespace Util
     /// Returns the total physical memory (in kB) available in the system
     size_t getTotalSystemMemoryKb();
 
+    /// Returns the maximum number of concurrent TCP connections, zero if undefined.
+    /// Value is memory bound. On GNU/Linux approximately 4 concurrent TCP connections per MB system memory are provided.
+    size_t getMaxConcurrentTCPConnections();
+
     /// Returns the numerical content of a file at @path
-    std::size_t getFromFile(const char *path);
+    std::size_t getFromFile(const char *path, const size_t defaultValue=0);
 
     /// Returns the cgroup's memory limit, or 0 if not available in bytes
     std::size_t getCGroupMemLimit();

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -36,6 +36,9 @@ public:
     std::chrono::microseconds inactivityTimeout;
 
     /// Maximum number of concurrent external TCP connections. Zero disables instrument.
+    /// Set to COOLWSD config `net.max_ext_connections` if >= `COOLWSD::MinConnectedSessions`
+    /// or is disabled (zeroed) if config < 0.
+    /// Otherwise set to system-value, see `Util::getMaxConcurrentTCPConnections`.
     size_t maxExtConnections;
 };
 extern DefaultValues Defaults;

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -72,7 +72,7 @@ std::unique_ptr<Watchdog> SocketPoll::PollWatchdog;
 std::atomic<size_t> StreamSocket::ExternalConnectionCount = 0;
 
 net::DefaultValues net::Defaults = { .inactivityTimeout = std::chrono::seconds(3600),
-                                     .maxExtConnections = 200000 /* arbitrary value to be resolved */ };
+                                     .maxExtConnections = 0 /* disabled by default */};
 
 #define SOCKET_ABSTRACT_UNIX_NAME "0coolwsd-"
 

--- a/test/UnitTimeoutConnections.cpp
+++ b/test/UnitTimeoutConnections.cpp
@@ -11,6 +11,7 @@
 
 #include <config.h>
 
+#include <cstdint>
 #include <string>
 
 #include <HttpRequest.hpp>
@@ -32,9 +33,9 @@ static constexpr size_t ConnectionCount = 9;
 /// Base test suite class for connection limit (limited) using HTTP and WS sessions.
 class UnitTimeoutConnections : public UnitTimeoutBase1
 {
-    void configure(Poco::Util::LayeredConfiguration& /* config */) override
+    void configure(Poco::Util::LayeredConfiguration& config) override
     {
-        net::Defaults.maxExtConnections = ConnectionLimit;
+        config.setInt64("net.max_ext_connections", static_cast<int64_t>(ConnectionLimit)); // Sets `net::Defaults.maxExtConnections`
     }
 
 public:

--- a/test/UnitTimeoutInactive.cpp
+++ b/test/UnitTimeoutInactive.cpp
@@ -34,8 +34,11 @@ class UnitTimeoutInactivity : public UnitTimeoutBase0
     TestResult testHttp(bool forceInactivityTO);
     TestResult testWS(bool forceInactivityTO);
 
-    void configure(Poco::Util::LayeredConfiguration& /* config */) override
+    void configure(Poco::Util::LayeredConfiguration& config) override
     {
+        // Ensured config-default zero to use system-default for `net::Defaults.maxExtConnections`
+        config.setInt64("net.max_ext_connections", 0);
+
         // net::Defaults.inactivityTimeout = std::chrono::seconds(3600);
         net::Defaults.inactivityTimeout = std::chrono::milliseconds(100);
         //

--- a/test/UnitTimeoutNone.cpp
+++ b/test/UnitTimeoutNone.cpp
@@ -31,9 +31,12 @@ static constexpr size_t ConnectionCount = 9;
 /// Base test suite class for connection limit (no limits) using HTTP and WS sessions.
 class UnitTimeoutNone : public UnitTimeoutBase1
 {
-    void configure(Poco::Util::LayeredConfiguration& /* config */) override
+    void configure(Poco::Util::LayeredConfiguration& config) override
     {
         // Keep original values -> No timeout
+
+        // Disable `net::Defaults.maxExtConnections` instrument, i.e. setting it to zero (skipping system default)
+        config.setInt64("net.max_ext_connections", -1);
     }
 
 public:

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -319,6 +319,7 @@ public:
 #endif
 
     static std::unordered_set<std::string> EditFileExtensions;
+    static constexpr unsigned MinConnectedSessions = 3; ///< Minimum value for MaxConnections
     static unsigned MaxConnections;
     static unsigned MaxDocuments;
     static std::string HardwareResourceWarning;


### PR DESCRIPTION
* Resolves: #9833  refining PR #9916 and subsuming PR #10366 and PR #10370
* Target version: master 

### Summary
net::Defaults.maxTCPConnections: Use WSD-config or system's maximum concurrent TCP connections
    
`net::Defaults.maxExtConnections` is set:
- use COOLWSD config `net.max_ext_connections` if >= `COOLWSD::MinConnectedSessions`
- or is disabled (zeroed) if config < 0.
- otherwise set to system-value, see `Util::getMaxConcurrentTCPConnections`.

`Util::getMaxConcurrentTCPConnections` uses Linux kernel values
- /proc/sys/net/ipv4/tcp_max_orphans
  See https://www.kernel.org/doc/html/latest/networking/ip-sysctl.html
- /proc/sys/net/nf_conntrack_max
  See https://www.kernel.org/doc/html/latest/networking/nf_conntrack-sysctl.html
- or returns zero if undefined

The Linux kernel values are memory bound, approximately 4 concurrent TCP connections per MB system memory are provided,
e.g. {4096M -> 16384}, {16384M -> 65536}, {65407M -> 262144}, ...

`COOLWSD::MinConnectedSessions` is a static constexpr with value 3, symbolized for clarity.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required
