### PR TITLE
std::sort requires a strict weak ordering

### DIFF
--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -727,7 +727,7 @@ std::vector<DocBasicInfo> AdminModel::getDocumentsSortedByIdle() const
     std::sort(std::begin(docs), std::end(docs),
               [](const DocBasicInfo& a, const DocBasicInfo& b)
               {
-                return a.getIdleTime() >= b.getIdleTime();
+                return a.getIdleTime() > b.getIdleTime();
               });
 
     return docs;


### PR DESCRIPTION
otherwise unpleasant crashy things can happen

 #8  0x00007f7fbce37902 in abort () from /lib64/libc.so.6
 #9  0x00007f7fbdab0801 in Poco::SignalHandler::handleSignal(int) [clone .cold] () from /lib64/libPocoFoundation.so.103
 #10 <signal handler called>
 #11 0x00000000006ea6a8 in DocBasicInfo::getIdleTime (this=0x7f7f80020fe0) at wsd/AdminModel.hpp:148
 #12 0x0000000000714a6f in operator() (__closure=0x7f7f9cbeec67, a=..., b=...) at wsd/AdminModel.cpp:754
 ...
 #18 0x0000000000719f75 in std::sort<__gnu_cxx::__normal_iterator<DocBasicInfo*, std::vector<DocBasicInfo> >, AdminModel::getDocumentsSortedByIdle()
 #19 0x0000000000715079 in AdminModel::getDocumentsSortedByIdle (this=0xb7c988 <Admin::instance()::admin+264>) at wsd/AdminModel.cpp:751


Change-Id: I7fee4067c9af6be345be2c85262a78ca2e264758


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

