### PR TITLE
Revert "prevent double-dispatch of uno events bound to function keys"

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -400,11 +400,6 @@ L.Map.Keyboard = L.Handler.extend({
 		if (this._map.uiManager.isUIBlocked())
 			return;
 
-		// if we press F1/F2 then the keyboard event is handled twice, use that
-		// the defaultPrevented is set the first time to avoid the double dispatch
-		if (ev.defaultPrevented && ev.keyCode !== this.keyCodes.S)
-			return;
-
 		if (window.KeyboardShortcuts.processEvent(app.UI.language.fromURL, ev)) {
 			ev.preventDefault();
 			return;

--- a/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
@@ -12,7 +12,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'PDF View Tests', function(
 
 	it('PDF page down', { env: { 'pdf-view': true } }, function() {
 		cy.cGet('#map').type('{pagedown}');
-		cy.cGet('#map').type('{pagedown}');
 		cy.cGet('#preview-frame-part-1').should('have.attr', 'style', 'border: 2px solid darkgrey;');
 		cy.cGet('#map').type('{pageup}');
 		cy.cGet('#map').type('{pageup}');


### PR DESCRIPTION
and its follow up fix for ctrl+s. Which is a bit of a bodge. So revert the two together and have another round at this later.

The goal was to enable "F3" to do something which isn't needed yet.

This reverts commit b2b637e153ac2d73c272c8284ed85e5fcffa3e16.


Change-Id: I79869dc3e07c86edf9f99bb6100b9e6dcb5b5698


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

