### PR TITLE
setWopiFileInfo takes ownership of its arg

### DIFF
--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -178,7 +178,7 @@ public:
     }
 
     /// Set WOPI fileinfo object
-    void setWopiFileInfo(std::unique_ptr<WopiStorage::WOPIFileInfo>& wopiFileInfo) { _wopiFileInfo = std::move(wopiFileInfo); }
+    void setWopiFileInfo(std::unique_ptr<WopiStorage::WOPIFileInfo> wopiFileInfo) { _wopiFileInfo = std::move(wopiFileInfo); }
 
     /// Get requested tiles waiting for sending to the client
     std::deque<TileDesc>& getRequestedTiles() { return _requestedTiles; }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1430,7 +1430,7 @@ DocumentBroker::updateSessionWithWopiInfo(const std::shared_ptr<ClientSession>& 
     }
 
     // Pass the ownership to the client session.
-    session->setWopiFileInfo(wopiFileInfo);
+    session->setWopiFileInfo(std::move(wopiFileInfo));
     session->setUserId(userId);
     session->setUserName(username);
     session->setUserExtraInfo(userExtraInfo);


### PR DESCRIPTION
make this more clear with a more typical explicit std::move pattern


Change-Id: I8dc7da1af59c6aa09c608d3cbfcd2c9167eab418


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

