### PR TITLE
fix(iOS): Allow moving shapes

### DIFF
--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -897,12 +897,14 @@ class ShapeHandlesSection extends CanvasSectionObject {
 	}
 
 	onMouseMove(position: number[], dragDistance: number[]) {
-		if (this.containerObject.isDraggingSomething() && this.sectionProperties.svg && !app.file.textCursor.visible) {
+		if (this.containerObject.isDraggingSomething() && !app.file.textCursor.visible) {
 			(window as any).IgnorePanning = true;
 
-			this.sectionProperties.svg.style.left = String((this.myTopLeft[0] + dragDistance[0]) / app.dpiScale) + 'px';
-			this.sectionProperties.svg.style.top = String((this.myTopLeft[1] + dragDistance[1]) / app.dpiScale) + 'px';
-			this.sectionProperties.svg.style.opacity = 0.5;
+			if (this.sectionProperties.svg) {
+				this.sectionProperties.svg.style.left = String((this.myTopLeft[0] + dragDistance[0]) / app.dpiScale) + 'px';
+				this.sectionProperties.svg.style.top = String((this.myTopLeft[1] + dragDistance[1]) / app.dpiScale) + 'px';
+				this.sectionProperties.svg.style.opacity = 0.5;
+			}
 			this.sectionProperties.lastDragDistance = [dragDistance[0], dragDistance[1]];
 			this.checkHelperLinesAndSnapPoints(this.size, this.position, dragDistance);
 


### PR DESCRIPTION
Since the fix for tdf#123874, we've stopped sending "shapeselectioncontent" to iOS. That message provided an SVG which, elsewhere, is used to preview the movement of the shape.

When modifying the preview, we correctly gated it in a check that the SVG was set. Unfortunately, we also introduced a dependency on this SVG ƒor other things: critical pieces for moving shapes such as preventing panning when a shape is being dragged. Instead, it's better to restrict the dependency on the SVG to only where it's needed, as that allows iOS to move shapes even without the SVG existing.


Change-Id: I69c9ea25011dedd31c492e56bf0ef4aca5cfb21f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

