### PR TITLE
cool#9992 doc sign: add menu item for the compact UI

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -95,6 +95,7 @@ L.Control.Menubar = L.Control.extend({
 					{name: _('EPUB (.epub)'), id: !window.ThisIsAMobileApp ? 'exportepub' : 'downloadas-epub', type: 'action'},
 					{name: _('HTML file (.html)'), id: 'downloadas-html', type: 'action'}]},
 				{name: _UNO('.uno:SetDocumentProperties', 'text'), uno: '.uno:SetDocumentProperties', id: 'properties'},
+				{name: _UNO('.uno:Signature', 'text'), uno: '.uno:Signature', id: 'signature'},
 				{type: 'separator'},
 				{name: L.Control.MenubarShortcuts.addShortcut(_UNO('.uno:Print', 'text'), L.Control.MenubarShortcuts.shortcuts.PRINT), id: 'print', type: 'action'},
 				{name: _('Close document'), id: 'closedocument', type: 'action'}
@@ -417,6 +418,7 @@ L.Control.Menubar = L.Control.extend({
 					{name: _('Current slide as Tag Image File Format (.tiff)'), id: 'downloadas-tiff', type: 'action'},
 				]},
 				{name: _UNO('.uno:SetDocumentProperties', 'presentation'), uno: '.uno:SetDocumentProperties', id: 'properties'},
+				{name: _UNO('.uno:Signature', 'presentation'), uno: '.uno:Signature', id: 'signature'},
 				{type: 'separator'},
 				{name: L.Control.MenubarShortcuts.addShortcut(_UNO('.uno:Print', 'presentation'), L.Control.MenubarShortcuts.shortcuts.PRINT), id: 'print', type: 'menu', menu: [
 					{name: _('Full Page Slides'), id: 'print', type: 'action'},
@@ -578,6 +580,7 @@ L.Control.Menubar = L.Control.extend({
 					{name: _('ODF Drawing (.odg)'), id: 'downloadas-odg', type: 'action'}
 				]},
 				{name: _UNO('.uno:SetDocumentProperties', 'presentation'), uno: '.uno:SetDocumentProperties', id: 'properties'},
+				{name: _UNO('.uno:Signature', 'presentation'), uno: '.uno:Signature', id: 'signature'},
 				{type: 'separator'},
 				{name: _('Close document'), id: 'closedocument', type: 'action'}
 			]},
@@ -717,6 +720,7 @@ L.Control.Menubar = L.Control.extend({
 					{name: _('CSV file (.csv)'), id: 'downloadas-csv', type: 'action'},
 					{name: _('HTML file (.html)'), id: 'downloadas-html', type: 'action'}]},
 				{name: _UNO('.uno:SetDocumentProperties', 'spreadsheet'), uno: '.uno:SetDocumentProperties', id: 'properties'},
+				{name: _UNO('.uno:Signature', 'spreadsheet'), uno: '.uno:Signature', id: 'signature'},
 				{type: 'separator'},
 				{name: L.Control.MenubarShortcuts.addShortcut(_UNO('.uno:Print', 'spreadsheet'), L.Control.MenubarShortcuts.shortcuts.PRINT), id: 'print', type: 'menu', menu: [
 					{name: _('Active sheet'), id: 'print-active-sheet', type: 'action'},

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -292,7 +292,24 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 						'accessibility': { focusBack: true, combination: 'FP', de: null }
 					}
 				]
-			},
+			});
+		if (window.documentSigningEnabled) {
+			content.push(
+				{
+					'type': 'container',
+					'children': [
+						{
+							'id': 'signature',
+							'type': 'bigtoolitem',
+							'text': _('Signature'),
+							'command': '.uno:Signature',
+							'accessibility': { focusBack: true, combination: 'SN' }
+						}
+					]
+				}
+			);
+		}
+		content.push(
 			{
 				'type': 'container',
 				'children': [


### PR DESCRIPTION
Open Writer, switch to the compact (menu-based) UI, notice the file menu
has no entry to add a signature.

This is primarily interesting as notebookbar is our default, but PDF
files are still opened in compact & read-only mode by default.

Fix the problem by adding a menu entry to all 4 components in the menu
bar, at a position similar to the desktop.

Also the notebookbar button was missing for the Draw case, fix that.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I9af4e42d11f4717a3ab6c5e25b237dd35c407410
