### PR TITLE
Document/ClientSession/SessionMap: Make imutable methods `const`

### DIFF
--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -56,7 +56,7 @@ public:
     }
 
     /// Lookup one session in the map that matches this canonical view id, only used by Kit
-    std::shared_ptr<T> findByCanonicalId(int id)
+    std::shared_ptr<T> findByCanonicalId(int id) const
     {
         for (const auto &it : *this) {
             if (it.second->getCanonicalViewId() == id)

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2227,7 +2227,7 @@ bool Document::forwardToChild(const std::string& prefix, const std::vector<char>
     return std::string();
 }
 
-bool Document::isTileRequestInsideVisibleArea(const TileCombined& tileCombined)
+bool Document::isTileRequestInsideVisibleArea(const TileCombined& tileCombined) const
 {
     const auto session = _sessions.findByCanonicalId(tileCombined.getNormalizedViewId());
     if (!session)

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -327,7 +327,7 @@ private:
                                         const std::string& spellOnline, const std::string& theme,
                                         const std::string& backgroundTheme,
                                         const std::string& userPrivateInfo);
-    bool isTileRequestInsideVisibleArea(const TileCombined& tileCombined);
+    bool isTileRequestInsideVisibleArea(const TileCombined& tileCombined) const;
 
 public:
     bool processInputEnabled() const;

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -270,7 +270,7 @@ public:
     /// Process an SVG to replace embedded file:/// media URIs with public http URLs.
     std::string processSVGContent(const std::string& svg);
 
-    int  getCanonicalViewId() { return _canonicalViewId; }
+    int  getCanonicalViewId() const { return _canonicalViewId; }
 
 private:
     std::shared_ptr<ClientSession> client_from_this()


### PR DESCRIPTION
Change-Id: Ic71b03747e57976ce4ac69a5f97a015d5d210648

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Add const qualifier to certain immutable methods, allowing interoperability with const references.


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

