### PR TITLE
slideshow: prevent slide sorter to receive key events on fullscreen mode

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -709,6 +709,8 @@ class SlideShowPresenter {
 		if (!this._onPrepareScreen(false))
 			// opens full screen, has to be on user interaction
 			return;
+		// disable slide sorter or it will receive key events
+		this._map._docLayer._preview.partsFocused = false;
 
 		this._startSlide = that?.startSlideNumber ?? 0;
 		app.socket.sendMessage('getpresentationinfo');


### PR DESCRIPTION
Apart from changing the current slide in the editor,
this causes the onUpdateParts to be triggered which in turn request presentation
info again even if that's not needed.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I15efd3d205c7b03a76d04ff0e8f4f22b07bac00e
