### PR TITLE
cool#9992 doc electronic sign: add menu item to trigger hash extract

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -359,6 +359,7 @@ COOL_JS_LST =\
 	src/control/Control.LokDialog.js \
 	src/control/Control.AlertDialog.js \
 	src/control/Control.Tooltip.js \
+	src/control/Control.ESignature.ts \
 	src/control/ColorPicker.ts \
 	src/control/jsdialog/Component.Toolbar.ts \
 	src/control/jsdialog/Definitions.Menu.ts \
@@ -747,7 +748,7 @@ $(DIST_FOLDER)/global.js: $(srcdir)/js/global.js
 	@mkdir -p $(dir $@)
 	$(call global_file)
 
-$(INTERMEDIATE_DIR)/COOL_JS.m4:
+$(INTERMEDIATE_DIR)/COOL_JS.m4: $(COOL_JS_DST)
 	@rm -f COOL_JS.m4
 	$(foreach file,$(NODE_MODULES_JS) $(COOL_LIBS_JS) $(patsubst %.ts,%.js,$(COOL_JS_WEBORDER)), $(shell echo -n $(file), >> $(INTERMEDIATE_DIR)/COOL_JS.m4))
 # remove last ","

--- a/browser/src/control/Control.ESignature.ts
+++ b/browser/src/control/Control.ESignature.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace cool {
+	export interface SignatureResponse {
+		signatureTime: number;
+		digest: string;
+	}
+
+	export interface CommandValuesResponse {
+		commandName: string;
+		commandValues: SignatureResponse;
+	}
+
+	/**
+	 * Provides electronic signing with document hashes for PDF files.
+	 */
+	export class ESignature {
+		constructor() {
+			app.map.on('commandvalues', this.onCommandValues);
+		}
+
+		insert(): void {
+			// Step 1: extract the document hash.
+			app.socket.sendMessage('commandvalues command=.uno:Signature');
+		}
+
+		onCommandValues(event: CommandValuesResponse): void {
+			if (event.commandName != '.uno:Signature') {
+				return;
+			}
+
+			const signatureResponse = event.commandValues;
+			console.log(
+				'TODO(vmiklos) ESignature::onCommandValues: signature time is ' +
+					signatureResponse.signatureTime +
+					', digest is "' +
+					signatureResponse.digest +
+					'"',
+			);
+		}
+	}
+}
+
+L.Control.ESignature = cool.ESignature;
+
+L.control.eSignature = function () {
+	return new L.Control.ESignature();
+};

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -642,6 +642,7 @@ L.Control.Menubar = L.Control.extend({
 					{name: _UNO('.uno:InsertPageTitleField', 'presentation'), uno: '.uno:InsertPageTitleField'},
 					{name: _UNO('.uno:InsertPagesField', 'presentation'), uno: '.uno:InsertPagesField'},
 				]},
+				{name: _('Electronic signature...'), id: 'insert-esignature', type: 'action'},
 			]},
 			{name: _UNO('.uno:FormatMenu', 'presentation'), id: 'format', type: 'menu', menu: [
 				{uno: '.uno:FontDialog'},
@@ -1377,6 +1378,7 @@ L.Control.Menubar = L.Control.extend({
 			!window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf', !window.ThisIsAMobileApp ? 'exportepub' : 'downloadas-epub', // file menu
 			'downloadas-ods', 'downloadas-xls', 'downloadas-xlsx', 'downloadas-csv', 'closedocument', // file menu
 			!(L.Browser.ie || L.Browser.edge) ? 'fullscreen' : undefined, 'zoomin', 'zoomout', 'zoomreset', 'showstatusbar', 'showresolved', 'toggledarktheme', // view menu
+			() => app.map.eSignature ? 'insert-esignature' : undefined, // insert menu
 			'about', 'keyboard-shortcuts', 'latestupdates', 'feedback', 'serveraudit', 'online-help', 'report-an-issue', // help menu
 			'insertcomment'
 		]
@@ -1986,6 +1988,10 @@ L.Control.Menubar = L.Control.extend({
 			app.dispatcher.dispatch(id);
 		} else if (id === 'insertcomment') {
 			this._map.insertComment();
+		} else if (id === 'insert-esignature') {
+			if (this._map.eSignature) {
+				this._map.eSignature.insert();
+			}
 		} else if (id === 'insertgraphic') {
 			L.DomUtil.get('insertgraphic').click();
 		} else if (id === 'insertgraphicremote') {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1061,11 +1061,17 @@ L.Control.UIManager = L.Control.extend({
 				this.map.zotero.updateUserID();
 			}
 		}
-		if (window.documentSigningEnabled && this.notebookbar) {
-			const show = userPrivateInfo.SignatureCert && userPrivateInfo.SignatureKey;
-			// Show or hide the signature button on the notebookbar depending on if we
-			// have a signing cert/key specified.
-			this.showButton('signature', show);
+		if (window.documentSigningEnabled) {
+			if (this.notebookbar) {
+				const show = userPrivateInfo.SignatureCert && userPrivateInfo.SignatureKey;
+				// Show or hide the signature button on the notebookbar depending on if we
+				// have a signing cert/key specified.
+				this.showButton('signature', show);
+			}
+			const baseUrl = userPrivateInfo.ESignatureBaseUrl;
+			if (baseUrl !== undefined && !this.map.eSignature) {
+				this.map.eSignature = L.control.eSignature();
+			}
 		}
 	},
 


### PR DESCRIPTION
In short, the trouble with signing with PEM files is that many CAs won't
hand out software certs for signing, need to use a 3rd-party to do the
signing. This requires hash-extract / upload / sign / download /
serialize pipeline on our side.

This commit starts with the first step, to extract a hash of the
document to be signed.

Given that the hash depends on the time (the signed document has a
signature widget, and that contains a timestamp), also get that from
core. Do this with a new menu item of the Draw / PDF UI: only visible
when the user private info from WOPI has a ESignatureBaseUrl key, which
will be the API server we'll talk to in the future. (So all this is
hidden by default, allowing this add this incrementally.)

Also fix a missing make dependency, so COOL_JS.m4 gets rebuilt on adding
a new .ts file, to avoid the need to do a 'make clean' on adding a new
file, which sounded odd.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ib9f15fc1448eea4a4fa1784cf0d9b3de00c44019
