### PR TITLE
User Agent

### DIFF
--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -33,7 +33,6 @@ void sendError(http::StatusCode errorCode, const std::shared_ptr<StreamSocket>& 
     std::ostringstream oss;
     oss << "HTTP/1.1 " << errorCode << "\r\n"
         << "Date: " << Util::getHttpTimeNow() << "\r\n"
-        << "User-Agent: " << http::getAgentString() << "\r\n"
         << "Content-Length: " << body.size() << "\r\n"
         << extraHeader << "\r\n"
         << body;

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -151,8 +151,6 @@ public:
         onConnect(socket);
 
         req.set("Host", hostAndPort); // Make sure the host is set.
-        req.set("Date", Util::getHttpTimeNow());
-        req.set("User-Agent", http::getAgentString());
 
         req.header().setConnectionToken(http::Header::ConnectionToken::Upgrade);
         req.set("Upgrade", "websocket");

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -296,7 +296,6 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
             std::ostringstream oss;
             oss << "HTTP/1.1 403 Forbidden\r\n"
                 << "Date: " << Util::getHttpTimeNow() << "\r\n"
-                << "User-Agent: " << http::getAgentString() << "\r\n"
                 << "Content-Length: 0\r\n"
                 << "Connection: close\r\n"
                 << "\r\n";
@@ -406,7 +405,6 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
             std::ostringstream oss;
             oss << "HTTP/1.1 200 OK\r\n"
                 << "Date: " << Util::getHttpTimeNow() << "\r\n"
-                << "User-Agent: " << http::getAgentString() << "\r\n"
                 << "Content-Length: 0\r\n"
                 << "Connection: close\r\n"
                 << "\r\n";
@@ -2130,7 +2128,6 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
             // The custom header for the clipboard of a living document.
             oss << "HTTP/1.1 200 OK\r\n"
                 << "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
-                << "User-Agent: " << http::getAgentString() << "\r\n"
                 << "Content-Length: " << (empty ? 0 : (payload->size() - header)) << "\r\n"
                 << "Content-Type: application/octet-stream\r\n"
                 << "X-Content-Type-Options: nosniff\r\n"

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3836,7 +3836,6 @@ bool DocumentBroker::lookupSendClipboardTag(const std::shared_ptr<StreamSocket> 
             // The custom header for the clipboard of an already closed document.
             oss << "HTTP/1.1 200 OK\r\n"
                 << "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
-                << "User-Agent: " << http::getAgentString() << "\r\n"
                 << "Content-Length: " << saved->length() << "\r\n"
                 << "Content-Type: application/octet-stream\r\n"
                 << "X-Content-Type-Options: nosniff\r\n"

--- a/wsd/ProxyProtocol.cpp
+++ b/wsd/ProxyProtocol.cpp
@@ -59,7 +59,6 @@ void DocumentBroker::handleProxyRequest(
         std::ostringstream oss;
         oss << "HTTP/1.1 200 OK\r\n"
             "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
-            "User-Agent: " << http::getAgentString() << "\r\n"
             "Content-Length: " << sessionId.size() << "\r\n"
             "Content-Type: application/json; charset=utf-8\r\n"
             "X-Content-Type-Options: nosniff\r\n"
@@ -217,7 +216,6 @@ void ProxyProtocolHandler::handleRequest(bool isWaiting, const std::shared_ptr<S
             std::ostringstream oss;
             oss << "HTTP/1.1 200 OK\r\n"
                 "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
-                "User-Agent: " << http::getAgentString() << "\r\n"
                 "Content-Length: " << 0 << "\r\n"
                 "\r\n";
             streamSocket->send(oss.str());
@@ -345,7 +343,6 @@ bool ProxyProtocolHandler::flushQueueTo(const std::shared_ptr<StreamSocket> &soc
     std::ostringstream oss;
     oss << "HTTP/1.1 200 OK\r\n"
         "Last-Modified: " << Util::getHttpTimeNow() << "\r\n"
-        "User-Agent: " << http::getAgentString() << "\r\n"
         "Content-Length: " << totalSize << "\r\n"
         "Content-Type: application/json; charset=utf-8\r\n"
         "X-Content-Type-Options: nosniff\r\n"


### PR DESCRIPTION
Resolves #10454.

- wsd: remove redundant headers from WS request
- wsd: remove User-Agent from responses
- wsd: http: use http::Response
