### PR TITLE
rename generated CanvasTileWorker.js target to TileWorker.js

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -163,12 +163,12 @@ $(eval $(call file_targets,$(COOL_CSS)))
 WORKER_NODE_MODULES_JS =\
 	node_modules/fzstd/umd/index.js
 
-$(DIST_FOLDER)/src/layer/tile/CanvasTileWorker.js: \
+$(DIST_FOLDER)/src/layer/tile/TileWorker.js: \
 	$(srcdir)/src/layer/tile/CanvasTileWorker.js.m4 \
 	$(srcdir)/src/layer/tile/CanvasTileWorkerSrc.js \
 	$(WORKER_NODE_MODULES_JS)
 
-	@echo "Generating CanvasTileWorker.js..."
+	@echo "Generating TileWorker.js..."
 	m4 -PE -DDEBUG=$(ENABLE_DEBUG) \
 		-DNODE_MODULES_JS=$(subst $(SPACE),$(COMMA),$(WORKER_NODE_MODULES_JS)) \
 		-DWORKER_JS=$(srcdir)/src/layer/tile/CanvasTileWorkerSrc.js \
@@ -560,7 +560,7 @@ COOL_TS_SRC = $(filter %.ts,$(COOL_JS_WEBORDER))
 
 # beware these are not helpfully ordered
 COOL_TS_JS_DST = $(patsubst src/%.ts,$(DIST_FOLDER)/src/%.js,$(COOL_TS_SRC))
-COOL_JS_DST = $(patsubst src/%.js,$(DIST_FOLDER)/src/%.js,$(COOL_JS_SRC)) $(COOL_TS_JS_DST) $(DIST_FOLDER)/src/layer/tile/CanvasTileWorker.js
+COOL_JS_DST = $(patsubst src/%.js,$(DIST_FOLDER)/src/%.js,$(COOL_JS_SRC)) $(COOL_TS_JS_DST) $(DIST_FOLDER)/src/layer/tile/TileWorker.js
 # should be no lingering / obsolete files:
 COOL_ASSERT_INTERSECT = $(filter $(COOL_JS_SRC), $(patsubst %.ts,%.js,$(COOL_TS_SRC)))
 

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -731,7 +731,7 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		if (window.Worker && !window.ThisIsAMobileApp) {
 			window.app.console.info('Creating CanvasTileWorker');
-			this._worker = new Worker('src/layer/tile/CanvasTileWorker.js');
+			this._worker = new Worker('src/layer/tile/TileWorker.js');
 			this._worker.addEventListener('message', (e) => this._onWorkerMessage(e));
 			this._worker.addEventListener('error', (e) => this._disableWorker(e));
 		}


### PR DESCRIPTION
so any browser/src/layer/tile/CanvasTileLayer.js files left behind by a make *before*:

commit 906519623fc8cf88eb4cf09500f711b318c64360
    Generate CanvasTileWorker.js in DIST_FOLDER, not srcdir

are not relevant if auto-copied into browser/dist before this generation rule is applied


Change-Id: I1120ceada4e2d8a93576d43cecc09e5a38333a8c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

