### PR TITLE
calc: fix Ctrl+Space to select a column

### DIFF
--- a/browser/src/map/handler/Map.KeyboardShortcuts.ts
+++ b/browser/src/map/handler/Map.KeyboardShortcuts.ts
@@ -171,7 +171,7 @@ keyboardShortcuts.definitions.set('default', new Array<ShortcutDescriptor>(
     new ShortcutDescriptor('spreadsheet', 'keydown', Mod.CTRL | Mod.SHIFT, 'PageUp', undefined, undefined),
     new ShortcutDescriptor('spreadsheet', 'keydown', Mod.CTRL | Mod.SHIFT, 'PageDown', undefined, undefined),
     new ShortcutDescriptor('spreadsheet', 'keydown', 0, 'F5', null, null, null),
-
+    new ShortcutDescriptor('spreadsheet', 'keydown', Mod.CTRL, ' ', '.uno:SelectColumn', null, null),
 
     new ShortcutDescriptor('text', 'keydown', 0, 'F2', null, null, null),
     new ShortcutDescriptor('text', 'keydown', 0, 'F5', null, null, null),


### PR DESCRIPTION
Change-Id: Icc13560fbb6754ce4c5fc73cbacf2f4dcc41e829


* Resolves: #3077
* Target version: master 

### Summary
This resolves the Ctrl+Space issue and improves consistency across platforms.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

