### PR TITLE
fix(keyboard): Allow using Ctrl+Shift+Z for redo

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -734,14 +734,17 @@ L.Map.Keyboard = L.Handler.extend({
 			return true;
 		}
 
-		if (this._isCtrlKey(e) && e.keyCode === this.keyCodes.Z) {
-			app.socket.sendMessage('uno .uno:Undo');
+		if (
+			(this._isCtrlKey(e) && e.keyCode === this.keyCodes.Y) ||
+			(this._isCtrlKey(e) && e.shiftKey && e.keyCode === this.keyCodes.Z)
+		) {
+			app.socket.sendMessage('uno .uno:Redo');
 			e.preventDefault();
 			return true;
 		}
 
-		if (this._isCtrlKey(e) && e.keyCode === this.keyCodes.Y) {
-			app.socket.sendMessage('uno .uno:Redo');
+		if (this._isCtrlKey(e) && e.keyCode === this.keyCodes.Z) {
+			app.socket.sendMessage('uno .uno:Undo');
 			e.preventDefault();
 			return true;
 		}


### PR DESCRIPTION
I found this on an Apple device, as Cmd+Z and Cmd+Shift+Z were both undoing. On every other app I could find, Cmd+Shift+Z was bound to redo, however here we hadn't set it. Without setting this shortcut, it instead also activates undo, causing trouble for people who are used to using it as redo.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

