### PR TITLE
Check canvas size before copy in CanvasSectionContainer.onResize

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1339,7 +1339,7 @@ class CanvasSectionContainer {
 		// Drawing may happen asynchronously so backup the old contents to avoid
 		// showing a blank canvas.
 		var oldImageData: ImageData = null;
-		if (this.paintedEver)
+		if (this.paintedEver && this.canvas.width > 0 && this.canvas.height > 0)
 			oldImageData = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
 
 		this.canvas.width = newWidth;


### PR DESCRIPTION
Don't try to call getImageData if the canvas width or height are zero, as this will result in an IndexSizeError.