### PR TITLE
Don't update the render state if the payload is empty.

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1179,8 +1179,11 @@ void Document::trimAfterInactivity()
             std::shared_ptr<ChildSession> session = document->findSessionByViewId(descriptor->getViewId());
             if (session)
             {
-                session->setViewRenderState(payload);
-                document->invalidateCanonicalId(session->getId());
+                if (!payload.empty())
+                {
+                    session->setViewRenderState(payload);
+                    document->invalidateCanonicalId(session->getId());
+                }
             }
             else
             {


### PR DESCRIPTION
When switching between views, new pages may be created and old ones may get deleted. In this case, some pointers are null. Check "DrawViewShell not available!" warning on the core side. This null pointer causes render state payload to be empty. Empty payload is not correct value for client side renderState parameter.


Change-Id: I08af6208807e0dc38538b85539dd992bb166695c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

