### PR TITLE
kit: fix: templates don't get imported when mounting is disabled

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3950,7 +3950,7 @@ bool globalPreinit(const std::string &loTemplate)
     // desktop or developer's install if env. var not set.
     ::setenv("UNODISABLELIBRARY",
              "abp avmediagst avmediavlc cmdmail losessioninstall OGLTrans PresenterScreen "
-             "syssh ucpftp1 ucpgio1 ucphier1 ucpimage updatecheckui updatefeed updchk"
+             "syssh ucpftp1 ucpgio1 ucpimage updatecheckui updatefeed updchk"
              // Database
              "dbaxml dbmm dbp dbu deployment firebird_sdbc mork "
              "mysql mysqlc odbc postgresql-sdbc postgresql-sdbc-impl sdbc2 sdbt"


### PR DESCRIPTION
- SfxDocTplService::init_Impl doesn't get initialized because unolibrary `ucphier1` is disabled

```
warn:sal.osl:1269089:1269017:sal/osl/unx/module.cxx:100:
dlopen(/lo/program/../program/libucphier1.so, 257):
/lo/program/../program/libucphier1.so: cannot open shared object file:
No such file or directory
warn:legacy.osl:1269089:1269017:ucb/source/core/provprox.cxx:347:
UcbContentProviderProxy::getContentProvider - No provider for
'com.sun.star.ucb.HierarchyContentProvider.
warn:sal.osl:1269089:1269017:sal/osl/unx/module.cxx:100:
dlopen(/lo/program/../program/libucphier1.so, 257):
/lo/program/../program/libucphier1.so: cannot open shared object file:
No such file or directory
warn:legacy.osl:1269089:1269017:ucb/source/core/provprox.cxx:347:
UcbContentProviderProxy::getContentProvider - No provider for
'com.sun.star.ucb.HierarchyContentProvider.
warn:sal.osl:1269089:1269017:sal/osl/unx/module.cxx:100:
dlopen(/lo/program/../program/libucphier1.so, 257):
/lo/program/../program/libucphier1.so: cannot open shared object file:
No such file or directory
warn:legacy.osl:1269089:1269017:ucb/source/core/provprox.cxx:347:
UcbContentProviderProxy::getContentProvider - No provider for
'com.sun.star.ucb.HierarchyContentProvider.
warn:sal.osl:1269089:1269017:sal/osl/unx/module.cxx:100:
dlopen(/lo/program/../program/libucphier1.so, 257):
/lo/program/../program/libucphier1.so: cannot open shared object file:
No such file or directory
warn:legacy.osl:1269089:1269017:ucb/source/core/provprox.cxx:347:
UcbContentProviderProxy::getContentProvider - No provider for
'com.sun.star.ucb.HierarchyContentProvider.
warn:sal.osl:1269089:1269017:sal/osl/unx/module.cxx:100:
dlopen(/lo/program/../program/libucphier1.so, 257):
/lo/program/../program/libucphier1.so: cannot open shared object file:
No such file or directory
warn:legacy.osl:1269089:1269017:ucb/source/core/provprox.cxx:347:
UcbContentProviderProxy::getContentProvider - No provider for
'com.sun.star.ucb.HierarchyContentProvider.
warn:sal.osl:1269089:1269017:sal/osl/unx/module.cxx:100:
dlopen(/lo/program/../program/libucphier1.so, 257):
/lo/program/../program/libucphier1.so: cannot open shared object file:
No such file or directory
warn:legacy.osl:1269089:1269017:ucb/source/core/provprox.cxx:347:
UcbContentProviderProxy::getContentProvider - No provider for
'com.sun.star.ucb.HierarchyContentProvider.
warn:sal.osl:1269089:1269017:sal/osl/unx/module.cxx:100:
dlopen(/lo/program/../program/libucphier1.so, 257):
/lo/program/../program/libucphier1.so: cannot open shared object file:
No such file or directory
warn:legacy.osl:1269089:1269017:ucb/source/core/provprox.cxx:347:
UcbContentProviderProxy::getContentProvider - No provider for
'com.sun.star.ucb.HierarchyContentProvider.
warn:sfx.doc:1269089:1269017:sfx2/source/doc/doctemplates.cxx:483:
init_Impl(): Could not create root
```

Change-Id: Ia8d22eaccc30dadf2e8cdc2ff140702a432612b5

* Target version: master 
* It is also required for our new remote template feature: https://github.com/CollaboraOnline/online/pull/10463