### PR TITLE
Avoid "warning: underquoted definition of AC_PROG_LCOV" from autogen.sh

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1083,7 +1083,7 @@ fi
 AC_MSG_CHECKING([whether code-coverage is enabled])
 if test "x$with_coverage" != "x"; then
 
-    AC_DEFUN(AC_PROG_LCOV, [AC_CHECK_PROG(LCOV,lcov,yes)])
+    AC_DEFUN([AC_PROG_LCOV], [AC_CHECK_PROG(LCOV,lcov,yes)])
     AC_PROG_LCOV
     if test x"${LCOV}" == x"yes" ; then
         AC_MSG_RESULT([yes ($with_coverage)])


### PR DESCRIPTION
Change-Id: I9b4d12bf9baa6e64097447a228d863fdec19fdff


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

