### PR TITLE
HTTPCrashTest::testCrashForkit can timeout while forkit is still rest…

### DIFF
--- a/test/httpcrashtest.cpp
+++ b/test/httpcrashtest.cpp
@@ -39,6 +39,10 @@
 
 using namespace helpers;
 
+// The default is KIT_PID_TIMEOUT_MS, but we may have to wait for coolforkit to restart, which
+// may take up to the default CHILD_SPAWN_TIMEOUT_MS which is larger than KIT_PID_TIMEOUT_MS
+const std::chrono::milliseconds timeoutMs = std::chrono::milliseconds(KIT_PID_TIMEOUT_MS + CHILD_SPAWN_TIMEOUT_MS);
+
 /// Tests the HTTP WebSocket API of coolwsd. The server has to be started manually before running this test.
 class HTTPCrashTest : public CPPUNIT_NS::TestFixture
 {
@@ -96,9 +100,6 @@ public:
     {
         _socketPoll->joinThread();
         resetTestStartTime();
-        // The default is KIT_PID_TIMEOUT_MS, but we may have to wait for coolforkit to restart, which
-        // may take up to the default CHILD_SPAWN_TIMEOUT_MS which is larger than KIT_PID_TIMEOUT_MS
-        const std::chrono::milliseconds timeoutMs = std::chrono::milliseconds(KIT_PID_TIMEOUT_MS + CHILD_SPAWN_TIMEOUT_MS);
         waitForKitPidsReady("tearDown", timeoutMs);
         resetTestStartTime();
     }
@@ -231,7 +232,7 @@ void HTTPCrashTest::testCrashForkit()
         helpers::killAllKitProcesses(testname);
 
         // Forkit should restart
-        waitForKitPidsReady(testname);
+        waitForKitPidsReady(testname, timeoutMs);
 
         TST_LOG("Communicating after kill.");
         socket = loadDocAndGetSession(_socketPoll, "empty.odt", _uri, testname);


### PR DESCRIPTION
…arting

under high load with a -O0 debug online build and dbgutil core build


Change-Id: Id740772ac421f6c29594a5ded26573d71f8d39b3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

