### PR TITLE
fix(calc): Improve grid colors in dark mode

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -50,6 +50,8 @@
 	--color-box-shadow: rgba(0, 0, 0, 0.5);
 	--color-hyperlink: #1d99f3;
 
+	--color-calc-grid: #474747;
+
 	--color-grid-helper-line-solid: #e6e6e6;
 	--color-grid-helper-line-dashed: #191919;
 	--color-smart-guides-helper-line: #f36d4f;

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -50,6 +50,8 @@
 	--color-box-shadow: rgba(77, 77, 77, 0.5);
 	--color-hyperlink: #000080;
 
+	--color-calc-grid: #c0c0c0;
+
 	--color-grid-helper-line-solid: #e6e6e6;
 	--color-grid-helper-line-dashed: #191919;
 	--color-smart-guides-helper-line: #f36d4f;

--- a/browser/src/canvas/sections/CalcGridSection.ts
+++ b/browser/src/canvas/sections/CalcGridSection.ts
@@ -24,7 +24,7 @@ class CalcGridSection extends app.definitions.canvasSectionObject {
         this.boundToSection = 'tiles';
         this.sectionProperties = {
             docLayer: app.map._docLayer,
-            strokeStyle: '#c0c0c0',
+            strokeStyle: getComputedStyle(document.body).getPropertyValue('--color-calc-grid'),
 			tsManager: null
         };
 	}

--- a/browser/src/canvas/sections/CalcGridSection.ts
+++ b/browser/src/canvas/sections/CalcGridSection.ts
@@ -29,6 +29,10 @@ class CalcGridSection extends app.definitions.canvasSectionObject {
         };
 	}
 
+	public resetStrokeStyle() {
+		this.sectionProperties.strokeStyle = getComputedStyle(document.body).getPropertyValue('--color-calc-grid');
+	}
+
 	// repaintArea, paneTopLeft, canvasCtx
 	onDrawArea(area?: Bounds, paneTopLeft?: any): void {
 		if (!this.sectionProperties.docLayer.sheetGeometry)

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -187,6 +187,12 @@ L.Control.UIManager = L.Control.extend({
 		if (!window.mode.isMobile())
 			this.refreshAfterThemeChange();
 
+		if (app.map._docLayer._docType === 'spreadsheet') {
+			const calcGridSection = app.sectionContainer.getSectionWithName(L.CSections.CalcGrid.name);
+			if (calcGridSection)
+				calcGridSection.resetStrokeStyle();
+		}
+
 		this.map.fire('themechanged');
 	},
 


### PR DESCRIPTION
Change-Id: Ie379efb16f5e82de8d53203b88fdccad15e8da37


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

This allow to adjust the calc grid line color through css variables. It also sets a different value for dark mode to make the contrast ratio with the background similar to light mode.

Change might be subtle but makes calc in dark mode look much nicer as discussed at some point already with @pedropintosilva and @jancborchardt

One issue seems still that a reload is required, on switching to dark mode the grid color is not picked up again. I'm not sure what the best way would be to update the sectionProperties values in that case. Maybe someone has a pointer there?

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/2a66696a-edbe-45f1-bb3c-34c5b1ceb050) | ![image](https://github.com/user-attachments/assets/86c964f0-5946-43f4-9f3b-05023e8f6f8f) |
| ![image](https://github.com/user-attachments/assets/d42db200-e0bd-46f8-a524-48d0fe9aeffc) | ![image](https://github.com/user-attachments/assets/c60fc539-3497-4e51-9e52-5f7d1d4c0a18) |



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

