### PR TITLE
Issue: There is a JS error when we scroll while mouse pointer is abov…

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1203,7 +1203,7 @@ class CanvasSectionContainer {
 		return this.scrollLineHeight;
 	}
 
-	private onMouseWheel (e: WheelEvent) {
+	public onMouseWheel (e: WheelEvent) {
 		var point = this.convertPositionToCanvasLocale(e);
 		var delta: Array<number>;
 

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -170,8 +170,14 @@ export class Comment extends CanvasSectionObject {
 		var events = ['click', 'dblclick', 'mousedown', 'mouseup', 'mouseover', 'mouseout', 'keydown', 'keypress', 'keyup', 'touchstart', 'touchmove', 'touchend'];
 		L.DomEvent.on(this.sectionProperties.container, 'click', this.onMouseClick, this);
 		L.DomEvent.on(this.sectionProperties.container, 'keydown', this.onEscKey, this);
-		L.DomEvent.on(this.sectionProperties.container, 'wheel', app.sectionContainer.onMouseWheel, app.sectionContainer);
-		L.DomEvent.on(this.sectionProperties.contentNode, 'wheel', this.onMouseWheel, this);
+
+		this.sectionProperties.container.onwheel = function(e: WheelEvent) {
+			// Don't scroll the document if mouse is over comment content. Scrolling the comment content is priority.
+			if (!this.sectionProperties.contentNode.matches(':hover')) {
+				e.preventDefault();
+				app.sectionContainer.onMouseWheel(e);
+			}
+		}.bind(this);
 
 		for (var it = 0; it < events.length; it++) {
 			L.DomEvent.on(this.sectionProperties.container, events[it], L.DomEvent.stopPropagation, this);
@@ -188,18 +194,6 @@ export class Comment extends CanvasSectionObject {
 		this.update();
 
 		this.pendingInit = false;
-	}
-
-	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-	onMouseWheel(point: Array<number>, delta: Array<number>, e: MouseEvent): void {
-		if ((e as any).currentTarget.clientHeight === (e as any).currentTarget.scrollHeight)
-			return;
-
-		var _scrollTop = (e as any).currentTarget.scrollTop;
-		if ((e as any).deltaY < 0 && _scrollTop > 0)
-			e.stopPropagation();
-		else if ((e as any).deltaY > 0 && _scrollTop + $(e.currentTarget).height() < (e as any).target.scrollHeight)
-			e.stopPropagation();
 	}
 
 	public onInitialize (): void {


### PR DESCRIPTION
…e a comment.

Fix: Simplify event propagation from comment container to CanvasSectionContainer.

Now we call sectionContainer's event from comment container.

Why we need it: Comment container is an HTML object and we want to selectively propagate events from it to canvas.
Note: The coordinate of action is probably wrong but ScrollSection is not using the mouse coordinates, so it's fine.


Change-Id: If2819146c9d055b419944156cef12798b8974de8
