### PR TITLE
Log UI commands related to undo

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -127,6 +127,7 @@ shared_sources = common/FileUtil.cpp \
                  common/Simd.cpp \
                  common/CoolMount.cpp \
                  kit/KitQueue.cpp \
+                 kit/LogUI.cpp \
                  net/DelaySocket.cpp \
                  net/HttpRequest.cpp \
                  net/HttpHelper.cpp \
@@ -395,6 +396,7 @@ shared_headers = common/Anonymizer.hpp \
                  common/ThreadPool.hpp \
                  common/Watchdog.hpp \
                  kit/KitQueue.hpp \
+                 kit/LogUI.hpp \
                  net/AsyncDNS.hpp \
                  net/Buffer.hpp \
                  net/DelaySocket.hpp \
@@ -569,30 +571,35 @@ run: setup-wsd
 	fi
 	$(ENABLE_NAMESPACE) ./coolwsd $(COMMON_PARAMS) \
 			--o:logging.file[@enable]=${OUTPUT_TO_FILE} --o:logging.level=trace \
+			--o:logging_ui_cmd.file[@enable]=${OUTPUT_TO_FILE} \
 			--o:trace_event[@enable]=true
 
 if ENABLE_DEBUG
 run-one: setup-wsd
 	$(ENABLE_NAMESPACE) ./coolwsd $(COMMON_PARAMS) \
 			--o:logging.file[@enable]=true --o:logging.level=trace \
+			--o:logging_ui_cmd.file[@enable]=true \
 			--singlekit
 
 run-inproc: setup-wsd
 	@echo "Launching coolwsd-inproc"
 	./coolwsd-inproc $(COMMON_PARAMS) \
-			--o:logging.file[@enable]=true --o:logging.level=trace
+			--o:logging.file[@enable]=true --o:logging.level=trace \
+			--o:logging_ui_cmd.file[@enable]=true
 
 run-massif-inproc: setup-wsd
 	@echo "Launching coolwsd under valgrind for single process"
 	$(ENABLE_NAMESPACE) valgrind --tool=massif --num-callers=64 --trace-children=no -v \
 		./coolwsd-inproc $(COMMON_PARAMS) \
-			--o:logging.file[@enable]=false --o:logging.level=trace
+			--o:logging.file[@enable]=false --o:logging.level=trace \
+			--o:logging_ui_cmd.file[@enable]=false
 
 run-heaptrack-inproc: setup-wsd
 	@echo "Launching coolwsd under heaptrack for single process"
 	$(ENABLE_NAMESPACE) heaptrack \
 		./coolwsd-inproc $(COMMON_PARAMS) \
-			--o:logging.file[@enable]=false --o:logging.level=trace
+			--o:logging.file[@enable]=false --o:logging.level=trace \
+			--o:logging_ui_cmd.file[@enable]=false
 endif
 
 sync-writer:
@@ -607,6 +614,7 @@ sync-impress:
 run-trace: setup-wsd
 	$(ENABLE_NAMESPACE) ./coolwsd $(COMMON_PARAMS) \
 			--o:logging.file[@enable]=false --o:logging.level=trace \
+			--o:logging_ui_cmd.file[@enable]=false \
 			--o:trace[@enable]=true --o:trace.path=${builddir}/trace.txt.gz \
 			--o:trace.outgoing.record=false
 
@@ -614,25 +622,29 @@ run-valgrind: setup-wsd
 	@echo "Launching coolwsd under valgrind (but not forkit/coolkit, yet)"
 	$(ENABLE_NAMESPACE) valgrind --tool=memcheck --trace-children=no -v --read-var-info=yes \
 		./coolwsd $(COMMON_PARAMS) \
-			--o:logging.file[@enable]=false --o:logging.level=trace
+			--o:logging.file[@enable]=false --o:logging.level=trace \
+			--o:logging_ui_cmd.file[@enable]=false
 
 run-gdb: setup-wsd
 	@echo "Launching coolwsd under gdb"
 	$(ENABLE_NAMESPACE) $(RUN_GDB) \
 		./coolwsd $(COMMON_PARAMS) \
-			--o:logging.file[@enable]=false --o:logging.level=error
+			--o:logging.file[@enable]=false --o:logging.level=error \
+			--o:logging_ui_cmd.file[@enable]=false
 
 run-callgrind: setup-wsd
 	@echo "Launching coolwsd under valgrind's callgrind"
 	$(ENABLE_NAMESPACE) valgrind --tool=callgrind --simulate-cache=yes --dump-instr=yes --num-callers=50 --error-limit=no --trace-children=yes \
 		./coolwsd $(COMMON_PARAMS) \
-			--o:logging.file[@enable]=false --o:logging.level=error
+			--o:logging.file[@enable]=false --o:logging.level=error \
+			--o:logging_ui_cmd.file[@enable]=false
 
 run-strace: setup-wsd
 	@echo "Launching coolwsd under strace"
 	$(ENABLE_NAMESPACE) strace -o strace.log -f -tt -s 256 \
 		./coolwsd $(COMMON_PARAMS) \
-			--o:logging.file[@enable]=false --o:logging.level=error
+			--o:logging.file[@enable]=false --o:logging.level=error \
+			--o:logging_ui_cmd.file[@enable]=false
 
 else
 

--- a/android/lib/src/main/cpp/CMakeLists.txt.in
+++ b/android/lib/src/main/cpp/CMakeLists.txt.in
@@ -26,6 +26,7 @@ add_library(androidapp SHARED
             ../../../../../kit/DeltaSimd.c
             ../../../../../kit/Kit.cpp
             ../../../../../kit/KitQueue.cpp
+            ../../../../../kit/LogUI.cpp
             ../../../../../kit/KitWebSocket.cpp
             ../../../../../net/FakeSocket.cpp
             ../../../../../net/Socket.cpp

--- a/android/lib/src/main/cpp/androidapp.cpp
+++ b/android/lib/src/main/cpp/androidapp.cpp
@@ -56,9 +56,9 @@ JNI_OnLoad(JavaVM* vm, void*) {
     // Uncomment the following to see the logs from the core too
     //setenv("SAL_LOG", "+WARN+INFO", 0);
 #if ENABLE_DEBUG
-    Log::initialize("Mobile", "debug", false, false, {});
+    Log::initialize("Mobile", "debug", false, false, {}, false, {});
 #else
-    Log::initialize("Mobile", "information", false, false, {});
+    Log::initialize("Mobile", "information", false, false, {}, false, {});
 #endif
     return JNI_VERSION_1_6;
 }

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -69,7 +69,9 @@ namespace Log
                     const std::string& logLevel,
                     bool withColor,
                     bool logToFile,
-                    const std::map<std::string, std::string>& config);
+                    const std::map<std::string, std::string>& config,
+                    bool logToFileUICmd,
+                    const std::map<std::string, std::string>& configUICmd);
 
     /// Shutdown and release the logging system.
     void shutdown();
@@ -104,6 +106,11 @@ namespace Log
 
     /// Main entry function for all logging
     void log(Level l, const std::string &text);
+    bool isLogUIEnabled();
+    void logUI(Level l, const std::string &text);
+    bool isLogUIMerged();
+    bool isLogUITimeEnd();
+    void setUILogMergeInfo(bool mergeCmd, bool logTimeEndOfMergedCmd);
 
     /// Setting the logging level
     void setLevel(const std::string &l);

--- a/configure.ac
+++ b/configure.ac
@@ -412,6 +412,8 @@ COOLWSD_LOG_TO_FILE="false"
 COOLWSD_LOGFILE="/var/log/coolwsd.log"
 COOLWSD_TRACEEVENTFILE="/var/log/coolwsd.trace.json"
 COOLWSD_ANONYMIZE_USER_DATA=false
+COOLWSD_LOG_UICMD_TO_FILE="false"
+COOLWSD_LOGFILE_UICMD="/var/log/coolwsd-ui-cmd.log"
 BROWSER_LOGGING="false"
 debug_msg="secure mode: product build"
 anonym_msg=""
@@ -438,6 +440,8 @@ if test "$enable_debug" = "yes"; then
    COOLWSD_LOGFILE="/tmp/coolwsd.log"
    COOLWSD_TRACEEVENTFILE="/tmp/coolwsd.trace.json"
    COOLWSD_ANONYMIZE_USER_DATA=false
+   COOLWSD_LOG_UICMD_TO_FILE="true"
+   COOLWSD_LOGFILE_UICMD="/tmp/coolwsd-ui-cmd.log"
    BROWSER_LOGGING="true"
    debug_msg="low security debugging mode"
    SSL_VERIFY="false"
@@ -472,6 +476,7 @@ AC_SUBST(ENABLE_DEBUG)
 AC_SUBST(ENABLE_BUNDLE)
 AC_SUBST(COOLWSD_LOGLEVEL)
 AC_SUBST(COOLWSD_LOG_TO_FILE)
+AC_SUBST(COOLWSD_LOG_UICMD_TO_FILE)
 AC_SUBST(BROWSER_LOGGING)
 AC_SUBST(NUM_PRESPAWN_CHILDREN)
 
@@ -492,6 +497,7 @@ if test -n "$with_logfile" ; then
    COOLWSD_LOGFILE="$with_logfile"
 fi
 AC_SUBST(COOLWSD_LOGFILE)
+AC_SUBST(COOLWSD_LOGFILE_UICMD)
 
 if test -n "$with_trace_event_file" ; then
    COOLWSD_TRACEEVENTFILE="$with_trace_event_file"

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -124,6 +124,18 @@
         <disable_server_audit type="bool" desc="Disabled server audit dialog and notification. Admin will no longer see warnings in the application user interface. This doesn't affect log file." default="false">false</disable_server_audit>
     </logging>
 
+    <logging_ui_cmd>
+        <merge type="bool" desc="If true, repeated commands after each other will be merged into 1 line. If false, every command will be 1 new line." default="true">true</merge>
+        <merge_display_end_time type="bool" desc="If true, the duration of the merged command will also be logged." default="false">false</merge_display_end_time>
+        <file enable="@COOLWSD_LOG_UICMD_TO_FILE@">
+            <!-- If you use other path than /var/log and you run coolwsd from systemd, make sure that you enable that path in coolwsd.service (ReadWritePaths). -->
+            <property name="path" desc="Log file path.">@COOLWSD_LOGFILE_UICMD@</property>
+            <property name="purgeCount" desc="The maximum number of log archives to preserve. Use 'none' to disable purging. See Poco FileChannel.">10</property>
+            <property name="rotateOnOpen" desc="Enable/disable log file rotation on opening.">true</property>
+            <property name="flush" desc="Enable/disable flushing after logging each line. May harm performance. Note that without flushing after each line, the log lines from the different processes will not appear in chronological order.">false</property>
+        </file>
+    </logging_ui_cmd>
+
     <!--
          Note to developers: When you do "make run", the trace_event[@enable] will be set on the
          coolwsd command line, so if you want to change it for your testing, do it in Makefile.am,

--- a/fuzzer/Common.cpp
+++ b/fuzzer/Common.cpp
@@ -25,7 +25,7 @@ bool DoInitialization()
     bool withColor = false;
     bool logToFile = false;
     std::map<std::string, std::string> logProperties;
-    Log::initialize("wsd", logLevel, withColor, logToFile, logProperties);
+    Log::initialize("wsd", logLevel, withColor, logToFile, logProperties, false, {});
     ssl::Manager::initializeClientContext(
             /*certificateFile=*/"", /*privateKeyFile=*/"", /*caLocation=*/"",
             /*cipherList=*/"", ssl::CertificateVerification::Required);

--- a/fuzzer/HttpEcho.cpp
+++ b/fuzzer/HttpEcho.cpp
@@ -65,7 +65,7 @@ public:
         if (log_level)
         {
             Log::initialize("fuz", log_level ? log_level : "error", isatty(fileno(stderr)), false,
-                            logProperties);
+                            logProperties, false, {});
         }
 
         std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();

--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -43,6 +43,7 @@ cmake_list= \
             ../kit/DeltaSimd.c \
             ../kit/Kit.cpp \
             ../kit/KitQueue.cpp \
+            ../kit/LogUI.cpp \
             ../kit/KitWebSocket.cpp \
             ../net/FakeSocket.cpp \
             ../net/Socket.cpp \

--- a/gtk/mobile.cpp
+++ b/gtk/mobile.cpp
@@ -312,7 +312,7 @@ int main(int argc, char* argv[])
         _exit(1); // avoid log cleanup
     }
 
-    Log::initialize("Mobile", "trace", false, false, {});
+    Log::initialize("Mobile", "trace", false, false, {}, false, {});
     Util::setThreadName("main");
 
     fakeSocketSetLoggingCallback([](const std::string& line)

--- a/ios/Mobile.xcodeproj/project.pbxproj
+++ b/ios/Mobile.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		BE5EB5C4213FE29900E0826C /* Util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BC213FE29900E0826C /* Util.cpp */; };
 		BE5EB5C4214FE29900E0826C /* Uri.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BC214FE29900E0826C /* Uri.cpp */; };
 		BE5EB5C5213FE29900E0826C /* KitQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BD213FE29900E0826C /* KitQueue.cpp */; };
+		BE5EB5C5214FE29900E0826C /* LogUI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BD214FE29900E0826C /* LogUI.cpp */; };
 		BE5EB5C6213FE29900E0826C /* SigUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BE213FE29900E0826C /* SigUtil.cpp */; };
 		BE5EB5C7213FE29900E0826C /* Protocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BF213FE29900E0826C /* Protocol.cpp */; };
 		BE5EB5C8213FE29900E0826C /* FileUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5C0213FE29900E0826C /* FileUtil.cpp */; };
@@ -564,6 +565,7 @@
 		BE58E12C217F295B00249358 /* Util.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Util.hpp; sourceTree = "<group>"; };
 		BE58E12C218F295B00249358 /* Uri.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Uri.hpp; sourceTree = "<group>"; };
 		BE58E12D217F295B00249358 /* KitQueue.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = KitQueue.hpp; sourceTree = "<group>"; };
+		BE58E12D218F295B00249358 /* LogUI.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = LogUI.hpp; sourceTree = "<group>"; };
 		BE58E12E217F295B00249358 /* Protocol.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Protocol.hpp; sourceTree = "<group>"; };
 		BE58E12F217F295B00249358 /* Session.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Session.hpp; sourceTree = "<group>"; };
 		BE58E13021874A2E00249358 /* Mobile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Mobile.entitlements; sourceTree = "<group>"; };
@@ -584,6 +586,7 @@
 		BE5EB5BC213FE29900E0826C /* Util.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Util.cpp; sourceTree = "<group>"; };
 		BE5EB5BC214FE29900E0826C /* Uri.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Uri.cpp; sourceTree = "<group>"; };
 		BE5EB5BD213FE29900E0826C /* KitQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KitQueue.cpp; sourceTree = "<group>"; };
+		BE5EB5BD214FE29900E0826C /* LogUI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LogUI.cpp; sourceTree = "<group>"; };
 		BE5EB5BE213FE29900E0826C /* SigUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SigUtil.cpp; sourceTree = "<group>"; };
 		BE5EB5BF213FE29900E0826C /* Protocol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Protocol.cpp; sourceTree = "<group>"; };
 		BE5EB5C0213FE29900E0826C /* FileUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileUtil.cpp; sourceTree = "<group>"; };
@@ -2924,6 +2927,8 @@
 				BEA2835521467FDD00848631 /* Kit.cpp */,
 				BE5EB5BD213FE29900E0826C /* KitQueue.cpp */,
 				BE58E12D217F295B00249358 /* KitQueue.hpp */,
+				BE5EB5BD214FE29900E0826C /* LogUI.cpp */,
+				BE58E12D218F295B00249358 /* LogUI.hpp */,
 				BEA2835521467F0D00848631 /* KitWebSocket.cpp */,
 			);
 			name = kit;
@@ -3691,6 +3696,7 @@
 				BE5EB5D0213FE2D000E0826C /* TileCache.cpp in Sources */,
 				1F957DC22BA8229A006C9E78 /* Util-mobile.cpp in Sources */,
 				BE5EB5C5213FE29900E0826C /* KitQueue.cpp in Sources */,
+				BE5EB5C5214FE29900E0826C /* LogUI.cpp in Sources */,
 				BE7228E22417BC9F000ADABD /* StringVector.cpp in Sources */,
 				BE55E0EB2653FCCB007DDF29 /* ConfigUtil.cpp in Sources */,
 				BE55E0EB3653FCCB007DDF29 /* Crypto-stub.cpp in Sources */,

--- a/ios/Mobile/AppDelegate.mm
+++ b/ios/Mobile/AppDelegate.mm
@@ -51,7 +51,7 @@ NSString *app_text_direction;
     else
         setupKitEnvironment("");
 
-    Log::initialize("Mobile", trace, false, false, {});
+    Log::initialize("Mobile", trace, false, false, {}, false, {});
     Util::setThreadName("main");
 
     // Clear the cache directory if it is for another build of the app

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -29,6 +29,33 @@
 class Document;
 class ChildSession;
 
+struct LogUiCommandsLine {
+    std::chrono::steady_clock::time_point _timeStart;
+    std::chrono::steady_clock::time_point _timeEnd;
+    int _repeat = 0;
+    int _undoChange = 0;
+    std::string _cmd;
+    std::string _subCmd;
+};
+
+class LogUiCommands {
+public:
+    ChildSession* _session;
+    int _lastUndoCount = 0;
+    const StringVector* _tokens;
+    LogUiCommands(ChildSession* session, const StringVector* tokens) : _session(session),_tokens(tokens) {}
+    ~LogUiCommands();
+private:
+    // list the commands to log here.
+    std::set<std::string> _cmdToLog = {
+        "uno", "key", "mouse", "textinput", "removetextcontext",
+        "paste", "insertfile", "dialogevent" };
+    // list the the uno commands here, that are not to log. It will serach these strings as a prefixes
+    std::set<std::string> _unoCmdToNotLog = {
+        ".uno:SidebarShow", ".uno:ToolbarMode" };
+    void logLine(LogUiCommandsLine &line, bool isUndoChange=false);
+};
+
 enum class LokEventTargetEnum
 {
     Document,
@@ -300,6 +327,10 @@ private:
     bool _hasURP;
 
     // When state is added - please update dumpState above.
+
+    friend class LogUiCommands;
+    int _lastUiCmdLinesLoggedCount = 0;
+    LogUiCommandsLine _lastUiCmdLinesLogged[2];
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -685,9 +685,23 @@ int forkit_main(int argc, char** argv)
     {
         logProperties["path"] = std::string(logFilename);
     }
+    const bool logToFileUICmd = std::getenv("COOL_LOGFILE_UICMD");
+    const char* logFilenameUICmd = std::getenv("COOL_LOGFILENAME_UICMD");
+    std::map<std::string, std::string> logPropertiesUICmd;
+    if (logToFileUICmd && logFilenameUICmd)
+    {
+        logPropertiesUICmd["path"] = std::string(logFilenameUICmd);
+    }
 
     LogLevelStartup = logLevelStartup ? logLevelStartup : "trace";
-    Log::initialize("frk", LogLevelStartup, logColor != nullptr, logToFile, logProperties);
+    Log::initialize("frk", LogLevelStartup, logColor != nullptr, logToFile, logProperties, logToFileUICmd, logPropertiesUICmd);
+
+    if (logToFileUICmd)
+    {
+        const bool mergeUiCmd = std::getenv("COOL_LOG_UICMD_MERGE");
+        const bool logTimeEndOfMergedUiCmd = std::getenv("COOL_LOG_UICMD_END_TIME");
+        Log::setUILogMergeInfo(mergeUiCmd, logTimeEndOfMergedUiCmd);
+    }
 
     LogLevel = logLevel ? logLevel : "trace";
     if (LogLevel != LogLevelStartup)

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -20,6 +20,7 @@
 #include <common/Session.hpp>
 #include <common/ThreadPool.hpp>
 #include <kit/KitQueue.hpp>
+#include <kit/LogUI.hpp>
 
 #include <wsd/TileDesc.hpp>
 
@@ -393,6 +394,8 @@ public:
 
     std::shared_ptr<KitQueue> getQueue() const { return _queue; }
 
+    LogUiCmd& getLogUiCmd() { return logUiCmd; }
+
 private:
     void postForceModifiedCommand(bool modified);
 
@@ -458,6 +461,8 @@ private:
 
     const unsigned _mobileAppDocId;
     int _duringLoad;
+
+    LogUiCmd logUiCmd;
 };
 
 /// main function of the forkit process or thread

--- a/kit/LogUI.cpp
+++ b/kit/LogUI.cpp
@@ -1,0 +1,51 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+#include <kit/LogUI.hpp>
+#include <Log.hpp>
+
+void LogUiCmd::logUiCmdLine(int userId, std::string line)
+{
+    _fileStreamUICommands.write(line.c_str(), line.length());
+    _fileStreamUICommands.write("\n", 1);
+    _usersLogged.insert(userId);
+}
+
+void LogUiCmd::saveLogFile()
+{
+    std::string timeLog = "log-start-time: " + _kitStartTimeStr + " user-count:" + std::to_string(_usersLogged.size());
+    Log::logUI(Log::WRN, timeLog.c_str());
+    _fileStreamUICommands.seekg(0, std::ios::beg);
+    std::string line;
+    while (std::getline(_fileStreamUICommands, line))
+    {
+        if (line.size()>0)
+            Log::logUI(Log::WRN, line);
+    }
+    _fileStreamUICommands.close();
+    timeLog = "log-end-time: ";
+    timeLog.append(Util::getTimeNow("%Y-%m-%d %T"));
+    Log::logUI(Log::WRN, timeLog.c_str());
+}
+
+void LogUiCmd::createTmpFile()
+{
+    const std::string tempFile = "/tmp/kit-ui-cmd.log";
+    _fileStreamUICommands.open(tempFile, std::fstream::in | std::fstream::out | std::fstream::trunc);
+    _kitStartTimeSec = std::chrono::steady_clock::now();
+    _kitStartTimeStr = Util::getTimeNow("%Y-%m-%d %T");
+}
+
+std::chrono::steady_clock::time_point LogUiCmd::getKitStartTimeSec()
+{
+    return _kitStartTimeSec;
+}

--- a/kit/LogUI.hpp
+++ b/kit/LogUI.hpp
@@ -1,0 +1,32 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <Poco/Util/XMLConfiguration.h>
+#include <string>
+#include <fstream>
+#include <chrono>
+
+class LogUiCmd
+{
+public:
+    void createTmpFile();
+    void logUiCmdLine(int userId, std::string line);
+    void saveLogFile();
+    std::chrono::steady_clock::time_point getKitStartTimeSec();
+
+private:
+    std::fstream _fileStreamUICommands;
+    std::chrono::steady_clock::time_point _kitStartTimeSec;
+    std::string _kitStartTimeStr;
+    std::set<int> _usersLogged;
+};

--- a/scripts/undoStatistics.py
+++ b/scripts/undoStatistics.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# -*- tab-width: 4; indent-tabs-mode: nil; py-indent-offset: 4 -*-
+#
+# Copyright the Collabora Online contributors.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+import os
+import sys
+
+def usageAndExit():
+    message = """usage: {program} logfile_path
+
+Reads the logfile and make a statisctics about what commands was undo-ed most times.
+And how many times  was a command like that was undoed.
+
+    {program} /path/to/logfile
+
+"""
+    print(message.format(program=sys.argv[0]))
+    exit(1)
+
+class Document:
+    def __init__(self, users, activeUsers):
+        self.users = users
+        self.activeUsers = activeUsers
+    users = 0
+    activeUsers = 0
+
+class User:
+    edited = False
+    undoChgStack = []       # list of commands that made changes
+    lastCmd = ""
+
+if __name__ == "__main__":
+
+    if len(sys.argv) != 2:
+        usageAndExit()
+
+    documents = []
+    users = {}
+
+    # dict of (command - count of undo)
+    undoedCommands = {}
+    totalUndoedCommands = {}
+
+    # Process all Document related, and undo related calculations
+    f = open(sys.argv[1], 'r')
+    for line in f:
+        if line.startswith("log-start-time:"):
+            pass
+        elif line.startswith("log-end-time:"):
+            active = 0
+            for user in users.values():
+                if user.edited:
+                    active += 1
+            documents.append(Document(len(users), active))
+            users = {}
+        else:
+            numbUser = line.find("user=")
+            numbrep = line.find("rep=")
+            cmdStart = line[numbrep:].find(" ")+numbrep+1
+
+            userId = int(line[numbUser+5:numbrep])
+            repeat = int(line[numbrep+4:cmdStart])
+            lineCmd = line[cmdStart:]
+
+            if userId not in users:
+                users[userId] = User()
+
+            if lineCmd.startswith("cmd:"):
+                users[userId].lastCmd = lineCmd[4:-1]
+                if lineCmd.startswith("cmd:textinput") or lineCmd.startswith("cmd:removetextcontext"):
+                    users[userId].edited = True
+
+            elif lineCmd.startswith("undo-count-change:"):
+                if lineCmd[18] == "+":
+                    users[userId].undoChgStack.append([repeat, users[userId].lastCmd])
+                else: #"-"
+                    toDelete = repeat
+                    while toDelete > 0:
+                        deleted = 0
+                        stackLen = len(users[userId].undoChgStack) - 1
+                        cmd = users[userId].undoChgStack[stackLen][1]
+                        if users[userId].undoChgStack[stackLen][0] > toDelete:
+                            users[userId].undoChgStack[stackLen][0] -= toDelete
+                            deleted = toDelete
+                            toDelete = 0
+                        else:
+                            deleted = users[userId].undoChgStack[stackLen][0]
+                            toDelete -= users[userId].undoChgStack[stackLen][0]
+                            users[userId].undoChgStack.pop()
+
+                        actValue = 0
+                        if cmd in undoedCommands:
+                            actValue = undoedCommands[cmd]
+
+                        actValue += deleted
+                        undoedCommands[cmd] = actValue
+
+    # re-check undoed commands, how many times they are used, to calculate how many % of it undoed.
+    for cmd in undoedCommands.keys():
+        totalUndoedCommands[cmd] = 0
+
+    actIndex=-1
+    f = open(sys.argv[1], 'r')
+    for line in f:
+        if line.startswith("time="):
+            numbrep = line.find("rep=")
+            cmdStart = line[numbrep:].find(" ")+numbrep+1
+            repeat = int(line[numbrep+4:cmdStart])
+            lineCmd = line[cmdStart:]
+            if lineCmd.startswith("cmd:"):
+                cmd = lineCmd[4:-1]
+                if cmd in totalUndoedCommands.keys():
+                    totalUndoedCommands[cmd] += repeat
+
+    documentsOpened = len(documents)
+    documentsEdited = 0
+    totalUsers = 0
+    totalUsersWhenDocEdited = 0
+    totalActiveUsers = 0
+    usersPerDocMin = documents[0].users
+    usersPerDocMax = 0
+    usersActivePerDocMin = documents[0].users
+    usersActivePerDocMax = 0
+    usersPassivePerDocMin = documents[0].users
+    usersPassivePerDocMax = 0
+
+    for actDoc in documents:
+        if actDoc.activeUsers > 0:
+            documentsEdited += 1
+            totalUsersWhenDocEdited += actDoc.users
+        totalUsers += actDoc.users
+        totalActiveUsers += actDoc.activeUsers
+        if usersPerDocMin > actDoc.users:
+            usersPerDocMin = actDoc.users
+        if usersPerDocMax < actDoc.users:
+            usersPerDocMax = actDoc.users
+        if usersActivePerDocMin > actDoc.activeUsers:
+            usersActivePerDocMin = actDoc.activeUsers
+        if usersActivePerDocMax < actDoc.activeUsers:
+            usersActivePerDocMax = actDoc.activeUsers
+        if usersPassivePerDocMin > actDoc.users - actDoc.activeUsers:
+            usersPassivePerDocMin = actDoc.users - actDoc.activeUsers
+        if usersPassivePerDocMax < actDoc.users - actDoc.activeUsers:
+            usersPassivePerDocMax = actDoc.users - actDoc.activeUsers
+
+    print("Documents opened: %d Documents edited: %d (=%4.2f%%)" % (documentsOpened, documentsEdited, 100.0*documentsEdited/documentsOpened))
+    print("Total Users: %d Active users: %d (=%4.2f%%)" % (totalUsers, totalActiveUsers, 100.0*totalActiveUsers/totalUsers))
+    print("Users/Document min-max: %d-%d Average: %4.2f)" % (usersPerDocMin, usersPerDocMax, 1.0*totalUsers/documentsOpened))
+    print("   Active Users/Document min-max: %d-%d Average: %4.2f)" % (usersActivePerDocMin, usersActivePerDocMax, 1.0*totalActiveUsers/documentsOpened))
+    print("   Passive Users/Document min-max: %d-%d Average: %4.2f)" % (usersPassivePerDocMin, usersPassivePerDocMax, 1.0*(totalUsers-totalActiveUsers)/documentsOpened))
+    print("(Acive Users/All users) when document edited: %4.2f%%)" % (100.0*totalActiveUsers/totalUsersWhenDocEdited))
+
+    # sort undoed commands by count
+    sortedUndoedCommands = sorted(undoedCommands.items(), key=lambda x:x[1], reverse=True)
+
+    # print statistics of undo
+    print("\nMost undoed commands:\n(Count of undo, Count of all Commands, The command)")
+    for cmd,count in sortedUndoedCommands:
+        print(count, totalUndoedCommands[cmd], cmd)
+
+# vim: set shiftwidth=4 softtabstop=4 expandtab:

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -165,6 +165,7 @@ common_sources = \
 	../common/Util-server.cpp \
 	../common/Util.cpp \
 	../kit/KitQueue.cpp \
+	../kit/LogUI.cpp \
 	../wsd/Exceptions.cpp \
 	../net/HttpRequest.cpp \
 	../net/Socket.cpp \

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -100,7 +100,7 @@ int main(int argc, char** argv)
 
     const char* loglevel = verbose ? "trace" : "warning";
     const bool withColor = isatty(fileno(stderr));
-    Log::initialize("tst", loglevel, withColor, false, {});
+    Log::initialize("tst", loglevel, withColor, false, {}, false, {});
 
     Poco::AutoPtr<Poco::Util::LayeredConfiguration> defConfig(new Poco::Util::LayeredConfiguration);
     ConfigUtil::initialize(defConfig.get());

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -230,6 +230,7 @@ int main (int argc, char **argv)
     }
 
     Log::initialize("WebSocketDump", "trace", true, false,
+                    std::map<std::string, std::string>(), false,
                     std::map<std::string, std::string>());
 
     CoolConfig config;

--- a/wasm/Makefile.am
+++ b/wasm/Makefile.am
@@ -42,6 +42,7 @@ online_SOURCES = \
 	../kit/ChildSession.cpp \
 	../kit/Kit.cpp \
 	../kit/KitQueue.cpp \
+	../kit/LogUI.cpp \
 	../kit/KitWebSocket.cpp \
 	../kit/DeltaSimd.c \
 	../net/FakeSocket.cpp \

--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -215,7 +215,7 @@ int main(int argc, char* argv_main[])
         return 1;
     }
 
-    Log::initialize("WASM", "error", false, false, {});
+    Log::initialize("WASM", "error", false, false, {}, false, {});
     Util::setThreadName("main");
 
     fakeSocketSetLoggingCallback([](const std::string& line)


### PR DESCRIPTION
Log several kind of commands, and Undo count change. This may helps to find what user try to undo at most cases.

We can set what kind of commands we want to log at:
    std::set<std::string> aCmdToLog = {
        "uno", "key", "mouse", "textinput", "removetextcontext",
        "paste", "insertfile", "commandvalues" };

We can set what commands should be merged at:
    std::set<std::string> aCmdToMergeLog = {
        "mouse", "textinput", "removetextcontext" };
Merged means, if the same command is called again, it wont be logged again, but the next time before a different command is called, the merged command's count will be logged.

Some commands merge may need some more deep logic. at "mouse" command only the move is merged.
"key" could be more complex as it can be an insert space, arrow keys, or pageup/down. now all of them are logged but sure we can merge some of them if needed

It is logged into session.log file.. that exist only while the file is opened. When Childsession is destructed this file is copied, appended into /tmp/coolwsd-ui-cmd.log This file is configurable similarly as coolwsd.log

added a python script to make actual statistics

Multi user case may confuse things, as undo may used on non-last undo change. maybe it could be handed too.

sample LOGs:

CMD:textinput id=0 text=f
UNDO_CHG:(4 -> 5):textinput id=0 text=f
CMD_REPATED:5
CMD:mouse type=move x=4485 y=7080 count=1 buttons=0 modifier=0 CMD_REPATED:2
CMD:mouse type=buttondown x=4530 y=7125 count=1 buttons=1 modifier=0 CMD:mouse type=buttonup x=4530 y=7125 count=1 buttons=1 modifier=0 CMD:mouse type=move x=4665 y=7305 count=1 buttons=0 modifier=0 CMD_REPATED:1
CMD:key type=input char=32 key=0
UNDO_CHG:(5 -> 6):key type=input char=32 key=0
CMD:uno .uno:Undo
UNDO_CHG:(6 -> 5):uno .uno:Undo

CMD:uno .uno:ToolbarMode?Mode:string=notebookbar_online.ui CMD:commandvalues command=.uno:LanguageStatus
CMD:commandvalues command=.uno:ViewAnnotations
CMD:uno .uno:SidebarShow

probably some more info may needed at some places.. maybe at document open/close...


Change-Id: I276b8fd42062e45f271f60644c1b79509bc60689


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

