### PR TITLE
fix(clipboard): set command in _doCopyCut

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -1040,6 +1040,7 @@ L.Clipboard = L.Class.extend({
 				this._clipboardSerial++;
 			}
 		} else {
+			this._unoCommandForCopyCutPaste = `.uno:${unoName}`;
 			preventDefault = this.populateClipboard(ev);
 		}
 


### PR DESCRIPTION
_doCopyCut has the ability to call functions that depend on _unoCommandForCopyCutPaste, but despite having access to the required uno command here it never sets the variable.

That causes copy/paste commands that go through this route to use the last command executed, or if no commands were executed before this to throw an error and fail entirely.

I noticed this while working on #10498, but decided to avoid including it there as that is a pure refactor

Change-Id: I00549aa872fee8f51b5c0426e5d1eb1569210378


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

