### PR TITLE
Fix close when map is not present

### DIFF
--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -1191,7 +1191,11 @@ function setupToolbar(e) {
 	}
 
 	$('#closebutton').click(function () {
-		global.app.dispatcher.dispatch('closeapp');
+		let dispatcher = global.app.dispatcher;
+		if (!dispatcher)
+			dispatcher = new app.definitions['dispatcher']('global');
+
+		dispatcher.dispatch('closeapp');
 	});
 }
 

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -706,18 +706,19 @@ class Dispatcher {
 		// }
 	}
 
-	constructor() {
+	/// optional docType specifies which commands should we load
+	constructor(docType: string = undefined) {
+		docType = docType ? docType : app.map._docLayer._docType;
+
 		this.addGeneralCommands();
 		this.addExportCommands();
 
-		if (app.map._docLayer._docType === 'text') {
+		if (docType === 'text') {
 			this.addWriterCommands();
 			this.addZoteroCommands();
-		} else if (app.map._docLayer._docType === 'spreadsheet') {
+		} else if (docType === 'spreadsheet') {
 			this.addCalcCommands();
-		} else if (
-			['presentation', 'drawing'].includes(app.map._docLayer._docType)
-		) {
+		} else if (['presentation', 'drawing'].includes(docType)) {
 			this.addImpressAndDrawCommands();
 		}
 


### PR DESCRIPTION
fixes regression from commit 662a707ec87d0a1855ca81102fa4dd512bece91a Share code for close action

if we open broken file and cancel repair - we end with closed document map is not initialized and dispatcher too, we need to use dummy one to allow close button to close view