### PR TITLE
Calc: Set spreasheet header colors from CSS vars

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -51,6 +51,11 @@
 	--color-hyperlink: #1d99f3;
 
 	--color-calc-grid: #474747;
+	--color-calc-header: #0a0a0a;
+	--color-calc-header-selected: #646464;
+	--color-text-calc-header-selected: #fff;
+	--color-border-calc-header: var(--color-border-dark);
+	--color-calc-header-hover: #646464;
 
 	--color-grid-helper-line-solid: #e6e6e6;
 	--color-grid-helper-line-dashed: #191919;

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -51,6 +51,11 @@
 	--color-hyperlink: #000080;
 
 	--color-calc-grid: #c0c0c0;
+	--color-calc-header: #f0f0f0;
+	--color-calc-header-selected: #e1e1e1;
+	--color-text-calc-header-selected: var(--color-text-darker);
+	--color-border-calc-header: #c0c0c0;
+	--color-calc-header-hover: #fff;
 
 	--color-grid-helper-line-solid: #e6e6e6;
 	--color-grid-helper-line-dashed: #191919;

--- a/browser/css/spreadsheet.css
+++ b/browser/css/spreadsheet.css
@@ -148,8 +148,8 @@
 
 .spreadsheet-header-row,
 .spreadsheet-header-column {
-	border: 1px solid var(--color-border-dark);
-	background-color: var(--colo-background-dark);
+	border: 1px solid var(--color-border-calc-header);
+	background-color: var(--color-calc-header);
 	font: var(--default-font-size)/1.5 var(--cool-font);
 	color: var(--color-text-dark);
 	cursor: pointer;
@@ -157,13 +157,13 @@
 
 .spreadsheet-header-row-hover,
 .spreadsheet-header-column-hover {
-	background-color: var(--background-color-darker);
+	background-color: var(--color-calc-header-hover);
 }
 
 .spreadsheet-header-row-selected,
 .spreadsheet-header-column-selected {
-	color: var(--color-primary-text);
-	background: linear-gradient(var(--color-primary), var(--color-primary), var(--color-primary));
+	color: var(--color-text-calc-header-selected);
+	background: linear-gradient(var(--color-calc-header-selected), var(--color-calc-header-selected), var(--color-calc-header-selected));
 }
 
 .spreadsheet-header-column-resize {

--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -58,7 +58,7 @@ export class Header extends app.definitions.canvasSectionObject {
 		const baseElem = document.getElementsByTagName('body')[0];
 		const elem = L.DomUtil.create('div', className, baseElem);
 		this._textColor = L.DomUtil.getStyle(elem, 'color');
-		this._backgroundColor = getComputedStyle(document.body).getPropertyValue('--color-background-darker');
+		this._backgroundColor = L.DomUtil.getStyle(elem, 'background-color');
 		const fontFamily = L.DomUtil.getStyle(elem, 'font-family');
 		this.getFont = function() {
 			const selectedSize = this._getFontSize();
@@ -85,7 +85,7 @@ export class Header extends app.definitions.canvasSectionObject {
 	_initHeaderEntryHoverStyles (className: string): void {
 		const baseElem = document.getElementsByTagName('body')[0];
 		const elem = L.DomUtil.create('div', className, baseElem);
-		this._hoverColor = getComputedStyle(document.body).getPropertyValue('--color-background-lighter');
+		this._hoverColor = L.DomUtil.getStyle(elem, 'background-color');
 		L.DomUtil.remove(elem);
 	}
 


### PR DESCRIPTION
Note: this commit doesn't touch or fix the problem with the corner
header being always white even if on dark mode. That is outside of the
scope of this patch.

Better to create dedicated css vars instead of rely on other generic
CSS vars such as background-color-darker etc. this way we avoid
calc regressions when someone changes those more generic values.

Also avoid setting the fill of header-row and header-column-selected
to the primary color. If the integrator wants to set that they are
free to overwrite that but better to default to neutral color that
looks ok on both light and dark mode.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I3c6d0b7a8e58ae8c239bda97d35454cdc70826fe
