### PR TITLE
fix automake warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,15 @@ endif
 
 else
 
-SUBDIRS = . browser test cypress_test
+SUBDIRS = . browser
+
+if ENABLE_TESTS
+SUBDIRS += test
+endif
+
+if ENABLE_CYPRESS
+SUBDIRS += cypress_test
+endif
 
 export ENABLE_DEBUG
 

--- a/cypress_test/Makefile.am
+++ b/cypress_test/Makefile.am
@@ -1,5 +1,3 @@
-if ENABLE_CYPRESS
-
 export NODE_PATH=$(abs_builddir)/node_modules
 
 V = $(if $(verbose),,@)
@@ -789,5 +787,4 @@ else
 check-local:
 	$(error CypressError: Can't find LibreOffice core installation!)
 
-endif
 endif

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,3 @@
-if ENABLE_TESTS
-
 # Cap threadpools to 4 threads.
 export MAX_CONCURRENCY=4
 AUTOMAKE_OPTION = serial-tests
@@ -214,8 +212,8 @@ unit_http_la_LIBADD = $(CPPUNIT_LIBS)
 if ENABLE_LIBFUZZER
 unit_fuzz_la_SOURCES = UnitFuzz.cpp
 endif
-unit_admin_la_SOURCES = UnitAdmin.cpp
-unit_admin_la_LIBADD = $(CPPUNIT_LIBS)
+#unit_admin_la_SOURCES = UnitAdmin.cpp
+#unit_admin_la_LIBADD = $(CPPUNIT_LIBS)
 unit_typing_la_SOURCES = UnitTyping.cpp
 unit_typing_la_LIBADD = $(CPPUNIT_LIBS)
 unit_copy_paste_la_SOURCES = UnitCopyPaste.cpp
@@ -302,7 +300,7 @@ unit_load_torture_la_LIBADD = $(CPPUNIT_LIBS)
 unit_save_torture_la_SOURCES = UnitSaveTorture.cpp
 unit_save_torture_la_LIBADD = $(CPPUNIT_LIBS)
 unit_synthetic_lok_la_SOURCES = UnitSyntheticLok.cpp
-unit_synthetic_lok__la_LIBADD = $(CPPUNIT_LIBS)
+unit_synthetic_lok_la_LIBADD = $(CPPUNIT_LIBS)
 unit_rendering_options_la_SOURCES = UnitRenderingOptions.cpp
 unit_rendering_options_la_LIBADD = $(CPPUNIT_LIBS)
 unit_password_protected_la_SOURCES = UnitPasswordProtected.cpp
@@ -381,4 +379,3 @@ all-local: unittest
 	@$(CLEANUP_COMMAND)
 
 .PRECIOUS: $(TEST_LOGS)
-endif


### PR DESCRIPTION
test/Makefile.am:362: warning: 'TEST_EXTENSIONS' cannot have conditional contents
- I removed the conditional from the test/Makefile.am and added conditional whether to descend into test/ subdirectory to the main Makefile.am. I did the same for cypress_test/Makefile.am, although that one did not cause warning.

test/Makefile.am:217: warning: variable 'unit_admin_la_SOURCES' is defined but no program or test/Makefile.am:217: library has 'unit_admin_la' as canonical name (possible typo) test/Makefile.am:218: warning: variable 'unit_admin_la_LIBADD' is defined but no program or test/Makefile.am:218: library has 'unit_admin_la' as canonical name (possible typo)
- unit_admin_la is commented out, so I commented out these lines, too

test/Makefile.am:305: warning: variable 'unit_synthetic_lok__la_LIBADD' is defined but no program or test/Makefile.am:305: library has 'unit_synthetic_lok__la' as canonical name (possible typo)
- This one was a typo indeed, double underscore '_' character.


Change-Id: Ia166363e7e725570881fb7d7ca94d534ce2f8286

