### PR TITLE
increase UnitTimeoutInactive inactivityTimeout

### DIFF
--- a/test/UnitTimeoutInactive.cpp
+++ b/test/UnitTimeoutInactive.cpp
@@ -37,7 +37,7 @@ class UnitTimeoutInactivity : public UnitTimeoutBase0
     void configure(Poco::Util::LayeredConfiguration& /* config */) override
     {
         // net::Defaults.inactivityTimeout = std::chrono::seconds(3600);
-        net::Defaults.inactivityTimeout = std::chrono::milliseconds(100);
+        net::Defaults.inactivityTimeout = std::chrono::milliseconds(150);
         //
         // The following WSPing setup would cause ping/pong packages avoiding the inactivity TO
         //   net::Defaults.wsPingAvgTimeout = std::chrono::microseconds(25);


### PR DESCRIPTION
fails for me locally with --enable-debug 'CFLAGS=-O0 -ggdb' 'CXXFLAGS=-O0 -ggdb'


Change-Id: I8cd0cb1d187bf3adab1f81345c1cd83b5180eee4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

