### PR TITLE
kit: fix div by zero in ChildSession::renderWindow()

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2482,7 +2482,7 @@ bool ChildSession::renderWindow(const StringVector& tokens)
     const double elapsedMics = elapsedMs.count() * 1000.; // Need MPixels/second, use Pixels/mics.
     LOG_TRC("paintWindow for " << winId << " returned " << width << 'X' << height << "@(" << startX
                                << ',' << startY << ',' << " with dpi scale: " << dpiScale
-                               << " and rendered in " << elapsedMs << " (" << area / elapsedMics
+                               << " and rendered in " << elapsedMs << " (" << (elapsedMics ? area / elapsedMics : 0)
                                << " MP/s).");
 
     uint64_t pixmapHash = hashSubBuffer(pixmap.data(), 0, 0, width, height, bufferWidth, bufferHeight) + getViewId();


### PR DESCRIPTION
Running 'make -C cypress_test check-desktop' in a san environment and
checking cypress_test/cypress/wsd_logs/coolwsd_output.log after the run
contains:

kit/ChildSession.cpp:2482:5: runtime error: division by zero

If the rendering is fast enough that we round the cost of it to 0, then
avoid the division by zero.

This typically doesn't affect production setups, since the log is only
for trace level.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I19285a8b21f5b5594d7e9a2df6ae19e2c1e43f8a
