### PR TITLE
kit, BackgroundSaveWatchdog: fix memory management in the ctor

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -184,7 +184,8 @@ public:
     BackgroundSaveWatchdog(unsigned mobileAppDocId)
         : _saveCompleted(false)
         , _watchdogThread(
-              [&]()
+            // mobileAppDocId is on the stack, so capture it by value.
+              [mobileAppDocId, this]()
               {
                   Util::setThreadName("kitbgsv_" + Util::encodeId(mobileAppDocId, 3) + "_wdg");
 


### PR DESCRIPTION
By the time the thread runs, the ctor's stack is gone, so capture the
doc ID by value.

A problem since commit f27f2e297eadcf06171bfeb86ce99d717f6c73fc (wsd:
bgsave watchdog thread, 2024-11-14).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Iec98aeff059104b1ba321442bff98198dce5cc61
