### PR TITLE
calc: allow to use shortcut ctrl+Enter in comments

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -436,7 +436,7 @@ export class Comment extends CanvasSectionObject {
 	private textAreaKeyDown (ev: any): void {
 		if (ev && ev.ctrlKey && ev.key === "Enter") {
 			ev.preventDefault();
-			this.map.mention.closeMentionPopup(false);
+			this.map.mention?.closeMentionPopup(false);
 			this.onSaveComment(ev);
 			return;
 		}


### PR DESCRIPTION
this.map.mention can be unset in particular in calc.

Amends  https://github.com/CollaboraOnline/online/pull/10383

Change-Id: I8dba5d36f20d6fe3bf0df9b9fa15a98b70b51eaa

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

In calc > insert a  comment > type some text > hit Ctrl+Enter

Expected:
The popup closes, the comment is saved.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

