### PR TITLE
Add concurrent TCP connections to 'getMetrics' REST endpoint

### DIFF
--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -1211,6 +1211,7 @@ void Admin::getMetrics(std::ostringstream &metrics)
     size_t memUsed = getTotalMemoryUsage();
 
     metrics << "global_host_system_memory_bytes " << _totalSysMemKb * 1024 << std::endl;
+    metrics << "global_host_tcp_connections " << net::Defaults.maxExtConnections << std::endl;
     metrics << "global_memory_available_bytes " << memAvail * 1024 << std::endl;
     metrics << "global_memory_used_bytes " << memUsed * 1024 << std::endl;
     metrics << "global_memory_free_bytes " << (memAvail - memUsed) * 1024 << std::endl;

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -1133,6 +1133,7 @@ void AdminModel::getMetrics(std::ostringstream &oss)
     oss << "coolwsd_thread_count " << Util::getStatFromPid(getpid(), 19) << std::endl;
     oss << "coolwsd_cpu_time_seconds " << Util::getCpuUsage(getpid()) / sysconf (_SC_CLK_TCK) << std::endl;
     oss << "coolwsd_memory_used_bytes " << Util::getMemoryUsagePSS(getpid()) * 1024 << std::endl;
+    oss << "coolwsd_tcp_connections_used " << StreamSocket::getExternalConnectionCount() << std::endl;
     oss << std::endl;
 
     oss << "forkit_count " << getPidsFromProcName(std::regex("forkit"), nullptr) << std::endl;

--- a/wsd/metrics.txt
+++ b/wsd/metrics.txt
@@ -5,6 +5,7 @@ which can be found here: https://prometheus.io/docs/instrumenting/exposition_for
 GLOBAL
 
     global_host_system_memory_bytes - Total host system memory in bytes.
+    global_host_tcp_connections - Configured maximum number of concurrent TCP connections.
     global_memory_available_bytes – Memory available to our application in bytes. This is equal to global_host_system_memory_bytes * memproportion where memproportion represents the maximum percentage of system memory consumed by all of the Collabora Online, after which we start cleaning up idle documents. This parameter can be setup in coolwsd.xml.
     global_memory_used_bytes – Total memory usage: PSS(coolwsd) + RSS(forkit) + Private_Dirty(all assigned coolkits).
     global_memory_free_bytes - global_memory_available_bytes - global_memory_used_bytes
@@ -15,6 +16,7 @@ COOLWSD
     coolwsd_thread_count – number of threads in the current coolwsd process.
     coolwsd_cpu_time_seconds – the CPU usage by current coolwsd process.
     coolwsd_memory_used_bytes – the memory used by current coolwsd process: PSS(coolwsd).
+    coolwsd_tcp_connections_used - number of used TCP connections.
 
 FORKIT
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Add max/used concurrent TCP connections to Prometheus text-based 'getMetrics' REST endpoint

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

