### PR TITLE
slideshow: fix Uncaught TypeError undefined

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -530,7 +530,9 @@ class SlideShowPresenter {
 
 		document.removeEventListener('visibilitychange', this._pauseEnterFunc);
 		this._pauseEnterFunc = undefined;
-		this._slideShowWindowProxy.clearInterval(this._pauseRenderTimer);
+		if (this._slideShowWindowProxy) {
+			this._slideShowWindowProxy.clearInterval(this._pauseRenderTimer);
+		}
 	}
 
 	_doInWindowPresentation() {


### PR DESCRIPTION
SlideShowPresenter.ts:499 Uncaught TypeError: Cannot read properties of null (reading 'clearInterval')
    at SlideShowPresenter.disablePauseHandler (SlideShowPresenter.ts:499:30)
    at SlideShowPresenter.<anonymous> (SlideShowPresenter.ts:574:11)
SlideShowPresenter.disablePauseHandler @ SlideShowPresenter.ts:499
(anonymous) @ SlideShowPresenter.ts:574

Change-Id: Icb55f06b89a5a930a47203caf5b6b2fbc6802530
Signed-off-by: Henry Castro <hcastro@collabora.com>
