### PR TITLE
coolconfig: Allow passing admin user name password

### DIFF
--- a/man/coolconfig.1
+++ b/man/coolconfig.1
@@ -45,6 +45,10 @@ set\-admin\-password
 .PP
 \fB\-\-pwd\-hash\-length\fR=\fInumber\fR  Length of password hash to generate.
 .PP
+\fB\-\-user\fR=\fIname\fR               User name for the admin console. If unspecified will be requested on the terminal.
+.PP
+\fB\-\-password\fR=\fIpassword\fR       Password for the admin console. If unspecified will be requested on the terminal.
+.PP
 .SS "update\-system\-template"
 The \fBupdate\-system\-template\fR command updates Collabora Online's system template. It is used typically when new fonts are added to the system, that need to be used with Collabora Online.
 .PP


### PR DESCRIPTION
use --user and --password to pass the user and / or password to set-admin-password


Change-Id: I192262fde6fbef812487e4d4e49049d5ebd5c776


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

--user and --password for `coolconfig set-admin-password`

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

