### PR TITLE
Fix combined keyframe+delta tile updates

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3967,6 +3967,9 @@ L.CanvasTileLayer = L.Layer.extend({
 				// Synchronous path
 				var tile = this._tiles[e.key];
 				var deltas = window.fzstd.decompress(e.rawDelta);
+
+				var keyframeDeltaSize = 0;
+				var keyframeImage = null;
 				if (e.isKeyframe)
 				{
 					if (this._debugDeltas)
@@ -3976,14 +3979,16 @@ L.CanvasTileLayer = L.Layer.extend({
 					var width = window.tileSize;
 					var height = window.tileSize;
 					var resultu8 = new Uint8ClampedArray(width * height * 4);
-					L.CanvasTileUtils.unrle(deltas, width, height, resultu8);
-					deltas = resultu8;
+					keyframeDeltaSize = L.CanvasTileUtils.unrle(deltas, width, height, resultu8);
+					keyframeImage = new ImageData(resultu8, width, height);
 
 					if (this._debugDeltas)
 						window.app.console.log('Applied keyframe of total size ' + resultu8.length +
 										' at stream offset 0');
 				}
-				this._applyDelta(tile, e.rawDelta, deltas, e.isKeyframe, e.wireMessage, true);
+
+				this._applyDelta(tile, e.rawDelta, deltas, keyframeDeltaSize, keyframeImage, e.wireMessage, true);
+
 				if (e.isKeyframe)
 					--tile.hasPendingKeyframe;
 				else
@@ -5452,15 +5457,15 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._pendingDeltas.push(e);
 	},
 
-	_applyDelta: function(tile, rawDelta, deltas, isKeyframe, wireMessage, deltasNeedUnpremultiply) {
+	_applyDelta: function(tile, rawDelta, deltas, keyframeDeltaSize, keyframeImage, wireMessage, deltasNeedUnpremultiply) {
 		// 'Uint8Array' rawDelta
 
 		if (this._debugDeltas)
-			window.app.console.log('Applying a raw ' + (isKeyframe ? 'keyframe' : 'delta') +
+			window.app.console.log('Applying a raw ' + (keyframeDeltaSize ? 'keyframe' : 'delta') +
 					       ' of length ' + rawDelta.length +
 					       (this._debugDeltasDetail ? (' hex: ' + hex2string(rawDelta, rawDelta.length)) : ''));
 
-		if (isKeyframe) {
+		if (keyframeDeltaSize) {
 			// Important to do this before ensuring the context, or we'll needlessly
 			// reconstitute the old keyframe from compressed data.
 			tile.rawKeyframe = null;
@@ -5474,7 +5479,7 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		// if re-creating a canvas from rawKeyframe/rawDeltas don't update counts
 		if (wireMessage) {
-			if (isKeyframe) {
+			if (keyframeDeltaSize) {
 				tile.loadCount++;
 				tile.deltaCount = 0;
 				tile.updateCount = 0;
@@ -5501,17 +5506,15 @@ L.CanvasTileLayer = L.Layer.extend({
 		// else - re-constituting from tile.rawData
 
 		var traceEvent = app.socket.createCompleteTraceEvent('L.CanvasTileLayer.applyDelta',
-								     { keyFrame: isKeyframe, length: rawDelta.length });
+								     { keyFrame: !!keyframeDeltaSize, length: rawDelta.length });
 
 		// store the compressed version for later in its current
 		// form as byte arrays, so that we can manage our canvases
 		// better.
-		var offset = 0;
-		if (isKeyframe)
+		if (keyframeDeltaSize)
 		{
 			tile.rawKeyframe = rawDelta; // overwrite
 			tile.rawDeltas = new Uint8Array(0);
-			offset = deltas.length;
 		}
 		else if (!tile.rawKeyframe)
 		{
@@ -5530,14 +5533,12 @@ L.CanvasTileLayer = L.Layer.extend({
 		// apply potentially several deltas in turn.
 		var i = 0;
 
-		// FIXME:used clamped array ... as a 2nd parameter
-		var imgData;
-
 		// May have been changed by _ensureContext garbage collection
 		var canvas = tile.canvas;
 
-		if (isKeyframe)
-			imgData = new ImageData(deltas, canvas.width, canvas.height);
+		// If it's a new keyframe, use the given image and offset
+		var imgData = keyframeImage;
+		var offset = keyframeDeltaSize;
 
 		while (offset < deltas.length)
 		{
@@ -5786,7 +5787,12 @@ L.CanvasTileLayer = L.Layer.extend({
 					window.app.console.warn('Tile deleted during rawDelta decompression.');
 					continue;
 				}
-				this._applyDelta(tile, x.rawDelta, x.deltas, x.isKeyframe, x.wireMessage, false);
+				
+				var keyframeImage = null;
+				if (x.isKeyframe)
+					keyframeImage = new ImageData(x.keyframeBuffer, e.data.tileSize, e.data.tileSize);
+				this._applyDelta(tile, x.rawDelta, x.deltas, x.keyframeDeltaSize, keyframeImage, x.wireMessage, false);
+
 				if (x.isKeyframe)
 					--tile.hasPendingKeyframe;
 				else


### PR DESCRIPTION
### Summary

I'd made the bad assumption that keyframe and delta tile updates always arrived separately, but this is very much not the case, especially outside of Writer apparently. This change fixes that assumption and un-breaks the very obvious breakage in Impress when editing.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

