### PR TITLE
Use better checks for determining if a comment is focused or not.

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -242,8 +242,6 @@ export class Comment extends CanvasSectionObject {
 		var isRTL = document.documentElement.dir === 'rtl';
 		this.sectionProperties.container = L.DomUtil.create('div', 'cool-annotation' + (isRTL ? ' rtl' : ''));
 		this.sectionProperties.container.id = 'comment-container-' + this.sectionProperties.data.id;
-		this.sectionProperties.container.addEventListener('focusin', this.onContainerGotFocus.bind(this));
-		this.sectionProperties.container.addEventListener('focusout', this.onContainerLostFocus.bind(this));
 
 		var mobileClass = (<any>window).mode.isMobile() ? ' wizard-comment-box': '';
 
@@ -261,14 +259,6 @@ export class Comment extends CanvasSectionObject {
 		// We make comment directly visible when its transitioned to its determined position
 		if (cool.CommentSection.autoSavedComment)
 			this.sectionProperties.container.style.visibility = 'hidden';
-	}
-
-	private onContainerGotFocus() {
-		app.view.commentHasFocus = true;
-	}
-
-	private onContainerLostFocus() {
-		app.view.commentHasFocus = false;
 	}
 
 	private createAuthorTable (): void {
@@ -1125,7 +1115,6 @@ export class Comment extends CanvasSectionObject {
 				}
 			}
 		}
-		app.view.commentHasFocus = false;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -1193,6 +1182,16 @@ export class Comment extends CanvasSectionObject {
 					return commentList[i];
 		}
 		return null;
+	}
+
+	public static isAnyFocus(): boolean {
+		const comment_: Comment = Comment.isAnyEdit();
+
+		// We have a comment in edit mode. Is it focused?
+		if (comment_ && (document.activeElement === comment_.sectionProperties.nodeModifyText || document.activeElement === comment_.sectionProperties.nodeReplyText))
+			return true;
+
+		return false;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types

--- a/browser/src/control/jsdialog/Util.FocusCycle.js
+++ b/browser/src/control/jsdialog/Util.FocusCycle.js
@@ -13,7 +13,7 @@
  * JSDialog.FocusCycle - focus related functions
  */
 
-/* global app JSDialog $ */
+/* global app JSDialog $ cool */
 
 function isAnyInputFocused() {
 	if (!app.map)
@@ -22,7 +22,7 @@ function isAnyInputFocused() {
 	var hasTunneledDialogOpened = app.map.dialog ? app.map.dialog.hasOpenedDialog() : false;
 	var hasJSDialogOpened = app.map.jsdialog ? app.map.jsdialog.hasDialogOpened() : false;
 	var hasJSDialogFocused = L.DomUtil.hasClass(document.activeElement, 'jsdialog');
-	var commentHasFocus = app.view.commentHasFocus;
+	var commentHasFocus = cool.Comment.isAnyFocus();
 	var inputHasFocus = $('input:focus').length > 0 || $('textarea.jsdialog:focus').length > 0;
 
 	return hasTunneledDialogOpened || hasJSDialogOpened || hasJSDialogFocused

--- a/browser/src/docstate.js
+++ b/browser/src/docstate.js
@@ -75,7 +75,6 @@ window.app = {
 		exportFormats: [] // possible output formats
 	},
 	view: {
-		commentHasFocus: false,
 		size: {
 			pixels: [0, 0] // This can be larger than the document's size.
 		}

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -13,7 +13,7 @@
  * local & remote clipboard data.
  */
 
-/* global app DocUtil _ brandProductName $ ClipboardItem Promise GraphicSelection */
+/* global app DocUtil _ brandProductName $ ClipboardItem Promise GraphicSelection cool */
 
 // Get all interesting clipboard related events here, and handle
 // download logic in one place ...
@@ -594,7 +594,7 @@ L.Clipboard = L.Class.extend({
 			&& !this.isPasteSpecialDialogOpen())
 			return true;
 
-		if (app.view.commentHasFocus)
+		if (cool.Comment.isAnyFocus())
 		    return true;
 
 		if (forCopy) {


### PR DESCRIPTION
Some browsers don't support events like focusin focusout, also browsers may have different behaviour about parent of a focused element.

The issue: commentHasFocus variable is not updated correctly. This prevents cut/paste operations. Because when a comment is focused, cut/paste from document is prevented.
Fix: It's better to check if a modify / reply field is focused via document.activeElement.

This changes the code introduced in below commit:
* https://github.com/CollaboraOnline/online/pull/7634/files

So the fix will be re-checked.