### PR TITLE
Keyboard: allow Ctrl+shift+I shortcut

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -662,6 +662,11 @@ L.Map.Keyboard = L.Handler.extend({
 			return true;
 		}
 
+		// Control + Shift + I, open browser developper tools
+		if (this._isCtrlKey(e) && e.shiftKey && e.keyCode === this.keyCodes.I) {
+			return true;
+		}
+
 		if (e.keyCode !== this.keyCodes.C[DEFAULT] && e.keyCode !== this.keyCodes.V[DEFAULT] && e.keyCode !== this.keyCodes.X[DEFAULT] &&
 		/* Safari */ e.keyCode !== this.keyCodes.C[MAC] && e.keyCode !== this.keyCodes.V[MAC] && e.keyCode !== this.keyCodes.X[MAC]) {
 			// not copy or paste


### PR DESCRIPTION
Change-Id: Ic57c7f0825522b78f33f23fcebba4b4f8d9ba15b

* Target version: master 

### Summary

Allow to trigger the browser web developper tools with the short Ctrl+Shift+I 


