### PR TITLE
Main-nav: Fix close button divider (separator) position

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -330,7 +330,7 @@
 	width: var(--btn-size);
 	height: var(--btn-size);
 	background-color: transparent;
-	/* same margin as sidebar buttons */
+	/* same margin as main-nav padding-inline-start */
 	margin-inline-end: 5px;
 }
 
@@ -338,8 +338,8 @@
 	background: var(--color-background-darker);
 	width: 1px;
 	height: 14px;
-	/* same margin as sidebar buttons */
-	margin-inline-end: 5px;
+	/* same margin as sidebar buttons' padding */
+	margin-inline: 4px;
 }
 
 .main-nav:not(.hasnotebookbar) ~ #closebuttonwrapper {


### PR DESCRIPTION
With the improvements from db10c453e95f732d85c489fe8da8708cec0ad09c
https://github.com/CollaboraOnline/online/pull/10027 and its follow
ups, it is now needed to update close button divider margin so, it
goes back on being centered aligned

Also update code comments around that.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ie3fac7e7131c46eb165b2c2d07eef97bfdbce4ce
