### PR TITLE
cool#9992 doc electronic sign: add a provider selector dialog

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -360,6 +360,7 @@ COOL_JS_LST =\
 	src/control/Control.AlertDialog.js \
 	src/control/Control.Tooltip.js \
 	src/control/Control.ESignature.ts \
+	src/control/Control.ESignatureDialog.ts \
 	src/control/ColorPicker.ts \
 	src/control/jsdialog/Component.Toolbar.ts \
 	src/control/jsdialog/Definitions.Menu.ts \

--- a/browser/src/control/Control.ESignatureDialog.ts
+++ b/browser/src/control/Control.ESignatureDialog.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+namespace cool {
+	export interface SignatureProvider {
+		action_type: string;
+		name: string;
+	}
+
+	/**
+	 * Provides a dialog to select an electronic signing provider.
+	 */
+	export class ESignatureDialog {
+		id: string = 'ESignatureDialog';
+
+		providers: Array<SignatureProvider>;
+
+		constructor(providers: Array<SignatureProvider>) {
+			this.providers = providers;
+		}
+
+		getChildrenJSON(entries: Array<string>): Array<WidgetJSON> {
+			return [
+				{
+					id: 'providerft',
+					type: 'fixedtext',
+					text: _('Provider:'),
+					enabled: true,
+					labelFor: 'providerlb',
+				} as TextWidget,
+				{
+					id: 'providerlb',
+					type: 'listbox',
+					enabled: true,
+					children: [
+						{
+							id: '',
+							type: 'control',
+							enabled: true,
+							children: [],
+						},
+						{
+							type: 'pushbutton',
+							enabled: true,
+							symbol: 'SPIN_DOWN',
+						} as PushButtonWidget,
+					],
+					labelledBy: 'providerft',
+					entries: entries,
+					selectedCount: 1,
+					selectedEntries: ['0'],
+				} as ListBoxWidget,
+				{
+					id: this.id + '-buttonbox',
+					type: 'buttonbox',
+					children: [
+						{
+							id: 'ok',
+							type: 'pushbutton',
+							text: _('OK'),
+						} as PushButtonWidget,
+					],
+					layoutstyle: 'end',
+				} as ButtonBoxWidget,
+			];
+		}
+
+		getJSON(): JSDialogJSON {
+			const entries = this.providers.map((entry) => entry.name);
+			const children = this.getChildrenJSON(entries);
+			return {
+				id: this.id,
+				dialogid: this.id,
+				type: 'dialog',
+				text: _('Select provider'),
+				title: _('Select provider'),
+				jsontype: 'dialog',
+				responses: [
+					{
+						id: 'ok',
+						response: 1,
+					},
+				],
+				children: [
+					{
+						id: this.id + '-mainbox',
+						type: 'container',
+						vertical: true,
+						children: children,
+					} as ContainerWidgetJSON,
+				],
+			} as JSDialogJSON;
+		}
+
+		public close(): void {
+			const closeEvent = {
+				data: {
+					action: 'close',
+					id: this.id,
+				},
+			};
+			app.map.fire('jsdialog', closeEvent);
+		}
+
+		private callback(
+			objectType: string,
+			eventType: string,
+			object: any,
+			data: any,
+			builder: any,
+		) {
+			if (eventType === 'response' || object.id === 'ok') this.close();
+		}
+
+		open(): void {
+			const dialogBuildEvent = {
+				data: this.getJSON(),
+				callback: this.callback.bind(this) as JSDialogCallback,
+			};
+			app.map.fire('jsdialog', dialogBuildEvent);
+		}
+	}
+}
+
+JSDialog.eSignatureDialog = (providers: Array<cool.SignatureProvider>) => {
+	return new cool.ESignatureDialog(providers);
+};

--- a/browser/src/control/Control.ServerAuditDialog.ts
+++ b/browser/src/control/Control.ServerAuditDialog.ts
@@ -220,14 +220,14 @@ class ServerAuditDialog {
 									id: 'ok',
 									type: 'pushbutton',
 									text: _('OK'),
-								},
+								} as PushButtonWidget,
 							],
 							layoutstyle: 'end',
-						},
+						} as ButtonBoxWidget,
 					],
-				},
+				} as ContainerWidgetJSON,
 			],
-		} as any as JSDialogJSON;
+		} as JSDialogJSON;
 	}
 
 	public close() {

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -24,6 +24,7 @@ interface WidgetJSON {
 	top?: string; // placement in the grid - row
 	left?: string; // placement in the grid - column
 	width?: string; // inside grid - width in number of columns
+	labelledBy?: string;
 }
 
 interface DialogResponse {
@@ -100,8 +101,26 @@ interface PanelWidgetJSON extends WidgetJSON {
 
 type ExpanderWidgetJSON = any;
 
+// type: 'fixedtext'
 interface TextWidget extends WidgetJSON {
 	text: string;
+	labelFor?: string;
+}
+
+// type: 'pushbutton'
+interface PushButtonWidget extends WidgetJSON {
+	symbol?: string;
+	text?: string;
+}
+
+// type: 'buttonbox'
+interface ButtonBoxWidget extends WidgetJSON {
+	layoutstyle: string;
+}
+
+// type: 'listbox'
+interface ListBoxWidget extends WidgetJSON {
+	entries: Array<string>;
 }
 
 interface TreeColumnJSON {


### PR DESCRIPTION
- **jsdialog: avoid 'as any' cast by adding more types**
- **cool#9992 doc electronic sign: add a provider selector dialog**
