### PR TITLE
PostMessage: added Show/Hide_NotebookTab

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -23,6 +23,8 @@ L.Control.UIManager = L.Control.extend({
 	customButtons: [], // added by WOPI InsertButton
 	hiddenButtons: {},
 	hiddenCommands: {},
+	// Hidden Notebookbar tabs.
+	hiddenTabs: {},
 
 	onAdd: function (map) {
 		this.map = map;
@@ -950,6 +952,21 @@ L.Control.UIManager = L.Control.extend({
 		$('#document-container').removeClass('tabs-collapsed');
 
 		this.map._docLayer._syncTileContainerSize();
+	},
+
+	showNotebookTab: function(id, show) {
+		if (show) {
+			delete this.hiddenTabs[id];
+		} else {
+			this.hiddenTabs[id] = true;
+		}
+		if (this.notebookbar) {
+			this.notebookbar.refreshContextTabsVisibility();
+		}
+	},
+
+	isTabVisible: function(name) {
+		return !(name in this.hiddenTabs);
 	},
 
 	isNotebookbarCollapsed: function() {

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -375,6 +375,20 @@ L.Map.WOPI = L.Handler.extend({
 			this._map.uiManager.extendNotebookbar();
 			return;
 		}
+		else if (msg.MessageId === 'Show_NotebookTab' || msg.MessageId === 'Hide_NotebookTab') {
+			if (!msg.Values) {
+				window.app.console.error('Property "Values" not set');
+				return;
+			}
+			if (!msg.Values.id) {
+				window.app.console.error('Property "Values.id" not set');
+				return;
+			}
+
+			let show = msg.MessageId === 'Show_NotebookTab';
+			this._map.uiManager.showNotebookTab(msg.Values.id, show);
+			return;
+		}
 		else if (msg.MessageId === 'Show_Sidebar') {
 			/* id is optional */
                         if (msg.Values) {


### PR DESCRIPTION
Show_NotebookTab will show a previously hidden Notebookbar Tab Hide_NotebookTab will hide a Notebookbar Tab


Change-Id: If138b5f9327e8737dece211c70db19f63bb70465


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [x] Check that it works with `NotebookBar.onContextChange`
    - [x] Fix: `Hide` will have no effect on a contextually show tab.
    - [x] Fix: `Show` will show a contextually hidden tab... (like `Table`)

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

