### PR TITLE
slideshow: pause mode refresh

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -392,7 +392,7 @@ class SlideShowPresenter {
 		overlay.style.right = '0';
 		overlay.style.left = '0';
 
-		overlay.style.opacity = '40%';
+		overlay.style.opacity = '65%';
 		overlay.style.backgroundColor = 'black';
 		overlay.style.color = 'white';
 

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -422,7 +422,7 @@ class SlideShowPresenter {
 			</head>
 			<body>
 				<div id="root-in-window"></div>
-				<div id="overlay-in-window" style="display: none">
+				<div id="overlay-in-window">
 					<span>${pauseText}</span>
 				</div>
 			</body>

--- a/browser/src/slideshow/Transition2d.ts
+++ b/browser/src/slideshow/Transition2d.ts
@@ -148,6 +148,11 @@ class Transition2d extends TransitionBase {
 			gl.clear(gl.COLOR_BUFFER_BIT);
 		}
 
+		if (!this.program) {
+			console.error('Transition2d.render: this.program is missing');
+			return;
+		}
+
 		gl.useProgram(this.program);
 		gl.bindVertexArray(this.vao);
 		gl.uniform1f(gl.getUniformLocation(this.program, 'time'), nT);


### PR DESCRIPTION
    slideshow: refresh paused screen in Firefox
    
    followup for commit b4decaee2bcd5f65a92ea887b9298968a9440db1
    slideshow: show pause indicator in the in-window presentation
    
    we detected that Firefox renders from time to time (around 1 / s)
    the popup if main window is hidden - what doesn't happen in Chrome
    
---------------------------------------

    slideshow: prevent Transition2d exception on program
    
    this.program might be missing if using with hidden
    main window browser tab
    
    Transition2d.render (Transition2d.ts:153)
    SlideChangeTemplate.SlideChangeBase.animate (SlideChangeBase.ts:82)
    requestAnimationFrame
    TransitionBase.startTransition (Transition2d.ts:36)
    TransitionBase.start (Transition2d.ts:42)
    SimpleActivity.startAnimation (SimpleActivity.ts:53)
    ActivityBase.calcTimeLag (ActivityBase.ts:76)
    SimpleContinuousActivityBase.calcTimeLag (SimpleContinuousActivityBase.ts:40)
    ActivityQueue.process (ActivityQueue.ts:45)
    SlideShowHandler.update (SlideShowHandler.ts:864)
    SlideShowHandler.displaySlide (SlideShowHandler.ts:840)
    (anonymous) (SlideShowNavigator.ts:265)

------------------------------------------------

    slideshow: remove inline style error
    
    Content-Security-Policy: The page’s settings blocked an inline style (style-src-attr) from being applied because it violates the following directive: “style-src 'self'”

-------------------------------------------------------------------

    slideshow: make pause overlay text more visible
