### PR TITLE
Reset autofill mark on close autofill context menu

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -204,7 +204,11 @@ L.Control.ContextMenu = L.Control.extend({
 						var $menu = opt.$menu;
 						$menu.attr('tabindex', 0); // Make the context menu focusable
 					},
-					hide: function() { map.focus(); }
+					hide: function() {
+						if(autoFillContextMenu)
+							app.map._docLayer._resetReferencesMarks();
+						map.focus();
+					}
 				}
 			});
 			if (autoFillContextMenu)

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3027,6 +3027,12 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._references.clear();
 	},
 
+	_resetReferencesMarks: function () {
+		this._referencesAll = [];
+		this._clearReferences();
+		this._updateReferenceMarks();
+	},
+
 	_postMouseEvent: function(type, x, y, count, buttons, modifier) {
 		if (!this._map._docLoaded)
 			return;


### PR DESCRIPTION
When we click outside of the autofill context menu, menu is closed but marked area doesn't reset.

We fix the problem with the patch


Change-Id: I819d1b0393d1f062570c5b1d4776c32ae90aa887


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

