### PR TITLE
slideshow: invalidate cached layers on slideshow restart

### DIFF
--- a/browser/src/slideshow/LayerDrawing.ts
+++ b/browser/src/slideshow/LayerDrawing.ts
@@ -193,6 +193,11 @@ class LayerDrawing {
 
 	public invalidateAll(): void {
 		this.slideCache.invalidateAll();
+		this.slideTextFieldsMap.clear();
+		this.cachedTextFields.clear();
+		this.cachedBackgrounds.clear();
+		this.cachedMasterPages.clear();
+		this.cachedDrawPages.clear();
 	}
 
 	public getCanvasSize(): [number, number] {


### PR DESCRIPTION
Current slideshow implementation is not notified about presentation
modification. A complete solotion would require a good amount of work.
In the meanwhile we need a workround, which it's waht this patch provides.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I1ae3c09a60a1273dfe829f0932bd0fd83404de93
