### PR TITLE
cool#9992 doc electronic sign: actually sign the hash in a popup

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1077,8 +1077,9 @@ L.Control.UIManager = L.Control.extend({
 			const baseUrl = userPrivateInfo.ESignatureBaseUrl;
 			const secret = userPrivateInfo.ESignatureSecret;
 			const clientId = userPrivateInfo.ESignatureClientId;
+			const method = userPrivateInfo.ESignatureMethod;
 			if (baseUrl !== undefined && !this.map.eSignature) {
-				this.map.eSignature = L.control.eSignature(baseUrl, secret, clientId);
+				this.map.eSignature = L.control.eSignature(baseUrl, secret, clientId, method);
 			}
 		}
 	},

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -263,6 +263,12 @@ L.Map.WOPI = L.Handler.extend({
 			return true;
 		}
 
+		const eSignature = this._map.eSignature;
+		if (eSignature && eSignature.url === e.origin) {
+			// The sender is our esign popup: accept it.
+			return true;
+		}
+
 		return false;
 	},
 
@@ -276,6 +282,9 @@ L.Map.WOPI = L.Handler.extend({
 
 		if (('data' in e) && Object.hasOwnProperty.call(e.data, 'MessageId')) {
 			// when e.data already contains the right props, but isn't JSON (a blob is passed for ex)
+			msg = e.data;
+		} else if (typeof e.data === 'object') {
+			// E.g. the esign popup sends us an object, no need to JSON-parse it.
 			msg = e.data;
 		} else {
 			try {
@@ -683,6 +692,13 @@ L.Map.WOPI = L.Handler.extend({
 		else if (msg.MessageId === 'Action_Mention') {
 			var list = msg.Values.list;
 			this._map.mention.openMentionPopup(list);
+		}
+		else if (msg.sender === 'EIDEASY_SINGLE_METHOD_SIGNATURE') {
+			// This is produced by the esign popup.
+			const eSignature = this._map.eSignature;
+			if (eSignature) {
+				eSignature.handleSigned(msg);
+			}
 		}
 	},
 


### PR DESCRIPTION
Open an PDF in Draw, Insert -> Electronic signature, the doc hash is
sent to ESignatureBaseUrl, but we don't attempt to sign it.

The actual signing happens using a HTML page provided by eIDEasy, so
open that in a popup.

We can avoid polling for the signature result by listening for
postmessages: the signing popups sends us a postmessage on completion.

This is the same mechanism that's used by the SignatureJS npm library,
developed by eIDEasy (but don't use that here, since it would pull in a
number of dependencies since it doesn't use the fetch() API).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I10902ec6868a64f250fe5afdd0cf9ba36a2f63e6
