### PR TITLE
KitQueue - re-spin poll loop when we have tiles to render.

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2446,8 +2446,7 @@ void Document::drainQueue()
             }
         }
 
-        if (processInputEnabled() && !isLoadOngoing() &&
-            !isBackgroundSaveProcess() && _queue->getTileQueueSize() > 0)
+        if (canRenderTiles())
         {
             std::vector<TileCombined> tileRequests = _queue->popWholeTileQueue();
 

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -336,6 +336,11 @@ public:
     /// A new message from wsd for the queue
     void queueMessage(const std::string &msg) { _queue->put(msg); }
     bool hasQueueItems() const { return _queue && !_queue->isEmpty(); }
+    bool canRenderTiles() const {
+        return processInputEnabled() && !isLoadOngoing() &&
+            !isBackgroundSaveProcess() && _queue &&
+            _queue->getTileQueueSize() > 0;
+    }
     bool hasCallbacks() const { return _queue && _queue->callbackSize() > 0; }
 
     /// Should we get through the SocketPoll fast to process queus ?
@@ -343,7 +348,10 @@ public:
     {
         if (hasCallbacks())
             return true;
-        if (hasQueueItems() && processInputEnabled())
+        // not processing input messages or tile renders
+        if (!processInputEnabled())
+            return false;
+        if (hasQueueItems() || canRenderTiles())
             return true;
         return false;
     }

--- a/kit/KitQueue.hpp
+++ b/kit/KitQueue.hpp
@@ -191,13 +191,13 @@ private:
     int priority(const TileDesc &desc);
 
 private:
-    /// The incoming underlying queue
+    /// Queue of incoming messages from coolwsd
     std::vector<Payload> _queue;
 
-    /// Incoming tile request queue
+    /// Queue of incoming tile requests from coolwsd
     std::vector<TileDesc> _tileQueue;
 
-    /// Outgoing queued callbacks
+    /// Queue of callbacks from Kit to send out to coolwsd
     std::vector<Callback> _callbacks;
 
     std::map<int, CursorPosition> _cursorPositions;


### PR DESCRIPTION
Prepares us for having tiles that need rendering left over from a drainQueue and not necessarily having another queue item to trigger fast iteration of the poll.

Should do nothing at all as of now =) ... 

Change-Id: Id51441070dfb883a5964308d54880d46a3210087
