### PR TITLE
Remove duplicate sending of copy and cut commands.

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -827,12 +827,13 @@ L.Clipboard = L.Class.extend({
 
 	_sendCommandAndWaitForCompletion: function(command) {
 		if (command !== '.uno:Copy' && command !== '.uno:Cut') {
-			throw `_sendCommandAndWaitForCompletion was called with '${command}', but anything except Copy or Cut will never complete`;
+			console.error(`_sendCommandAndWaitForCompletion was called with '${command}', but anything except Copy or Cut will never complete`);
+			return null;
 		}
 
 		if (this._commandCompletion.length > 0) {
-			throw 'Already have ' + this._commandCompletion.length +
-				' pending clipboard command(s)';
+			console.warn('Already have ' + this._commandCompletion.length + ' pending clipboard command(s)');
+			return null;
 		}
 
 		app.socket.sendMessage('uno ' + command);
@@ -870,7 +871,10 @@ L.Clipboard = L.Class.extend({
 
 	_asyncAttemptNavigatorClipboardWrite: async function() {
 		const command = this._unoCommandForCopyCutPaste;
-		await this._sendCommandAndWaitForCompletion(command);
+		const check_ = await this._sendCommandAndWaitForCompletion(command);
+
+		if (check_ === null)
+			return; // Either wrong command or a pending event.
 
 		// This is sent down the websocket URL which can race with the
 		// web fetch - so first step is to wait for the result of

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -547,37 +547,29 @@ L.Clipboard = L.Class.extend({
 
 	// returns whether we shold stop processing the event
 	populateClipboard: function(ev) {
-		this._checkSelection();
+		// If the copy paste API is not supported, we download the content as a fallback method.
+		var text = this._getHtmlForClipboard();
 
-		// This is the codepath (_navigatorClipboardWrite) where the browser initiates the clipboard operation, e.g. the keyboard is used.
-		if (!this._navigatorClipboardWrite()) {
-			// If the copy paste API is not supported, we download the content as a fallback method.
-
-			var text = this._getHtmlForClipboard();
-
-			var plainText = DocUtil.stripHTML(text);
-			if (text == this._selectionContent && this._selectionPlainTextContent != '') {
-				plainText = this._selectionPlainTextContent;
-			}
-			if (ev.clipboardData) { // Standard
-				if (this._unoCommandForCopyCutPaste === '.uno:CopyHyperlinkLocation') {
-					var ess = 's';
-					var re = new RegExp('^(.*)(<a href=")([^"]+)(">.*</a>)(</p>\n</body>\n</html>)$', ess);
-					var match = re.exec(text);
-					if (match !== null && match.length === 6) {
-						text = match[1] + match[3] + match[5];
-						plainText = DocUtil.stripHTML(text);
-					}
-				}
-				// if copied content is graphical then plainText is null and it does not work on mobile.
-				ev.clipboardData.setData('text/plain', plainText ? plainText: ' ');
-				ev.clipboardData.setData('text/html', text);
-				window.app.console.log('Put "' + text + '" on the clipboard');
-				this._clipboardSerial++;
-			}
+		var plainText = DocUtil.stripHTML(text);
+		if (text == this._selectionContent && this._selectionPlainTextContent != '') {
+			plainText = this._selectionPlainTextContent;
 		}
-
-		return true; // prevent default
+		if (ev.clipboardData) { // Standard
+			if (this._unoCommandForCopyCutPaste === '.uno:CopyHyperlinkLocation') {
+				var ess = 's';
+				var re = new RegExp('^(.*)(<a href=")([^"]+)(">.*</a>)(</p>\n</body>\n</html>)$', ess);
+				var match = re.exec(text);
+				if (match !== null && match.length === 6) {
+					text = match[1] + match[3] + match[5];
+					plainText = DocUtil.stripHTML(text);
+				}
+			}
+			// if copied content is graphical then plainText is null and it does not work on mobile.
+			ev.clipboardData.setData('text/plain', plainText ? plainText: ' ');
+			ev.clipboardData.setData('text/html', text);
+			window.app.console.log('Put "' + text + '" on the clipboard');
+			this._clipboardSerial++;
+		}
 	},
 
 	_isAnyInputFieldSelected: function(forCopy = false) {
@@ -915,7 +907,7 @@ L.Clipboard = L.Class.extend({
 				// Prefetch selection, so next time copy will work with the keyboard.
 				app.socket.sendMessage('gettextselection mimetype=text/html,text/plain;charset=utf-8');
 			}
-			}
+		}
 	},
 
 	// Parses the result from the clipboard endpoint into HTML and plain text.
@@ -1093,10 +1085,15 @@ L.Clipboard = L.Class.extend({
 			}
 		} else {
 			this._unoCommandForCopyCutPaste = `.uno:${unoName}`;
-			preventDefault = this.populateClipboard(ev);
+			this._checkSelection();
+
+			// This is the codepath (_navigatorClipboardWrite) where the browser initiates the clipboard operation, e.g. the keyboard is used.
+			if (!this._navigatorClipboardWrite()) {
+				app.socket.sendMessage('uno .uno:' + unoName);
+				this.populateClipboard(ev);
+			}
 		}
 
-		app.socket.sendMessage('uno .uno:' + unoName);
 		if (ev.clipboardData && unoName === 'Cut') {
 			// Cut text is not removed from the editable area,
 			// so we need to request the focused paragraph.


### PR DESCRIPTION
_doCopyCut function is already sending the relevant command.

Also saw that _sendCommandAndWaitForCompletion returns a promise that is not needed anymore (after Skyler's refactorings).

So we can remove that and use a boolean value for pursuing the state of cut/copy commands.

This fixes (Calc):
* Cut text.
* Paste it.
* It pastes empty text - because of double issuing of cut command, second time it cuts empty text.


Change-Id: I0d4a2b0637892234a7dab68638f26cacadd8bb11


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

