### PR TITLE
cypress: reenable multi/calc/cell_cursor_spec.js

### DIFF
--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -47,7 +47,7 @@ function clickOnFirstCell(firstClick = true, dblClick = false, isA1 = true) {
 			var XPos = items[0].getBoundingClientRect().left + 10;
 			var YPos = items[0].getBoundingClientRect().top + 10;
 			if (dblClick)
-				cy.cGet('body').dblclick(XPos, YPos);
+				cy.cGet('body').click(XPos, YPos).dblclick(XPos, YPos);
 			else
 				cy.cGet('body').click(XPos, YPos);
 		});

--- a/cypress_test/integration_tests/multiuser/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/cell_cursor_spec.js
@@ -48,7 +48,7 @@ describe(['tagmultiuser'], 'Check cell cursor and view behavior', function() {
 		cy.cGet(helper.addressInputSelector).should('have.prop', 'value', 'A589');
 	});
 
-	it.skip('Jump to the other sheet', function() {
+	it('Jump to the other sheet', function() {
 		// second view follow the first one
 		cy.cSetActiveFrame('#iframe2');
 		cy.cGet('#userListHeader').click();


### PR DESCRIPTION
we need to select a cell before double click to type, it was like that before