### PR TITLE
wsd: use the 'flush' logging property to disable buffering

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -622,7 +622,17 @@ namespace Log
         }
         else
         {
-            channel = static_cast<Poco::Channel*>(new Log::BufferedConsoleChannel());
+            const auto it = config.find("flush");
+            if (it != config.end() && Util::toLower(it->second) != "false")
+            {
+                // Buffered logging, reduces number of write(2) syscalls.
+                channel = static_cast<Poco::Channel*>(new Log::BufferedConsoleChannel());
+            }
+            else
+            {
+                // Unbuffered logging, directly writes each entry (to stderr).
+                channel = static_cast<Poco::Channel*>(new Log::ConsoleChannel());
+            }
         }
 
         /**


### PR DESCRIPTION
In some cases it's benefitial to disable buffered-
logging and flush after each entry is generated.

We already have an unbuffered logger and a
property, called 'flush', already exists and
is used by Poco to also disable buffering its
file-logger.

We leverage this property to disable buffering
in both the console logger (this patch), as well
as in Poco's file-logger (existing functionality).

Change-Id: I5e3b75e66f82a8a5df57901ef4f6c8264aee3565
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
