### PR TITLE
dumpState Improvements

### DIFF
--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -232,6 +232,7 @@ void requestShutdown()
         signalLog(buf + i + 1);
     }
 
+#endif // !MOBILEAPP
 
     const char *signalName(const int signo)
     {
@@ -294,6 +295,8 @@ void requestShutdown()
         }
         // LCOV_EXCL_STOP Coverage for these is not very useful.
     }
+
+#if !MOBILEAPP
 
     static
     void handleTerminationSignal(const int signal)

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -84,8 +84,12 @@ namespace SigUtil
     /// Signal log number
     void signalLogNumber(std::size_t num, int base = 10);
 
+#endif // !MOBILEAPP
+
     /// Returns the name of the signal.
     const char* signalName(int signo);
+
+#if !MOBILEAPP
 
     /// Register a wakeup function when changing
 

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1643,6 +1643,9 @@ int main(int argc, char**argv)
     // coverity[+kill]
     void forcedExit(int code) __attribute__ ((__noreturn__));
 
+    /// Returns the result of malloc_info, which is an XML string with all the arenas.
+    std::string getMallocInfo();
+
     // std::size isn't available on our android baseline so use this
     // solution as a workaround
     template <typename T, size_t S> char (&n_array_size( T(&)[S] ))[S];

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -94,6 +94,8 @@ void dump_forkit_state()
         << "  MasterLocation: " << MasterLocation
         << "\n";
 
+    oss << "\nMalloc info: \n" << Util::getMallocInfo() << '\n';
+
     const std::string msg = oss.str();
     fprintf(stderr, "%s", msg.c_str());
     LOG_TRC(msg);

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3919,13 +3919,4 @@ void dump_kit_state()
     LOG_TRC(msg);
 }
 
-#if defined __GLIBC__
-#  include <malloc.h>
-void dump_malloc_state()
-{
-    malloc_info(0, stderr);
-    fflush(stderr);
-}
-#endif
-
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3914,6 +3914,8 @@ void dump_kit_state()
     std::ostringstream oss;
     KitSocketPoll::dumpGlobalState(oss);
 
+    oss << "\nMalloc info: \n" << Util::getMallocInfo() << '\n';
+
     const std::string msg = oss.str();
     fprintf(stderr, "%s", msg.c_str());
     LOG_TRC(msg);

--- a/net/Buffer.hpp
+++ b/net/Buffer.hpp
@@ -37,6 +37,7 @@ public:
     typedef std::vector<char>::const_iterator const_iterator;
 
     std::size_t size() const { return _buffer.size() - _offset; }
+    std::size_t capacity() const { return _buffer.capacity(); }
     bool empty() const { return _offset == _buffer.size(); }
 
     const char *getBlock() const

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1019,10 +1019,11 @@ void StreamSocket::dumpState(std::ostream& os)
 {
     int64_t timeoutMaxMicroS = SocketPoll::DefaultPollTimeoutMicroS.count();
     const int events = getPollEvents(std::chrono::steady_clock::now(), timeoutMaxMicroS);
-    os << '\t' << std::setw(6) << getFD() << "\t0x" << std::hex << events << std::dec << '\t'
-       << (ignoringInput() ? "ignore\t" : "process\t") << std::setw(6) << _inBuffer.size() << '\t'
-       << std::setw(6) << _outBuffer.size() << '\t' << " r: " << std::setw(6) << bytesRcvd()
-       << "\t w: " << std::setw(6) << bytesSent() << '\t' << clientAddress() << '\t';
+    os << '\t' << std::setw(6) << getFD() << "\t0x" << std::hex << events << std::dec
+       << (ignoringInput() ? "\t\tignore\t" : "\t\tprocess\t") << std::setw(7) << _inBuffer.size()
+       << '\t' << std::setw(7) << _inBuffer.capacity() << '\t' << std::setw(6) << _outBuffer.size()
+       << '\t' << std::setw(7) << _outBuffer.capacity() << '\t' << " r: " << std::setw(6)
+       << bytesRcvd() << "\t w: " << std::setw(6) << bytesSent() << '\t' << clientAddress() << '\t';
     _socketHandler->dumpState(os);
     if (_inBuffer.size() > 0)
         Util::dumpHex(os, _inBuffer, "\t\tinBuffer:\n", "\t\t");
@@ -1080,7 +1081,8 @@ void SocketPoll::dumpState(std::ostream& os) const
     const auto callbacks = _newCallbacks.size();
     if (callbacks > 0)
         os << "\tcallbacks: " << callbacks << '\n';
-    os << "\t    fd\tevents\trbuffered\twbuffered\trtotal\twtotal\tclientaddress\n";
+    os << "\t\tfd\tevents\tstatus\trbuffered\trcapacity\twbuffered\twcapacity\trtotal\twtotal\tclie"
+          "ntaddress\n";
     for (const std::shared_ptr<Socket>& socket : pollSockets)
         socket->dumpState(os);
     os << "\n  Done [" << name() << "]\n";

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -999,7 +999,7 @@ void SocketDisposition::execute()
     }
 }
 
-void WebSocketHandler::dumpState(std::ostream& os, const std::string& /*indent*/) const
+void WebSocketHandler::dumpState(std::ostream& os, const std::string& indent) const
 {
     os << (_shuttingDown ? "shutd " : "alive ");
 #if !MOBILEAPP
@@ -1010,7 +1010,7 @@ void WebSocketHandler::dumpState(std::ostream& os, const std::string& /*indent*/
     os << '\n';
     if (_msgHandler)
     {
-        os << "msgHandler:\n";
+        os << indent << "msgHandler:\n";
         _msgHandler->dumpState(os);
     }
 }

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -592,7 +592,7 @@ public:
 
     virtual void getIOStats(uint64_t &sent, uint64_t &recv) = 0;
 
-    void dumpState(std::ostream& os) const { dumpState(os, "\n"); }
+    void dumpState(std::ostream& os) const { dumpState(os, "\n\t"); }
 
     /// Append pretty printed internal state to a line
     virtual void dumpState(std::ostream& os, const std::string& indent) const

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4046,7 +4046,7 @@ public:
         std::string version, hash;
         Util::getVersionInfo(version, hash);
 
-        os << "COOLWSDServer: " << version << " - " << hash
+        os << "COOLWSDServer: " << version << " - " << hash << " state dumping"
 #if !MOBILEAPP
            << "\n  Kit version: " << COOLWSD::LOKitVersion
            << "\n  Ports: server " << ClientPortNumber << " prisoner " << MasterLocation
@@ -4059,7 +4059,7 @@ public:
 #endif
            << "\n  TerminationFlag: " << SigUtil::getTerminationFlag()
            << "\n  isShuttingDown: " << SigUtil::getShutdownRequestFlag()
-           << "\n  NewChildren: " << NewChildren.size()
+           << "\n  NewChildren: " << NewChildren.size() << " (" << NewChildren.capacity() << ')'
            << "\n  OutstandingForks: " << OutstandingForks
            << "\n  NumPreSpawnedChildren: " << COOLWSD::NumPreSpawnedChildren
            << "\n  ChildSpawnTimeoutMs: " << ChildSpawnTimeoutMs

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4959,6 +4959,10 @@ void dump_state()
 #if !MOBILEAPP
     Admin::dumpMetrics();
 #endif
+
+    std::lock_guard<std::mutex> docBrokerLock(DocBrokersMutex);
+    std::lock_guard<std::mutex> newChildLock(NewChildrenMutex);
+    forwardSignal(SIGUSR1);
 }
 
 void lslr_childroot()

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4940,6 +4940,8 @@ void alertAllUsers(const std::string& msg)
 
 #endif
 
+void forwardSignal(const int signum);
+
 void dump_state()
 {
     std::ostringstream oss;
@@ -4976,11 +4978,21 @@ void forwardSigUsr2()
     Util::assertIsLocked(DocBrokersMutex);
     std::lock_guard<std::mutex> newChildLock(NewChildrenMutex);
 
+    forwardSignal(SIGUSR2);
+}
+
+void forwardSignal(const int signum)
+{
+    const char* name = SigUtil::signalName(signum);
+
+    Util::assertIsLocked(DocBrokersMutex);
+    Util::assertIsLocked(NewChildrenMutex);
+
 #if !MOBILEAPP
     if (COOLWSD::ForKitProcId > 0)
     {
-        LOG_INF("Sending SIGUSR2 to forkit " << COOLWSD::ForKitProcId);
-        ::kill(COOLWSD::ForKitProcId, SIGUSR2);
+        LOG_INF("Sending " << name << " to forkit " << COOLWSD::ForKitProcId);
+        ::kill(COOLWSD::ForKitProcId, signum);
     }
 #endif
 
@@ -4988,8 +5000,8 @@ void forwardSigUsr2()
     {
         if (child && child->getPid() > 0)
         {
-            LOG_INF("Sending SIGUSR2 to child " << child->getPid());
-            ::kill(child->getPid(), SIGUSR2);
+            LOG_INF("Sending " << name << " to child " << child->getPid());
+            ::kill(child->getPid(), signum);
         }
     }
 
@@ -4998,8 +5010,8 @@ void forwardSigUsr2()
         std::shared_ptr<DocumentBroker> docBroker = pair.second;
         if (docBroker)
         {
-            LOG_INF("Sending SIGUSR2 to docBroker " << docBroker->getPid());
-            ::kill(docBroker->getPid(), SIGUSR2);
+            LOG_INF("Sending " << name << " to docBroker " << docBroker->getPid());
+            ::kill(docBroker->getPid(), signum);
         }
     }
 }

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4107,33 +4107,37 @@ public:
         os << "\nServer poll:\n";
         _acceptPoll.dumpState(os);
 
-        os << "Web Server poll:\n";
+        os << "\nWeb Server poll:\n";
         WebServerPoll->dumpState(os);
 
-        os << "Prisoner poll:\n";
+        os << "\nPrisoner poll:\n";
         PrisonerPoll->dumpState(os);
 
 #if !MOBILEAPP
-        os << "Admin poll:\n";
+        os << "\nAdmin poll:\n";
         _admin.dumpState(os);
 
         // If we have any delaying work going on.
+        os << '\n';
         Delay::dumpState(os);
 
         // If we have any DNS work going on.
+        os << '\n';
         net::AsyncDNS::dumpState(os);
 
+        os << '\n';
         COOLWSD::SavedClipboards->dumpState(os);
 #endif
 
-        os << "Document Broker polls "
-                  << "[ " << DocBrokers.size() << " ]:\n";
+        os << "\nDocument Broker polls " << "[ " << DocBrokers.size() << " ]:\n";
         for (auto &i : DocBrokers)
             i.second->dumpState(os);
 
 #if !MOBILEAPP
-        os << "Converter count: " << ConvertToBroker::getInstanceCount() << '\n';
+        os << "\nConverter count: " << ConvertToBroker::getInstanceCount() << '\n';
 #endif
+
+        os << "\nDone COOLWSDServer state dumping.\n";
 
         Socket::InhibitThreadChecks = false;
         SocketPoll::InhibitThreadChecks = false;

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4947,8 +4947,11 @@ void dump_state()
     if (Server)
         Server->dumpState(oss);
 
+    oss << "\nMalloc info: \n" << Util::getMallocInfo() << '\n';
+
     const std::string msg = oss.str();
     fprintf(stderr, "%s\n", msg.c_str());
+
     LOG_TRC(msg);
 
 #if !MOBILEAPP


### PR DESCRIPTION
Better formatting of `dumpState()` and more memory stats included. Also, we now forward SIGUSR1 to the child processes, to get their memory stats and other info.

- wsd: better dumpState formatting
- wsd: dump malloc-info with USR1
- wsd: refactor forwarding a signal to our children
- wsd: forward SIGUSR1 to children
- wsd: unify dump_malloc_state with getMallocInfo
- wsd: dump malloc_info in the children
