### PR TITLE
Hiding server signature

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1742,7 +1742,7 @@ std::string getServerString()
     if (sig)
         return "COOLWSD HTTP Server " + Util::getCoolVersion();
 
-    return "COOLWSD HTTP Server";
+    return " ";
 }
 }
 


### PR DESCRIPTION
We were advised to hide not only version number but the 'COOLWSD HTTP Server' string, too.


Change-Id: I5f737405c4f44c18cc033ef634ce363e5c9a74ea
