### PR TITLE
Use 10 characters for short git hash

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -434,10 +434,10 @@ noinst_HEADERS = $(wsd_headers) $(shared_headers) $(kit_headers) \
                  test/helpers.hpp
 
 GIT_BRANCH := $(shell git symbolic-ref --short HEAD)
-GIT_HASH := $(shell git log -1 --format=%h)
+GIT_HASH := $(shell git log -1 --format=%h --abbrev=10)
 
 dist-hook:
-	git log -1 --format=%h > $(distdir)/dist_git_hash 2> /dev/null || rm $(distdir)/dist_git_hash
+	git log -1 --format=%h --abbrev=10 > $(distdir)/dist_git_hash 2> /dev/null || rm $(distdir)/dist_git_hash
 	mkdir -p $(distdir)/bundled/include/LibreOfficeKit/
 	cp @LOKIT_PATH@/LibreOfficeKit/LibreOfficeKit.h \
 	   @LOKIT_PATH@/LibreOfficeKit/LibreOfficeKit.hxx \

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -568,7 +568,7 @@ COOL_ASSERT_INTERSECT = $(filter $(COOL_JS_SRC), $(patsubst %.ts,%.js,$(COOL_TS_
 COMMA := ,
 EMPTY :=
 SPACE := $(EMPTY) $(EMPTY)
-COOL_VERSION = $(shell cd $(srcdir) && git log -1 --pretty=format:"%h")
+COOL_VERSION = $(shell cd $(srcdir) && git log -1 --format=%h --abbrev=10)
 INTERMEDIATE_DIR ?= $(if $(IS_SEPARATE),$(abs_builddir)/debug,$(abs_builddir)/release)
 
 EXTRA_DIST = $(shell find . -type f -not -path './.git/*' -not -path './node_modules/*' -not -path './l10n/*' | sed 's/.\///')

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AC_DEFINE_UNQUOTED([COOLWSD_VERSION],[["$COOLWSD_VERSION"]],[Collabora Online We
 
 # try to add a git hash for a version if we're developing
 COOLWSD_VERSION_HASH="$COOLWSD_VERSION"
-git_hash=`cd ${srcdir} && ( cat dist_git_hash 2> /dev/null || git log -1 --format=%h 2> /dev/null )`
+git_hash=`cd ${srcdir} && ( cat dist_git_hash 2> /dev/null || git log -1 --format=%h --abbrev=10 2> /dev/null )`
 if test "z$git_hash" != "z"; then
    COOLWSD_VERSION_HASH=$git_hash
 fi


### PR DESCRIPTION
In release build only 8 character long hash was generated, and it turned out that it was too short. For example the link in About box did not work:
- https://github.com/CollaboraOnline/online/commits/778b9f6 
But a longer hash would have worked:
- https://github.com/CollaboraOnline/online/commits/778b9f619

Change-Id: I5b24d7dcc4ef30acac49b7c8d72f2eca55880aed
