### PR TITLE
UI: don't show pencil edit button for protected file in mobile

### DIFF
--- a/browser/src/control/Control.MobileTopBar.ts
+++ b/browser/src/control/Control.MobileTopBar.ts
@@ -116,6 +116,12 @@ class MobileTopBar extends JSDialog.Toolbar {
 				this.enableItem(id, false);
 			}
 		}
+		if (commandName === '.uno:EditDoc') {
+			if (state === 'false')
+				this.map.setPermission('view');
+			else
+				this.map.setPermission('edit');
+		}
 	}
 
 	_generateHtmlItem(id: string) {

--- a/browser/src/control/Permission.js
+++ b/browser/src/control/Permission.js
@@ -68,7 +68,9 @@ L.Map.include({
 				button.on('click', function () {
 					that._requestFileCopy();
 				});
-			} else if ((!window.ThisIsAMobileApp && !this['wopi'].UserCanWrite) || (!this.options.canTryLock && (window.mode.isMobile() || window.mode.isTablet()))) {
+			} else if ((!window.ThisIsAMobileApp && !this['wopi'].UserCanWrite)
+				|| (!this.options.canTryLock && (window.mode.isMobile() || window.mode.isTablet()))
+				|| (app.map['stateChangeHandler'].getItemValue('EditDoc') === 'false')) {
 				$('#mobile-edit-button').hide();
 			}
 


### PR DESCRIPTION
Change-Id: I1541270f26327c7292a17dc7b32d43584796f50c


* Target version: master 



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

