### PR TITLE
Fix localization of Calc AutoFill context menu

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -254,20 +254,14 @@ L.Control.ContextMenu = L.Control.extend({
 				item.menu = undefined;
 			}
 
-			if (item.type === 'command' && item.text && item.text.replace('~', '') === 'Copy Cells'
-				&& item.menu && item.menu.length) {
+			if (item.type === 'command' && item.text && item.text.replace('~', '') === 'Copy Cells') {
 				item.text = _('Copy Cells');
 				item.command = '.uno:AutoFill?Copy:bool=true';
-				item.type = item.menu[0].type;
-				item.menu = undefined;
 			}
 
-			if (item.type === 'command' && item.text && item.text.replace('~', '') === 'Fill Series'
-				&& item.menu && item.menu.length) {
+			if (item.type === 'command' && item.text && item.text.replace('~', '') === 'Fill Series') {
 				item.text = _('Fill Series');
 				item.command = '.uno:AutoFill?Copy:bool=false';
-				item.type = item.menu[0].type;
-				item.menu = undefined;
 			}
 
 			if (item.type === 'separator') {


### PR DESCRIPTION
I think the original author copy&pasted code from the previous condition, which was a menu. But in this case the item.type is command, and item.menu is undefined. Therefore with my fix the localization works, also the functionality works. I don't know what I'm doing, though.


Change-Id: I2e929d9f104beac83c195cdf03eba620a1a4ebb3

