### PR TITLE
ui: add hover effect for combobox buttons

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -887,6 +887,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	width: 100%;
 }
 
+.jsdialog .ui-combobox {
+	line-height: 22px;
+}
+
 .ui-listbox option {
 	font-weight: normal;
 	display: block;
@@ -944,6 +948,12 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .ui-combobox-button {
 	padding-left: 20px;
 	border-left: 1px solid var(--color-border);
+}
+
+.ui-combobox-button:hover {
+	cursor: pointer;
+	border-left-color: transparent;
+	background-color: var(--color-background-darker);
 }
 
 .ui-combobox-dropdown {
@@ -1746,7 +1756,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 .notebookbar .ui-content.unobutton:hover,
-.jsdialog .ui-content.unobutton:hover {
+.jsdialog .ui-content.unobutton:hover .ui-combobox-button:hover{
 	background-color: var(--color-background-darker);
 }
 


### PR DESCRIPTION
Change-Id: I2d795338cc94803bd49ed3d9ea5c7d12c15717aa


* Resolves: #10636 
* Target version: master 

### Summary
Add stylings for hover effect on combobox button

### TODO

https://github.com/user-attachments/assets/67cb091a-be97-47ac-97b0-2dbd8ecf4f7a


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

