### PR TITLE
Adjust user avatar size to align with sidebar icon dimensions

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1587,10 +1587,14 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	justify-content: end;
 }
 
+#userListHeader .avatar-img {
+	box-sizing: border-box;
+}
+
 #userListHeader .avatar-img,
 #userlist-dropdown .avatar-img {
-	width: var(--btn-size);
-	height: var(--btn-size);
+	width: var(--btn-img-size);
+	height: var(--btn-img-size);
 	background-color: var(--color-background-lighter);
 	background-position: center;
 	background-size: cover;


### PR DESCRIPTION
Change-Id: Ib7d5ae234efd9fc2d0438090f4a90e6b229b53e1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Adjusts the size of the user avatar to ensure consistency with the sidebar icon dimensions. Previously, the avatar appeared disproportionately larger, which affected the visual alignment on the Toolbar

### TODO
<img width="324" alt="Screenshot 2024-12-09 at 03 16 14" src="https://github.com/user-attachments/assets/0571d7ee-2dcc-46a0-b811-c0ec19a87558">

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

