### PR TITLE
cool#9992 doc electronic sign: allow passing sign params from JS

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -676,7 +676,8 @@ bool ChildSession::_handleInput(const char *buffer, int length)
             }
             else if (tokens[1].find(".uno:Signature") != std::string::npos)
             {
-                if (unoSignatureCommand())
+                // See if the command has parameters: if not, annotate with sign cert/key.
+                if (tokens.size() == 2 && unoSignatureCommand())
                 {
                     // .uno:Signature has been sent with parameters from user private info, done.
                     return true;


### PR DESCRIPTION
Try to dispatch the .uno:Signature command from the JS console with
parameters, the parameters get lost by the time they hit the LOK API
boundary.

This is because kit/ code tries to annotate .uno:Signature with the
signature cert/key PEM data, but it won't append this data the
parameters, just replace the original parameters.

Given that there is no use-case to combine the parameters, just avoid
annotating when there are parameters already: electronic signing /
external signatures will have all the info as parameters in JS.

With this, a code snippet like:
app.socket.sendMessage('uno .uno:Signature {"SignatureTime":{"type":"string","value":"..."},"SignatureValue":{"type":"string","value":"..."}}');
works as expected, similar to how it works in core in a cppunit test.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I42df9bf864fe0f7a2854429652d15e4e61efda7a
