### PR TITLE
feat: unify mobile clipboard with online

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -439,6 +439,19 @@ L.Clipboard = L.Class.extend({
 		return true;
 	},
 
+	_sendToInternalClipboard: async function (content) {
+		if (window.ThisIsTheiOSApp) {
+			await window.webkit.messageHandlers.clipboard.postMessage(`sendToInternal ${await content.text()}`); // no need to base64 in this direction...
+		} else {
+			var formData = new FormData();
+			formData.append('file', content);
+
+			return await this._doAsyncDownload('POST', this.getMetaURL(), formData, false,
+				function(progress) { return progress; }
+			);
+		}
+	},
+
 	dataTransferToDocumentFallback: async function(dataTransfer, htmlText, usePasteKeyEvent) {
 		var content;
 		if (dataTransfer) {
@@ -484,21 +497,18 @@ L.Clipboard = L.Class.extend({
 			return;
 		}
 
-		if (content != null) {
-			window.app.console.log('Normal HTML, so smart paste not possible');
-
-			var formData = new FormData();
-			formData.append('file', content);
-
-			var that = this;
-			await this._doAsyncDownload('POST', this.getMetaURL(), formData, false,
-				function(progress) { return progress; }
-			);
-			window.app.console.log('Posted ' + content.size + ' bytes successfully');
-			that._doInternalPaste(that._map, usePasteKeyEvent);
-		} else {
+		if (content == null) {
 			window.app.console.log('Nothing we can paste on the clipboard');
+			return;
 		}
+
+		window.app.console.log('Normal HTML, so smart paste not possible');
+
+		await this._sendToInternalClipboard(content);
+
+		window.app.console.log('clipboard: Sent ' + content.size + ' bytes successfully');
+
+		this._doInternalPaste(this._map, usePasteKeyEvent);
 	},
 
 	_checkSelection: function() {
@@ -698,7 +708,8 @@ L.Clipboard = L.Class.extend({
 			return;
 		}
 
-		if (document.execCommand(operation) &&
+		if (!window.ThisIsTheiOSApp && // in mobile apps, we want to drop straight to navigatorClipboardRead as execCommand will require user interaction...
+			document.execCommand(operation) &&
 			serial !== this._clipboardSerial) {
 			window.app.console.log('copied successfully');
 			this._unoCommandForCopyCutPaste = null;
@@ -853,7 +864,7 @@ L.Clipboard = L.Class.extend({
 
 	// Executes the navigator.clipboard.write() call, if it's available.
 	_navigatorClipboardWrite: function() {
-		if (!L.Browser.clipboardApiAvailable) {
+		if (!L.Browser.clipboardApiAvailable && !window.ThisIsTheiOSApp) {
 			return false;
 		}
 
@@ -874,33 +885,37 @@ L.Clipboard = L.Class.extend({
 		// that command so we are sure the clipboard is set before
 		// fetching it.
 
-		const url = this.getMetaURL() + '&MimeType=text/html,text/plain;charset=utf-8';
+		if (window.ThisIsTheiOSApp) {
+			await window.webkit.messageHandlers.clipboard.postMessage(`write`);
+		} else {
+			const url = this.getMetaURL() + '&MimeType=text/html,text/plain;charset=utf-8';
 
-		var result = await fetch(url);
-		var text = await result.text();
+			var result = await fetch(url);
+			var text = await result.text();
 
-		const clipboardItem = new ClipboardItem({
-			'text/html': this._parseClipboardFetchResult(text, 'text/html', 'html'),
-			'text/plain': this._parseClipboardFetchResult(text, 'text/plain', 'plain')
-		});
-		let clipboard = navigator.clipboard;
-		if (L.Browser.cypressTest) {
-			clipboard = this._dummyClipboard;
-		}
+			const clipboardItem = new ClipboardItem({
+				'text/html': this._parseClipboardFetchResult(text, 'text/html', 'html'),
+				'text/plain': this._parseClipboardFetchResult(text, 'text/plain', 'plain')
+			});
+			let clipboard = navigator.clipboard;
+			if (L.Browser.cypressTest) {
+				clipboard = this._dummyClipboard;
+			}
 
-		try {
-			await clipboard.write([clipboardItem]);
-		} catch (error) {
-			window.app.console.log('navigator.clipboard.write() failed: ' + error.message);
+			try {
+				await clipboard.write([clipboardItem]);
+			} catch (error) {
+				window.app.console.log('navigator.clipboard.write() failed: ' + error.message);
 
-			// Warn that the copy failed.
-			this._warnCopyPaste();
-			// Once broken, always broken.
-			L.Browser.clipboardApiAvailable = false;
-			window.prefs.set('clipboardApiAvailable', false);
-			// Prefetch selection, so next time copy will work with the keyboard.
-			app.socket.sendMessage('gettextselection mimetype=text/html,text/plain;charset=utf-8');
-		}
+				// Warn that the copy failed.
+				this._warnCopyPaste();
+				// Once broken, always broken.
+				L.Browser.clipboardApiAvailable = false;
+				window.prefs.set('clipboardApiAvailable', false);
+				// Prefetch selection, so next time copy will work with the keyboard.
+				app.socket.sendMessage('gettextselection mimetype=text/html,text/plain;charset=utf-8');
+			}
+			}
 	},
 
 	// Parses the result from the clipboard endpoint into HTML and plain text.
@@ -932,12 +947,37 @@ L.Clipboard = L.Class.extend({
 
 	// Executes the navigator.clipboard.read() call, if it's available.
 	_navigatorClipboardRead: function(isSpecial) {
-		if (!L.Browser.clipboardApiAvailable) {
+		if (!L.Browser.clipboardApiAvailable && !window.ThisIsTheiOSApp) {
 			return false;
 		}
 
 		this._asyncAttemptNavigatorClipboardRead(isSpecial);
 		return true;
+	},
+
+	_iOSReadClipboard: async function() {
+		const encodedClipboardData = await window.webkit.messageHandlers.clipboard.postMessage('read');
+		const clipboardData = Array.from(
+			encodedClipboardData.split(' '),
+		).map((encoded) =>
+			(encoded === '(null)' ? '' : window.b64d(encoded)),
+		);
+
+		const dataByMimeType = {};
+
+		if (clipboardData[0]) {
+			dataByMimeType['text/plain'] = new Blob([clipboardData[0]]);
+		}
+
+		if (clipboardData[1]) {
+			dataByMimeType['text/html'] = new Blob([clipboardData[1]]);
+		}
+
+		if (Object.keys(dataByMimeType).length === 0) {
+			return [];
+		}
+
+		return [new ClipboardItem(dataByMimeType)];
 	},
 
 	_asyncAttemptNavigatorClipboardRead: async function(isSpecial) {
@@ -947,7 +987,9 @@ L.Clipboard = L.Class.extend({
 		}
 		let clipboardContents;
 		try {
-			clipboardContents = await clipboard.read();
+			clipboardContents = window.ThisIsTheiOSApp
+				? await this._iOSReadClipboard()
+				: await clipboard.read();
 		} catch (error) {
 			window.app.console.log('navigator.clipboard.read() failed: ' + error.message);
 			if (isSpecial) {
@@ -965,7 +1007,7 @@ L.Clipboard = L.Class.extend({
 		}
 
 		if (clipboardContents.length < 1) {
-			window.app.console.log('navigator.clipboard has no clipboard items');
+			window.app.console.log('clipboard has no items');
 			return;
 		}
 
@@ -1004,7 +1046,7 @@ L.Clipboard = L.Class.extend({
 			return true;
 		}
 
-		if (window.ThisIsAMobileApp) {
+		if (window.ThisIsTheAndroidApp) {
 			// perform internal operations
 			app.socket.sendMessage('uno ' + cmd);
 			return true;
@@ -1349,7 +1391,7 @@ L.Clipboard = L.Class.extend({
 });
 
 L.clipboard = function(map) {
-	if (window.ThisIsAMobileApp)
-		window.app.console.log('======> Assertion failed!? No L.Clipboard object should be needed in a mobile app');
+	if (window.ThisIsTheAndroidApp)
+		window.app.console.log('======> Assertion failed!? No L.Clipboard object should be needed in the Android app');
 	return new L.Clipboard(map);
 };

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -114,6 +114,9 @@ L.Clipboard = L.Class.extend({
 	},
 
 	getMetaBase: function() {
+		if (window.ThisIsAMobileApp) {
+			return 'collabora-online-mobile'; // makeHttpUrl does not work with the file:// protocol used in mobile apps...
+		}
 		return window.makeHttpUrl('');
 	},
 

--- a/common/MobileApp.hpp
+++ b/common/MobileApp.hpp
@@ -13,6 +13,7 @@
 
 #if MOBILEAPP
 
+#define LIBO_INTERNAL_ONLY
 #include <LibreOfficeKit/LibreOfficeKit.hxx>
 
 #include <Storage.hpp>

--- a/ios/Mobile/AppDelegate.mm
+++ b/ios/Mobile/AppDelegate.mm
@@ -15,9 +15,9 @@
 #import <cstdlib>
 #import <cstring>
 
+#define LIBO_INTERNAL_ONLY
 #import <LibreOfficeKit/LibreOfficeKit.hxx>
 
-#define LIBO_INTERNAL_ONLY
 #include <comphelper/lok.hxx>
 #include <i18nlangtag/languagetag.hxx>
 

--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -28,10 +28,14 @@
 #import "MobileApp.hpp"
 #import "SigUtil.hpp"
 #import "Util.hpp"
+#import "Clipboard.hpp"
 
 #import "DocumentViewController.h"
 
-@interface DocumentViewController() <WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler, UIScrollViewDelegate, UIDocumentPickerDelegate, UIFontPickerViewControllerDelegate> {
+#import <MobileCoreServices/UTCoreTypes.h>
+#import <Poco/MemoryStream.h>
+
+@interface DocumentViewController() <WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler, WKScriptMessageHandlerWithReply, UIScrollViewDelegate, UIDocumentPickerDelegate, UIFontPickerViewControllerDelegate> {
     int closeNotificationPipeForForwardingThread[2];
     NSURL *downloadAsTmpURL;
 }
@@ -87,6 +91,7 @@ static IMP standardImpOfInputAccessoryView = nil;
     [userContentController addScriptMessageHandler:self name:@"debug"];
     [userContentController addScriptMessageHandler:self name:@"lok"];
     [userContentController addScriptMessageHandler:self name:@"error"];
+    [userContentController addScriptMessageHandlerWithReply:self contentWorld:[WKContentWorld pageWorld] name:@"clipboard"];
 
     configuration.userContentController = userContentController;
 
@@ -287,6 +292,152 @@ static IMP standardImpOfInputAccessoryView = nil;
     // Fix issue #5876 by closing the document if the content process dies
     [self bye];
     LOG_ERR("WebContent process terminated! Is closing the document enough?");
+}
+
+// This is the same method as Java_org_libreoffice_androidlib_LOActivity_getClipboardContent, with minimal editing to work with objective C
+- (bool)getClipboardWithTypesPlain:(out NSString ** _Nullable)plain HTML:(out NSString ** _Nullable)html {
+    const char** mimeTypes = nullptr;
+    size_t outCount = 0;
+    char  **outMimeTypes = nullptr;
+    size_t *outSizes = nullptr;
+    char  **outStreams = nullptr;
+    bool bResult = false;
+
+    if (DocumentData::get(self.document->appDocId).loKitDocument->getClipboard(mimeTypes,
+                                                     &outCount, &outMimeTypes,
+                                                     &outSizes, &outStreams))
+    {
+        // return early
+        if (outCount == 0)
+            return bResult;
+
+        for (size_t i = 0; i < outCount; ++i)
+        {
+            // Create new LokClipboardEntry instance
+            
+            if (strcmp(outMimeTypes[i], "text/html") == 0) {
+                *html = outStreams[i] == NULL ? @"" : [NSString stringWithUTF8String:outStreams[i]];
+            } else {
+                *plain = outStreams[i] == NULL ? @"" : [NSString stringWithUTF8String:outStreams[i]];
+            }
+        }
+        bResult = true;
+    }
+    else
+        LOG_DBG("failed to fetch mime-types");
+
+    const char* mimeTypesHTML[] = { "text/plain;charset=utf-8", "text/html", nullptr };
+
+    if (DocumentData::get(self.document->appDocId).loKitDocument->getClipboard(mimeTypesHTML,
+                                                     &outCount, &outMimeTypes,
+                                                     &outSizes, &outStreams))
+    {
+        // return early
+        if (outCount == 0)
+            return bResult;
+
+        for (size_t i = 0; i < outCount; ++i)
+        {
+            // Create new LokClipboardEntry instance
+            
+            if (strcmp(outMimeTypes[i], "text/html") == 0) {
+                *html = outStreams[i] == NULL ? @"" : [NSString stringWithUTF8String:outStreams[i]];
+            } else {
+                *plain = outStreams[i] == NULL ? @"" : [NSString stringWithUTF8String:outStreams[i]];
+            }
+        }
+        bResult = true;
+    }
+    else
+        LOG_DBG("failed to fetch mime-types");
+
+    return bResult;
+}
+
+- (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message replyHandler:(nonnull void (^)(id _Nullable, NSString * _Nullable))replyHandler {
+
+    if ([message.name isEqualToString:@"clipboard"]) {
+        if ([message.body isEqualToString:@"read"]) {
+            UIPasteboard * pasteboard = [UIPasteboard generalPasteboard];
+            
+            NSString * _Nullable plain = [pasteboard string];
+            NSData * htmlPayload = [pasteboard dataForPasteboardType:(NSString*)kUTTypeHTML];
+                        
+            NSData * plainPayload = [plain dataUsingEncoding:NSUTF8StringEncoding];
+
+            NSString * encodedPlainPayload = [plainPayload base64EncodedStringWithOptions:0];
+            NSString * encodedHtmlPayload = [htmlPayload base64EncodedStringWithOptions:0];
+            
+            replyHandler([NSString stringWithFormat:@"%@ %@", encodedPlainPayload, encodedHtmlPayload], nil);
+        } else if ([message.body isEqualToString:@"write"]) {
+            NSString * _Nullable plain;
+            NSString * _Nullable html;
+
+            bool success = [self getClipboardWithTypesPlain:&plain HTML:&html];
+            
+            if (!success) {
+                replyHandler(nil, @"Failed to get clipboard contents...");
+                return;
+            }
+            
+            UIPasteboard * pasteboard = [UIPasteboard generalPasteboard];
+            
+            NSMutableDictionary * pasteboardItem = [NSMutableDictionary dictionaryWithCapacity:2];
+            [pasteboardItem setValue:plain forKey:(NSString*)kUTTypeUTF8PlainText];
+            [pasteboardItem setValue:html forKey:(NSString*)kUTTypeHTML];
+
+            [pasteboard setItems:[NSArray arrayWithObject:pasteboardItem]];
+            
+            replyHandler(nil, nil);
+        } else if ([message.body hasPrefix:@"sendToInternal "]) {
+            ClipboardData data;
+            NSString * content = [message.body substringFromIndex:[@"sendToInternal " length]];
+            std::vector<char> html;
+            
+            size_t nInCount;
+            
+            if ([content hasPrefix:@"<!DOCTYPE html>"]) {
+                // Content is just HTML
+                const char * _Nullable content_cstr = [content cStringUsingEncoding:NSUTF8StringEncoding];
+                html = std::vector(content_cstr, content_cstr + [content lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
+                nInCount = 1;
+            } else {
+                Poco::MemoryInputStream stream([content cStringUsingEncoding:NSUTF8StringEncoding], [content lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
+                data.read(stream);
+                nInCount = data.size();
+            }
+            
+            std::vector<size_t> pInSizes(nInCount);
+            std::vector<const char*> pInMimeTypes(nInCount);
+            std::vector<const char*> pInStreams(nInCount);
+            
+            if (html.empty()) {
+                for (size_t i = 0; i < nInCount; ++i) {
+                    pInSizes[i] = data._content[i].length();
+                    pInStreams[i] = data._content[i].c_str();
+                    pInMimeTypes[i] = data._mimeTypes[i].c_str();
+                }
+            } else {
+                pInSizes[0] = html.size();
+                pInStreams[0] = html.data();
+                pInMimeTypes[0] = "text/html";
+            }
+            
+            if (!DocumentData::get(self.document->appDocId).loKitDocument->setClipboard(nInCount, pInMimeTypes.data(), pInSizes.data(),
+                                                                                        pInStreams.data())) {
+                LOG_ERR("set clipboard returned failure");
+                replyHandler(nil, @"set clipboard returned failure");
+            } else {
+                LOG_TRC("set clipboard succeeded");
+                replyHandler(nil, nil);
+            }
+        } else {
+            replyHandler(nil, [NSString stringWithFormat:@"Invalid clipboard action %@", message.body]);
+        }
+    } else {
+        LOG_ERR("Unrecognized kind of message received from WebView: " << [message.name UTF8String] << ":" << [message.body UTF8String]);
+        replyHandler(nil, [NSString stringWithFormat:@"Message of type %@ does not exist or is not replyable", message.name]);
+    }
 }
 
 - (void)userContentController:(WKUserContentController *)userContentController didReceiveScriptMessage:(WKScriptMessage *)message {

--- a/ios/Mobile/TemplateCollectionViewController.mm
+++ b/ios/Mobile/TemplateCollectionViewController.mm
@@ -9,6 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#define LIBO_INTERNAL_ONLY
 #import <LibreOfficeKit/LibreOfficeKitInit.h>
 
 #import "ios.h"

--- a/ios/ios.h
+++ b/ios/ios.h
@@ -9,6 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#define LIBO_INTERNAL_ONLY
 #include <LibreOfficeKit/LibreOfficeKit.hxx>
 
 extern const char *user_name;


### PR DESCRIPTION
- There is a dependency in the iOS parts with https://gerrit.libreoffice.org/q/topic:%22private/skyler/ios-clipboard%22
- On Android specifically, this introduces several regressions, of which I have found the following
	- This pastes formulas by value, rather than by reference
	- This cannot copy images or graphics

	On iOS these are not regressions, not because they don't exist but because copy/paste is already so broken that it doesn't matter. This is strictly an improvement.

---

I'm going to spend some time investigating these regressions, but if I'm not able to fix them within a timely fashion then I think the solution will be to split I9352a4473be7ab38acc6187a93a5b63e22208815 into iOS/Android copies, and then merge the following in a separate PR
- I64a268c1bdb1412ea2002882389fd49a96bc97d8
- Ia8bbe65f4cd4b31b42f2a8bb24cefe668196dedc
- I40e65150bd41ea99f42c61f75118f3e1aecb3220
- I9352a4473be7ab38acc6187a93a5b63e22208815 (iOS half of split only)