### PR TITLE
stateChangeHandler: EditDoc now uses boolean or disabled payload

### DIFF
--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -389,14 +389,14 @@ class StatusBar extends JSDialog.Toolbar {
 		}
 
 		var canUserWrite = window.ThisIsAMobileApp ? !app.isReadOnly() : this.map['wopi'].UserCanWrite;
-		var EditDocMode = true;
+		var NotEditDocMode = false;
 		if (app.map['stateChangeHandler'].getItemValue('EditDoc') !== undefined) {
-			EditDocMode = app.map['stateChangeHandler'].getItemValue('EditDoc') === "true";
-			if (!EditDocMode)
+			NotEditDocMode = app.map['stateChangeHandler'].getItemValue('EditDoc') === "false"; // can be true, false or disabled
+			if (NotEditDocMode)
 				app.map.uiManager.showSnackbar(_('To prevent accidental changes, the author has set this file to open as view-only'));
 		}
 
-		canUserWrite = canUserWrite && EditDocMode;
+		canUserWrite = canUserWrite && !NotEditDocMode;
 
 		var permissionContainer = document.getElementById('permissionmode-container');
 		if (permissionContainer) {
@@ -491,7 +491,7 @@ class StatusBar extends JSDialog.Toolbar {
 			}
 		}
 		else if (commandName === '.uno:EditDoc') {
-			state = state === "true";
+			state = state !== "false";
 			this.onPermissionChanged({detail : {
 				perm: state && this.map.isEditMode() ? "edit" : "readonly"
 			} });


### PR DESCRIPTION
now EditDoc may have true, false or disabled values, handle it accordingly


Change-Id: I52668290007cc07d3f1bae015d533d50fc538c76


* Target version: master 

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

