### PR TITLE
Back-port: #10653

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -61,7 +61,6 @@ L.Control.Notebookbar = L.Control.extend({
 		this.map.on('darkmodechanged', this.onDarkModeToggleChange, this);
 		this.map.on('showannotationschanged', this.onShowAnnotationsChange, this);
 		this.map.on('a11ystatechanged', this.onAccessibilityToggleChange, this);
-		this.map.on('enablecommand', this.disableNotebookbarControl, this);
 		if (docType === 'presentation') {
 			this.map.on('updateparts', this.onSlideHideToggle, this);
 			this.map.on('toggleslidehide', this.onSlideHideToggle, this);
@@ -338,14 +337,6 @@ L.Control.Notebookbar = L.Control.extend({
 		);
 
 		this.reloadShortcutsBar();
-	},
-
-	disableNotebookbarControl: function(e) {
-		var toolbar = L.DomUtil.get('toolbar-up');
-		this.builder.executeAction(toolbar, {
-			control_id: e.controlId,
-			action_type: e.enable ? 'enable' : 'disable',
-		});
 	},
 
 	showNotebookbarButton: function(buttonId, show) {

--- a/browser/src/slideshow/PresenterConsole.js
+++ b/browser/src/slideshow/PresenterConsole.js
@@ -179,12 +179,6 @@ class PresenterConsole {
 			return;
 		}
 
-		this._map.fire('enablecommand', {
-			controlId: 'view-presentation-in-console',
-			enable: false,
-		});
-		this._map.off('newpresentinconsole', this._onPresentInConsole, this);
-
 		this._proxyPresenter.document.open();
 		this._proxyPresenter.document.write(
 			this._generateHtml(_('Presenter Console')),
@@ -1071,11 +1065,6 @@ class PresenterConsole {
 		this._map.off('transitionstart', this._onTransitionStart, this);
 		this._map.off('transitionend', this._onTransitionEnd, this);
 		this._map.off('tilepreview', this._onTilePreview, this);
-		this._map.on('newpresentinconsole', this._onPresentInConsole, this);
-		this._map.fire('enablecommand', {
-			controlId: 'view-presentation-in-console',
-			enable: true,
-		});
 	}
 
 	_resizeSlideView(viewContainerId, slideViewId) {

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -437,6 +437,8 @@ class SlideShowPresenter {
 			this._slideShowWindowProxy == null ||
 			this._slideShowWindowProxy.closed
 		) {
+			// enable present in console on closeSlideShowWindow
+			this._enablePresenterConsole(false);
 			return;
 		}
 		this._slideShowWindowProxy.opener.focus();
@@ -688,6 +690,13 @@ class SlideShowPresenter {
 		);
 	}
 
+	_enablePresenterConsole(state: boolean) {
+		this._map.fire('commandstatechanged', {
+			commandName: 'presenterconsole',
+			disabled: state,
+		});
+	}
+
 	_checkPresentationDisabled() {
 		return this._map['wopi'].DisablePresentation;
 	}
@@ -721,7 +730,8 @@ class SlideShowPresenter {
 		if (!this._onPrepareScreen(true))
 			// opens full screen, has to be on user interaction
 			return;
-
+		// disable present in console onStartInWindow
+		this._enablePresenterConsole(true);
 		this._startSlide = that?.startSlideNumber ?? 0;
 		app.socket.sendMessage('getpresentationinfo');
 	}


### PR DESCRIPTION
Back port PR: https://github.com/CollaboraOnline/online/pull/10653

- Fire "state change command" to disable toolbar option for "Present Console" when we already in "Present in Window".
- This ensures the "Presenter Console" option is disabled while the presentation is in window mode.


Change-Id: I65d37187be901a073a83cfcdd987fbb2e14bc896


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

