### PR TITLE
Check LayerRenderer is disposed before drawBitmap

### DIFF
--- a/browser/src/slideshow/LayerRenderer.ts
+++ b/browser/src/slideshow/LayerRenderer.ts
@@ -46,12 +46,14 @@ class LayerRendererGl implements LayerRenderer {
 	private imageBitmapIdCounter = 0;
 	private textureCache: Map<string, WebGLTexture> = new Map();
 	private imageBitmapIdMap = new WeakMap<ImageBitmap, number>();
+	private isDisposed: boolean;
 
 	constructor(offscreenCanvas: OffscreenCanvas) {
 		this.offscreenCanvas = offscreenCanvas;
 		this.glContext = new RenderContextGl(this.offscreenCanvas);
 		this.gl = this.glContext.getGl();
 		this.initializeWebGL();
+		this.isDisposed = false;
 	}
 
 	initialize(): void {
@@ -162,15 +164,21 @@ class LayerRendererGl implements LayerRenderer {
 	}
 
 	clearCanvas(): void {
-		const gl = this.gl;
-		gl.clearColor(1.0, 1.0, 1.0, 1.0); // Clear to white
-		gl.clear(gl.COLOR_BUFFER_BIT);
+		if (!this.isDisposed) {
+			const gl = this.gl;
+			gl.clearColor(1.0, 1.0, 1.0, 1.0); // Clear to white
+			gl.clear(gl.COLOR_BUFFER_BIT);
+		}
 	}
 
 	drawBitmap(
 		imageInfo: ImageInfo | ImageBitmap,
 		properties?: AnimatedElementRenderProperties,
 	): void {
+		if (this.isDisposed) {
+			console.log('LayerRenderer is disposed');
+			return;
+		}
 		if (!imageInfo) {
 			console.log('LayerRenderer.drawBitmap: no image');
 			return;
@@ -257,6 +265,7 @@ class LayerRendererGl implements LayerRenderer {
 	dispose(): void {
 		this.gl = null;
 		this.offscreenCanvas = null;
+		this.isDisposed = true;
 	}
 
 	hexToRgb(hex: string): { r: number; g: number; b: number } | null {


### PR DESCRIPTION
When user stopped presentation early, online still tries to draw slides because of delayed "slidelayer" messages from core. That is the cause of following error

TypeError: Cannot read properties of null (reading 'useProgram')

So we shold check if the user exited from presentation before drawing slides.


Change-Id: If3b3cb340cfc15632de16d0fed1c730ab4d9d763


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

