### PR TITLE
WebSocketHandler::handleTCPStream abort

### DIFF
--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -426,7 +426,7 @@ private:
                     const auto now = std::chrono::steady_clock::now();
                     _pingTimeUs = std::chrono::duration_cast<std::chrono::microseconds>
                                             (now - _lastPingSentTime).count();
-                    sendPong(now, &ctrlPayload[0], payloadLen, socket);
+                    sendPong(now, ctrlPayload.data(), payloadLen, socket);
                     gotPing(code, _pingTimeUs);
                 }
                 break;


### PR DESCRIPTION
```
 #0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:51
 #1  0x00007f5eba5167f1 in __GI_abort () at abort.c:79
 #2  0x0000000000bee08e in std::__glibcxx_assert_fail(char const*, int, char const*, char const*) ()
 #3  0x00000000005cf12f in std::vector<char, std::allocator<char> >::operator[] (__n=0, this=0x7f5e397e7260)
     at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/stl_vector.h:1121
 #4  0x00000000005f2b46 in std::vector<char, std::allocator<char> >::operator[] (__n=<optimized out>, this=<optimized out>)
     at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/stl_iterator.h:1072
 #5  WebSocketHandler::handleTCPStream (this=this@entry=0x7f5ea09a62d0, socket=std::shared_ptr<StreamSocket> (use count 3, weak count 2) = {...})
     at ./net/WebSocketHandler.hpp:431
 #6  0x00000000005f39d5 in WebSocketHandler::handleIncomingMessage (this=0x7f5ea09a62d0) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/allocator.h:174
 #7  0x000000000082e66e in StreamSocket::handlePoll (this=0x7f5ea42094d0, disposition=..., now=..., events=1)
     at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/shared_ptr_base.h:1665

sendPong(now, &ctrlPayload[0], payloadLen, socket);

(gdb) print ctrlPayload
$1 = std::vector of length 0, capacity 0
(gdb) print payloadLen
$2 = 0
```

Change-Id: Ib5ee3b302adeef09b8c320caf7f65be2ad980beb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

