### PR TITLE
fix for log UI Commands

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -697,7 +697,6 @@ namespace Log
                 channelUILog->setProperty(pair.first, pair.second);
             }
 
-            channelUILog = static_cast<Poco::Channel*>(new Poco::FileChannel("/tmp/coolwsd-ui-cmd.log"));
             channelUILog->open();
             try
             {

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -775,7 +775,7 @@ Document::Document(const std::shared_ptr<lok::Office>& loKit, const std::string&
     // Open file for UI Logging
     if (Log::isLogUIEnabled())
     {
-        logUiCmd.createTmpFile();
+        logUiCmd.createTmpFile(_docId);
     }
 }
 

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -248,6 +248,7 @@ public:
     }
 
     unsigned getMobileAppDocId() const { return _mobileAppDocId; }
+    const std::string getDocId() const { return _docId; }
 
     /// See if we should clear out our memory
     void trimIfInactive();

--- a/kit/LogUI.cpp
+++ b/kit/LogUI.cpp
@@ -22,7 +22,7 @@ void LogUiCmd::logUiCmdLine(int userId, const std::string& line)
 
 void LogUiCmd::saveLogFile()
 {
-    std::string timeLog = "log-start-time: " + _kitStartTimeStr + " user-count:" + std::to_string(_usersLogged.size());
+    std::string timeLog = "log-start-time: " + _kitStartTimeStr + " kit=" + _docId + " user-count:" + std::to_string(_usersLogged.size());
     Log::logUI(Log::WRN, timeLog);
     _fileStreamUICommands.seekg(0, std::ios::beg);
     std::string line;
@@ -34,15 +34,17 @@ void LogUiCmd::saveLogFile()
     _fileStreamUICommands.close();
     timeLog = "log-end-time: ";
     timeLog.append(Util::getTimeNow("%Y-%m-%d %T"));
+    timeLog += " kit=" + _docId;
     Log::logUI(Log::WRN, timeLog);
 }
 
-void LogUiCmd::createTmpFile()
+void LogUiCmd::createTmpFile(std::string docId)
 {
     const std::string tempFile = "/tmp/kit-ui-cmd.log";
     _fileStreamUICommands.open(tempFile, std::fstream::in | std::fstream::out | std::fstream::trunc);
     _kitStartTimeSec = std::chrono::steady_clock::now();
     _kitStartTimeStr = Util::getTimeNow("%Y-%m-%d %T");
+    _docId = docId;
 }
 
 std::chrono::steady_clock::time_point LogUiCmd::getKitStartTimeSec()

--- a/kit/LogUI.hpp
+++ b/kit/LogUI.hpp
@@ -19,7 +19,7 @@
 class LogUiCmd
 {
 public:
-    void createTmpFile();
+    void createTmpFile(std::string docId);
     void logUiCmdLine(int userId, const std::string& line);
     void saveLogFile();
     std::chrono::steady_clock::time_point getKitStartTimeSec();
@@ -29,4 +29,5 @@ private:
     std::chrono::steady_clock::time_point _kitStartTimeSec;
     std::string _kitStartTimeStr;
     std::set<int> _usersLogged;
+    std::string _docId;
 };


### PR DESCRIPTION
Save documentID to the log, and rewrote reporting script to reorder the file. (because looks like some cases more kit processes wrote into the permanent file at the same time, and their log mixed)

fixed a configuration path problem
fixed a click merge problem


Change-Id: Ibf1281b560d94c7ea9a97614dd1648aaa10f00f7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

