### PR TITLE
Consolidate Reaping Helper and Reap on SIGCHLD

### DIFF
--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -119,7 +119,10 @@ namespace SigUtil
     /// after a certain (short) timeout.
     bool killChild(const int pid, const int signal);
 
-    extern "C" { typedef void (*SigChildHandler)(uint32_t); }
+    extern "C"
+    {
+        typedef void (*SigChildHandler)(int);
+    }
 
     /// Sets a child death signal handler
     void setSigChildHandler(SigChildHandler fn);

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -70,6 +70,11 @@ namespace SigUtil
     /// faulting, so we do not wait unnecessarily. Otherwise, we wait for 60s.
     void setUnattended();
 
+    /// Reap one or more children.
+    /// Returns a pair of the return value of waitpid(2)
+    /// and WTERMSIG(stat_loc), if it were SEGV, ABRT, or BUS.
+    std::pair<int, int> reapZombieChild(int pid);
+
 #if !MOBILEAPP
 
     /// Open the signalLog file.

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -555,7 +555,7 @@ static void printArgumentHelp()
 }
 
 extern "C" {
-    static void wakeupPoll(uint32_t /*pid*/)
+    static void wakeupPoll(int /*pid*/)
     {
         if (ForKitPoll)
             ForKitPoll->wakeup();

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3083,6 +3083,17 @@ void wakeCallback(void* pData)
 namespace
 {
 #if !MOBILEAPP
+
+extern "C"
+{
+    [[maybe_unused]]
+    static void sigChildHandler(int pid)
+    {
+        // Reap the child; will log failures.
+        SigUtil::reapZombieChild(pid);
+    }
+}
+
 void copyCertificateDatabaseToTmp(Poco::Path const& jailPath)
 {
     std::string aCertificatePathString = ConfigUtil::getString("certificates.database_path", "");
@@ -3121,10 +3132,7 @@ void copyCertificateDatabaseToTmp(Poco::Path const& jailPath)
 }
 
 #endif
-}
-
-
-
+} // namespace
 
 void lokit_main(
 #if !MOBILEAPP
@@ -3680,6 +3688,15 @@ void lokit_main(
         LOG_INF("New kit client websocket inserted.");
 
 #if !MOBILEAPP
+
+        // Since we don't track the bg-save process,
+        // for example to prevent multiple parallel saves,
+        // we could, in principle, ignore SIGCHLD and avoid
+        // the problem of zombies and reaping. Unfortunately,
+        // ignoring SIGCHLD is not portable, according to
+        // man 2 sigaction. So we simply waitpid(2) on SIGCHLD.
+        SigUtil::setSigChildHandler(sigChildHandler);
+
         if (bTraceStartup && LogLevel != LogLevelStartup)
         {
             LOG_INF("Kit initialization complete: setting log-level to [" << LogLevel << "] as configured.");

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1625,18 +1625,12 @@ void Document::reapZombieChildren()
     /// memory footprint, unloading the process is fast, and we reap it.
     /// For large documents, however, the process ends up a zombie.
     /// Here, we reap any zombies that might exist--at most 1.
-    int status = 0;
-    pid_t pid;
-    while ((pid = ::waitpid(-1, &status, WUNTRACED | WNOHANG)) > 0)
+    for (;;)
     {
-        if (WIFSIGNALED(status) && (WTERMSIG(status) == SIGSEGV || WTERMSIG(status) == SIGBUS ||
-                                    WTERMSIG(status) == SIGABRT))
+        const auto [ret, sig] = SigUtil::reapZombieChild(-1);
+        if (ret <= 0)
         {
-            LOG_WRN("BgSave zombie child " << pid << " has exited abnormally");
-        }
-        else
-        {
-            LOG_DBG("Reaped zombie BgSave child " << pid);
+            break;
         }
     }
 }


### PR DESCRIPTION
This adds logic to reap zombie children on SIGCHLD, which doesn't leave zombies around until the next background save (which would leak if bg-save got disabled).

To avoid adding yet another reaping logic, we consolidate the implementations into a neat helper that also logs.

- wsd: sigaction's sa_handler takes int
- wsd: extract reapZombieChild and reuse
- wsd: reap bg-save on SIGCHLD
