### PR TITLE
cool#9992 doc sign: add UI to sign PDF files

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1363,6 +1363,11 @@ L.Control.Menubar = L.Control.extend({
 		// Only these menu options will be visible in readonly mode
 		allowedReadonlyMenus: ['file', 'downloadas', 'view', 'insert', 'slide', 'help'],
 
+		// Only these UNO commands will be enabled in readonly mode
+		allowedViewModeCommands: [
+			'.uno:Signature',
+		],
+
 		allowedViewModeActions: [
 			() => app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).hasAnyComments() ? 'savecomments' : undefined,
 			'shareas', 'print', // file menu
@@ -1723,6 +1728,7 @@ L.Control.Menubar = L.Control.extend({
 			var aItem = this;
 			var type = $(aItem).data('type');
 			var id = $(aItem).data('id');
+			let uno = $(aItem).data('uno');
 			var constChecked = 'lo-menu-item-checked';
 			if (self._map.isEditMode()) {
 				if (type === 'unocommand') { // enable all depending on stored commandStates
@@ -1874,8 +1880,12 @@ L.Control.Menubar = L.Control.extend({
 				}
 			} else { // eslint-disable-next-line no-lonely-if
 				if (type === 'unocommand') { // disable all uno commands
-					$(aItem).addClass('disabled');
-					aItem.title = _('Read-only mode');
+					// Except the ones listed in allowedViewModeCommands:
+					let allowed = self.options.allowedViewModeCommands.includes(uno);
+					if (!allowed) {
+						$(aItem).addClass('disabled');
+						aItem.title = _('Read-only mode');
+					}
 				} else if (type === 'action') { // disable all except allowedViewModeActions
 					var found = false;
 					for (var i in self.options.allowedViewModeActions) {

--- a/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
@@ -13,25 +13,21 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 
 	it('Add File Description.', function() {
 		writerHelper.openFileProperties();
+		// Too early click on the 'Description' button would have no effect.
+		cy.wait(500);
 		cy.cGet('#tabcontrol-2').click();
 		helper.waitUntilIdle('#title-input.ui-edit');
 		cy.cGet('#title-input.ui-edit').type('New Title');
 		// sometimes it doesn't finish typing
 		helper.waitUntilIdle('#title-input.ui-edit');
 
-		// Fixme: type now char by char because we receive update messages
-		//        can be reverted after core update
-		cy.cGet('#comments.ui-textarea').type('N');
-		cy.wait(500);
-		cy.cGet('#comments.ui-textarea').type('e');
-		cy.wait(500);
-		cy.cGet('#comments.ui-textarea').type('w');
-		cy.wait(500);
+		cy.cGet('#comments.ui-textarea').type('New');
 
 		helper.waitUntilIdle('#comments.ui-textarea');
 		cy.cGet('#ok.ui-pushbutton').click();
 		writerHelper.openFileProperties();
 
+		cy.wait(500);
 		cy.cGet('#tabcontrol-2').click();
 		cy.cGet('#title-input.ui-edit').should('have.value', 'New Title');
 		cy.cGet('#comments.ui-textarea').should('have.value', 'New');


### PR DESCRIPTION
Open a PDF file, it is loaded into a read-only Draw view, so the File
menu has no signing menu item to sign the document.

There are some menu items, but all of those are actions, and one of
those are inserting a comment: so probably the intent is to avoid not
necessary modifications to the PDF file (like delete the only bitmap on
the draw page), than to actually avoid modifying the document.

Similar to how we have an allowlist for actions, add an allowlist for
UNO commands which are OK to dispatch in read-only mode: just have the
signature command there for now.

In the future, we may want to revisit this to also have a more strict
read-only mode without commenting/signing, but treating signing similar
to commenting is probably good enough for now.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ib3b396f110cd2d99dbb5d4704f5733bb135f891e
