### PR TITLE
Comment popup: Use Ctrl+Enter shortcut to save and close

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -425,6 +425,13 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	private textAreaKeyDown (ev: any): void {
+		if (ev && ev.ctrlKey && ev.key === "Enter") {
+			ev.preventDefault();
+			this.map.mention.closeMentionPopup(false);
+			this.onSaveComment(ev);
+			return;
+		}
+
 		this.handleKeyDownForPopup(ev, 'mentionPopup');
 	}
 


### PR DESCRIPTION
Change-Id: I8da6e1208b0cbba6b51da97c6926d29da19a47a4

### Summary

Use Shift+Enter to save and close the comment popup for convenience.
This is a common shortcut for such functionnality.

### Checklist

- [ ] Documentation (manuals or wiki) has been updated or is not required

