### PR TITLE
Fix black flashing when resizing the canvas

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1333,6 +1333,9 @@ class CanvasSectionContainer {
 		newWidth = Math.floor(newWidth * app.dpiScale);
 		newHeight = Math.floor(newHeight * app.dpiScale);
 
+		if (this.right === newWidth && this.bottom === newHeight)
+			return;
+
 		this.canvas.width = newWidth;
 		this.canvas.height = newHeight;
 

--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1336,6 +1336,12 @@ class CanvasSectionContainer {
 		if (this.right === newWidth && this.bottom === newHeight)
 			return;
 
+		// Drawing may happen asynchronously so backup the old contents to avoid
+		// showing a blank canvas.
+		var oldImageData: ImageData = null;
+		if (this.paintedEver)
+			oldImageData = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
+
 		this.canvas.width = newWidth;
 		this.canvas.height = newHeight;
 
@@ -1348,9 +1354,10 @@ class CanvasSectionContainer {
 		app.canvasSize.pX = newWidth;
 		app.canvasSize.pY = newHeight;
 
-		// Avoid black default background if canvas was never painted
-		// since construction.
-		if (!this.paintedEver)
+		// Avoid black default background.
+		if (oldImageData)
+			this.context.putImageData(oldImageData, 0, 0);
+		else
 			this.clearCanvas();
 
 		this.clearMousePositions();

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -757,6 +757,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		this.setSplitPosFromCell();
 		this.dontSendSplitPosToCore = false;
 
+		app.sectionContainer.reNewAllSections(true);
 		this._syncTileContainerSize();
 
 		this._map.fire('sheetgeometrychanged');


### PR DESCRIPTION
* Resolves: #10436
* Target version: master 

### Summary

With workers enabled, drawing is sometimes not synchronous. This causes a problem when resizing, which clears the canvas entirely and expects tile rehydration to happen synchronously afterwards. Work around this by redrawing the old canvas contents when resizing.

I considered more comprehensive fixes, but they all added a lot of complexity and used more memory than this. I think there's probably a better possible fix here of doing less work when resizing, but how to do that wasn't immediately obvious.

I've also bundled a much smaller fix which is the more common case, where we were dumping the old canvas contents and redrawing everything even when the canvas size wasn't changed (for example, copy/paste from another open sheet causes two null resizes to happen in both sheets).

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

