### PR TITLE
Fix incorrect order of message arguments

### DIFF
--- a/browser/src/map/handler/Map.FileInserter.js
+++ b/browser/src/map/handler/Map.FileInserter.js
@@ -210,7 +210,8 @@ L.Map.FileInserter = L.Handler.extend({
 		}
 
 		if (e.urltype == "graphicurl" && section && section.sectionProperties.picturePicker) {
-			app.socket.sendMessage('contentcontrolevent name=' + encodeURIComponent(e.url) + ' type=pictureurl');
+			// The order argument is important
+			app.socket.sendMessage('contentcontrolevent type=pictureurl name=' + encodeURIComponent(e.url));
 		} else {
 			app.socket.sendMessage('insertfile name=' + encodeURIComponent(e.url) + ' type=' + e.urltype);
 		}


### PR DESCRIPTION
The 'pictureurl' message is handled in ChildSession::contentControlEvent,
which relies on the order of the arguments.
In commit 60d9a9c20bf69b3f1d8591b2d8400c4a453970ab (Implement remote
multimedia insertion support, 2024-11-19), I incorrectly modified the
order, trying to unify it between nearby calls. Fix it here.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I612973e1b8aa245a601d3053e516b67007482a69
