### PR TITLE
Improved hover text labels in table menu in calc, impress and writer for clarity

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -697,14 +697,14 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 							{
 								'id': 'home-insert-rows-before',
 								'type': 'toolitem',
-								'text': _UNO('.uno:InsertRowsBefore', 'spreadsheet'),
+								'text': _UNO('.uno:InsertRowsBefore', 'spreadsheet', true),
 								'command': '.uno:InsertRowsBefore',
 								'accessibility': { focusBack: true,	combination: 'RB', de: null }
 							},
 							{
 								'id': 'home-insert-rows-after',
 								'type': 'toolitem',
-								'text': _UNO('.uno:InsertRowsAfter', 'spreadsheet'),
+								'text': _UNO('.uno:InsertRowsAfter', 'spreadsheet', true),
 								'command': '.uno:InsertRowsAfter',
 								'accessibility': { focusBack: true,	combination: 'RA', de: null }
 							},
@@ -730,14 +730,14 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 							{
 								'id': 'home-insert-columns-before',
 								'type': 'toolitem',
-								'text': _UNO('.uno:InsertColumnsBefore', 'spreadsheet'),
+								'text': _UNO('.uno:InsertColumnsBefore', 'spreadsheet', true),
 								'command': '.uno:InsertColumnsBefore',
 								'accessibility': { focusBack: true,	combination: 'UB', de: null }
 							},
 							{
 								'id': 'home-insert-columns-after',
 								'type': 'toolitem',
-								'text': _UNO('.uno:InsertColumnsAfter', 'spreadsheet'),
+								'text': _UNO('.uno:InsertColumnsAfter', 'spreadsheet', true),
 								'command': '.uno:InsertColumnsAfter',
 								'accessibility': { focusBack: true,	combination: 'UA', de: null }
 							},

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1833,7 +1833,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'table-table-dialog',
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:TableDialog', 'presentation'),
+				'text': _UNO('.uno:TableDialog', 'presentation', true),
 				'command': '.uno:TableDialog',
 				'accessibility': { focusBack: false, combination: 'SD', de: null }
 			},

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2370,7 +2370,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 		var content = [
 			{
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:TableDialog', 'text'),
+				'text': _UNO('.uno:TableDialog', 'text', true),
 				'command': '.uno:TableDialog'
 			},
 			{
@@ -2381,12 +2381,12 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:InsertColumnsBefore', 'text'),
+								'text': _UNO('.uno:InsertColumnsBefore', 'text', true),
 								'command': '.uno:InsertColumnsBefore'
 							},
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:InsertColumnsAfter', 'text'),
+								'text': _UNO('.uno:InsertColumnsAfter', 'text', true),
 								'command': '.uno:InsertColumnsAfter'
 							},
 							{
@@ -2401,12 +2401,12 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'children': [
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:InsertRowsBefore', 'text'),
+								'text': _UNO('.uno:InsertRowsBefore', 'text', true),
 								'command': '.uno:InsertRowsBefore'
 							},
 							{
 								'type': 'toolitem',
-								'text': _UNO('.uno:InsertRowsAfter', 'text'),
+								'text': _UNO('.uno:InsertRowsAfter', 'text', true),
 								'command': '.uno:InsertRowsAfter'
 							},
 							{


### PR DESCRIPTION
This update modifies the text labels in the Tabbed View's Table menu to provide clearer, more consistent descriptions.
The following changes have been made:

- "Column Before" → "Insert Column Before"
- "Column After" → "Insert Column After"
- "Rows Above" → "Insert Rows Above"
- "Rows Below" → "Insert Rows Below"
- "Properties" → "Table Properties"

Change-Id: I7041f6296808759dcd0913e18be53cf414f42be4

* Resolves: #10175
* Target version: master 

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

