### PR TITLE
make unit tests reliable wrt SIGKILL

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -479,8 +479,6 @@ public:
     /// When we get a killed message from forkit; override to test crashes ...
     virtual void kitKilled(int /* count */)
     {
-        if (get().isUnitTesting())
-            exitTest(TestResult::Failed, "kit killed");
     }
 
     /// When we get killed by oom message from forkit; override to test crashes ...

--- a/test/UnitClient.cpp
+++ b/test/UnitClient.cpp
@@ -68,9 +68,6 @@ public:
                     exitTest(TestResult::Failed);
             });
     }
-
-    // ignore child being killed
-    void kitKilled(int /* count */) override {};
 };
 
 UnitBase *unit_create_wsd(void)

--- a/test/UnitQuarantine.cpp
+++ b/test/UnitQuarantine.cpp
@@ -341,8 +341,6 @@ public:
     {
         LOG_TST("Kit killed");
         LOK_ASSERT(static_cast<std::size_t>(count) <= _kitsPids.size());
-
-        // This supresses the default handler which fails the test.
     }
 
     // Called when we have modified document data at exit.


### PR DESCRIPTION
```
    [ docbroker_001 ] DBG  Cannot save to disk: CanSave::NotLoaded| wsd/DocumentBroker.cpp:2816
    [ docbroker_001 ] TRC  Disconnect session internal 001, LastEditableSession: true destroy? true locked? false, have 0 sessions (inclusive)| wsd/DocumentBroker.cpp:3365
    [ docbroker_001 ] DBG  Disconnecting session [001] from Kit| wsd/DocumentBroker.cpp:3388
    [ docbroker_001 ] INF  Session [ToClient-001] disconnected but DocKey [http%3A%2F%2F127.0.0.1%3A9981%2Fwopi%2Ffiles%2F0] isn't loaded yet. Terminating the child roughly| wsd/DocumentBroker.cpp:3399
    [ docbroker_001 ] INF  Killing child [1283222].| wsd/Process.hpp:106
    [ docbroker_001 ] DBG  Killing PID: 1283222 with SIGKILL| common/SigUtil.cpp:630
    [ docbroker_001 ] TRC  Removed non-readonly session [001] from docKey [http%3A%2F%2F127.0.0.1%3A9981%2Fwopi%2Ffiles%2F0] to have 0 sessions:| wsd/DocumentBroker.cpp:3438
    [ docbroker_001 ] DBG  No more sessions after removing last. Setting MarkToDestroy flag.| wsd/DocumentBroker.cpp:3325
    ...
    [ prisoner_poll ] TST  UnitStorage [exitTest] (+6525ms): ERROR: FAILURE: exitTest: TestResult::Failed: kit killed| comm
```

presumably a problem since:

commit 6f4eeaa75d27cfb5dee8d70335757545dce1cc18
CommitDate: Tue Nov 5 19:59:33 2024 +0000

    ForKit: log killed child processes by users & oom

uncertain however why it reliably fails for me, but generally passed on ci


Change-Id: I94bf2f2b294540dfdfb9c19f38499038b37310d9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

