### PR TITLE
private/pedro/status bar permission mode mobile vs desktop

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -48,6 +48,11 @@ html[dir='rtl'] .sub-menu-arrow {
 	background: url('images/lc_listitem-selected.svg') no-repeat center / 28px !important;
 }
 
+/* Permisson mode status */
+.mobile .ui-badge {
+	background-color: transparent;
+	color: var(--color-text-lighter);
+}
 
 /* No ruler on mobile phones. */
 .cool-ruler {

--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -53,6 +53,10 @@ html[dir='rtl'] .sub-menu-arrow {
 	background-color: transparent;
 	color: var(--color-text-lighter);
 }
+.status-edit-mode {
+	display: none;
+}
+
 
 /* No ruler on mobile phones. */
 .cool-ruler {

--- a/browser/src/control/jsdialog/Widget.HTMLContent.ts
+++ b/browser/src/control/jsdialog/Widget.HTMLContent.ts
@@ -50,7 +50,7 @@ function getPermissionModeElements(
 	} else {
 		permissionModeDiv.classList.add('status-edit-mode');
 		permissionModeDiv.title = _('Permission Mode');
-		permissionModeDiv.textContent = _('Edit');
+		permissionModeDiv.textContent = _('Edit mode');
 	}
 
 	return permissionModeDiv;


### PR DESCRIPTION
- **Desktop Status bar and Mobile top bar: clarify Edit mode label**
- **Mobile: badges should be subtle**
- **Mobile: Do not display permission mode label when in edit mode**
