### PR TITLE
prevent double-dispatch of uno events bound to function keys

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -397,6 +397,11 @@ L.Map.Keyboard = L.Handler.extend({
 		if (this._map.uiManager.isUIBlocked())
 			return;
 
+		// if we press F1/F2 then the keyboard event is handled twice, use that
+		// the defaultPrevented is set the first time to avoid the double dispatch
+		if (ev.defaultPrevented)
+			return;
+
 		if (window.KeyboardShortcuts.processEvent(app.UI.language.fromURL, ev)) {
 			ev.preventDefault();
 			return;

--- a/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
@@ -12,6 +12,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'PDF View Tests', function(
 
 	it('PDF page down', { env: { 'pdf-view': true } }, function() {
 		cy.cGet('#map').type('{pagedown}');
+		cy.cGet('#map').type('{pagedown}');
 		cy.cGet('#preview-frame-part-1').should('have.attr', 'style', 'border: 2px solid darkgrey;');
 		cy.cGet('#map').type('{pageup}');
 		cy.cGet('#map').type('{pageup}');


### PR DESCRIPTION
this is reproducible with F1 and a breakpoint on

app.map.showHelp('online-help-content');

in browser/src/docdispatcher.ts


Change-Id: Id140878d3a5d19450fe8141977c3324f97541cea


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

