### PR TITLE
cool#10440 - perf: don't touch comment's innerText unless it changes.

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -1524,14 +1524,18 @@ export class Comment extends CanvasSectionObject {
 		if (this.sectionProperties.docLayer._docType === 'spreadsheet')
 			return;
 
+		var innerText;
 		if (this.isEdit())
-			this.sectionProperties.collapsedInfoNode.innerText = '!';
+			innerText = '!';
 		else if (replycount === '!' || typeof replycount === "number" && replycount > 0)
-			this.sectionProperties.collapsedInfoNode.innerText = replycount;
+			innerText = replycount;
 		else
-			this.sectionProperties.collapsedInfoNode.innerText = '';
+			innerText = '';
 
-		if (this.sectionProperties.collapsedInfoNode.innerText === '' || this.isContainerVisible())
+		if (this.sectionProperties.collapsedInfoNode.innerText != innerText)
+			this.sectionProperties.collapsedInfoNode.innerText = innerText;
+
+		if (innerText === '' || this.isContainerVisible())
 			this.sectionProperties.collapsedInfoNode.style.display = 'none';
 		else if ((!this.isContainerVisible() && this.sectionProperties.collapsedInfoNode.innerText !== ''))
 			this.sectionProperties.collapsedInfoNode.style.display = '';


### PR DESCRIPTION
Previously CanvasSectionContainer.onMouseWheel - spent 30% of its time setting comment properties to the same value.


Change-Id: I0e50de9bae65db762fd6637618002485514c13b6
