### PR TITLE
Impress: Don't activate draggin if text cursor is visible.

### DIFF
--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -897,7 +897,7 @@ class ShapeHandlesSection extends CanvasSectionObject {
 	}
 
 	onMouseMove(position: number[], dragDistance: number[]) {
-		if (this.containerObject.isDraggingSomething() && this.sectionProperties.svg) {
+		if (this.containerObject.isDraggingSomething() && this.sectionProperties.svg && !app.file.textCursor.visible) {
 			(window as any).IgnorePanning = true;
 
 			this.sectionProperties.svg.style.left = String((this.myTopLeft[0] + dragDistance[0]) / app.dpiScale) + 'px';


### PR DESCRIPTION
When selecting a portion of text, ShapeHandlesSection's dragging is activated. This causes the shape to move while selecting a portion of text. Check the visibility of the cursor and don't start dragging event if cursor is visible.


Change-Id: I9a7c8917125cc3c32ffd14c81ab07bf491b7158d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

