### PR TITLE
Calc: Fix spreadsheet toolbox button size

### DIFF
--- a/browser/css/spreadsheet.css
+++ b/browser/css/spreadsheet.css
@@ -282,6 +282,11 @@
 	height: 38px;
 }
 
+#sheets-buttons-toolbox .unotoolbutton {
+	width: var(--btn-size);
+	height: var(--btn-size);
+}
+
 .tab-drop-area {
 	height: 32px;
 	width: 4px;


### PR DESCRIPTION
Before this commit the unotoolbutton was bigger than the inner button
resulting in a faulty hover style

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Id63c4b9e05629d2d0584af1b6fefc6e4e2f1cbe7
