### PR TITLE
fuzzer: fix the build of 'clientsession_fuzzer'

### DIFF
--- a/fuzzer/ClientSession.cpp
+++ b/fuzzer/ClientSession.cpp
@@ -3,6 +3,7 @@
 #include "config.h"
 
 #include "ClientSession.hpp"
+#include <common/Anonymizer.hpp>
 #include <fuzzer/Common.hpp>
 
 bool DoInitialization()
@@ -51,7 +52,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     Admin::instance().poll(std::chrono::microseconds(0));
 
     // Make sure the anon map does not grow forever, leading to OOM.
-    Util::clearAnonymized();
+    Anonymizer::clearAnonymized();
     return 0;
 }
 


### PR DESCRIPTION
Seems to be a fallout from commit
fc2c44198812060095d016000906e9d926af1735 (wsd: move anonymization
implementation to own home, 2024-11-20).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I7392c7ebc40acae910fb308ccaa5bd7d702f0e46
