### PR TITLE
Do not put Makefile.am and Makefile.in in browser/dist/l10n/ directory

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -53,7 +53,7 @@ COOL_IMAGES_SRC = $(shell find $(srcdir)/images -name '*.*')
 COOL_IMAGES_DST = $(patsubst $(srcdir)/%,$(DIST_FOLDER)/%,$(COOL_IMAGES_SRC))
 COOL_IMAGES_CUSTOM_SRC = $(shell if test -n "$(CUSTOM_ICONS_DIRECTORY)"; then find $(CUSTOM_ICONS_DIRECTORY) -name '*.*'; fi)
 COOL_IMAGES_CUSTOM_DST = $(patsubst $(CUSTOM_ICONS_DIRECTORY)/%,$(DIST_FOLDER)/images/%,$(COOL_IMAGES_CUSTOM_SRC))
-COOL_L10N_SRC = $(shell find $(srcdir)/l10n -name '*.*')
+COOL_L10N_SRC = $(shell find $(srcdir)/l10n -name '*.json')
 if !ENABLE_MOBILEAPP
 COOL_L10N_DST =  $(patsubst $(srcdir)/l10n/%,$(DIST_FOLDER)/l10n/%,$(COOL_L10N_SRC))
 endif


### PR DESCRIPTION
Change-Id: I99da267352b1caaa0f44ce032aa9131abdc2e62e

see e.g. https://share.collaboraonline.com/browser/dist/l10n/Makefile.am – totally unnecessary.