### PR TITLE
sidebar: fix TypeError on switch

### DIFF
--- a/browser/src/control/Control.Sidebar.ts
+++ b/browser/src/control/Control.Sidebar.ts
@@ -194,6 +194,7 @@ class Sidebar {
 					sidebarData.children[i].visible === false
 				) {
 					sidebarData.children.splice(i, 1);
+					continue;
 				}
 
 				if (


### PR DESCRIPTION
This fixes the error on switching the decks in Writer. Regression from commit b5eab2c988515c904f8c4b6c975a25e1f777e028 browser: treeview: remove global var hack

