### PR TITLE
backport: feat(touch): Determine last-used input method

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -497,12 +497,10 @@ L.TextInput = L.Layer.extend({
 
 		// Move and display under-caret marker
 
-		if (window.touch.hasAnyTouchscreen()) {
-			if (this._map._docLayer._textCSelections.empty()) {
-				this._cursorHandler.setLatLng(bottom).addTo(this._map);
-			} else {
-				this._map.removeLayer(this._cursorHandler);
-			}
+		if (window.touch.currentlyUsingTouchscreen() && this._map._docLayer._textCSelections.empty()) {
+			this._cursorHandler.setLatLng(bottom).addTo(this._map);
+		} else {
+			this._map.removeLayer(this._cursorHandler);
 		}
 
 		// Move the hidden text area with the cursor

--- a/browser/src/layer/vector/CPath.ts
+++ b/browser/src/layer/vector/CPath.ts
@@ -262,7 +262,14 @@ abstract class CPath extends CEventsHandler {
 
 	clickTolerance(): number {
 		// used when doing hit detection for Canvas layers
-		return (this.stroke ? this.weight / 2 : 0) + ((window as typeof window & { touch: any; }).touch.hasAnyTouchscreen() ? 10 : 0);
+		return (
+			(this.stroke ? this.weight / 2 : 0) +
+			((
+				window as typeof window & { touch: any }
+			).touch.currentlyUsingTouchscreen()
+				? 10
+				: 0)
+		);
 	}
 
 	setCursorType(cursorType: string) {

--- a/browser/src/layer/vector/Path.js
+++ b/browser/src/layer/vector/Path.js
@@ -81,7 +81,10 @@ L.Path = L.Layer.extend({
 
 	_clickTolerance: function () {
 		// used when doing hit detection for Canvas layers
-		return (this.options.stroke ? this.options.weight / 2 : 0) + (window.touch.hasAnyTouchscreen() ? 10 : 0);
+		return (
+			(this.options.stroke ? this.options.weight / 2 : 0) +
+			(window.touch.currentlyUsingTouchscreen() ? 10 : 0)
+		);
 	},
 
 	addPathNode: function (pathNode, actualRenderer) {


### PR DESCRIPTION
Previously, when we wanted to determine if some touch UI should be shown
we would check if there were any touchscreens on the system. This is
still used in some places, but it turns out that this is poor in many
cases (a key example would be the cursor droplet, which showed on
touchscreen laptops even when the touchscreen was not being used, for
example).

You might think that this problem is easily solved: "Just check if the
thing that clicked into the document was a touchscreen, and only show
the droplet then". We can't, however, trivially detect if the input that
caused the cursor to show was from a touchscreen as we roundtrip through
core before showing the cursor. This sort of property (hard to get a
triggering event) holds true for the other events we were using
hasAnyTouchscreen for previously.

Instead, we can listen to *all* mouse or tap events, and change our
behavior based on whatever was triggered last. This isn't quite the
"triggering event" behavior (e.g. if we close a jsdialog with a
touchscreen we will get a droplet cursor, when arguably we might not
want that) but it'll be the same a vast majority of the time (and I am
undecided on whether this behavior is in-fact preferable in the cases
where it differs)

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: I88f7936495415ad04012fa998b1bd242b3bd8f5b