### PR TITLE
fix(tooltips): Don't display on touch events

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -430,11 +430,6 @@ textarea.cool-annotation-textarea {
 	overflow-y: auto !important;
 }
 
-/* Disable tooltips when on touch devices */
-.w2ui-tag .w2ui-tag-top {
-	display: none !important;
-}
-
 .impress-comment-highlight {
 	filter: grayscale(1);
 }

--- a/browser/css/device-tablet.css
+++ b/browser/css/device-tablet.css
@@ -1,10 +1,5 @@
 /* CSS specific for tablets. */
 
-/* Disable tooltips when on touch devices */
-.w2ui-tag .w2ui-tag-top {
-	display: none !important;
-}
-
 /* Make the upper toolbar scrollable using swipe as on phones. */
 .ui-scroll-wrapper {
 	overflow-x: scroll !important;

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2469,10 +2469,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			e.stopPropagation();
 		};
 
-		var mouseEnterFunction = function () {
+		var mouseEnterFunction = window.touch.mouseOnly(function () {
 			if (builder.map.tooltip)
 				builder.map.tooltip.beginShow(div);
-		};
+		});
 
 		var mouseLeaveFunction = function () {
 			if (builder.map.tooltip)
@@ -2512,10 +2512,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	_handleCutomTooltip: function(elem, builder) {
 		switch (elem.id) {
 			case 'save':
-				$(elem).on('mouseenter', function() {
+				$(elem).on('mouseenter', window.touch.mouseOnly(function() {
 					if (builder.map.tooltip)
 						builder.map.tooltip.show(elem, builder.map.getLastModDateValue()); // Show the tooltip with the correct content
-				});
+				}));
 	
 				$(elem).on('mouseleave', function() {
 					if (builder.map.tooltip)


### PR DESCRIPTION
When we used w2-ui, we hid tooltips on mobile devices and tablets. When
we moved to using JQuery's tooltips we didn't carry this over, causing
persistent tooltips when people were touching mobile devices. This was
not ideal.

Rather than hiding these on mobile devices we can show them only on
mouse events, since as you can use mobile devices without a touchscreen
or have touchscreen desktop devices (commonly touchscreen laptops).
We've just added support for touch event detection of the mouseenter
events that we need for this. We don't want to lock touchleave events to
mouse, as we want to close the tooltip if we start tapping on other
things.