### PR TITLE
cool#9992 doc sign: fix handling of saveas options containing spaces

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2759,7 +2759,8 @@ bool ChildSession::saveAs(const StringVector& tokens)
     {
         if (tokens.size() > 4)
         {
-            filterOptions += tokens.cat(' ', 4);
+            // Syntax is options=<options>, and <options> may contain spaces, account for that.
+            filterOptions += " " + tokens.cat(' ', 4);
         }
     }
 


### PR DESCRIPTION
Trying to create signed PDFs during ODT->PDF conversion, a signature is
created, but it's not valid. The first trouble noticed while
investigating is that the load option we get is like this:

debug:666:660: doc_saveAs: pFilterOptions is '{"SignPDF":{"type":"boolean","value":"true"},"SignCertificateCaPem":{"type":"string","value":"-----BEGINCERTIFICATE-----

While this should be '-----BEGIN CERTIFICATE-----', since the syntax is
"load ... [options=<options>]".

Fix the problem in ChildSession::saveAs(), where a space was lost while
"load ... options=foo bar" was tokenized as "load", "...", "options=foo"
and "bar", and later we constructed <options> as "foobar", not "foo
bar".

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ibadcb3218d8776191193ca13788cfca4a8d1e11d
