### PR TITLE
Ignore empty CanvasTileLayer transactions

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4001,8 +4001,16 @@ L.CanvasTileLayer = L.Layer.extend({
 			return;
 		}
 
+		--this._inTransaction;
+
+		// Ignore transactions that did nothing
+		if (this._pendingDeltas.length === 0 && !this._hasPendingTransactions()) {
+			if (callback) callback();
+			return;
+		}
+
 		this._transactionCallbacks.push(callback);
-		if (--this._inTransaction !== 0)
+		if (this._inTransaction !== 0)
 			return;
 
 		try {
@@ -4784,7 +4792,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		// be sure canvas is initialized already, has correct size and that we aren't
 		// currently processing a transaction
 		var size = map.getSize();
-		if (size.x === 0 || size.y === 0 || this._hasPendingTransactions()) {
+		if (size.x === 0 || size.y === 0) {
 			setTimeout(function () { this._update(); }.bind(this), 1);
 			return;
 		}


### PR DESCRIPTION
This cuts down on unnecessary messages to the worker and fixes black flashing when opening/closing the sidebar caused by a delayed resumeDrawing.


Change-Id: I64cf0f28308ae41439839c0633f538269b686b0c


* Resolves: #10434
* Target version: master 

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

