### PR TITLE
_fd might be -1 if ::socket failed

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -450,7 +450,7 @@ private:
 
     void init()
     {
-        if (_type != Type::Unix)
+        if (_type != Type::Unix && _fd >= 0)
             setNoDelay();
         _ignoreInput = false;
         _noShutdown = false;

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -2139,7 +2139,7 @@ static std::string getCapabilitiesJson(bool convertToAvailable)
         std::string timezoneName =
             config::getString("indirection_endpoint.geolocation_setup.timezone", "");
         if (!timezoneName.empty())
-            capabilities->set("timezone", std::string(timezoneName));
+            capabilities->set("timezone", timezoneName);
     }
 
     std::ostringstream ostrJSON;


### PR DESCRIPTION
from Socket::createSocket during construction and init calls setNoDelay

Socket::Socket
...
, _fd(createSocket(type))
...
{
    init()
}

cid#427983 Improper use of negative value


Change-Id: Ie1d197394f77071ac023485f291cd4626a08a2df


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

