### PR TITLE
Align checkbox label vertically and centered in user popup

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1727,11 +1727,13 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 
 #follow-editor {
 	padding: 8px;
+	display: flex;
+	align-items: center;
 }
 
 #follow-editor .follow-editor-checkbox {
-	margin-right: 12px;
-	margin-left: 7px;
+	margin-inline-end: 11px;
+	margin-inline-start: 6px;
 	border-radius: 1px;
 	height: 16px;
 	width: 16px;


### PR DESCRIPTION
Change-Id: Ic7857910b9321a087798ebfa83cca81aed622845


* Resolves: #10725 
* Target version: master 

### Summary
Vertical alignment of the checkbox label in the user popup, ensuring it is properly centered for better visual consistency and user experience.

### TODO
<img width="266" alt="Screenshot 2024-12-12 at 17 02 51" src="https://github.com/user-attachments/assets/f5e82c2b-7511-43db-bf93-7e6c1f255867" />


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

