### PR TITLE
Misc small fixes to docker build from source

### DIFF
--- a/docker/from-source-gh-action/Dockerfile
+++ b/docker/from-source-gh-action/Dockerfile
@@ -18,8 +18,8 @@ RUN --mount=type=cache,target=/var/cache/apt apt-get update && \
     libcap2-bin python3-lxml libpng-dev libcppunit-dev \
     pkg-config fontconfig snapd chromium-browser \
     rsync curl \
-    # core build dependencies
-    git build-essential zip ccache junit4 libkrb5-dev nasm graphviz python3 python3-dev qtbase5-dev libkf5coreaddons-dev libkf5i18n-dev libkf5config-dev libkf5windowsystem-dev libkf5kio-dev libqt5x11extras5-dev autoconf libcups2-dev libfontconfig1-dev gperf openjdk-17-jdk doxygen libxslt1-dev xsltproc libxml2-utils libxrandr-dev libx11-dev bison flex libgtk-3-dev libgstreamer-plugins-base1.0-dev libgstreamer1.0-dev ant ant-optional libnss3-dev libavahi-client-dev libxt-dev
+    # core build dependencies, only those that are needed for LOKit
+    git build-essential zip ccache autoconf gperf nasm xsltproc flex bison
 
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && bash nodesource_setup.sh && apt install -y nodejs
 

--- a/docker/from-source-gh-action/Dockerfile
+++ b/docker/from-source-gh-action/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /build
 RUN --mount=type=cache,target=/var/cache/apt apt-get update && \
     DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install libpng16-16 fontconfig adduser cpio tzdata \
     findutils nano \
-    libcap2-bin openssl openssh-client inotify-tools procps \
+    libcap2-bin openssl openssh-client \
     libxcb-shm0 libxcb-render0 libxrender1 libxext6 \
     fonts-wqy-zenhei fonts-wqy-microhei fonts-droid-fallback \
     fonts-noto-cjk \
@@ -49,7 +49,7 @@ FROM ubuntu:24.04
 RUN apt-get update \
     && apt-get -y install libpng16-16 fontconfig adduser cpio tzdata \
     findutils nano \
-    libcap2-bin openssl openssh-client inotify-tools procps \
+    libcap2-bin openssl openssh-client \
     libxcb-shm0 libxcb-render0 libxrender1 libxext6 \
     fonts-wqy-zenhei fonts-wqy-microhei fonts-droid-fallback \
     fonts-noto-cjk ca-certificates \

--- a/docker/from-source-gh-action/Dockerfile
+++ b/docker/from-source-gh-action/Dockerfile
@@ -26,9 +26,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh && b
 RUN mkdir -p $BUILDDIR
 
 # Build poco separately to cache it
-ADD https://github.com/pocoproject/poco/archive/poco-1.11.1-release.tar.gz /build/builddir/poco-1.11.1-release.tar.gz
+ADD https://pocoproject.org/releases/poco-1.12.5p2/poco-1.12.5p2-all.tar.gz /build/builddir/poco-1.12.5p2-all.tar.gz
 
-RUN cd builddir && tar xf poco-1.11.1-release.tar.gz && cd poco-poco-1.11.1-release/ && \
+RUN cd builddir && tar xf poco-1.12.5p2-all.tar.gz && cd poco-1.12.5p2-all/ && \
     ./configure --static --no-tests --no-samples --no-sharedlibs --cflags="-fPIC" --omit=Zip,Data,Data/SQLite,Data/ODBC,Data/MySQL,MongoDB,PDF,CppParser,PageCompiler,Redis,Encodings,ActiveRecord --prefix=$BUILDDIR/poco && \
     make -j $(nproc) && \
     make install

--- a/docker/from-source-gh-action/build.sh
+++ b/docker/from-source-gh-action/build.sh
@@ -13,7 +13,7 @@
 
 if [ -z "$CORE_ASSETS" ]; then
   if [ -z "$CORE_BRANCH" ]; then
-    CORE_BRANCH="distro/collabora/co-24.05"
+    CORE_BRANCH="distro/collabora/co-24.04"
   fi;
   echo "Building core branch '$CORE_BRANCH'"
 else

--- a/docker/from-source-gh-action/build.sh
+++ b/docker/from-source-gh-action/build.sh
@@ -112,7 +112,7 @@ fi
 
 # Build online branding if available
 if test -d online-branding ; then
-  npm install -g sass
+  if ! which sass &> /dev/null; then npm install -g sass; fi
   cd online-branding
   ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist 3 # CODE
   ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist 5 # Nextcloud Office

--- a/docker/from-source-gh-action/build.sh
+++ b/docker/from-source-gh-action/build.sh
@@ -46,9 +46,9 @@ mkdir -p "$INSTDIR"
 ##### build static poco #####
 
 if test ! -f poco/lib/libPocoFoundation.a ; then
-    wget https://github.com/pocoproject/poco/archive/poco-1.11.1-release.tar.gz
-    tar -xzf poco-1.11.1-release.tar.gz
-    cd poco-poco-1.11.1-release/
+    wget https://pocoproject.org/releases/poco-1.12.5p2/poco-1.12.5p2-all.tar.gz
+    tar -xzf poco-1.12.5p2-all.tar.gz
+    cd poco-1.12.5p2-all/
     ./configure --static --no-tests --no-samples --no-sharedlibs --cflags="-fPIC" --omit=Zip,Data,Data/SQLite,Data/ODBC,Data/MySQL,MongoDB,PDF,CppParser,PageCompiler,Redis,Encodings,ActiveRecord --prefix=$BUILDDIR/poco
     make -j $(nproc)
     make install

--- a/docker/from-source-gh-action/build.sh
+++ b/docker/from-source-gh-action/build.sh
@@ -114,7 +114,7 @@ fi
 if test -d online-branding ; then
   if ! which sass &> /dev/null; then npm install -g sass; fi
   cd online-branding
-  ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist 3 # CODE
-  ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist 5 # Nextcloud Office
+  ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist CODE # CODE
+  ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist NC-theme-community # Nextcloud Office
   cd ..
 fi

--- a/docker/from-source/ArchLinux
+++ b/docker/from-source/ArchLinux
@@ -7,7 +7,7 @@ FROM archlinux
 RUN pacman -Syu --noconfirm && \
     pacman -S --noconfirm libpng fontconfig cpio \
               nano \
-              openssh inotify-tools \
+              openssh \
               libxcb libxrender libxext \
               wqy-zenhei wqy-microhei ttf-droid \
               noto-fonts-cjk perl

--- a/docker/from-source/Debian
+++ b/docker/from-source/Debian
@@ -11,8 +11,8 @@ FROM debian:stable
 # tdf#117557 - Add CJK Fonts to Collabora Online Docker Image
 RUN apt-get update && \
     apt-get -y install libpng16-16 fontconfig adduser cpio \
-               findutils nano libcap2-bin openssl inotify-tools \
-               procps libubsan1 openssh-client fonts-wqy-zenhei \
+               findutils nano libcap2-bin openssl \
+               libubsan1 openssh-client fonts-wqy-zenhei \
                fonts-wqy-microhei fonts-droid-fallback fonts-noto-cjk \
                ca-certificates
 

--- a/docker/from-source/Fedora
+++ b/docker/from-source/Fedora
@@ -7,7 +7,7 @@ FROM fedora:latest
 # install LibreOffice run-time dependencies
 # install timezone data to accept the TZ environment variable
 # install an editor
-RUN dnf -y install libcap libpng fontconfig nano openssl inotify-tools
+RUN dnf -y install libcap libpng fontconfig nano openssl
 
 # copy freshly built LOKit and Collabora Online
 COPY /instdir /

--- a/docker/from-source/README.md
+++ b/docker/from-source/README.md
@@ -1,3 +1,1 @@
-# FIXME
-
-This folder needs to be updated for Collabora Online 23.05.
+This directory contains relevant files for building a docker image from source code.

--- a/docker/from-source/README.md
+++ b/docker/from-source/README.md
@@ -1,1 +1,3 @@
-This directory contains relevant files for building a docker image from source code.
+# FIXME
+
+This folder needs to be updated for Collabora Online 23.05.

--- a/docker/from-source/Ubuntu
+++ b/docker/from-source/Ubuntu
@@ -13,7 +13,7 @@ FROM ubuntu:24.04
 RUN apt-get update && \
     apt-get -y install libpng16-16 fontconfig adduser cpio tzdata \
                findutils nano \
-               libcap2-bin openssl openssh-client inotify-tools procps \
+               libcap2-bin openssl openssh-client \
                libxcb-shm0 libxcb-render0 libxrender1 libxext6 \
                fonts-wqy-zenhei fonts-wqy-microhei fonts-droid-fallback \
                fonts-noto-cjk ca-certificates

--- a/docker/from-source/build.sh
+++ b/docker/from-source/build.sh
@@ -123,7 +123,7 @@ cp -a core/instdir "$INSTDIR"/opt/lokit
 
 # build
 ( cd online && ./autogen.sh ) || exit 1
-( cd online && ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --enable-silent-rules --with-lokit-path="$BUILDDIR"/core/include --with-lo-path=/opt/lokit --with-poco-includes=$BUILDDIR/poco/include --with-poco-libs=$BUILDDIR/poco/lib $ONLINE_EXTRA_BUILD_OPTIONS) || exit 1
+( cd online && ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var --enable-silent-rules --disable-tests --with-lokit-path="$BUILDDIR"/core/include --with-lo-path=/opt/lokit --with-poco-includes=$BUILDDIR/poco/include --with-poco-libs=$BUILDDIR/poco/lib $ONLINE_EXTRA_BUILD_OPTIONS) || exit 1
 ( cd online && make -j $(nproc)) || exit 1
 
 # copy stuff

--- a/docker/from-source/build.sh
+++ b/docker/from-source/build.sh
@@ -13,14 +13,6 @@
 # * ONLINE_EXTRA_BUILD_OPTIONS - extra build options for online
 # * NO_DOCKER_IMAGE - if set, don't build the docker image itself, just do all the preps
 
-# check we can sudo without asking a pwd
-echo "Trying if sudo works without a password"
-echo
-echo "If you get a password prompt now, break, and fix your setup using 'sudo visudo'; add something like:"
-echo "yourusername ALL=(ALL) NOPASSWD: /sbin/setcap"
-echo
-sudo echo "works"
-
 # Check env variables
 if [ -z "$DOCKER_HUB_REPO" ]; then
   DOCKER_HUB_REPO="mydomain/collaboraonline"

--- a/docker/from-source/build.sh
+++ b/docker/from-source/build.sh
@@ -131,6 +131,7 @@ cp -a core/instdir "$INSTDIR"/opt/lokit
 
 ##### online branding #####
 if test -d online-branding ; then
+  if ! which sass &> /dev/null; then npm install -g sass; fi
   cd online-branding
   ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist 6 # CODE
   ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist 7 # Nextcloud Office

--- a/docker/from-source/build.sh
+++ b/docker/from-source/build.sh
@@ -90,7 +90,7 @@ fi
 
 # online repo
 if test ! -d online ; then
-  git clone "$COLLABORA_ONLINE_REPO" online || exit 1
+  git clone --depth=1 "$COLLABORA_ONLINE_REPO" online || exit 1
 fi
 
 ( cd online && git fetch --all && git checkout -f $COLLABORA_ONLINE_BRANCH && git clean -f -d && git pull -r ) || exit 1

--- a/docker/from-source/build.sh
+++ b/docker/from-source/build.sh
@@ -133,8 +133,8 @@ cp -a core/instdir "$INSTDIR"/opt/lokit
 if test -d online-branding ; then
   if ! which sass &> /dev/null; then npm install -g sass; fi
   cd online-branding
-  ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist 6 # CODE
-  ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist 7 # Nextcloud Office
+  ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist CODE # CODE
+  ./brand.sh $INSTDIR/opt/lokit $INSTDIR/usr/share/coolwsd/browser/dist NC-theme-community # Nextcloud Office
   cd ..
 fi
 

--- a/docker/from-source/openSUSE
+++ b/docker/from-source/openSUSE
@@ -10,7 +10,7 @@ FROM opensuse/leap
 # install an editor
 # tdf#117557 - Add CJK Fonts to Collabora Online Docker Image
 RUN zypper ref && \
-    zypper --non-interactive install libcap-progs libpng16-16 fontconfig nano openssh inotify-tools timezone
+    zypper --non-interactive install libcap-progs libpng16-16 fontconfig nano openssh timezone
 
 # copy freshly built LOKit and Collabora Online
 COPY /instdir /


### PR DESCRIPTION
* Target version: master 

- docker: updated docker/from-source/README.md
- docker: inotifytools and procps are not dependencies
- docker: use theme names instead of magic numbers
- docker: install sass, if it's not installed
- docker: when building from source, --disable-tests saves build time
- docker: git clone --depth=1 saves some time, disk space and bandwidth
- docker: use poco version 1.12.5p2 (the same version is used in production)
- docker: wrong default, distro/collabora/co-24.05 never existed
- docker: we don't have to check for sudo without asking a password