### PR TITLE
Fix clang build of --without-support-public-key

### DIFF
--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -74,6 +74,7 @@ extern void cleanupDocBrokers();
 namespace
 {
 
+#if ENABLE_SUPPORT_KEY
 /// Used in support key enabled builds
 inline void shutdownLimitReached(const std::shared_ptr<ProtocolHandlerInterface>& proto)
 {
@@ -97,6 +98,7 @@ inline void shutdownLimitReached(const std::shared_ptr<ProtocolHandlerInterface>
         LOG_ERR("Error while shutting down socket on reaching limit: " << ex.what());
     }
 }
+#endif
 
 } // end anonymous namespace
 
@@ -1915,7 +1917,9 @@ bool ClientRequestDispatcher::handleClientWsUpgrade(const Poco::Net::HTTPRequest
                                                                  << " reached.");
             if (ConfigUtil::isSupportKeyEnabled())
             {
+#if ENABLE_SUPPORT_KEY
                 shutdownLimitReached(ws);
+#endif
                 return true;
             }
         }


### PR DESCRIPTION
The build failed with:

wsd/ClientRequestDispatcher.cpp:78:13: error: function 'shutdownLimitReached' is not needed and will not be emitted [-Werror,-Wunneeded-internal-declaration]

I.e. the trouble is that the compiler is aware that
shutdownLimitReached() will be never called at build time.

Silence that with ifdefs for now, we may want to provide 2 definitions
for one declaration in the future to avoid the ifdefs.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I7adb6328a8833c909638e8fc72bd633ee4004229
