### PR TITLE
treeview: missing columns

### DIFF
--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -353,8 +353,7 @@ class TreeViewControl {
 		parent: HTMLElement,
 	) {
 		const tr = L.DomUtil.create('div', 'ui-treeview-entry', parent);
-		let dummyColumns =
-			this._columns - (entry.columns ? entry.columns.length : 0);
+		let dummyColumns = 0;
 		if (this._hasState) dummyColumns++;
 		tr.style.gridColumn = '1 / ' + (this._columns + dummyColumns + 1);
 
@@ -477,15 +476,6 @@ class TreeViewControl {
 					builder.options.cssClass + ' ui-treeview-expander',
 					td,
 				);
-		}
-
-		// dummy columns (for missing elements in current row - eg. icon)
-		let dummyColumns =
-			this._columns - (entry.columns ? entry.columns.length : 0);
-		if (this._isRealTree) dummyColumns--;
-		for (let index = dummyColumns; index > 0; index--) {
-			td = L.DomUtil.create('div', '', tr);
-			rowElements.push(td);
 		}
 
 		// regular columns
@@ -1083,9 +1073,7 @@ class TreeViewControl {
 					parent,
 				);
 
-				let dummyColumns =
-					this._columns -
-					(entries[index].columns ? entries[index].columns.length : 0);
+				let dummyColumns = 0;
 				if (this._hasState) dummyColumns++;
 				subGrid.style.gridColumn = '1 / ' + (this._columns + dummyColumns + 1);
 


### PR DESCRIPTION
jsdialog: treeview: put dummy columns at correct position
    
    It was a regression from commit aee68f732003d02bdf7c9b0768df8ca0a3880123
    browser: treeview: align listbox with headers using subgrid
    
    If we used autofilter in calc which has icons at the end of an entry,
    we got dummy column at the beginning of the row...
    
    This adds preprocessing of columns so we always have all of them
    unified (the same number of cols in every row) with dummy ones at
    the correct position. Exception is separator which has to be only
    one in the row to be full width.