### PR TITLE
fix: redundant 'Download failed' string in snackbar

### DIFF
--- a/browser/src/docstatefunctions.js
+++ b/browser/src/docstatefunctions.js
@@ -173,8 +173,7 @@ app.showAsyncDownloadError = function (response, initalMsg) {
 	const timeout = 10000;
 	reader.onload = function () {
 		if (reader.result === 'wrong server') {
-			initalMsg +=
-				initalMsg + _(', cluster configuration error: mis-matching serverid');
+			initalMsg += _(', cluster configuration error: mis-matching serverid');
 			app.map.uiManager.showSnackbar(initalMsg, '', null, timeout);
 		} else {
 			app.map.uiManager.showSnackbar(initalMsg, '', null, timeout);


### PR DESCRIPTION
- it happens when download failed with cluster configuration error

![image](https://github.com/user-attachments/assets/3ce99b2a-bb90-4c92-a5b5-288bce3db545)

Change-Id: Ifc2fbc875f378d943cbb932b98c198aba773a48f


