### PR TITLE
slideshow: exit notes view before starting the slideshow

### DIFF
--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -315,6 +315,7 @@ L.ImpressTileLayer = L.CanvasTileLayer.extend({
 			}
 
 			this._selectedMode = (statusJSON.mode !== undefined) ? statusJSON.mode : (statusJSON.parts.length > 0 && statusJSON.parts[0].mode !== undefined ? statusJSON.parts[0].mode : 0);
+			this._map.fire('impressmodechanged', {mode: this._selectedMode});
 
 			if (statusJSON.gridSnapEnabled === true)
 				app.map.stateChangeHandler.setItemValue('.uno:GridUse', 'true');


### PR DESCRIPTION
If the slideshow is started when impress is in notes view mode slides have a
wrong size and content is messed up.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I6621f8d756f2c6b6b1bcf478fb50be0fd83d25db
