### PR TITLE
refactor(clipboard): convert to async/await

### DIFF
--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -288,31 +288,31 @@ L.Control.DownloadProgress = L.Control.extend({
 			this._map.focus();
 	},
 
-	_download: function () {
+	_download: async function () {
 		var that = this;
-		this._map._clip._doAsyncDownload(
-			'GET', that._uri, null, true,
-			function(progress) { return progress/2; },
-		).then(
-			function(response) {
-				window.app.console.log('clipboard async download done');
-				// annoying async parse of the blob ...
-				var reader = new FileReader();
-				reader.onload = function() {
-					var text = reader.result;
-					window.app.console.log('async clipboard parse done: ' + text.substring(0, 256));
-					let result = that._map._clip.parseClipboard(text);
-					that._map._clip.setTextSelectionHTML(result['html'], result['plain']);
-				};
-				// TODO: failure to parse ? ...
-				reader.readAsText(response);
-			}
-		).catch(
-			function (response) {
-				that._onClose();
-				app.showAsyncDownloadError(response, _('Download failed'));
-			}
-		);
+		let response;
+		try {
+			response = await this._map._clip._doAsyncDownload(
+				'GET', this._uri, null, true,
+				function(progress) { return progress/2; },
+			);
+		} catch (error) {
+			that._onClose();
+			app.showAsyncDownloadError(error, _('Download failed'));
+			return;
+		}
+
+		window.app.console.log('clipboard async download done');
+		// annoying async parse of the blob ...
+		var reader = new FileReader();
+		reader.onload = function() {
+			var text = reader.result;
+			window.app.console.log('async clipboard parse done: ' + text.substring(0, 256));
+			let result = that._map._clip.parseClipboard(text);
+			that._map._clip.setTextSelectionHTML(result['html'], result['plain']);
+		};
+		// TODO: failure to parse ? ...
+		reader.readAsText(response);
 	},
 
 	_cancelDownload: function () {

--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -289,7 +289,6 @@ L.Control.DownloadProgress = L.Control.extend({
 	},
 
 	_download: async function () {
-		var that = this;
 		let response;
 		try {
 			response = await this._map._clip._doAsyncDownload(
@@ -297,7 +296,7 @@ L.Control.DownloadProgress = L.Control.extend({
 				function(progress) { return progress/2; },
 			);
 		} catch (error) {
-			that._onClose();
+			this._onClose();
 			app.showAsyncDownloadError(error, _('Download failed'));
 			return;
 		}
@@ -305,11 +304,11 @@ L.Control.DownloadProgress = L.Control.extend({
 		window.app.console.log('clipboard async download done');
 		// annoying async parse of the blob ...
 		var reader = new FileReader();
-		reader.onload = function() {
+		reader.onload = () => {
 			var text = reader.result;
 			window.app.console.log('async clipboard parse done: ' + text.substring(0, 256));
-			let result = that._map._clip.parseClipboard(text);
-			that._map._clip.setTextSelectionHTML(result['html'], result['plain']);
+			let result = this._map._clip.parseClipboard(text);
+			this._map._clip.setTextSelectionHTML(result['html'], result['plain']);
 		};
 		// TODO: failure to parse ? ...
 		reader.readAsText(response);

--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -292,6 +292,8 @@ L.Control.DownloadProgress = L.Control.extend({
 		var that = this;
 		this._map._clip._doAsyncDownload(
 			'GET', that._uri, null, true,
+			function(progress) { return progress/2; },
+		).then(
 			function(response) {
 				window.app.console.log('clipboard async download done');
 				// annoying async parse of the blob ...
@@ -304,8 +306,8 @@ L.Control.DownloadProgress = L.Control.extend({
 				};
 				// TODO: failure to parse ? ...
 				reader.readAsText(response);
-			},
-			function(progress) { return progress/2; },
+			}
+		).catch(
 			function (response) {
 				that._onClose();
 				app.showAsyncDownloadError(response, _('Download failed'));

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -340,14 +340,14 @@ L.Clipboard = L.Class.extend({
 				commandName: commandName,
 			});
 			formData.append('data', new Blob([data]), 'clipboard');
-			that._doAsyncDownload(
-				'POST', dest, formData, false,
-				function(progress) { return 50 + progress/2; },
-			).catch(
-				function() {
-					that.dataTransferToDocumentFallback(null, fallbackHtml);
-				}
-			);
+			try {
+				await that._doAsyncDownload(
+					'POST', dest, formData, false,
+					function(progress) { return 50 + progress/2; },
+				);
+			} catch (_error) {
+				that.dataTransferToDocumentFallback(null, fallbackHtml);
+			}
 			return;
 		}
 
@@ -355,21 +355,18 @@ L.Clipboard = L.Class.extend({
 		var formData = new FormData();
 		formData.append('data', response, 'clipboard');
 
-		that._doAsyncDownload(
+		await that._doAsyncDownload(
 			'POST', dest, formData, false,
 			function(progress) { return 50 + progress/2; }
-		).then(
-			function() {
-				if (that._checkAndDisablePasteSpecial()) {
-					window.app.console.log('up-load done, now paste special');
-					app.socket.sendMessage('uno .uno:PasteSpecial');
-				} else {
-					window.app.console.log('up-load done, now paste');
-					app.socket.sendMessage('uno .uno:Paste');
-				}
-
-			}.bind(this),
 		);
+
+		if (that._checkAndDisablePasteSpecial()) {
+			window.app.console.log('up-load done, now paste special');
+			app.socket.sendMessage('uno .uno:PasteSpecial');
+		} else {
+			window.app.console.log('up-load done, now paste');
+			app.socket.sendMessage('uno .uno:Paste');
+		}
 	},
 
 	_onImageLoadFunc: function (file) {

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -899,7 +899,7 @@ L.Clipboard = L.Class.extend({
 			that._warnCopyPaste();
 			// Once broken, always broken.
 			L.Browser.clipboardApiAvailable = false;
-			window.prefs.set('clipboardApiAvailable', 'false');
+			window.prefs.set('clipboardApiAvailable', false);
 			// Prefetch selection, so next time copy will work with the keyboard.
 			app.socket.sendMessage('gettextselection mimetype=text/html,text/plain;charset=utf-8');
 		}

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -306,7 +306,7 @@ L.Clipboard = L.Class.extend({
 	},
 
 	// Suck the data from one server to another asynchronously ...
-	_dataTransferDownloadAndPasteAsync: async function(src, dest, fallbackHtml) {
+	_dataTransferDownloadAndPasteAsync: async function(src, fallbackHtml) {
 		// FIXME: add a timestamp in the links (?) ignore old / un-responsive servers (?)
 		let response;
 
@@ -340,7 +340,7 @@ L.Clipboard = L.Class.extend({
 			formData.append('data', new Blob([data]), 'clipboard');
 			try {
 				await this._doAsyncDownload(
-					'POST', dest, formData, false,
+					'POST', this.getMetaURL(), formData, false,
 					function(progress) { return 50 + progress/2; },
 				);
 			} catch (_error) {
@@ -354,7 +354,7 @@ L.Clipboard = L.Class.extend({
 		formData.append('data', response, 'clipboard');
 
 		await this._doAsyncDownload(
-			'POST', dest, formData, false,
+			'POST', this.getMetaURL(), formData, false,
 			function(progress) { return 50 + progress/2; }
 		);
 
@@ -427,7 +427,7 @@ L.Clipboard = L.Class.extend({
 		if (meta !== '')
 		{
 			window.app.console.log('Transfer between servers\n\t"' + meta + '" vs. \n\t"' + id + '"');
-			this._dataTransferDownloadAndPasteAsync(meta, this.getMetaURL(), htmlText);
+			this._dataTransferDownloadAndPasteAsync(meta, htmlText);
 			return false; // just started async operation - did not finish yet
 		}
 

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -246,49 +246,48 @@ L.Clipboard = L.Class.extend({
 	// completeFn: called on completion - with response.
 	// progressFn: allows splitting the progress bar up.
 	_doAsyncDownload: async function(type,url,optionalFormData,forClipboard,progressFn,) {
-		var that = this;
 		var request = new XMLHttpRequest();
 
 		// avoid to invoke the following code if the download widget depends on user interaction
-		if (!that._downloadProgress || that._downloadProgress.isClosed()) {
-			that._startProgress(false);
-			that._downloadProgress.startProgressMode();
+		if (!this._downloadProgress || this._downloadProgress.isClosed()) {
+			this._startProgress(false);
+			this._downloadProgress.startProgressMode();
 		}
 
 		return await new Promise((resolve, reject) => {
-			request.onload = function() {
-				that._downloadProgress._onComplete();
+			request.onload = () => {
+				this._downloadProgress._onComplete();
 				if (!forClipboard) {
-					that._downloadProgress._onClose();
+					this._downloadProgress._onClose();
 				}
 
 				// For some reason 400 error from the server doesn't
 				// invoke onerror callback, but we do get here with
 				// size==0, which signifies no response from the server.
 				// So we check the status code instead.
-				if (this.status == 200) {
-					resolve(this.response);
+				if (request.status == 200) {
+					resolve(request.response);
 				} else {
-					reject(this.response);
+					reject(request.response);
 				}
 			};
-			request.onerror = function(error) {
+			request.onerror = (error) => {
 				reject(error);
-				that._downloadProgress._onComplete();
-				that._downloadProgress._onClose();
+				this._downloadProgress._onComplete();
+				this._downloadProgress._onClose();
 			};
 
-			request.ontimeout = function() {
-				that._map.uiManager.showSnackbar(_('warning: copy/paste request timed out'));
-				that._downloadProgress._onClose();
+			request.ontimeout = () => {
+				this._map.uiManager.showSnackbar(_('warning: copy/paste request timed out'));
+				this._downloadProgress._onClose();
 				reject('request timed out');
 			};
 
-			request.upload.addEventListener('progress', function (e) {
+			request.upload.addEventListener('progress', (e) => {
 				if (e.lengthComputable) {
 					var percent = progressFn(e.loaded / e.total * 100);
 					var progress = { statusType: 'setvalue', value: percent };
-					that._downloadProgress._onUpdateProgress(progress);
+					this._downloadProgress._onUpdateProgress(progress);
 				}
 			}, false);
 
@@ -308,12 +307,11 @@ L.Clipboard = L.Class.extend({
 
 	// Suck the data from one server to another asynchronously ...
 	_dataTransferDownloadAndPasteAsync: async function(src, dest, fallbackHtml) {
-		var that = this;
 		// FIXME: add a timestamp in the links (?) ignore old / un-responsive servers (?)
 		let response;
 
 		try {
-			response = await that._doAsyncDownload(
+			response = await this._doAsyncDownload(
 				'GET', src, null, false,
 				function(progress) { return progress/2; },
 			);
@@ -321,16 +319,16 @@ L.Clipboard = L.Class.extend({
 			window.app.console.log('failed to download clipboard using fallback html');
 
 			// If it's the stub, avoid pasting.
-			if (that._isStubHtml(fallbackHtml))
+			if (this._isStubHtml(fallbackHtml))
 			{
 				// Let the user know they haven't really copied document content.
-				that._map.uiManager.showInfoModal('data transfer warning', '', _('Failed to download clipboard, please re-copy'));
+				this._map.uiManager.showInfoModal('data transfer warning', '', _('Failed to download clipboard, please re-copy'));
 				return;
 			}
 
 			var formData = new FormData();
 			let commandName = null;
-			if (that._checkAndDisablePasteSpecial()) {
+			if (this._checkAndDisablePasteSpecial()) {
 				commandName = '.uno:PasteSpecial';
 			} else {
 				commandName = '.uno:Paste';
@@ -341,12 +339,12 @@ L.Clipboard = L.Class.extend({
 			});
 			formData.append('data', new Blob([data]), 'clipboard');
 			try {
-				await that._doAsyncDownload(
+				await this._doAsyncDownload(
 					'POST', dest, formData, false,
 					function(progress) { return 50 + progress/2; },
 				);
 			} catch (_error) {
-				await that.dataTransferToDocumentFallback(null, fallbackHtml);
+				await this.dataTransferToDocumentFallback(null, fallbackHtml);
 			}
 			return;
 		}
@@ -355,12 +353,12 @@ L.Clipboard = L.Class.extend({
 		var formData = new FormData();
 		formData.append('data', response, 'clipboard');
 
-		await that._doAsyncDownload(
+		await this._doAsyncDownload(
 			'POST', dest, formData, false,
 			function(progress) { return 50 + progress/2; }
 		);
 
-		if (that._checkAndDisablePasteSpecial()) {
+		if (this._checkAndDisablePasteSpecial()) {
 			window.app.console.log('up-load done, now paste special');
 			app.socket.sendMessage('uno .uno:PasteSpecial');
 		} else {
@@ -813,10 +811,9 @@ L.Clipboard = L.Class.extend({
         if (e.commandName === '.uno:Copy' || e.commandName === '.uno:Cut')
 		{
 			window.app.console.log('Resolve clipboard command promise ' + e.commandName);
-			const that = this;
-			while (that._commandCompletion.length > 0)
+			while (this._commandCompletion.length > 0)
 			{
-				let a = that._commandCompletion.shift();
+				let a = this._commandCompletion.shift();
 				a.resolve();
 			}
 		}
@@ -874,9 +871,7 @@ L.Clipboard = L.Class.extend({
 		// that command so we are sure the clipboard is set before
 		// fetching it.
 
-		const that = this;
-
-		const url = that.getMetaURL() + '&MimeType=text/html,text/plain;charset=utf-8';
+		const url = this.getMetaURL() + '&MimeType=text/html,text/plain;charset=utf-8';
 
 		var result = await fetch(url);
 		var text = await result.text();
@@ -896,7 +891,7 @@ L.Clipboard = L.Class.extend({
 			window.app.console.log('navigator.clipboard.write() failed: ' + error.message);
 
 			// Warn that the copy failed.
-			that._warnCopyPaste();
+			this._warnCopyPaste();
 			// Once broken, always broken.
 			L.Browser.clipboardApiAvailable = false;
 			window.prefs.set('clipboardApiAvailable', false);
@@ -943,7 +938,6 @@ L.Clipboard = L.Class.extend({
 	},
 
 	_asyncAttemptNavigatorClipboardRead: async function(isSpecial) {
-		var that = this;
 		var clipboard = navigator.clipboard;
 		if (L.Browser.cypressTest) {
 			clipboard = this._dummyClipboard;
@@ -955,16 +949,16 @@ L.Clipboard = L.Class.extend({
 			window.app.console.log('navigator.clipboard.read() failed: ' + error.message);
 			if (isSpecial) {
 				// Fallback to the old code, as in filterExecCopyPaste().
-				that._openPasteSpecialPopup();
+				this._openPasteSpecialPopup();
 			} else {
 				// Fallback to the old code, as in _execCopyCutPaste().
-				that._afterCopyCutPaste('paste');
+				this._afterCopyCutPaste('paste');
 			}
 			return;
 		}
 
 		if (isSpecial) {
-			that._navigatorClipboardPasteSpecial = true;
+			this._navigatorClipboardPasteSpecial = true;
 		}
 
 		if (clipboardContents.length < 1) {
@@ -974,7 +968,6 @@ L.Clipboard = L.Class.extend({
 
 		var clipboardContent = clipboardContents[0];
 
-		var that = this;
 		if (clipboardContent.types.includes('text/html')) {
 			let blob;
 			try {
@@ -983,7 +976,7 @@ L.Clipboard = L.Class.extend({
 				window.app.console.log('clipboardContent.getType(text/html) failed: ' + error.message);
 				return;
 			}
-			that._navigatorClipboardGetTypeCallback(clipboardContent, blob, 'text/html');
+			this._navigatorClipboardGetTypeCallback(clipboardContent, blob, 'text/html');
 		} else if (clipboardContent.types.includes('text/plain')) {
 			let blob;
 			try {
@@ -992,7 +985,7 @@ L.Clipboard = L.Class.extend({
 				window.app.console.log('clipboardContent.getType(text/plain) failed: ' + error.message);
 				return;
 			}
-			that._navigatorClipboardGetTypeCallback(clipboardContent, blob, 'text/plain');
+			this._navigatorClipboardGetTypeCallback(clipboardContent, blob, 'text/plain');
 		} else {
 			window.app.console.log('navigator.clipboard has no text/html or text/plain');
 			return;

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -245,16 +245,17 @@ L.Clipboard = L.Class.extend({
 	// forClipboard: a boolean telling if we need the "Confirm copy to clipboard" link in the end
 	// completeFn: called on completion - with response.
 	// progressFn: allows splitting the progress bar up.
-	_doAsyncDownload: function(type,url,optionalFormData,forClipboard,completeFn,progressFn,onErrorFn) {
-		try {
-			var that = this;
-			var request = new XMLHttpRequest();
+	_doAsyncDownload: async function(type,url,optionalFormData,forClipboard,progressFn,) {
+		var that = this;
+		var request = new XMLHttpRequest();
 
-			// avoid to invoke the following code if the download widget depends on user interaction
-			if (!that._downloadProgress || that._downloadProgress.isClosed()) {
-				that._startProgress(false);
-				that._downloadProgress.startProgressMode();
-			}
+		// avoid to invoke the following code if the download widget depends on user interaction
+		if (!that._downloadProgress || that._downloadProgress.isClosed()) {
+			that._startProgress(false);
+			that._downloadProgress.startProgressMode();
+		}
+
+		return await new Promise((resolve, reject) => {
 			request.onload = function() {
 				that._downloadProgress._onComplete();
 				if (!forClipboard) {
@@ -266,14 +267,13 @@ L.Clipboard = L.Class.extend({
 				// size==0, which signifies no response from the server.
 				// So we check the status code instead.
 				if (this.status == 200) {
-					completeFn(this.response);
-				} else if (onErrorFn) {
-					onErrorFn(this.response);
+					resolve(this.response);
+				} else {
+					reject(this.response);
 				}
 			};
-			request.onerror = function() {
-				if (onErrorFn)
-					onErrorFn();
+			request.onerror = function(error) {
+				reject(error);
 				that._downloadProgress._onComplete();
 				that._downloadProgress._onClose();
 			};
@@ -281,6 +281,7 @@ L.Clipboard = L.Class.extend({
 			request.ontimeout = function() {
 				that._map.uiManager.showSnackbar(_('warning: copy/paste request timed out'));
 				that._downloadProgress._onClose();
+				reject('request timed out');
 			};
 
 			request.upload.addEventListener('progress', function (e) {
@@ -302,10 +303,7 @@ L.Clipboard = L.Class.extend({
 				request.send(optionalFormData);
 			else
 				request.send();
-		} catch (error) {
-			if (onErrorFn)
-				onErrorFn();
-		}
+		});
 	},
 
 	// Suck the data from one server to another asynchronously ...
@@ -314,12 +312,16 @@ L.Clipboard = L.Class.extend({
 		// FIXME: add a timestamp in the links (?) ignore old / un-responsive servers (?)
 		that._doAsyncDownload(
 			'GET', src, null, false,
+			function(progress) { return progress/2; },
+		).then(
 			function(response) {
 				window.app.console.log('download done - response ' + response);
 				var formData = new FormData();
 				formData.append('data', response, 'clipboard');
 				that._doAsyncDownload(
 					'POST', dest, formData, false,
+					function(progress) { return 50 + progress/2; }
+				).then(
 					function() {
 						if (that._checkAndDisablePasteSpecial()) {
 							window.app.console.log('up-load done, now paste special');
@@ -330,10 +332,10 @@ L.Clipboard = L.Class.extend({
 						}
 
 					}.bind(this),
-					function(progress) { return 50 + progress/2; }
 				);
 			}.bind(this),
-			function(progress) { return progress/2; },
+		)
+		.catch(
 			function() {
 				window.app.console.log('failed to download clipboard using fallback html');
 
@@ -359,9 +361,8 @@ L.Clipboard = L.Class.extend({
 				formData.append('data', new Blob([data]), 'clipboard');
 				that._doAsyncDownload(
 					'POST', dest, formData, false,
-					function() {
-					}.bind(this),
 					function(progress) { return 50 + progress/2; },
+				).catch(
 					function() {
 						that.dataTransferToDocumentFallback(null, fallbackHtml);
 					}
@@ -492,12 +493,13 @@ L.Clipboard = L.Class.extend({
 
 			var that = this;
 			this._doAsyncDownload('POST', this.getMetaURL(), formData, false,
+				function(progress) { return progress; }
+			).then(
 				function() {
 					window.app.console.log('Posted ' + content.size + ' bytes successfully');
 					that._doInternalPaste(that._map, usePasteKeyEvent);
 				},
-				function(progress) { return progress; }
-					    );
+			);
 		} else {
 			window.app.console.log('Nothing we can paste on the clipboard');
 		}

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -845,14 +845,38 @@ L.Clipboard = L.Class.extend({
 			while (that._commandCompletion.length > 0)
 			{
 				let a = that._commandCompletion.shift();
-				a.resolve(a.fetch().then(function(text) {
-					const content = that.parseClipboard(text)[a.shorttype];
-					const blob = new Blob([content], { 'type': a.mimetype });
-					console.log('Generate blob of type ' + a.mimetype + ' from ' +a.shorttype + ' text: ' +content);
-					return blob;
-				}));
+				a.resolve();
 			}
 		}
+	},
+
+	_sendCommandAndWaitForCompletion: function(command) {
+		if (command !== '.uno:Copy' && command !== '.uno:Cut') {
+			throw `_sendCommandAndWaitForCompletion was called with '${command}', but anything except Copy or Cut will never complete`;
+		}
+
+		if (this._commandCompletion.length > 0) {
+			throw 'Already have ' + this._commandCompletion.length +
+				' pending clipboard command(s)';
+		}
+
+		app.socket.sendMessage('uno ' + command);
+
+		return new Promise((resolve, reject) => {
+			window.app.console.log('New ' + command + ' promise');
+			// FIXME: add a timeout cleanup too ...
+			this._commandCompletion.push({
+				resolve: resolve,
+				reject: reject,
+			});
+		});
+	},
+
+	_parseClipboardFetchResult: function(text, mimetype, shorttype) {
+		const content = this.parseClipboard(text)[shorttype];
+		const blob = new Blob([content], { 'type': mimetype });
+		console.log('Generate blob of type ' + mimetype + ' from ' + shorttype + ' text: ' + content);
+		return blob;
 	},
 
 	// Executes the navigator.clipboard.write() call, if it's available.
@@ -866,7 +890,7 @@ L.Clipboard = L.Class.extend({
 		}
 
 		const command = this._unoCommandForCopyCutPaste;
-		app.socket.sendMessage('uno ' + command);
+		const commandCompletion = this._sendCommandAndWaitForCompletion(command);
 
 		// This is sent down the websocket URL which can race with the
 		// web fetch - so first step is to wait for the result of
@@ -875,31 +899,15 @@ L.Clipboard = L.Class.extend({
 
 		const that = this;
 
-		if (that._commandCompletion.length > 0)
-			window.app.console.error('Already have ' + that._commandCompletion.length +
-						 ' pending clipboard command(s)');
-
 		const url = that.getMetaURL() + '&MimeType=text/html,text/plain;charset=utf-8';
 
-		// Share a single fetch
-		var fetchPromise = function() {
-			return new Promise((resolve, reject) => {
-				try {
-					var result = fetch(url).then(response => response.text());
-					resolve(result);
-				} catch (err) {
-					reject(err);
-				}
-			});
-		};
-
+		// TODO: Share a single fetch
 		var awaitPromise = function(url, mimetype, shorttype) {
-			return new Promise((resolve, reject) => {
-				window.app.console.log('New ' + command + ' promise');
-				// FIXME: add a timeout cleanup too ...
-				that._commandCompletion.push({ fetch: fetchPromise, command: command,
-							       resolve: resolve, reject: reject,
-							       mimetype: mimetype, shorttype: shorttype});
+			return new Promise(async (resolve, reject) => {
+				await commandCompletion;
+				var result = await fetch(url);
+				var text = await result.text();
+				resolve(_parseClipboardFetchResult(text, mimetype, shorttype));
 		}); };
 
 		const text = new ClipboardItem({


### PR DESCRIPTION
Previously the read and write functions were using callbacks and promise
chains, which worked but would have been more annoying for me to extend
with android-specific clipboard things.

As a bonus, async/await reduces nesting and jumping around in the code,
which should also make this easier to read, and arrow functions remove
this->that aliasing

Finally, using async/await in new places allows us to better use
existing places which do provide promises, for example we can go back to
only fetching the clipboard a single time without re-introducing the
race condition which fetching twice solved