### PR TITLE
wsd: fix: failed to pass aliases using `--use-env-vars` option

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3270,6 +3270,7 @@ void COOLWSD::initializeEnvOptions()
         bool first = true;
         std::istringstream aliasGroupStream;
         aliasGroupStream.str(aliasGroup);
+        int j = 0;
         for (std::string alias; std::getline(aliasGroupStream, alias, ',');)
         {
             if (first)
@@ -3282,7 +3283,8 @@ void COOLWSD::initializeEnvOptions()
             else
             {
                 _overrideSettings["storage.wopi.alias_groups.group[" + std::to_string(n) +
-                                  "].alias"] = alias;
+                                  "].alias[" + std::to_string(j) + ']'] = alias;
+                j++;
             }
         }
 


### PR DESCRIPTION
- regression from 1b3218df0466a59fd1e9a8df72d97ede6448425e
- Steps to reproduce/test:
  1. create env variable `export aliasgroup1=http://test.integrator,http://test.integrator1,http://test.integrator2`
  2. Run COOL binary with `--use-env-vars`
  3. You can either search for 'Adding trusted WOPIHost' in coolwsd logs and make sure all the aliases and hosts are allowed or you can add multiple entries to your `/etc/hosts` that points to same WOPIHost instance


Change-Id: I16785458724c81b681b8ebb979c119af5db9b808


* Resolves: #7730 

