### PR TITLE
Add (external) connections stats to #NetVisualisation graph

### DIFF
--- a/browser/admin/src/Util.js
+++ b/browser/admin/src/Util.js
@@ -31,6 +31,37 @@ var Util = Base.extend({
 		return kbytes.toFixed(1) + ' ' + units[i];
 	},
 
+    /// Return human readable quantity with added multiple, percentage (1/100) or permyriad (1/10'000) to maximum, if maximum > 1.
+    humanizeQty: function (quantity, maximum) {
+        var qtyPrecision = 1;
+        var pct_s = '';
+        if (maximum > 1) {
+            qtyPrecision = 0;
+            var pct = ( 100 * quantity ) / maximum;
+            if( pct > 100 ) {
+                pct = quantity / maximum;
+                pct_s = ', ' + pct.toFixed(1) + 'x';
+            } else if( pct >= 10 ) {
+                pct_s = ', ' + pct.toFixed(0) + '%';
+            } else if( pct >= 0.1 ) {
+                pct_s = ', ' + pct.toFixed(1) + '%';
+            } else {
+                pct = ( 10000 * quantity ) / maximum;
+                if( pct >= 10 ) {
+                    pct_s = ', ' + pct.toFixed(0) + '‱';
+                } else {
+                    pct_s = ', ' + pct.toFixed(1) + '‱';
+                }
+            }
+        }
+        var unit = 1000;
+        var units = [_(''), ('k'), _('M'), _('G'), _('T'), _('P'), _('E'), _('Z'), _('Y'), _('B')];
+        for (var i = 0; Math.abs(quantity) >= unit && i < units.length; i++) {
+            quantity /= unit;
+        }
+        return quantity.toFixed(qtyPrecision) + units[i] + pct_s;
+    },
+
 	humanizeSecs: function(secs) {
 		var mins = 0;
 		var hrs = 0;

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -122,7 +122,8 @@ void AdminSocketHandler::handleMessage(const std::vector<char> &payload)
              tokens.equals(0, "mem_stats") ||
              tokens.equals(0, "cpu_stats") ||
              tokens.equals(0, "sent_activity") ||
-             tokens.equals(0, "recv_activity"))
+             tokens.equals(0, "recv_activity") ||
+             tokens.equals(0, "connection_activity"))
     {
         const std::string result = model.query(tokens[0]);
         if (!result.empty())
@@ -219,7 +220,9 @@ void AdminSocketHandler::handleMessage(const std::vector<char> &payload)
             << "cpu_stats_size="  << model.query("cpu_stats_size") << ' '
             << "cpu_stats_interval=" << std::to_string(_admin->getCpuStatsInterval()) << ' '
             << "net_stats_size=" << model.query("net_stats_size") << ' '
-            << "net_stats_interval=" << std::to_string(_admin->getNetStatsInterval()) << ' ';
+            << "net_stats_interval=" << std::to_string(_admin->getNetStatsInterval()) << ' '
+            << "connection_stats_size=" << model.query("connection_stats_size") << ' '
+            << "global_host_tcp_connections=" << net::Defaults.maxExtConnections << ' ';
 
         const DocProcSettings& docProcSettings = _admin->getDefDocProcSettings();
         oss << "limit_virt_mem_mb=" << docProcSettings.getLimitVirtMemMb() << ' '
@@ -659,6 +662,7 @@ void Admin::pollingThread()
 
             _model.addSentStats(sentCount - _lastSentCount);
             _model.addRecvStats(recvCount - _lastRecvCount);
+            _model.addConnectionStats(StreamSocket::getExternalConnectionCount());
 
             if (_lastRecvCount != recvCount || _lastSentCount != sentCount)
             {

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -277,6 +277,14 @@ std::string AdminModel::query(const std::string& command)
     {
         return std::to_string(std::max(_sentStatsSize, _recvStatsSize));
     }
+    else if (token == "connection_activity")
+    {
+        return getConnectionActivity();
+    }
+    else if (token == "connection_stats_size")
+    {
+        return std::to_string(_connStatsSize);
+    }
 
     return std::string("");
 }
@@ -408,6 +416,17 @@ void AdminModel::addRecvStats(uint64_t recv)
         _recvStats.pop_front();
 
     notify("recv_activity " + std::to_string(recv));
+}
+
+void AdminModel::addConnectionStats(size_t connections)
+{
+    ASSERT_CORRECT_THREAD_OWNER(_owner);
+
+    _connStats.push_back(connections);
+    if (_connStats.size() > _connStatsSize)
+        _connStats.pop_front();
+
+    notify("connection_activity " + std::to_string(connections));
 }
 
 void AdminModel::setCpuStatsSize(unsigned size)
@@ -688,6 +707,19 @@ std::string AdminModel::getRecvActivity()
 
     std::ostringstream oss;
     for (const auto& i: _recvStats)
+    {
+        oss << i << ',';
+    }
+
+    return oss.str();
+}
+
+std::string AdminModel::getConnectionActivity()
+{
+    ASSERT_CORRECT_THREAD_OWNER(_owner);
+
+    std::ostringstream oss;
+    for (const auto& i: _connStats)
     {
         oss << i << ',';
     }

--- a/wsd/AdminModel.hpp
+++ b/wsd/AdminModel.hpp
@@ -383,6 +383,8 @@ public:
 
     void addRecvStats(uint64_t recv);
 
+    void addConnectionStats(size_t connections);
+
     void setCpuStatsSize(unsigned size);
 
     void setMemStatsSize(unsigned size);
@@ -452,6 +454,8 @@ private:
 
     std::string getRecvActivity();
 
+    std::string getConnectionActivity();
+
     std::string getCpuStats();
 
     unsigned getTotalActiveViews();
@@ -477,6 +481,9 @@ private:
 
     std::list<unsigned> _recvStats;
     unsigned _recvStatsSize = 200;
+
+    std::list<size_t> _connStats;
+    unsigned _connStatsSize = 200;
 
     uint64_t _sentBytesTotal = 0;
     uint64_t _recvBytesTotal = 0;


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary    
Have AdminModel accumulate StreamSocket::getExternalConnectionCount() statistics
in same size and interval as net recv/sent.
    
The added statistic is rendered into the #NetVisualisation graph using a second y-axis on the right.
Here we use a human-readable quantity tick with added multiple, percentage (1/100) or permyriad (1/10'000) to net::Defaults.maxExtConnections.

Graph is accessible via `/browser/dist/admin/adminAnalytics.html#networkview`.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

