### PR TITLE
slideshow: when presenter window is resized, slide is not

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -492,10 +492,7 @@ class SlideShowPresenter {
 		);
 		this._slideShowCanvas.focus();
 
-		this._slideShowWindowProxy.addEventListener(
-			'resize',
-			this.onSlideWindowResize.bind(this),
-		);
+		window.addEventListener('resize', this.onSlideWindowResize.bind(this));
 		this._getProxyDocumentNode().addEventListener(
 			'keydown',
 			this._onKeyDownHandler,
@@ -534,6 +531,7 @@ class SlideShowPresenter {
 		this._slideShowCanvas = null;
 		this._presenterContainer = null;
 		this._slideShowWindowProxy = null;
+		window.removeEventListener('resize', this.onSlideWindowResize.bind(this));
 		window.removeEventListener(
 			'beforeunload',
 			this.slideshowWindowCleanUp.bind(this),


### PR DESCRIPTION
Now that the presenter window is an iframe, its no more able to trigger the
resize event so we need to attach it to the main window.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I208aa90fd52bfa956bd30eebd6e8cd03538776a1
