### PR TITLE
forward-port: Mobile: Status bar dropdown is always an icon:...

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1730,7 +1730,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	align-items: center;
 }
 
-#toolbar-down .has-dropdown > .ui-content.unobutton {
+#toolbar-wrapper:not(.mobile) ~ #toolbar-down .has-dropdown > .ui-content.unobutton {
 	width: max-content;
 }
 


### PR DESCRIPTION
...no need for dedicated width

Previously the commit bellow fixed a regression related to dropdown width:

591e003a300ecf9ffe5a5ce770e5d62f3cc1b28f
"Status bar: fix dropdown width"

However there seems to be no reason to apply this fix to the mobile toolbar since we can safely conclude that the dropdowns always have the same fixed size (icons)


Change-Id: I3733b4d736d1481a382fffb71b451b82ad77d04d

This is a trivial *forward-port* of #10639


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

