### PR TITLE
Revert "browser: fix PageDown cursor position"

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2144,12 +2144,6 @@ L.CanvasTileLayer = L.Layer.extend({
 			return;
 		}
 
-		if (obj.scroll) {
-			this.scrollToPos(new app.definitions.simplePoint(recCursor.getTopLeft().x,
-									 recCursor.getTopLeft().y));
-			return;
-		}
-
 		// tells who trigerred cursor invalidation, but recCursors is stil "our"
 		var modifierViewId = parseInt(obj.viewId);
 		var weAreModifier = (modifierViewId === this._viewId);


### PR DESCRIPTION
This reverts commit a074a6f199c0594afd173fe3638b72d1d649b3ff. browser: fix PageDown cursor position

This causes randomm jumps on tile rendering when we need to move view to render. It sends additional curosr updates which are not correct (like 0,0,0,0 and scroll: true).

We already have logic here to scroll if needed, we shouldn't need any information from core.

see: https://gerrit.libreoffice.org/c/core/+/177520