### PR TITLE
cool#9992 doc electronic sign: send the hash to be signed

### DIFF
--- a/browser/src/control/Control.ESignature.ts
+++ b/browser/src/control/Control.ESignature.ts
@@ -19,12 +19,30 @@ namespace cool {
 		commandValues: SignatureResponse;
 	}
 
+	export interface HashSendResponse {
+		doc_id: string;
+	}
+
 	/**
 	 * Provides electronic signing with document hashes for PDF files.
 	 */
 	export class ESignature {
-		constructor() {
-			app.map.on('commandvalues', this.onCommandValues);
+		// Base url, e.g. https://id.eideasy.com or https://test.eideasy.com
+		url: string;
+		// These are kind of API tokens, see
+		// <https://docs.eideasy.com/guide/api-credentials.html>
+		secret: string;
+		clientId: string;
+
+		// Timestamp of the hash extraction
+		signatureTime: number;
+
+		constructor(url: string, secret: string, clientId: string) {
+			this.url = url;
+			this.secret = secret;
+			this.clientId = clientId;
+
+			app.map.on('commandvalues', this.onCommandValues.bind(this));
 		}
 
 		insert(): void {
@@ -32,17 +50,79 @@ namespace cool {
 			app.socket.sendMessage('commandvalues command=.uno:Signature');
 		}
 
+		// Handles the command values response for .uno:Signature
 		onCommandValues(event: CommandValuesResponse): void {
 			if (event.commandName != '.uno:Signature') {
 				return;
 			}
 
 			const signatureResponse = event.commandValues;
+
+			// Save this, we'll need it for the serialize step.
+			this.signatureTime = signatureResponse.signatureTime;
+
+			const digest = signatureResponse.digest;
+
+			// Step 2: send the hash, get a document ID.
+			const url = this.url + '/api/signatures/prepare-files-for-signing';
+			const body = {
+				secret: this.secret,
+				client_id: this.clientId,
+				// Create a PKCS#7 binary signature
+				container_type: 'cades',
+				files: [
+					{
+						// Actual file name doesn't seem to matter
+						fileName: 'document.pdf',
+						mimeType: 'application/pdf',
+						fileContent: digest,
+					},
+				],
+				// Learn about possible providers
+				return_available_methods: true,
+			};
+			const headers = {
+				'Content-Type': 'application/json',
+			};
+			const request = new Request(url, {
+				method: 'POST',
+				body: JSON.stringify(body),
+				headers: headers,
+			});
+			window.fetch(request).then(
+				(response) => {
+					this.handleSendHashBytes(response);
+				},
+				(error) => {
+					app.console.log(
+						'failed to fetch /api/signatures/prepare-files-for-signing: ' +
+							error.message,
+					);
+				},
+			);
+		}
+
+		// Handles the 'send hash' response bytes
+		handleSendHashBytes(response: Response): void {
+			response.json().then(
+				(json) => {
+					this.handleSendHashJson(json);
+				},
+				(error) => {
+					app.console.log(
+						'failed to parse response from /api/signatures/prepare-files-for-signing as JSON: ' +
+							error.message,
+					);
+				},
+			);
+		}
+
+		// Handles the 'send hash' response JSON
+		handleSendHashJson(response: HashSendResponse): void {
+			const docId = response.doc_id;
 			console.log(
-				'TODO(vmiklos) ESignature::onCommandValues: signature time is ' +
-					signatureResponse.signatureTime +
-					', digest is "' +
-					signatureResponse.digest +
+				'TODO(vmiklos) ESignature::handleSendHashJson: docId is "' +
+					docId +
 					'"',
 			);
 		}
@@ -51,6 +131,10 @@ namespace cool {
 
 L.Control.ESignature = cool.ESignature;
 
-L.control.eSignature = function () {
-	return new L.Control.ESignature();
+L.control.eSignature = function (
+	url: string,
+	secret: string,
+	clientId: string,
+) {
+	return new L.Control.ESignature(url, secret, clientId);
 };

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1069,8 +1069,10 @@ L.Control.UIManager = L.Control.extend({
 				this.showButton('signature', show);
 			}
 			const baseUrl = userPrivateInfo.ESignatureBaseUrl;
+			const secret = userPrivateInfo.ESignatureSecret;
+			const clientId = userPrivateInfo.ESignatureClientId;
 			if (baseUrl !== undefined && !this.map.eSignature) {
-				this.map.eSignature = L.control.eSignature();
+				this.map.eSignature = L.control.eSignature(baseUrl, secret, clientId);
 			}
 		}
 	},

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1439,8 +1439,6 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
 
     const std::string mimeType = "text/html";
 
-    // Document signing: if endpoint URL is configured, whitelist that for
-    // iframe purposes.
     ContentSecurityPolicy csp;
     csp.appendDirective("default-src", "'none'");
     csp.appendDirective("frame-src", "'self'");
@@ -1451,6 +1449,14 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
     csp.appendDirective("connect-src", "'self'");
     csp.appendDirectiveUrl("connect-src", "https://www.zotero.org");
     csp.appendDirectiveUrl("connect-src", "https://api.zotero.org");
+
+    if (ConfigUtil::getBool("document_signing.enable", true))
+    {
+        // Document signing: if enabled, whitelist that for iframe purposes.
+        csp.appendDirectiveUrl("connect-src", "https://id.eideasy.com");
+        csp.appendDirectiveUrl("connect-src", "https://test.eideasy.com");
+    }
+
     csp.appendDirectiveUrl("connect-src", cnxDetails.getWebSocketUrl());
     csp.appendDirectiveUrl("connect-src", cnxDetails.getWebServerUrl());
     csp.appendDirectiveUrl("connect-src", indirectionURI.getAuthority());


### PR DESCRIPTION
Once the hash is extracted from the document, we need to send it to the
3rd-party for signing.

Given that we don't want to send the entire document, our signature
container should not be an entire PDF file, we just want this for the
signature binary itself (PKCS#7 blob), set the file type to "cades",
which does exactly this.

This requires passing the API URL, and credentials to
L.Control.ESignature.

Finally allow communicating with these hosts in the CSP headers.
Initially I attempted to take the URL from CheckFileInfo, but we seem to
decide this when serving cool.html, so that order doesn't allow making
the CSP headers depend on the CheckFileInfo response. In practice only 2
public servers implement this protocol (production and test), so just
allow them for now, similar to Zotero. If there is a need for a custom
server later, it can be always added to net.content_security_policy in
coolwsd.xml.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: If1dfa50defb37205e54b2f3708f7bdaeab22afce
