### PR TITLE
Revert "UI: replace conditional format dialog with conditiona manager"

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -864,7 +864,7 @@ L.Control.Menubar = L.Control.extend({
 						{name: _('Values duplicate...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=8'},
 						{name: _('Containing text...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=23'},
 						{type: 'separator'},
-						{name: _('More highlights...'), uno: '.uno:ConditionalFormatManagerDialog'},
+						{name: _('More highlights...'), uno: '.uno:ConditionalFormatDialog'},
 					]},
 					{name: _('Top/Bottom Rules...'), type: 'menu', menu: [
 						{name: _('Top N elements...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=11'},
@@ -874,7 +874,7 @@ L.Control.Menubar = L.Control.extend({
 						{name: _('Above Average...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=15'},
 						{name: _('Below Average...'), uno: '.uno:ConditionalFormatEasy?FormatRule:short=16'},
 						{type: 'separator'},
-						{name: _('More highlights...'), uno: '.uno:ConditionalFormatManagerDialog'},
+						{name: _('More highlights...'), uno: '.uno:ConditionalFormatDialog'},
 					]},
 					{uno: '.uno:ColorScaleFormatDialog'},
 					{uno: '.uno:DataBarFormatDialog'},

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -315,10 +315,7 @@ menuDefinitions.set('ConditionalFormatMenu', [
 				uno: '.uno:ConditionalFormatEasy?FormatRule:short=23',
 			},
 			{ type: 'separator' },
-			{
-				text: _('More highlights...'),
-				uno: '.uno:ConditionalFormatManagerDialog',
-			},
+			{ text: _('More highlights...'), uno: '.uno:ConditionalFormatDialog' },
 		],
 	},
 	{
@@ -349,10 +346,7 @@ menuDefinitions.set('ConditionalFormatMenu', [
 				uno: '.uno:ConditionalFormatEasy?FormatRule:short=16',
 			},
 			{ type: 'separator' },
-			{
-				text: _('More highlights...'),
-				uno: '.uno:ConditionalFormatManagerDialog',
-			},
+			{ text: _('More highlights...'), uno: '.uno:ConditionalFormatDialog' },
 		],
 	},
 	{ type: 'separator' },


### PR DESCRIPTION
This reverts commit 1e096ee31200c4f9e815f59034e6e721466f7f4f.


Change-Id: I173b6b88b7621bc46df4579a5de0816d6942e821

* Target version: master 

Core patches are reverted corresponding to this commit

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

