### PR TITLE
Update next slide preview after slide selection in slide sorter

### DIFF
--- a/browser/src/slideshow/PresenterConsole.js
+++ b/browser/src/slideshow/PresenterConsole.js
@@ -832,8 +832,8 @@ class PresenterConsole {
 		let notesSeparator =
 			this._proxyPresenter.document.querySelector('#notes-separator');
 		notesSeparator.style.display = 'none';
-		this._first.remove();
-		this._second.remove();
+		this._first.style.display = 'none';
+		this._second.style.display = 'none';
 
 		elem = this._proxyPresenter.document.querySelector('#presentation-content');
 		elem.appendChild(this._slides);
@@ -857,9 +857,9 @@ class PresenterConsole {
 		let notesSeparator =
 			this._proxyPresenter.document.querySelector('#notes-separator');
 		notesSeparator.style.display = 'block';
-		// Insert `this._first` before `notesSeparator`
-		elem.insertBefore(this._first, notesSeparator);
-		elem.appendChild(this._second);
+
+		this._first.style.display = 'flex';
+		this._second.style.display = 'flex';
 
 		elem = this._proxyPresenter.document.querySelector('#slides');
 		this.toggleButtonState(elem, false);


### PR DESCRIPTION
- Next slide preview not getting updated
- because we removed the element of nextslide preview when we show slide sorter
- we need to just make it's display none make sure to change back to flex on show normal view

Change-Id: Id6e756b1d17b4445f1f85e8299af25808806b2f6
