### PR TITLE
backport: fix(mobile): Style comment property on word count

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1233,7 +1233,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 #mobile-wizard #wordslabel2,
 #mobile-wizard #inclspaceslabel2,
 #mobile-wizard #exclspaceslabel2,
-#mobile-wizard #cjkcharsft2
+#mobile-wizard #cjkcharsft2,
+#mobile-wizard #commentslabel
 {
 	float: left !important;
 	clear: left !important;
@@ -1248,7 +1249,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 #mobile-wizard #docwords,
 #mobile-wizard #docchars,
 #mobile-wizard #doccharsnospaces,
-#mobile-wizard #doccjkchars
+#mobile-wizard #doccjkchars,
+#mobile-wizard #docComments
 {
 	float: right !important;
 	clear: right !important;


### PR DESCRIPTION
This is a trivial backport of #10564

In core change Ib94c8db5beb88d0b71035081680ce25a74774d08, we are adding support for the comments property in the word count dialog. Not styling this shows the property name and its value on separate lines


Change-Id: I12e7e07f59a5f30e51b65066adee5c90394a3991


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

