### PR TITLE
name the async dns thread

### DIFF
--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -299,6 +299,7 @@ AsyncDNS::~AsyncDNS()
 
 void AsyncDNS::resolveDNS()
 {
+    Util::setThreadName("asyncdns");
     std::unique_lock<std::mutex> guard(_lock);
     while (true)
     {


### PR DESCRIPTION
so there isn't a mystery thread with the same name as the parent process.

i.e. a diff on:
pstree -plt `pgrep coolwsd`
of;

```
 coolwsd(1753433)─┬─forkit(1753438)───kit_spare_001(1753456)
                  ├─{#1}(1753434)
                  ├─{accept_poll}(1753458)
                  ├─{admin}(1753460)
-                 ├─{coolwsd}(1753436)
+                 ├─{asyncdns}(1753436)
                  ├─{prisoner_poll}(1753437)
                  ├─{remotefontconfi}(1753457)
                  └─{websrv_poll}(1753459)
```

Change-Id: Ic63c2be172212b3fba6f80b7da4118c89dbba6a1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

