### PR TITLE
Fix intermittent searchbar_spec.js test failure

### DIFF
--- a/browser/src/control/Search.js
+++ b/browser/src/control/Search.js
@@ -11,7 +11,25 @@
 /* global app */
 
 L.Map.include({
+	_onSearch: function() {
+		this.off('search', this._onSearch, this);
+		if (this._pendingSearch) {
+			this.search.bind(this, ...this._pendingSearch)();
+			this._pendingSearch = null;
+		}
+	},
+
 	search: function (text, backward, replaceString,  command, expand) {
+		if (this._docLayer._searchRequested) {
+			// If we're waiting for a search result, wait for the response before
+			// sending a new one.
+			// This reduces traffic and also avoids the bug where fast successive
+			// searches can skip over results.
+			this.on('search', this._onSearch, this);
+			this._pendingSearch = arguments;
+			return;
+		}
+
 		if (backward === undefined) {
 			backward = false;
 		}


### PR DESCRIPTION
We need to wait for search results before sending new ones, or we end up skipping over valid results.


Change-Id: I957873ee8c80ac8c1ed04a33510b3c6b46886360


* Resolves: # <!-- related github issue -->
* Target version: master 

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

