### PR TITLE
Status bar: fix dropdown width

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1791,7 +1791,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	align-items: center;
 }
 
-#toolbar-down .has-dropdown > .ui-content.unobutton {
+#toolbar-wrapper:not(.mobile) ~ #toolbar-down .has-dropdown > .ui-content.unobutton {
 	width: max-content;
 }
 

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1792,7 +1792,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 #toolbar-down .has-dropdown > .ui-content.unobutton {
-	width: auto;
+	width: max-content;
 }
 
 .unoarrow::after,

--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -181,13 +181,20 @@ function shouldHaveZoomLevel(zoomLevel) {
 function makeZoomItemsVisible() {
 	cy.log('>> makeZoomItemsVisible - start');
 
-	cy.cGet('#toolbar-down #zoomin')
-		.then(function(zoomInItem) {
-			if (!Cypress.dom.isVisible(zoomInItem)) {
-				cy.cGet('#toolbar-down .ui-scroll-right').click();
+	const scrollRight = () => {
+		cy.cGet('#toolbar-down .ui-scroll-right').then($scrollRightButton => {
+			if ($scrollRightButton.is(':visible')) {
+				// Wrap .ui-scroll-right so we can continue executing commands
+				cy.wrap($scrollRightButton).click();
+				// Wait the same ms as in Util.ScrollableBar.ts timeout
+				cy.wait(350);
+				// Scroll again if $scrollRightButton is visible
+				scrollRight();
 			}
 		});
+	};
 
+	scrollRight();
 	cy.cGet('#toolbar-down #zoomin').should('be.visible');
 
 	cy.log('<< makeZoomItemsVisible - end');


### PR DESCRIPTION
commit 667103b356bf648a4f1323ceb8787f26bb6a961e (HEAD -> private/pedro/backport-mobile-5bfbb9b, origin/private/pedro/backport-mobile-5bfbb9b)
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Mon Dec 2 12:41:50 2024 +0100

    Mobile: Status bar dropdown is always an icon: no need for dedicated width
    
    Previously the commit bellow fixed a regression related to dropdown
    width:
    
    591e003a300ecf9ffe5a5ce770e5d62f3cc1b28f
    "Status bar: fix dropdown width"
    
    However there seems to be no reason to apply this fix to the mobile
    toolbar since we can safely conclude that the dropdowns always have
    the same fixed size (icons)
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I3733b4d736d1481a382fffb71b451b82ad77d04d

commit 591e003a300ecf9ffe5a5ce770e5d62f3cc1b28f **Cherry-picked from master**
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Wed Nov 6 15:36:08 2024 +0100

    Status bar: fix dropdown width
    
    Their container is now a flex box so we should allow them to grow but not to
    shrink but that would not solve the problem when there is no space to
    fit content (example higher UI zoom). The best would be to set the
    button in a way that doesn't allow in any circumstances wrapping /
    cropping.
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Ide87f81d403e1f77977c6098d6f1a6e85828468e

