### PR TITLE
add missing files to the install dir

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -911,6 +911,9 @@ install-data-hook:
 		--exclude='multidocs.html' \
 		--exclude='tsconfig.tsbuildinfo' \
 		dist $(DESTDIR)$(pkgdatadir)/browser/;
+	mkdir -p $(DESTDIR)$(pkgdatadir)/browser/dist/src/layer/tile;
+	cp -a dist/src/layer/tile/CanvasTileUtils.js $(DESTDIR)$(pkgdatadir)/browser/dist/src/layer/tile/CanvasTileUtils.js;
+	cp -a dist/src/layer/tile/TileWorker.js $(DESTDIR)$(pkgdatadir)/browser/dist/src/layer/tile/TileWorker.js;
 if ENABLE_WASM
 	find $(DESTDIR)$(pkgdatadir)/browser/dist -type f ! -iname "*.png" -exec brotli --force {} \;
 endif


### PR DESCRIPTION
We need
- src/layer/tile/CanvasTileUtils.js (included from TileWorker.js) and
- src/layer/tile/TileWorker.js (because we have `this._worker = new Worker('src/layer/tile/TileWorker.js');` in bundle.js

These files have to be present separately in install dir. Whether it's a permanent solution, or a temporary hack, I don't know.


Change-Id: I9d0d21463be0cef10ff95a0cd80226a5fc29fa75

