### PR TITLE
Replace TileLocation with TileDescription.

### DIFF
--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -71,7 +71,7 @@ namespace RenderTiles
                                  size_t pixmapHeight, int pixelWidth, int pixelHeight,
                                  LibreOfficeKitTileMode mode)>& blendWatermark,
         const std::function<void(const char* buffer, size_t length)>& outputMessage,
-        [[maybe_unused]] unsigned mobileAppDocId, int canonicalViewId, bool dumpTiles)
+        [[maybe_unused]] unsigned mobileAppDocId, bool dumpTiles)
     {
         const auto& tiles = tileCombined.getTiles();
 
@@ -191,14 +191,7 @@ namespace RenderTiles
                             deltaGen.compressOrDelta(pixmap.data(), offsetX, offsetY,
                                                      pixelWidth, pixelHeight,
                                                      pixmapWidth, pixmapHeight,
-                                                     TileLocation(
-                                                         tileRect.getLeft(),
-                                                         tileRect.getTop(),
-                                                         tileRect.getWidth(),
-                                                         tileCombined.getPart(),
-                                                         canonicalViewId,
-                                                         tileCombined.getEditMode()
-                                                         ),
+                                                     tiles[tileIndex],
                                                      data, wireId, forceKeyframe, dumpTiles, mode);
                         }
                         else

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -939,7 +939,7 @@ void Document::renderTiles(TileCombined &tileCombined)
 
     if (!RenderTiles::doRender(_loKitDocument, *_deltaGen, tileCombined, _deltaPool,
                                blenderFunc, postMessageFunc, _mobileAppDocId,
-                               session->getCanonicalViewId(), session->getDumpTiles()))
+                               session->getDumpTiles()))
     {
         LOG_DBG("All tiles skipped, not producing empty tilecombine: message");
         return;

--- a/test/DeltaTests.cpp
+++ b/test/DeltaTests.cpp
@@ -293,7 +293,7 @@ void DeltaTests::testRleComplex()
 
     DeltaGenerator::DeltaData data(
         textWid, reinterpret_cast<unsigned char*>(text.data()),
-        0, 0, 256, 256, TileLocation(9, 9, 9, 0, 1, 0), 256, 256);
+        0, 0, 256, 256, TileDesc(1, 0, 0, 3840, 3840, 256, 256, 9, 9, 0, 9, 0), 256, 256);
 
     size_t off = 0;
     for (int y = 0; y < 256; ++y)
@@ -330,13 +330,13 @@ void DeltaTests::testRleRandom()
 
     DeltaGenerator::DeltaData data(
         1, randomImg.data(), 0, 0, 256, 256,
-        TileLocation(9, 9, 9, 0, 1, 0), 256, 256);
+        TileDesc(1, 0, 0, 3840, 3840, 256, 256, 9, 9, 0, 9, 0), 256, 256);
 
     // Compress
     std::vector<char> output;
     size_t size = gen.compressOrDelta(
         randomImg.data(), 0, 0, 256, 256, 256, 256,
-        TileLocation(42, 2, 3, 0, 1, 0),
+        TileDesc(1, 0, 0, 3840, 3840, 256, 256, 42, 2, 0, 3, 0),
         output, 1, true, false, LOK_TILEMODE_RGBA);
     LOK_ASSERT(size > 1);
     LOK_ASSERT(output[0] == 'Z');
@@ -364,7 +364,7 @@ void DeltaTests::testRleIdentical()
 
     DeltaGenerator::DeltaData data(
         textWid, reinterpret_cast<unsigned char*>(text.data()),
-        0, 0, 256, 256, TileLocation(9, 9, 9, 0, 1, 0), 256, 256);
+        0, 0, 256, 256, TileDesc(1, 0, 0, 3840, 3840, 256, 256, 9, 9, 0, 9, 0), 256, 256);
 
     std::vector<char> text2 =
         Png::loadPng(TDOC "/delta-graphic2.png", height, width, rowBytes);
@@ -373,7 +373,7 @@ void DeltaTests::testRleIdentical()
 
     DeltaGenerator::DeltaData data2(
         textWid, reinterpret_cast<unsigned char*>(text.data()),
-        0, 0, 256, 256, TileLocation(9, 9, 9, 0, 1, 0), 256, 256);
+        0, 0, 256, 256, TileDesc(1, 0, 0, 3840, 3840, 256, 256, 9, 9, 0, 9, 0), 256, 256);
 
     // find identical rows
     for (int y = 0; y < 256; ++y)
@@ -427,14 +427,14 @@ void DeltaTests::testDeltaSequence()
     LOK_ASSERT(gen.createDelta(
                        reinterpret_cast<unsigned char *>(&text[0]),
                        0, 0, width, height, width, height,
-                       TileLocation(1, 2, 3, 0, 1, 0), delta, textWid, false, LOK_TILEMODE_RGBA, rleData) == false);
+                       TileDesc(1, 0, 0, 3840, 3840, 256, 256, 1, 2, 0, 3, 0), delta, textWid, false, LOK_TILEMODE_RGBA, rleData) == false);
     LOK_ASSERT(delta.empty());
 
     // Build a delta between text2 & textWid
     LOK_ASSERT(gen.createDelta(
                        reinterpret_cast<unsigned char *>(&text2[0]),
                        0, 0, width, height, width, height,
-                       TileLocation(1, 2, 3, 0, 1, 0), delta, text2Wid, false, LOK_TILEMODE_RGBA, rleData) == true);
+                       TileDesc(1, 0, 0, 3840, 3840, 256, 256, 1, 2, 0, 3, 0), delta, text2Wid, false, LOK_TILEMODE_RGBA, rleData) == true);
     LOK_ASSERT(delta.size() > 0);
     checkzDelta(delta, "text2 to textWid");
 
@@ -447,7 +447,7 @@ void DeltaTests::testDeltaSequence()
     LOK_ASSERT(gen.createDelta(
                        reinterpret_cast<unsigned char *>(&text[0]),
                        0, 0, width, height, width, height,
-                       TileLocation(1, 2, 3, 0, 1, 0), two2one, textWid, false, LOK_TILEMODE_RGBA, rleData) == true);
+                       TileDesc(1, 0, 0, 3840, 3840, 256, 256, 1, 2, 0, 3, 0), two2one, textWid, false, LOK_TILEMODE_RGBA, rleData) == true);
     LOK_ASSERT(two2one.size() > 0);
     checkzDelta(two2one, "text to text2Wid");
 
@@ -486,14 +486,14 @@ void DeltaTests::testDeltaCopyOutOfBounds()
     LOK_ASSERT(gen.createDelta(
                        reinterpret_cast<unsigned char *>(&text[0]),
                        0, 0, width, height, width, height,
-                       TileLocation(1, 2, 3, 0, 1, 0), delta, textWid, false, LOK_TILEMODE_RGBA, rleData) == false);
+                       TileDesc(1, 0, 0, 3840, 3840, 256, 256, 1, 2, 0, 3, 0), delta, textWid, false, LOK_TILEMODE_RGBA, rleData) == false);
     LOK_ASSERT(delta.empty());
 
     // Build a delta between the two frames
     LOK_ASSERT(gen.createDelta(
                        reinterpret_cast<unsigned char *>(&text2[0]),
                        0, 0, width, height, width, height,
-                       TileLocation(1, 2, 3, 0, 1, 0), delta, text2Wid, false, LOK_TILEMODE_RGBA, rleData) == true);
+                       TileDesc(1, 0, 0, 3840, 3840, 256, 256, 1, 2, 0, 3, 0), delta, text2Wid, false, LOK_TILEMODE_RGBA, rleData) == true);
     LOK_ASSERT(delta.size() > 0);
     checkzDelta(delta, "copy out of bounds");
 

--- a/tools/Benchmark.cpp
+++ b/tools/Benchmark.cpp
@@ -27,7 +27,7 @@ class DeltaTests {
 public:
     static void rleBitmap(Pixmap &pix)
     {
-        TileLocation loc = { 0, 0, 0, 0, 0, 0 };
+        TileDesc loc = { 0, 0, 0, 3840, 3840, 256, 256, 0, 0, 0, 0, 0 };
         DeltaGenerator::DeltaData rleData(
             1 /*wid*/, reinterpret_cast<unsigned char *>(pix.data()),
             0, 0, 256, 256, loc, 256, 256);

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -92,7 +92,7 @@ public:
             _tileHeight <= 0 ||
             _imgSize < 0)
         {
-            throw BadArgumentException("Invalid tile descriptor.");
+            LOG_ERR("Invalid tile descriptor.");
         }
     }
 
@@ -112,6 +112,7 @@ public:
     void setImgSize(const int imgSize) { _imgSize = imgSize; }
     bool isPreview() const { return _id >= 0; }
     void setId(TileWireId id) { _id = id; }
+    int getId() const { return _id; }
     void setOldWireId(TileWireId id) { _oldWireId = id; }
     void forceKeyframe() { setOldWireId(0); }
     TileWireId getOldWireId() const { return _oldWireId; }


### PR DESCRIPTION
Two structures are very similar.

Also replaced "throw" error with "log_err" or behchmark.cpp would complain about it.


Change-Id: I411a0b7f7763578ccdc9cee6fd35c8cec59a89ec


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

