### PR TITLE
fix(worker): Exclude from mobile app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ browser/admin/jsconfig.json
 browser/dist
 browser/compilets
 browser/typescript_js
+browser/src/layer/tile/CanvasTileWorker.js
 
 coolforkit
 coolforkitns

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -729,7 +729,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._pendingDeltas = [];
 		this._transactionCallbacks = [];
 
-		if (window.Worker) {
+		if (window.Worker && !window.ThisIsAMobileApp) {
 			window.app.console.info('Creating CanvasTileWorker');
 			this._worker = new Worker('src/layer/tile/CanvasTileWorker.js');
 			this._worker.addEventListener('message', (e) => this._onWorkerMessage(e));


### PR DESCRIPTION
Since Ia685a7396372967888a59cf579df49035c18eb32, we've been trying to
start a web worker if there was a window.Worker object available in the
browser...

The mobile apps can't support the worker (due to csp of file://
addresses), but also *do* have a window.Worker object. This caused a
load failure on entering any document

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: Icee556ba6da9c6be79c1bb63e2c0cd74bdb9d100