### PR TITLE
Misc Improvements

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -488,7 +488,7 @@ else
 CLEANUP_COMMAND=if test -s ./coolwsd -a -x ./coolwsd; then echo "Cleaning up..." && ./coolwsd --disable-cool-user-checking --cleanup --o:logging.level=trace || rm -f ./coolwsd; fi
 endif
 
-CLEANUP_COVERAGE=rm -rf ${abs_top_srcdir}/gcov; find . -iname "*.gc??" -delete
+CLEANUP_COVERAGE=rm -rf ${abs_top_srcdir}/gcov; find . -iname "*.gcda" -delete
 
 if HAVE_LO_PATH
 

--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -623,7 +623,7 @@ namespace Log
         else
         {
             const auto it = config.find("flush");
-            if (it != config.end() && Util::toLower(it->second) != "false")
+            if (it == config.end() || Util::toLower(it->second) != "false")
             {
                 // Buffered logging, reduces number of write(2) syscalls.
                 channel = static_cast<Poco::Channel*>(new Log::BufferedConsoleChannel());

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -683,7 +683,6 @@ private:
 #define TRANSITION_STATE(VAR, STATE) TRANSITION_STATE_MSG(VAR, STATE, "Transitioning " #VAR " from")
 
 #define LOK_ASSERT_STATE(VAR, STATE)                                                               \
-    LOK_ASSERT_MESSAGE("Expected " #VAR " to be in " #STATE " but was " + toString(VAR),           \
-                       VAR == STATE)
+    LOK_ASSERT_MESSAGE("Expected " #VAR " to be in " #STATE " but was " << name(VAR), VAR == STATE)
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/configure.ac
+++ b/configure.ac
@@ -1073,12 +1073,20 @@ fi
 # Code Coverage.
 AC_MSG_CHECKING([whether code-coverage is enabled])
 if test "x$with_coverage" != "x"; then
-    AC_MSG_RESULT([yes ($with_coverage)])
-    CODE_COVERAGE=1
-    CXXFLAGS="$CXXFLAGS --coverage"
-    CFLAGS="$CFLAGS --coverage"
-    LDFLAGS="$LDFLAGS -Wl,--dynamic-list-data --coverage"
-    coverage_msg="Code-Coverage is enabled"
+
+    AC_DEFUN(AC_PROG_LCOV, [AC_CHECK_PROG(LCOV,lcov,yes)])
+    AC_PROG_LCOV
+    if test x"${LCOV}" == x"yes" ; then
+        AC_MSG_RESULT([yes ($with_coverage)])
+        CODE_COVERAGE=1
+        CXXFLAGS="$CXXFLAGS --coverage"
+        CFLAGS="$CFLAGS --coverage"
+        LDFLAGS="$LDFLAGS -Wl,--dynamic-list-data --coverage"
+        coverage_msg="Code-Coverage is enabled"
+    else
+        AC_MSG_ERROR([Please install lcov (v1.16 preferred) to enable code-coverage])
+    fi
+
 else
     AC_MSG_RESULT([no])
     CODE_COVERAGE=0

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -557,18 +557,20 @@ namespace
     int linkGCDAFilesFunction(const char* fpath, const struct stat*, int typeflag,
                               struct FTW* /*ftwbuf*/)
     {
-        if (strcmp(fpath, sourceForGCDAFiles.c_str()) == 0)
+        const std::string path = fpath;
+        if (path == sourceForGCDAFiles)
         {
             LOG_TRC("nftw: Skipping redundant path: " << fpath);
             return FTW_CONTINUE;
         }
 
-        if (fpath.starts_with(childRootForGCDAFiles))
+        if (path.starts_with(childRootForGCDAFiles))
         {
             LOG_TRC("nftw: Skipping childRoot subtree: " << fpath);
             return FTW_SKIP_SUBTREE;
         }
 
+        assert(path.size() >= sourceForGCDAFiles.size());
         assert(fpath[strlen(sourceForGCDAFiles.c_str())] == '/');
         const char* relativeOldPath = fpath + strlen(sourceForGCDAFiles.c_str()) + 1;
         const Poco::Path newPath(destForGCDAFiles, Poco::Path(relativeOldPath));

--- a/test/UnitPrefork.cpp
+++ b/test/UnitPrefork.cpp
@@ -14,7 +14,12 @@
 #include <Unit.hpp>
 #include <wsd/COOLWSD.hpp>
 
-const int NumToPrefork = 20;
+#if CODE_COVERAGE
+// Multiple instances can deadlock in __gcov_dump().
+constexpr int NumToPrefork = 1;
+#else
+constexpr int NumToPrefork = 20;
+#endif // CODE_COVERAGE
 
 // Inside the WSD process
 class UnitPrefork : public UnitWSD

--- a/test/UnitQuarantine.cpp
+++ b/test/UnitQuarantine.cpp
@@ -85,7 +85,7 @@ public:
     std::unique_ptr<http::Response>
     assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("Testing " << toString(_scenario));
+        LOG_TST("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         assertGetFileCount();
@@ -101,7 +101,7 @@ public:
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
-        LOG_TST("Testing " << toString(_scenario));
+        LOG_TST("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         assertPutFileCount();
@@ -120,7 +120,7 @@ public:
 
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Testing " << toString(_scenario) << ": [" << message << ']');
+        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitDocClose);
@@ -153,7 +153,7 @@ public:
 
     bool onDocumentError(const std::string& message) override
     {
-        LOG_TST("Testing " << toString(_scenario) << ": [" << message << ']');
+        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         if (getCountCheckFileInfo() == 1)
@@ -194,7 +194,7 @@ public:
     // Wait for clean unloading.
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Testing " << toString(_scenario) << " with dockey [" << docKey << "] closed.");
+        LOG_TST("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         // Uploading fails and we can't have anything but the original.

--- a/test/UnitStorage.cpp
+++ b/test/UnitStorage.cpp
@@ -72,7 +72,7 @@ public:
 
     void invokeWSDTest() override
     {
-        LOG_TRC("invokeWSDTest: " << toString(_phase));
+        LOG_TRC("invokeWSDTest: " << name(_phase));
         switch (_phase)
         {
             case Phase::Load:

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -41,7 +41,7 @@ public:
     std::unique_ptr<http::Response>
     assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("Testing " << toString(_scenario));
+        LOG_TST("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         assertGetFileCount();
@@ -52,7 +52,7 @@ public:
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("Testing " << toString(_scenario));
+        LOG_TST("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         assertPutFileCount();
@@ -76,7 +76,7 @@ public:
 
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Testing " << toString(_scenario) << " with dockey [" << docKey << "] closed.");
+        LOG_TST("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         std::string expectedContents;

--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -125,7 +125,7 @@ public:
     std::unique_ptr<http::Response>
     assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("Testing " << toString(_scenario));
+        LOG_TST("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         assertGetFileCount();
@@ -141,7 +141,7 @@ public:
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
-        LOG_TST("Testing " << toString(_scenario));
+        LOG_TST("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         assertPutFileCount();
@@ -159,7 +159,7 @@ public:
 
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Testing " << toString(_scenario) << ": [" << message << ']');
+        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitDocClose);
@@ -192,7 +192,7 @@ public:
 
     bool onDocumentError(const std::string& message) override
     {
-        LOG_TST("Testing " << toString(_scenario) << ": [" << message << ']');
+        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         if (getCountCheckFileInfo() == 1)
@@ -233,7 +233,7 @@ public:
     // Wait for clean unloading.
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Testing " << toString(_scenario) << " with dockey [" << docKey << "] closed.");
+        LOG_TST("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         // Uploading fails and we can't have anything but the original.

--- a/test/UnitWOPISaveOnExit.cpp
+++ b/test/UnitWOPISaveOnExit.cpp
@@ -51,7 +51,7 @@ public:
     std::unique_ptr<http::Response>
     assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("Testing " << toString(_scenario));
+        LOG_TST("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         assertGetFileCount();
@@ -62,7 +62,7 @@ public:
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("Testing " << toString(_scenario));
+        LOG_TST("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         assertPutFileCount();
@@ -137,7 +137,7 @@ public:
 
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Testing " << toString(_scenario) << " with dockey [" << docKey << "] closed.");
+        LOG_TST("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         std::string expectedContents;

--- a/test/UnitWOPISlow.cpp
+++ b/test/UnitWOPISlow.cpp
@@ -82,7 +82,7 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Doc (" << toString(_phase) << "): [" << message << ']');
+        LOG_TST("Doc (" << name(_phase) << "): [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         // Modify and wait for the notification.
@@ -102,7 +102,7 @@ public:
         // Only the first time is handled here.
         if (_phase == Phase::WaitModifiedStatus)
         {
-            LOG_TST("Doc (" << toString(_phase) << "): [" << message << ']');
+            LOG_TST("Doc (" << name(_phase) << "): [" << message << ']');
             LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
             // Save and immediately modify, then close the connection.
@@ -197,7 +197,7 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Doc (" << toString(_phase) << "): [" << message << ']');
+        LOG_TST("Doc (" << name(_phase) << "): [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         // Modify and wait for the notification.
@@ -212,7 +212,7 @@ public:
     /// The document is modified. Save, modify, and close it.
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Doc (" << toString(_phase) << "): [" << message << ']');
+        LOG_TST("Doc (" << name(_phase) << "): [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         _stopwatch.restart();

--- a/test/WOPIUploadConflictCommon.hpp
+++ b/test/WOPIUploadConflictCommon.hpp
@@ -168,7 +168,7 @@ public:
 
     void assertPutFileCount()
     {
-        LOG_TST("Testing " << toString(_scenario));
+        LOG_TST("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         if (getExpectedPutRelative() < getCountPutRelative())
@@ -187,7 +187,7 @@ public:
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Testing " << toString(_scenario) << ": [" << message << ']');
+        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         if (_scenario != Scenario::VerifyOverwrite)
@@ -211,7 +211,7 @@ public:
 
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Testing " << toString(_scenario) << ": [" << message << ']');
+        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         // Change the underlying document in storage.
@@ -251,7 +251,7 @@ public:
 
     bool onDocumentError(const std::string& message) override
     {
-        LOG_TST("Testing " << toString(_scenario) << ": [" << message << ']');
+        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         LOK_ASSERT_EQUAL_MESSAGE("Expect only documentconflict errors",
@@ -292,8 +292,8 @@ public:
         // and upload. But because we don't wait for the modified=false, we can end-up
         // here. Since we will verify after reloading that we have no data-loss, it's OK.
         LOK_ASSERT_MESSAGE(
-            "Expected to be in Scenario::Disconnect OR Scenario::SaveOverwrite but was " +
-                toString(_scenario),
+            "Expected to be in Scenario::Disconnect OR Scenario::SaveOverwrite but was "
+                << name(_scenario),
             (_scenario == Scenario::Disconnect) || (_scenario == Scenario::SaveOverwrite));
 
         return failed();
@@ -346,7 +346,7 @@ public:
             {
                 startNewTest();
 
-                LOG_TST("Loading the document for " << toString(_scenario));
+                LOG_TST("Loading the document for " << name(_scenario));
 
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 

--- a/test/lokassert.hpp
+++ b/test/lokassert.hpp
@@ -206,7 +206,7 @@ inline constexpr bool failed() { return false; }
 #define LOK_ASSERT_FAIL(message)                                                                   \
     do                                                                                             \
     {                                                                                              \
-        TST_LOG("ERROR: Forced failure: " << (message));                                           \
+        TST_LOG("ERROR: Forced failure: " << message);                                             \
         LOK_ASSERT_IMPL(!"Forced failure: " #message); /* NOLINT(misc-static-assert) */            \
         CPPUNIT_FAIL((message));                                                                   \
     } while (false)

--- a/tools/Config.cpp
+++ b/tools/Config.cpp
@@ -133,7 +133,7 @@ void Config::displayHelp()
               << "    migrateconfig [--old-config-file=<path>] [--config-file=<path>] [--write]" << std::endl
               << "    anonymize [string-1]...[string-n]" << std::endl
               << "    set-admin-password" << std::endl;
-    if (ConfigUtil::isSupportKeyEnabled())
+    if constexpr (ConfigUtil::isSupportKeyEnabled())
     {
         std::cout << "    set-support-key" << std::endl;
     }
@@ -171,7 +171,7 @@ void Config::defineOptions(OptionSet& optionSet)
                         .repeatable(false)
                         .argument("number"));
 
-    if (ConfigUtil::isSupportKeyEnabled())
+    if constexpr (ConfigUtil::isSupportKeyEnabled())
     {
         optionSet.addOption(Option("support-key", "", "Specify the support key [set-support-key].")
                             .required(false)

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1499,7 +1499,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
         const auto it = DefAppConfig.find(pair.first);
         if (it == DefAppConfig.end() || it->second != pair.second)
         {
-            ossConfig << pair.first << ": " << pair.second << '\n';
+            ossConfig << '\t' << pair.first << ": " << pair.second << '\n';
         }
     }
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -358,7 +358,7 @@ void COOLWSD::writeTraceEventRecording(const std::string &recording)
 void COOLWSD::checkSessionLimitsAndWarnClients()
 {
 #if !MOBILEAPP
-    if (ConfigUtil::isSupportKeyEnabled())
+    if constexpr (ConfigUtil::isSupportKeyEnabled())
         return;
 
     ssize_t docBrokerCount = DocBrokers.size() - ConvertToBroker::getInstanceCount();
@@ -1991,7 +1991,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
     setenv("LOK_HELP_URL", "", 1);
 #endif
 
-    if (ConfigUtil::isSupportKeyEnabled())
+    if constexpr (ConfigUtil::isSupportKeyEnabled())
     {
         const std::string supportKeyString =
             ConfigUtil::getConfigValue<std::string>(conf, "support_key", "");

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -170,7 +170,7 @@ findOrCreateDocBroker(DocumentBroker::ChildType type, const std::string& uri,
             LOG_WRN("Maximum number of open documents of "
                     << COOLWSD::MaxDocuments << " reached while loading new session [" << id
                     << "] for docKey [" << docKey << ']');
-            if (ConfigUtil::isSupportKeyEnabled())
+            if constexpr (ConfigUtil::isSupportKeyEnabled())
             {
                 const std::string error = Poco::format(PAYLOAD_UNAVAILABLE_LIMIT_REACHED,
                                                        COOLWSD::MaxDocuments, COOLWSD::MaxConnections);
@@ -1913,7 +1913,7 @@ bool ClientRequestDispatcher::handleClientWsUpgrade(const Poco::Net::HTTPRequest
         {
             LOG_INF("Limit on maximum number of connections of " << COOLWSD::MaxConnections
                                                                  << " reached.");
-            if (ConfigUtil::isSupportKeyEnabled())
+            if constexpr (ConfigUtil::isSupportKeyEnabled())
             {
                 shutdownLimitReached(ws);
                 return true;

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1320,7 +1320,7 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
     std::string brandCSS(Poco::format(linkCSS, responseRoot, std::string(BRANDING)));
     std::string brandJS(Poco::format(scriptJS, responseRoot, std::string(BRANDING)));
 
-    if (ConfigUtil::isSupportKeyEnabled())
+    if constexpr (ConfigUtil::isSupportKeyEnabled())
     {
         const std::string keyString = config.getString("support_key", "");
         SupportKey key(keyString);
@@ -1725,7 +1725,7 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
     std::string brandJS(Poco::format(scriptJS, responseRoot, std::string(BRANDING)));
     std::string brandFooter;
 
-    if (ConfigUtil::isSupportKeyEnabled())
+    if constexpr (ConfigUtil::isSupportKeyEnabled())
     {
         const auto& config = Application::instance().config();
         const std::string keyString = config.getString("support_key", "");


### PR DESCRIPTION
- wsd: coverage: fix coverage bit-rot
- configure: --with-coverage now checks for lcov installation
- wsd: test: support code coverage in UnitPrefork
- wsd: ConfigUtil::isSupportKeyEnabled() is constexpr
- wsd: use buffered logging if 'flush' is missing
- make: coverage: only remove the coverage data when cleaning
- wsd: StateEnum::toString -> StateEnum::name
- wsd: indent the logged-config for readability
