### PR TITLE
anyInput - should only depend on incoming messages from coolwsd.

### DIFF
--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -144,7 +144,7 @@ public:
     // Only called by kit.
     void setCanonicalViewId(int viewId) { _canonicalViewId = viewId; }
 
-    int  getCanonicalViewId() { return _canonicalViewId; }
+    int  getCanonicalViewId() const { return _canonicalViewId; }
 
     void setViewRenderState(const std::string& state) { _viewRenderState = state; }
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3024,34 +3024,14 @@ int pollCallback(void* data, int timeoutUs)
 #endif
 }
 
+// Do we have any pending input events from coolwsd ?
+// FIXME: we could helpfully poll our incoming socket too here.
 bool anyInputCallback(void* data)
 {
     auto kitSocketPoll = reinterpret_cast<KitSocketPoll*>(data);
     std::shared_ptr<Document> document = kitSocketPoll->getDocument();
-    if (!document)
-    {
-        return false;
-    }
 
-    if (document->hasCallbacks())
-    {
-        return true;
-    }
-
-    std::shared_ptr<KitQueue> queue = document->getQueue();
-    if (!queue)
-    {
-        return false;
-    }
-
-    if (queue->getTileQueueSize() > 0)
-    {
-        return true;
-    }
-
-    // Have no pending callbacks and the tile queue is also empty, report that we have no
-    // pending input events.
-    return false;
+    return document && document->hasQueueItems();
 }
 
 /// Called by LOK main-loop

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -748,7 +748,7 @@ Document::Document(const std::shared_ptr<lok::Office>& loKit, const std::string&
     , _docId(docId)
     , _url(url)
     , _obfuscatedFileId(Uri::getFilenameFromURL(docKey))
-    , _queue(std::make_shared<KitQueue>())
+    , _queue(new KitQueue())
     , _websocketHandler(websocketHandler)
     , _modified(ModifiedState::UnModified)
     , _isBgSaveProcess(false)
@@ -1145,7 +1145,7 @@ void Document::trimAfterInactivity()
     assert(descriptor && "Null callback data.");
     assert(descriptor->getDoc() && "Null Document instance.");
 
-    std::shared_ptr<KitQueue> queue = descriptor->getDoc()->_queue;
+    std::unique_ptr<KitQueue> &queue = descriptor->getDoc()->_queue;
     assert(queue && "Null KitQueue.");
 
     const std::string payload = p ? p : "(nil)";

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -401,8 +401,6 @@ public:
     /// Are we currently performing a load ?
     bool isLoadOngoing() const { return _duringLoad > 0; }
 
-    std::shared_ptr<KitQueue> getQueue() const { return _queue; }
-
     LogUiCmd& getLogUiCmd() { return logUiCmd; }
 
 private:
@@ -427,7 +425,7 @@ private:
 #ifdef __ANDROID__
     static std::shared_ptr<lok::Document> _loKitDocumentForAndroidOnly;
 #endif
-    std::shared_ptr<KitQueue> _queue;
+    std::unique_ptr<KitQueue> _queue;
 
     // Connection to the coolwsd process
     std::shared_ptr<WebSocketHandler> _websocketHandler;

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -335,6 +335,7 @@ public:
 
     /// A new message from wsd for the queue
     void queueMessage(const std::string &msg) { _queue->put(msg); }
+    /// Do we have incoming messages from wsd ?
     bool hasQueueItems() const { return _queue && !_queue->isEmpty(); }
     bool canRenderTiles() const {
         return processInputEnabled() && !isLoadOngoing() &&

--- a/kit/KitWebSocket.hpp
+++ b/kit/KitWebSocket.hpp
@@ -21,7 +21,6 @@ class KitSocketPoll;
 
 class KitWebSocketHandler final : public WebSocketHandler
 {
-    std::shared_ptr<KitQueue> _queue;
     std::string _socketName;
     std::shared_ptr<lok::Office> _loKit;
     std::string _jailId;


### PR DESCRIPTION
Not on outgoing messages that have come from core.

We should not treat rendering / tile requests as input.


Change-Id: I0ced5ee0f07796e8aae015f31c91cb7845443ea8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

