### PR TITLE
kit: don't remove original file after save

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -79,6 +79,7 @@ all_la_unit_tests = \
 	unit-cursor.la \
 	unit-render-search-result.la \
 	unit-tiff-load.la \
+	unit-save.la \
 	unit-wopi-saveas-with-encoded-file-name.la \
 	unit-storage.la \
 	unit-wopi-async-upload-modifyclose.la \
@@ -284,6 +285,8 @@ unit_wopi_httpredirect_la_SOURCES = UnitWOPIHttpRedirect.cpp
 unit_wopi_httpredirect_la_LIBADD = $(CPPUNIT_LIBS)
 unit_tiff_load_la_SOURCES = UnitTiffLoad.cpp
 unit_tiff_load_la_LIBADD = $(CPPUNIT_LIBS)
+unit_save_la_SOURCES = UnitSave.cpp
+unit_save_la_LIBADD = $(CPPUNIT_LIBS)
 unit_large_paste_la_SOURCES = UnitLargePaste.cpp
 unit_large_paste_la_LIBADD = $(CPPUNIT_LIBS)
 unit_paste_la_SOURCES = UnitPaste.cpp

--- a/test/UnitSave.cpp
+++ b/test/UnitSave.cpp
@@ -1,0 +1,86 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <memory>
+#include <string>
+
+#include <Poco/URI.h>
+
+#include <test/lokassert.hpp>
+#include <wsd/DocumentBroker.hpp>
+
+#include <Unit.hpp>
+#include <helpers.hpp>
+
+/// Save testcase.
+class UnitSave : public UnitWSD
+{
+public:
+    UnitSave();
+
+    void invokeWSDTest() override;
+
+    void testKeepOrigFile();
+};
+
+UnitSave::UnitSave()
+    : UnitWSD("UnitSave")
+{
+}
+
+void UnitSave::invokeWSDTest()
+{
+    testKeepOrigFile();
+}
+
+void UnitSave::testKeepOrigFile()
+{
+    // Given a loaded document:
+    std::string name = "testKeepOrigFile";
+    std::string docName = "empty.ods";
+    std::string documentPath, documentURL;
+    helpers::getDocumentPathAndURL(docName, documentPath, documentURL, name);
+    std::shared_ptr<SocketPoll> poll = std::make_shared<SocketPoll>("WebSocketPoll");
+    poll->startThread();
+    Poco::URI uri(helpers::getTestServerURI());
+    auto wsSession = helpers::loadDocAndGetSession(poll, docName, uri, testname);
+
+    // When saving and waiting for the save to finish:
+    wsSession->sendMessage(std::string("save dontTerminateEdit=0 dontSaveIfUnmodified=0"));
+    while (!SigUtil::getShutdownRequestFlag())
+    {
+        std::chrono::seconds timeout = std::chrono::seconds(10);
+        auto message = wsSession->waitForMessage("unocommandresult:", timeout, name);
+        LOK_ASSERT(message.size() > 0);
+        Poco::JSON::Object::Ptr object;
+        LOK_ASSERT(JsonUtil::parseJSON(std::string(message.data(), message.size()), object));
+        if (JsonUtil::getJSONValue<std::string>(object, "commandName") == ".uno:Save")
+        {
+            break;
+        }
+    }
+
+    // Then make sure the original file is not removed:
+    std::vector<std::shared_ptr<DocumentBroker>> brokers = COOLWSD::getBrokersTestOnly();
+    LOK_ASSERT(brokers.size() > 0);
+    std::shared_ptr<DocumentBroker> broker = brokers[0];
+    StorageBase* storage = broker->getStorage();
+    std::string rootFilePath = storage->getRootFilePath();
+    LOK_ASSERT(FileUtil::Stat(rootFilePath).exists());
+    poll->joinThread();
+    exitTest(TestResult::Ok);
+}
+
+UnitBase* unit_create_wsd(void) { return new UnitSave(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -619,6 +619,8 @@ public:
     void switchMode(const std::shared_ptr<ClientSession>& session, const std::string& mode);
 #endif // !MOBILEAPP && !WASMAPP
 
+    StorageBase* getStorage() { return _storage.get(); }
+
 private:
     /// Get the session that can write the document for save / locking / uploading.
     /// Note that if there is no loaded and writable session, the first will be returned.


### PR DESCRIPTION
```
The bugreport was about an ODS file which was edited to have a model
where ODS export fails, but XLS(X) export works. No steps to reliably
reproduce the problem are known at the moment.

Investigating that problem, it turns out that we had logic in place, so
that once we get the UNO command result for an .uno:Save command, we
rename the result to "<original path>.upload". This has the benefit that
in case we would start uploading to storage but an other save starts in
the meantime, then we never upload a half-finished export result. The
downside is that some code in core.git expects the original file to be
around while editing, e.g. (at least) PDF signing won't work without it.
It's also hard to audit all save codepath to be sure that the lack of
original path doesn't break other corner-cases.

Fix the problem by still uploading "<original path>.upload" instead of
"<orignal path>", but copy the content to the new path, don't rename.
```

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I1110580981f64e9cadf6e075861d4f83ef38d119
