### PR TITLE
feat: Add user label to mention

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -521,8 +521,9 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 				else if (eventType === 'select' || eventType === 'activate') {
 					const item = mention.getMentionUserData(index);
 					const replacement = '@' + mention.getPartialMention();
-					if (item.username !== '' && item.profile !== '')
-						comment.autoCompleteMention(item.username, item.profile, replacement)
+					const uid = item.label ?? item.username
+					if (uid !== '' && item.profile !== '')
+						comment.autoCompleteMention(uid, item.profile, replacement)
 					mention.closeMentionPopup(false);
 				}
 		}.bind(this);

--- a/browser/src/control/Control.Mention.ts
+++ b/browser/src/control/Control.Mention.ts
@@ -17,6 +17,7 @@
 interface MentionUserData {
 	username: string;
 	profile: string;
+	label?: string;
 }
 
 class Mention extends L.Control.AutoCompletePopup {
@@ -70,8 +71,10 @@ class Mention extends L.Control.AutoCompletePopup {
 		// filterout the users from list according to the text
 		if (text.length > 1) {
 			this.filteredUsers = users.filter((element: any) => {
+				const uid = element.label ?? element.username;
+
 				// case insensitive
-				return element.username.toLowerCase().includes(text.toLowerCase());
+				return uid.toLowerCase().includes(text.toLowerCase());
 			});
 		} else {
 			this.filteredUsers = users;
@@ -79,11 +82,12 @@ class Mention extends L.Control.AutoCompletePopup {
 
 		if (this.filteredUsers.length !== 0) {
 			for (const i in this.filteredUsers) {
+				const currentUser = this.filteredUsers[i];
 				const entry = {
-					text: this.filteredUsers[i].username,
+					text: currentUser.label ?? currentUser.username,
 					columns: [
 						{
-							text: this.filteredUsers[i].username,
+							text: currentUser.label ?? currentUser.username,
 						},
 					],
 					row: i.toString(),
@@ -255,19 +259,19 @@ class Mention extends L.Control.AutoCompletePopup {
 
 	getMentionUserData(index: number): MentionUserData {
 		if (index >= this.filteredUsers.length)
-			return { username: '', profile: '' } as MentionUserData;
+			return { username: '', profile: '', label: null } as MentionUserData;
 		return this.filteredUsers[index];
 	}
 
 	private sendHyperlinkUnoCommand(
-		username: string,
+		uid: string,
 		profile: string,
 		replacement: string,
 	) {
 		var command = {
 			'Hyperlink.Text': {
 				type: 'string',
-				value: '@' + username,
+				value: '@' + uid,
 			},
 			'Hyperlink.URL': {
 				type: 'string',
@@ -291,17 +295,26 @@ class Mention extends L.Control.AutoCompletePopup {
 		} else if (eventType === 'select' || eventType === 'activate') {
 			const username = this.filteredUsers[index].username;
 			const profileLink = this.filteredUsers[index].profile;
+			const label = this.filteredUsers[index].label;
 			const replacement = '@' + this.getPartialMention();
 
 			if (comment) {
-				comment.autoCompleteMention(username, profileLink, replacement);
+				comment.autoCompleteMention(
+					label ?? username,
+					profileLink,
+					replacement,
+				);
 			} else {
-				this.sendHyperlinkUnoCommand(username, profileLink, replacement);
+				this.sendHyperlinkUnoCommand(
+					label ?? username,
+					profileLink,
+					replacement,
+				);
 				this.map._textInput._sendText(' ');
 			}
 			this.map.fire('postMessage', {
 				msgId: 'UI_Mention',
-				args: { type: 'selected', username: username },
+				args: { type: 'selected', username: username, label: label },
 			});
 			this.closeMentionPopup(false);
 		} else if (eventType === 'keydown') {


### PR DESCRIPTION
Change-Id: `Id2484d5dee155a7755e0cca55a97d7191ec83985`


* Target version: master 

### Summary
In Nextcloud, we are working on improving our mention support, and it would be really nice to also be able to pass a display name (label) along with a username (unique identifier) and the profile link. Having this would allow us to determine the user quicker and easier on our side, and I don't see the harm in having it there for other integrations as well, should they want it.

This is a work-in-progress PR, and it's my first contribution to this repository, so please bear with me and provide any constructive feedback you may have :)

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

