### PR TITLE
Ensure popup closes automatically on user selection

### DIFF
--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -520,6 +520,7 @@ class UserList extends L.Control {
 			listItem.appendChild(userLabelContainer);
 			listItem.addEventListener('click', () => {
 				this.followUser(viewId);
+				JSDialog.CloseDropdown('userlist');
 			});
 
 			return listItem;

--- a/cypress_test/integration_tests/multiuser/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/cell_cursor_spec.js
@@ -16,7 +16,7 @@ describe(['tagmultiuser'], 'Check cell cursor and view behavior', function() {
 		cy.cSetActiveFrame('#iframe2');
 		cy.cGet('#userListHeader').click();
 		cy.cGet('.user-list-item').eq(1).click();
-		cy.cGet('.jsdialog-overlay').click({force: true});
+		cy.cGet('.jsdialog-overlay').should('not.exist');
 
 		// first view goes somewhere in the middle of a sheet: A400
 		cy.cSetActiveFrame('#iframe1');
@@ -53,7 +53,7 @@ describe(['tagmultiuser'], 'Check cell cursor and view behavior', function() {
 		cy.cSetActiveFrame('#iframe2');
 		cy.cGet('#userListHeader').click();
 		cy.cGet('.user-list-item').eq(1).click();
-		cy.cGet('.jsdialog-overlay').click({force: true});
+		cy.cGet('.jsdialog-overlay').should('not.exist');
 
 		// first view goes somewhere in the middle of a sheet
 		cy.cSetActiveFrame('#iframe1');

--- a/cypress_test/integration_tests/multiuser/writer/cursor_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/cursor_spec.js
@@ -16,7 +16,7 @@ describe(['tagmultiuser'], 'Check cursor and view behavior', function() {
 		cy.cSetActiveFrame('#iframe2');
 		cy.cGet('#userListHeader').click();
 		cy.cGet('.user-list-item').eq(1).click();
-		cy.cGet('.jsdialog-overlay').click({force: true});
+		cy.cGet('.jsdialog-overlay').should('not.exist');
 		desktopHelper.assertScrollbarPosition('vertical', 0, 30);
 
 		// first view goes somewhere down


### PR DESCRIPTION
Change-Id: I4e7a06bab413dad0b5f2360c4bef729db7d5e0d0


* Resolves: #10167 
* Target version: master 

### Summary
Fixes a UX bug that disrupts user workflow by leaving the selection popup open after a user is chosen, blocking underlying content.

### TODO
Users Clicks in the avatars
Pop up closes when one of the users is clicked 

### Checklist

- ✅ I have run `make prettier-write` and formatted the code.
- ✅  All commits have Change-Id
- ✅  I have run tests with `make check`
- ✅ I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

