### PR TITLE
Clipboard write: Don't consider "Document is not focused." as an error.

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -901,15 +901,20 @@ L.Clipboard = L.Class.extend({
 			try {
 				await clipboard.write([clipboardItem]);
 			} catch (error) {
-				window.app.console.log('navigator.clipboard.write() failed: ' + error.message);
-
-				// Warn that the copy failed.
-				this._warnCopyPaste();
-				// Once broken, always broken.
-				L.Browser.clipboardApiAvailable = false;
-				window.prefs.set('clipboardApiAvailable', false);
-				// Prefetch selection, so next time copy will work with the keyboard.
-				app.socket.sendMessage('gettextselection mimetype=text/html,text/plain;charset=utf-8');
+				// When document is not focused, writing to clipboard is not allowed. But this error shouldn't stop the usage of clipboard API.
+				if (!document.hasFocus()) {
+					window.app.console.warn('navigator.clipboard.write() failed: ' + error.message);
+				}
+				else {
+					window.app.console.error('navigator.clipboard.write() failed: ' + error.message);
+					// Warn that the copy failed.
+					this._warnCopyPaste();
+					// Once broken, always broken.
+					L.Browser.clipboardApiAvailable = false;
+					window.prefs.set('clipboardApiAvailable', false);
+					// Prefetch selection, so next time copy will work with the keyboard.
+					app.socket.sendMessage('gettextselection mimetype=text/html,text/plain;charset=utf-8');
+				}
 			}
 		}
 	},


### PR DESCRIPTION
It causes the process to think that clipboard API has failed. Then we don't try again with the clipboard API. This commit logs a warning and skips the fallback part.


Change-Id: I4f04feb3bf77ea986453733a6c8976ef3d0ac2a4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

