### PR TITLE
debug frame: Limit the messages element in size

### DIFF
--- a/browser/html/framed.doc.html
+++ b/browser/html/framed.doc.html
@@ -63,6 +63,16 @@
           margin: 0px;
       }
 
+      #messages {
+          height: 5vh;
+          overflow: scroll;
+      }
+
+      #messages > p {
+              margin: 0;
+              font-family: monospace;
+      }
+
     </style>
 
     <script>
@@ -290,6 +300,14 @@
           display.querySelector("#UserState_Elapsed").textContent = msg.Values.Elapsed;
       }
 
+      function ClearMessages() {
+        let messageOut = document.getElementById("messages");
+        let child;
+        while (child = messageOut.firstChild) {
+          child.remove();
+        }
+      }
+
       // This function is invoked when the iframe posts a message back.
 
       function receiveMessage(event) {
@@ -300,7 +318,9 @@
         }
 
         let messageOut = document.getElementById("messages");
-        messageOut.textContent = messageOut.textContent + JSON.stringify(msg) + "\n";
+        let line = document.createElement("p");
+        line.textContent = JSON.stringify(msg);
+        messageOut.append(line);
 
         if (msg.MessageId == 'App_LoadingStatus') {
           if (msg.Values) {
@@ -588,9 +608,9 @@
 
     <div class="framed hbox">
       <div class="vbox">
-        <h3>Messages from editor</h3>
+        <h3>Messages from editor <button onclick="ClearMessages();">Clear</button></h3>
 
-        <pre id="messages"></pre>
+        <div id="messages"></div>
       </div>
     </div>
 


### PR DESCRIPTION
Change-Id: I1f43d4839341e9d1acac617cc6a6a96e2118a51f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

In the debug frame, if you let it run it would push the COOL frame down the page as the post message grew.

This does two things:
- add an overscroll limiting the height of the logs
- add a clear button to clear it up.

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

