### PR TITLE
jsdialog: added missing 'disabled' attribute to listbox

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -376,7 +376,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		if (data.enabled === false) {
 			div.disabled = true;
-			spinfield.setAttribute('disabled', '');
+			spinfield.setAttribute('disabled', 'true');
 		}
 
 		JSDialog.SynchronizeDisabledState(div, [spinfield]);
@@ -1683,12 +1683,13 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		listboxArrow.id = 'listbox-arrow-' + data.id;
 
 
-		JSDialog.SynchronizeDisabledState(container, [listbox]);
-
 		if (data.enabled === false) {
 			container.disabled = true;
 			listbox.disabled = true;
+			container.setAttribute('disabled', 'true');
 		}
+
+		JSDialog.SynchronizeDisabledState(container, [listbox]);
 
 		$(listbox).change(() => {
 			if ($(listbox).val())
@@ -2388,7 +2389,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 					}
 
 					if (disabled)
-						div.setAttribute('disabled', '');
+						div.setAttribute('disabled', 'true');
 					else
 						div.removeAttribute('disabled');
 				};
@@ -2408,7 +2409,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			}
 
 			if (disabled) {
-				div.setAttribute('disabled', '');
+				div.setAttribute('disabled', 'true');
 			}
 
 			var selectFn = function() {
@@ -2501,7 +2502,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		builder._preventDocumentLosingFocusOnClick(div);
 
 		if (data.enabled === 'false' || data.enabled === false)
-			div.setAttribute('disabled', '');
+			div.setAttribute('disabled', 'true');
 
 		builder.map.hideRestrictedItems(data, controls['container'], controls['container']);
 		builder.map.disableLockedItem(data, controls['container'], controls['container']);
@@ -2516,7 +2517,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 					if (builder.map.tooltip)
 						builder.map.tooltip.show(elem, builder.map.getLastModDateValue()); // Show the tooltip with the correct content
 				}));
-	
+
 				$(elem).on('mouseleave', function() {
 					if (builder.map.tooltip)
 						builder.map.tooltip.hide(elem);
@@ -2833,7 +2834,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			break;
 
 		case 'disable':
-			control.setAttribute('disabled', '');
+			control.setAttribute('disabled', 'true');
 			control.disabled = true;
 			break;
 

--- a/browser/src/control/jsdialog/Util.StateChange.ts
+++ b/browser/src/control/jsdialog/Util.StateChange.ts
@@ -21,7 +21,8 @@ function onStateChange(element: Element, callback: StateChangeCallback) {
 	var enabledCallback = function (mutations: Array<MutationRecord>) {
 		for (var i in mutations) {
 			if (mutations[i].attributeName === 'disabled') {
-				var enable = mutations[i].oldValue !== null;
+				const htmlElement = mutations[i].target as HTMLElement;
+				var enable = htmlElement.getAttribute('disabled') !== 'true';
 				callback(enable);
 			}
 		}

--- a/browser/src/control/jsdialog/Widget.HTMLContent.ts
+++ b/browser/src/control/jsdialog/Widget.HTMLContent.ts
@@ -197,7 +197,10 @@ function htmlContent(
 		setTimeout(() => builder.map.userList.renderAll(), 0);
 
 	if (data.enabled === false && parentContainer.firstChild)
-		(parentContainer.firstChild as HTMLElement).setAttribute('disabled', '');
+		(parentContainer.firstChild as HTMLElement).setAttribute(
+			'disabled',
+			'true',
+		);
 }
 
 JSDialog.htmlContent = htmlContent;


### PR DESCRIPTION
problem:
if listbox was initially disabled main container had missing disabled attribute, and because of that MutationObserver was never triggered to enable it


Change-Id: Ibc1686eb03f4099066ff5b1537c90747432aee66


* Target version: master 



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

