### PR TITLE
Synchronise comment blocks with document position

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -1250,7 +1250,10 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 				this.sectionProperties.selectedComment.hide();
 		}
 
-		this.update();
+		var previousAnimationState = this.disableLayoutAnimation;
+		this.disableLayoutAnimation = true;
+		this.update(true);
+		this.disableLayoutAnimation = previousAnimationState;
 	}
 
 	private showHideComments (): void {
@@ -2010,8 +2013,8 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 		this.disableLayoutAnimation = false;
 	}
 
-	private layout (zoom: any = null): void {
-		if (zoom)
+	private layout (immediate: any = null): void {
+		if (immediate)
 			this.doLayout();
 		else if (!this.sectionProperties.layoutTimer) {
 			this.sectionProperties.layoutTimer = setTimeout(function() {
@@ -2021,10 +2024,10 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 		} // else - avoid excessive re-layout
 	}
 
-	private update (): void {
+	private update (immediate: boolean = false): void {
 		if (this.sectionProperties.docLayer._docType === 'text')
 			this.updateThreadInfoIndicator();
-		this.layout();
+		this.layout(immediate);
 	}
 
 	private updateThreadInfoIndicator(): void {

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -337,9 +337,10 @@ export class Comment extends CanvasSectionObject {
 			lastPosY = childPositions[i].posY + 24;
 		}
 		if (i < this.sectionProperties.childLines.length) {
-			for (let j = i; j < this.sectionProperties.childLines.length; j++)
+			for (let j = i; j < this.sectionProperties.childLines.length; j++) {
 				this.sectionProperties.childLinesNode.removeChild(this.sectionProperties.childLines[i]);
-			this.sectionProperties.childLines.splice(i);
+				this.sectionProperties.childLines.splice(i);
+			}
 		}
 
 	}

--- a/browser/src/dom/PosAnimation.js
+++ b/browser/src/dom/PosAnimation.js
@@ -16,6 +16,17 @@ L.PosAnimation = L.Class.extend({
 
 		this.fire('start');
 
+		// Skip some work if the duration is zero
+		if (duration <= 0) {
+			el.style[L.DomUtil.TRANSITION] = '';
+			L.DomUtil.setPosition(el, newPos);
+			this._el._leaflet_pos = newPos;
+			this._inProgress = false;
+			this.fire('step').fire('end');
+			this._el.dataset.transitioning = false;
+			return;
+		}
+
 		el.style[L.DomUtil.TRANSITION] = 'all ' + (isNaN(duration) ? 0.25 : 0) +
 		        's cubic-bezier(0,0,' + (easeLinearity || 0.5) + ',1)';
 


### PR DESCRIPTION
Don't postpone and don't animate comment block position changes when scrolling or resizing the document.


Change-Id: I95c1ae1eb732c6dc682018b85debb6133d85ce8c