### PR TITLE
COOL_JS.m4 constantly grows in size

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -769,10 +769,9 @@ $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist: $(COOL_JS_DST)
 	if cmp -s $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist.tmp $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist; then rm $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist.tmp; else mv $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist.tmp $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist; fi
 
 $(INTERMEDIATE_DIR)/COOL_JS.m4: $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist
-	@rm -f COOL_JS.m4
-	$(foreach file,$(NODE_MODULES_JS) $(COOL_LIBS_JS) $(patsubst %.ts,%.js,$(COOL_JS_WEBORDER)), $(shell echo -n $(file), >> $(INTERMEDIATE_DIR)/COOL_JS.m4))
-# remove last ","
-	@truncate -s -1 $(INTERMEDIATE_DIR)/COOL_JS.m4
+	$(foreach file,$(NODE_MODULES_JS) $(COOL_LIBS_JS) $(patsubst %.ts,%.js,$(COOL_JS_WEBORDER)), $(shell echo -n $(file), >> $(INTERMEDIATE_DIR)/COOL_JS.m4.tmp))
+	@truncate -s -1 $(INTERMEDIATE_DIR)/COOL_JS.m4.tmp
+	@mv $(INTERMEDIATE_DIR)/COOL_JS.m4.tmp $(INTERMEDIATE_DIR)/COOL_JS.m4
 
 $(DIST_FOLDER)/cool.html: $(srcdir)/html/cool.html.m4 \
 	$(COOL_HTML_DST) \

--- a/test/integration-http-server.cpp
+++ b/test/integration-http-server.cpp
@@ -302,7 +302,8 @@ void HTTPServerTest::assertHTTPFilesExist(const Poco::URI& uri, Poco::RegularExp
 
             Poco::Net::HTTPResponse responseScript;
             session->receiveResponse(responseScript);
-            LOK_ASSERT_EQUAL(Poco::Net::HTTPResponse::HTTP_OK, responseScript.getStatus());
+            std::string msg("cool.html references: " + scriptString + " which should exist.");
+            LOK_ASSERT_EQUAL_MESSAGE(msg, Poco::Net::HTTPResponse::HTTP_OK, responseScript.getStatus());
 
             if (!mimetype.empty())
             LOK_ASSERT_EQUAL(mimetype, responseScript.getContentType());


### PR DESCRIPTION
and gets multiple duplicates of "script src=" lines in it

and on switching branches, etc there can be entries in it that doesn't exist, which then causes unit-integration to fail on the Fileserver not able to provide all files referenced in cool.html

presumably since:

commit e30367d6344a87787b816a9efd92294711e8c5ba
CommitDate: Wed Aug 28 12:44:57 2024 +0200

    input file to m4 macro through intermediate file, not parameter


Change-Id: Id48ff3b420649532740958e7fed86daf9fa64e99


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

