### PR TITLE
slideshow: not process left slide layers after quitting from slideshow

### DIFF
--- a/browser/src/slideshow/CanvasLoader.ts
+++ b/browser/src/slideshow/CanvasLoader.ts
@@ -38,6 +38,8 @@ class CanvasLoaderGl extends TextureAnimationBase implements CanvasLoader {
 	}
 
 	public renderUniformValue(): void {
+		if (this.context.isDisposed()) return;
+
 		this.gl.uniform2f(
 			this.gl.getUniformLocation(this.program, 'u_resolution'),
 			this.context.canvas.width,
@@ -50,6 +52,8 @@ class CanvasLoaderGl extends TextureAnimationBase implements CanvasLoader {
 	}
 
 	public startLoader(): void {
+		if (this.context.isDisposed()) return;
+
 		if (this.animationId === null) {
 			this.startTime = performance.now();
 			this.animate();
@@ -57,6 +61,8 @@ class CanvasLoaderGl extends TextureAnimationBase implements CanvasLoader {
 	}
 
 	public stopLoader(): void {
+		if (this.context.isDisposed()) return;
+
 		if (this.animationId !== null) {
 			cancelAnimationFrame(this.animationId);
 			this.animationId = null;
@@ -104,6 +110,8 @@ class CanvasLoaderGl extends TextureAnimationBase implements CanvasLoader {
 	};
 
 	public render(): void {
+		if (this.context.isDisposed()) return;
+
 		this.gl.viewport(
 			0,
 			0,

--- a/browser/src/slideshow/LayerDrawing.ts
+++ b/browser/src/slideshow/LayerDrawing.ts
@@ -117,7 +117,14 @@ class LayerDrawing {
 		this.map.off('sliderenderingcomplete', this.onSlideRenderingComplete, this);
 	}
 
+	public isDisposed() {
+		return this.layerRenderer && this.layerRenderer.isDisposed();
+	}
 	public deleteResources() {
+		this.requestedSlideHash = null;
+		this.prefetchedSlideHash = null;
+		this.nextRequestedSlideHash = null;
+		this.nextPrefetchedSlideHash = null;
 		this.layerRenderer.dispose();
 	}
 
@@ -156,6 +163,8 @@ class LayerDrawing {
 	}
 
 	public composeLayers(slideHash: string): void {
+		if (this.isDisposed()) return;
+
 		this.drawBackground(slideHash);
 		this.drawMasterPage(slideHash);
 		this.drawDrawPage(slideHash);
@@ -238,6 +247,8 @@ class LayerDrawing {
 	}
 
 	private requestSlideImpl(slideHash: string, prefetch: boolean = false) {
+		if (this.isDisposed()) return;
+
 		console.debug(
 			'LayerDrawing.requestSlideImpl: slide hash: ' +
 				slideHash +
@@ -320,6 +331,8 @@ class LayerDrawing {
 	}
 
 	onSlideLayerMsg(e: any) {
+		if (this.isDisposed()) return;
+
 		const info = e.message;
 		if (!info) {
 			window.app.console.log(
@@ -575,6 +588,8 @@ class LayerDrawing {
 	}
 
 	onSlideRenderingComplete(e: any) {
+		if (this.isDisposed()) return;
+
 		if (!e.success) {
 			const slideHash = this.requestedSlideHash || this.prefetchedSlideHash;
 			const slideInfo = this.getSlideInfo(slideHash);

--- a/browser/src/slideshow/PauseTimer.ts
+++ b/browser/src/slideshow/PauseTimer.ts
@@ -56,6 +56,8 @@ class PauseTimerGl extends StaticTextRenderer implements PauseTimer {
 		this.pauseTimeRemaining = pauseDuration;
 		this.onComplete = onComplete;
 
+		if (this.context.isDisposed()) return;
+
 		this.textCanvas = document.createElement('canvas');
 		this.textCanvas.width = this.context.canvas.width;
 		this.textCanvas.height = this.context.canvas.height;
@@ -66,6 +68,8 @@ class PauseTimerGl extends StaticTextRenderer implements PauseTimer {
 	}
 
 	public startTimer(): void {
+		if (this.context.isDisposed()) return;
+
 		this.startTime = performance.now();
 		requestAnimationFrame(this.animate.bind(this));
 	}
@@ -76,6 +80,8 @@ class PauseTimerGl extends StaticTextRenderer implements PauseTimer {
 	}
 
 	public animate(): void {
+		if (this.context.isDisposed()) return;
+
 		if (!this.textCanvas || !this.ctx) return;
 		const currentTime = performance.now();
 		const elapsedTime = (currentTime - this.startTime) / 1000;
@@ -94,6 +100,8 @@ class PauseTimerGl extends StaticTextRenderer implements PauseTimer {
 	}
 
 	public createTextTexture(displayText: string): WebGLTexture {
+		if (this.context.isDisposed()) return null;
+
 		this.clearCanvas();
 		this.drawText(displayText);
 		return this.load2dCanvasToGlCanvas(this.textCanvas);
@@ -107,6 +115,8 @@ class PauseTimerGl extends StaticTextRenderer implements PauseTimer {
 
 	// add text on off screen canvas...
 	private drawText(displayText: string): void {
+		if (this.context.isDisposed()) return;
+
 		this.ctx.fillStyle = 'white';
 		this.ctx.font = '20px sans-serif';
 		this.ctx.textAlign = 'center';

--- a/browser/src/slideshow/RenderContext.ts
+++ b/browser/src/slideshow/RenderContext.ts
@@ -19,6 +19,8 @@ abstract class RenderContext {
 		| CanvasRenderingContext2D
 		| OffscreenCanvasRenderingContext2D;
 
+	protected disposed = false;
+
 	constructor(canvas: HTMLCanvasElement | OffscreenCanvas) {
 		this.canvas = canvas;
 	}
@@ -35,6 +37,10 @@ abstract class RenderContext {
 		return this.gl instanceof OffscreenCanvasRenderingContext2D
 			? this.gl
 			: null;
+	}
+
+	public isDisposed() {
+		return this.disposed;
 	}
 
 	public createTextureWithColor(color: RGBAArray): WebGLTexture | ImageBitmap {
@@ -89,6 +95,7 @@ class RenderContextGl extends RenderContext {
 	}
 
 	public clear() {
+		this.disposed = true;
 		this.gl = null;
 	}
 
@@ -96,6 +103,8 @@ class RenderContextGl extends RenderContext {
 		image: HTMLImageElement | ImageBitmap,
 		isMipMapEnable: boolean = false,
 	): WebGLTexture | ImageBitmap {
+		if (this.isDisposed()) return null;
+
 		const gl = this.getGl();
 
 		const texture = gl.createTexture();
@@ -126,16 +135,22 @@ class RenderContextGl extends RenderContext {
 	}
 
 	public deleteTexture(texture: WebGLTexture | ImageBitmap): void {
+		if (this.isDisposed()) return;
+
 		const gl = this.getGl();
 		gl.deleteTexture(texture);
 	}
 
 	public deleteVertexArray(vao: WebGLVertexArrayObject): void {
+		if (this.isDisposed()) return;
+
 		const gl = this.getGl();
 		gl.deleteVertexArray(vao);
 	}
 
 	public createTextureWithColor(color: RGBAArray): WebGLTexture | ImageBitmap {
+		if (this.isDisposed()) return null;
+
 		const gl = this.getGl();
 		const texture = gl.createTexture();
 		if (!texture) {
@@ -182,6 +197,8 @@ class RenderContextGl extends RenderContext {
 	}
 
 	public createShader(type: number, source: string): WebGLShader {
+		if (this.isDisposed()) return null;
+
 		const gl = this.getGl();
 		const shader = gl.createShader(type);
 		if (!shader) {
@@ -205,6 +222,8 @@ class RenderContextGl extends RenderContext {
 		vertexShader: WebGLShader,
 		fragmentShader: WebGLShader,
 	): WebGLProgram {
+		if (this.isDisposed()) return null;
+
 		const gl = this.getGl();
 		const program = gl.createProgram();
 		if (!program) {
@@ -239,6 +258,7 @@ class RenderContext2d extends RenderContext {
 	}
 
 	public clear() {
+		this.disposed = true;
 		this.gl = null;
 	}
 

--- a/browser/src/slideshow/SimpleTextureRenderer.ts
+++ b/browser/src/slideshow/SimpleTextureRenderer.ts
@@ -28,6 +28,8 @@ abstract class SimpleTextureRenderer {
 	protected initProgramTemplateParams(): void {}
 
 	protected createProgram() {
+		if (this.context.isDisposed()) return;
+
 		this.initProgramTemplateParams();
 
 		const vertexShaderSource = this.getVertexShader();
@@ -56,11 +58,15 @@ abstract class SimpleTextureRenderer {
 	protected abstract getFragmentShader(): string;
 
 	protected prepareTransition(): void {
+		if (this.context.isDisposed()) return;
+
 		this.initBuffers();
 		this.initUniforms();
 	}
 
 	protected initUniforms(): void {
+		if (this.context.isDisposed()) return;
+
 		this.gl.useProgram(this.program);
 		// Add more uniform here if needed.
 	}

--- a/browser/src/slideshow/SlideRenderer.ts
+++ b/browser/src/slideshow/SlideRenderer.ts
@@ -57,6 +57,10 @@ abstract class SlideRenderer {
 		this._canvas = canvas;
 	}
 
+	public isDisposed() {
+		return this._context && this._context.isDisposed();
+	}
+
 	public get lastRenderedSlideIndex() {
 		return this._renderedSlideIndex;
 	}
@@ -244,6 +248,8 @@ class SlideRenderer2d extends SlideRenderer {
 	}
 
 	protected render() {
+		if (this.isDisposed()) return;
+
 		const gl = this._context.get2dGl();
 		gl.clearRect(0, 0, gl.canvas.width, gl.canvas.height);
 
@@ -340,6 +346,8 @@ class SlideRendererGl extends SlideRenderer {
 		yMin: number,
 		yMax: number,
 	): WebGLVertexArrayObject {
+		if (this.isDisposed()) return null;
+
 		if (this._context.is2dGl()) return;
 
 		const gl = this._context.getGl();
@@ -400,6 +408,8 @@ class SlideRendererGl extends SlideRenderer {
 	}
 
 	public deleteResources(): void {
+		if (this.isDisposed()) return;
+
 		this.pauseVideos();
 		for (var videoRenderInfo of this._videos) {
 			videoRenderInfo.deleteResources(this._context);
@@ -438,6 +448,8 @@ class SlideRendererGl extends SlideRenderer {
 		docWidth: number,
 		docHeight: number,
 	) {
+		if (this.isDisposed()) return;
+
 		this.pauseVideos();
 		this._videos = [];
 		if (slideInfo.videos !== undefined) {
@@ -487,6 +499,8 @@ class SlideRendererGl extends SlideRenderer {
 	}
 
 	protected render() {
+		if (this.isDisposed()) return;
+
 		console.debug('SlideRendererGl.render');
 		const gl = this._context.getGl();
 		gl.viewport(0, 0, this._canvas.width, this._canvas.height);

--- a/browser/src/slideshow/StaticTextRenderer.ts
+++ b/browser/src/slideshow/StaticTextRenderer.ts
@@ -25,6 +25,8 @@ class StaticTextRenderer extends TextureAnimationBase {
 	}
 
 	public display(displayText: string) {
+		if (this.context.isDisposed()) return;
+
 		this.textTexture = this.createTextTexture(displayText);
 		this.prepareTransition();
 		requestAnimationFrame(this.animate.bind(this));
@@ -41,6 +43,8 @@ class StaticTextRenderer extends TextureAnimationBase {
 
 	// Create an off-screen 2D canvas with text centered
 	public create2DCanvasWithText(displayText: string): HTMLCanvasElement {
+		if (this.context.isDisposed()) return null;
+
 		const canvas = document.createElement('canvas');
 		canvas.width = this.context.canvas.width;
 		canvas.height = this.context.canvas.height;
@@ -62,6 +66,8 @@ class StaticTextRenderer extends TextureAnimationBase {
 	}
 
 	public load2dCanvasToGlCanvas(canvas: HTMLCanvasElement): WebGLTexture {
+		if (this.context.isDisposed()) return null;
+
 		const texture = this.gl.createTexture();
 		if (!texture) {
 			throw new Error('Failed to create texture');
@@ -100,6 +106,8 @@ class StaticTextRenderer extends TextureAnimationBase {
 	}
 
 	public render(): void {
+		if (this.context.isDisposed()) return;
+
 		this.gl.viewport(
 			0,
 			0,

--- a/browser/src/slideshow/Transition2d.ts
+++ b/browser/src/slideshow/Transition2d.ts
@@ -48,6 +48,8 @@ abstract class TransitionBase extends SlideChangeGl {
 	}
 
 	private releaseResources(): void {
+		if (this.context.isDisposed()) return;
+
 		// Clean up vertex array
 		this.gl.bindVertexArray(null);
 		if (this.vao) {
@@ -137,6 +139,8 @@ class Transition2d extends TransitionBase {
 	}
 
 	public render(nT: number, properties?: AnimatedElementRenderProperties) {
+		if (this.context.isDisposed()) return;
+
 		const isSlideTransition: boolean = !!this.leavingSlide;
 
 		console.debug(`Transition2d.render: nT: ${nT}`);

--- a/browser/src/slideshow/Transition3d.ts
+++ b/browser/src/slideshow/Transition3d.ts
@@ -21,6 +21,7 @@ class TransitionParameters3D extends TransitionParameters {
 class Transition3d extends TransitionBase {
 	constructor(transitionParameters: TransitionParameters3D) {
 		super(transitionParameters);
+		if (this.context.isDisposed()) return;
 		this.gl.enable(this.gl.BLEND);
 		this.gl.blendFunc(this.gl.SRC_ALPHA, this.gl.ONE_MINUS_SRC_ALPHA);
 	}
@@ -165,6 +166,8 @@ class Transition3d extends TransitionBase {
 	}
 
 	public initUniforms(): void {
+		if (this.context.isDisposed()) return;
+
 		this.gl.useProgram(this.program);
 
 		const modelViewMatrix = this.calculateModelViewMatrix();
@@ -229,6 +232,8 @@ class Transition3d extends TransitionBase {
 	public otherUniformsInitialization(): void {}
 
 	public render(nT: number): void {
+		if (this.context.isDisposed()) return;
+
 		this.gl.viewport(
 			0,
 			0,

--- a/browser/src/slideshow/engine/AnimatedElement.ts
+++ b/browser/src/slideshow/engine/AnimatedElement.ts
@@ -677,6 +677,8 @@ class AnimatedElement {
 	}
 
 	renderLayer2d(renderer: LayerRenderer2d) {
+		if (renderer.isDisposed()) return;
+
 		const renderContext = renderer.getRenderContext();
 		const renderingContext = renderContext.get2dOffscreen();
 
@@ -736,6 +738,8 @@ class AnimatedElement {
 	}
 
 	renderLayerGl(renderer: LayerRendererGl) {
+		if (renderer.isDisposed()) return;
+
 		const T = this.aTMatrix;
 
 		console.debug(

--- a/browser/src/slideshow/transition3d/SimpleTransition.ts
+++ b/browser/src/slideshow/transition3d/SimpleTransition.ts
@@ -32,6 +32,8 @@ class SimpleTransition extends SlideShow.Transition3d {
 	}
 
 	public initWebglFlags(): void {
+		if (this.context.isDisposed()) return;
+
 		this.gl.disable(this.gl.DEPTH_TEST);
 		this.gl.disable(this.gl.CULL_FACE);
 
@@ -187,6 +189,8 @@ class SimpleTransition extends SlideShow.Transition3d {
 	}
 
 	public render(nT: number): void {
+		if (this.context.isDisposed()) return;
+
 		this.gl.viewport(
 			0,
 			0,


### PR DESCRIPTION
Moreover still after slideshow is ended, this patch tries to:
- skip to complete current layer rendering
- skip to complete current slide transition rendring
- skip to complete current animation rendering
- skip to go on with canvas loader rendering
- skip to go on with pause timer rendering

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I0fb387a5b7c4fea10bf95f3db5cd03a9d7bd75df
