### PR TITLE
cypress tests with --enable-debug and trace logging fail

### DIFF
--- a/cypress_test/Makefile.am
+++ b/cypress_test/Makefile.am
@@ -200,7 +200,7 @@ define start_coolwsd_instance
 			--o:ssl.key_file_path="$(abs_top_srcdir)/etc/key.pem" \
 			--o:ssl.ca_file_path="$(abs_top_srcdir)/etc/ca-chain.cert.pem" \
 			--o:admin_console.username=admin --o:admin_console.password=admin \
-			--o:logging.file[@enable]=true --o:logging.level=trace \
+			--o:logging.file[@enable]=true --o:logging.level=debug \
 			--o:logging.disabled_areas="" --o:welcome.enable=false \
 			--o:user_interface.mode=$(USER_INTERFACE) \
 			--o:accessibility.enable=$(A11Y_ENABLE) \


### PR DESCRIPTION
i.e. with:

./configure --enable-debug --enable-werror

and

cd cypress_test && make check-desktop spec=writer/form_field_spec.js

this always fails for me. And launching coolwsd with the same args of make check-desktop/run-desktop gives an online session that is entirely unresponsive.

changing:

../coolwsd ... --o:logging.level=trace --o:logging.file.property[0]=/path/to/cypress_test/cypress/wsd_logs/coolwsd.log

to

../coolwsd ... --o:logging.level=trace --o:logging.file.property[0]=/tmp/coolwsd.log

or

../coolwsd ... --o:logging.level=warning --o:logging.file.property[0]=/path/to/cypress_test/cypress/wsd_logs/coolwsd.log

works fine


Change-Id: I039cef96934ba6c164c37a03fa2c8816ac15f4f0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

