### PR TITLE
Fix: Notes placeholder string gets mixed up with "Slide of" string

### DIFF
--- a/browser/src/slideshow/PresenterConsole.js
+++ b/browser/src/slideshow/PresenterConsole.js
@@ -900,13 +900,10 @@ class PresenterConsole {
 
 		if (this._notes) {
 			let notes = this._presenter.getNotes(e.slide);
-			if (notes) elem = this._notes.querySelector('#notes');
-			if (elem) {
-				elem.innerText =
-					notes && notes.toLowerCase() !== 'click to add notes'.toLowerCase()
-						? notes
-						: _('No Notes');
-			}
+			let notesContentElem = this._notes.querySelector('#notes');
+			notesContentElem.innerText = _('No Notes');
+			if (notes && notes.toLowerCase() !== 'click to add notes'.toLowerCase())
+				notesContentElem.innerText = notes;
 		}
 
 		let next =


### PR DESCRIPTION
- Because we same variable is the reason that notes text gets into #slides container text
- this patch will get notes content container and set inner text by default "no notes"
- we will assign text only if notes are defined in current slide

Before:

![image](https://github.com/user-attachments/assets/8ecb2041-e006-4797-ba0a-e66a3caf9703)


After:

![image](https://github.com/user-attachments/assets/89241dab-ee28-4eb2-8069-33f299ee4e3a)


Change-Id: I32dd646ca4cbabce94842cbc3d34cda636ec45b1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

