### PR TITLE
feat: Allow drag and drop of A/V files

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -374,7 +374,7 @@ L.Clipboard = L.Class.extend({
 		);
 	},
 
-	_onFileLoadFunc: function(file) {
+	_onImageLoadFunc: function (file) {
 		var that = this;
 		return function(e) {
 			that._pasteTypedBlob(file.type, e.target.result);
@@ -387,14 +387,26 @@ L.Clipboard = L.Class.extend({
 		app.socket.sendMessage(blob);
 	},
 
-	_asyncReadPasteImage: function(file) {
+	_asyncReadPasteFile: function (file) {
 		if (file.type.match(/image.*/)) {
-			var reader = new FileReader();
-			reader.onload = this._onFileLoadFunc(file);
-			reader.readAsArrayBuffer(file);
-			return true;
+			return this._asyncReadPasteImage(file);
+		}
+		if (file.type.match(/audio.*/) || file.type.match(/video.*/)) {
+			return this._asyncReadPasteAVMedia(file);
 		}
 		return false;
+	},
+
+	_asyncReadPasteImage: function (file) {
+		var reader = new FileReader();
+		reader.onload = this._onImageLoadFunc(file);
+		reader.readAsArrayBuffer(file);
+		return true;
+	},
+
+	_asyncReadPasteAVMedia: function (file) {
+		this._map.insertMultimedia(file);
+		return true;
 	},
 
 	// Returns true if it finished synchronously, and false if it have started an async operation
@@ -463,10 +475,9 @@ L.Clipboard = L.Class.extend({
 					if (files !== null)
 					{
 						for (var f = 0; f < files.length; ++f)
-							this._asyncReadPasteImage(files[f]);
-					}
-					else // IE / Edge
-						this._asyncReadPasteImage(dataTransfer.items[t].getAsFile());
+							this._asyncReadPasteFile(files[f]);
+					} // IE / Edge
+					else this._asyncReadPasteFile(dataTransfer.items[t].getAsFile());
 				}
 			}
 


### PR DESCRIPTION
In I881818277edb69ee1e98ba1bd3454e8d29593889, we allowed inserting multimedia into the document. We didn't, however, add any provision for dragging/dropping it into the document, so only images remained drag/droppable.

This commit is a preliminary change to enable drag/drop for audio/video files. It doesn't use the same copy/paste mechanism as inserting images (as this fails, which appears to be for the same reasons we need to specify a size manually on insert...). Instead, we use the normal insert pathway, as if the user had clicked the insert button and uploaded their file. This comes with a disadvantage by way of insert position: the video is always uploaded at the top left of the document. The way to fix this is probably to change the way we determine insert position, however, as the default behavior is poor for the insert media button too...


Change-Id: I3f3fae9cc4de55552d8f5d27077c141d37539b10


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

