### PR TITLE
sometimes this test has 'Pages 1 and 2 of 6'

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
@@ -116,7 +116,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar' 
 		helper.copy();
 		helper.expectTextForClipboard('sit');
 		desktopHelper.assertScrollbarPosition('vertical', 60, 75);
-		cy.cGet('#StatePageNumber').should('have.text', 'Page 2 of 6');
+		cy.cGet('#StatePageNumber').invoke('text').should('be.oneOf', ['Page 2 of 6', 'Pages 1 and 2 of 6']);
 
 		// Scroll document to the top so cursor is no longer visible, that turns following off
 		desktopHelper.scrollWriterDocumentToTop();


### PR DESCRIPTION
instead of 'Page 2 of 6'

similar ambiguity exists in statusbar test


Change-Id: I436a749c663d35684140373189c8ff2a88799c3f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

