### PR TITLE
Fix Autofilter dialog position on browser zoom

### DIFF
--- a/browser/src/control/AutoCompletePopup.ts
+++ b/browser/src/control/AutoCompletePopup.ts
@@ -162,8 +162,21 @@ abstract class AutoCompletePopup {
 		data.children[0].children[0] = control;
 		(data.children[0].children[0] as TreeWidget).entries = entries;
 
-		data.posx = cursorPos.x;
-		data.posy = cursorPos.y;
+		const isSpreadsheetRTL = this.map._docLayer.isCalcRTL();
+		const canvasEl = this.map._docLayer._canvas.getBoundingClientRect();
+		const offsetX = isSpreadsheetRTL
+			? 0
+			: app.sectionContainer.getSectionWithName(L.CSections.RowHeader.name)
+					.size[0];
+		const offsetY = app.sectionContainer.getSectionWithName(
+			L.CSections.ColumnHeader.name,
+		).size[1];
+
+		if (isSpreadsheetRTL) cursorPos.x = this.map._size.x - cursorPos.x;
+
+		data.posx = cursorPos.x + offsetX + canvasEl.left;
+		data.posy = cursorPos.y + offsetY + canvasEl.top;
+
 		this.sendJSON(data);
 	}
 


### PR DESCRIPTION
- Change autofilter from canvas to whole document
- now on browser zoom because we change the parent autofilter dialog will go beyond the canvas and user can see content
- content will be visible for high browser zoom level
- as we now consider autofilter dialog for whole document and not canvas, i have adjusted the some corner case values to be sure at edge of document dialog stays visible

Change-Id: Ib467c3605ff55bf3d5df33979a923bcc31fe4583


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

