### PR TITLE
Anchor comments directly to the scroll position and optimise comment layout

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -1250,7 +1250,10 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 				this.sectionProperties.selectedComment.hide();
 		}
 
-		this.update();
+		var previousAnimationState = this.disableLayoutAnimation;
+		this.disableLayoutAnimation = true;
+		this.update(true);
+		this.disableLayoutAnimation = previousAnimationState;
 	}
 
 	private showHideComments (): void {
@@ -2010,8 +2013,8 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 		this.disableLayoutAnimation = false;
 	}
 
-	private layout (zoom: any = null): void {
-		if (zoom)
+	private layout (immediate: any = null): void {
+		if (immediate)
 			this.doLayout();
 		else if (!this.sectionProperties.layoutTimer) {
 			this.sectionProperties.layoutTimer = setTimeout(function() {
@@ -2021,10 +2024,10 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 		} // else - avoid excessive re-layout
 	}
 
-	private update (): void {
+	private update (immediate: boolean = false): void {
 		if (this.sectionProperties.docLayer._docType === 'text')
 			this.updateThreadInfoIndicator();
-		this.layout();
+		this.layout(immediate);
 	}
 
 	private updateThreadInfoIndicator(): void {

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -337,9 +337,10 @@ export class Comment extends CanvasSectionObject {
 			lastPosY = childPositions[i].posY + 24;
 		}
 		if (i < this.sectionProperties.childLines.length) {
-			for (let j = i; j < this.sectionProperties.childLines.length; j++)
+			for (let j = i; j < this.sectionProperties.childLines.length; j++) {
 				this.sectionProperties.childLinesNode.removeChild(this.sectionProperties.childLines[i]);
-			this.sectionProperties.childLines.splice(i);
+				this.sectionProperties.childLines.splice(i);
+			}
 		}
 
 	}

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -44,6 +44,10 @@ export class Comment extends CanvasSectionObject {
 	map: any;
 	pendingInit: boolean = true;
 
+	cachedCommentHeight: number | null = null;
+	cachedIsEdit: boolean = false;
+	hidden: boolean | null = null;
+
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	constructor (data: any, options: any, commentListSectionPointer: cool.CommentSection) {
 		super();
@@ -321,7 +325,7 @@ export class Comment extends CanvasSectionObject {
 									posY: this.sectionProperties.children[i].sectionProperties.container._leaflet_pos.y});
 		}
 		childPositions.sort((a, b) => { return a.posY - b.posY; });
-		let lastPosY = this.sectionProperties.container._leaflet_pos.y + this.getCommentHeight();
+		let lastPosY = this.sectionProperties.container._leaflet_pos.y + this.getCommentHeight(false);
 		let i = 0;
 		for (; i < childPositions.length; i++) {
 			if (this.sectionProperties.childLines[i] === undefined) {
@@ -783,6 +787,7 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.nodeModify.style.display = 'none';
 		this.sectionProperties.nodeReply.style.display = 'none';
 		this.sectionProperties.collapsedInfoNode.style.visibility = '';
+		this.cachedIsEdit = false;
 	}
 
 	private showCalc() {
@@ -790,6 +795,7 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.contentNode.style.display = '';
 		this.sectionProperties.nodeModify.style.display = 'none';
 		this.sectionProperties.nodeReply.style.display = 'none';
+		this.cachedIsEdit = false;
 
 		this.positionCalcComment();
 		if (!(<any>window).mode.isMobile()) {
@@ -822,6 +828,7 @@ export class Comment extends CanvasSectionObject {
 			this.sectionProperties.nodeModify.style.display = 'none';
 			this.sectionProperties.nodeReply.style.display = 'none';
 			this.sectionProperties.contentNode.style.display = '';
+			this.cachedIsEdit = false;
 			if (this.isSelected() || !this.isCollapsed) {
 				this.sectionProperties.container.style.visibility = '';
 			}
@@ -845,6 +852,9 @@ export class Comment extends CanvasSectionObject {
 
 	public show(): void {
 		this.doPendingInitializationInView(true /* force */);
+
+		if (this.hidden === false && !this.isEdit()) return;
+
 		this.showMarker();
 
 		// On mobile, container shouldn't be 'document-container', but it is 'document-container' on initialization. So we hide the comment until comment wizard is opened.
@@ -853,11 +863,16 @@ export class Comment extends CanvasSectionObject {
 
 		if (cool.CommentSection.commentWasAutoAdded)
 			return;
-		if (this.sectionProperties.docLayer._docType === 'text')
+
+		// We don't cache the hidden state for spreadsheets. Only one comment can be
+		// visible and they're hidden when scrolling, so it's easier this way.
+		if (this.sectionProperties.docLayer._docType === 'text') {
 			this.showWriter();
-		else if (this.sectionProperties.docLayer._docType === 'presentation' || this.sectionProperties.docLayer._docType === 'drawing')
+			this.hidden = false;
+		} else if (this.sectionProperties.docLayer._docType === 'presentation' || this.sectionProperties.docLayer._docType === 'drawing') {
 			this.showImpressDraw();
-		else if (this.sectionProperties.docLayer._docType === 'spreadsheet')
+			this.hidden = false;
+		} else if (this.sectionProperties.docLayer._docType === 'spreadsheet')
 			this.showCalc();
 
 		this.setLayoutClass();
@@ -869,12 +884,15 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.nodeReply.style.display = 'none';
 		this.sectionProperties.showSelectedCoordinate = false;
 		L.DomUtil.removeClass(this.sectionProperties.container, 'cool-annotation-collapsed-show');
+		this.cachedIsEdit = false;
+		this.hidden = true;
 	}
 
 	private hideCalc() {
 		this.sectionProperties.container.style.visibility = 'hidden';
 		this.sectionProperties.nodeModify.style.display = 'none';
 		this.sectionProperties.nodeReply.style.display = 'none';
+		this.cachedIsEdit = false;
 
 		if (this.sectionProperties.commentListSection.sectionProperties.selectedComment === this)
 			this.sectionProperties.commentListSection.sectionProperties.selectedComment = null;
@@ -892,8 +910,10 @@ export class Comment extends CanvasSectionObject {
 
 			this.sectionProperties.nodeModify.style.display = 'none';
 			this.sectionProperties.nodeReply.style.display = 'none';
+			this.cachedIsEdit = false;
 		}
 		L.DomUtil.removeClass(this.sectionProperties.container, 'cool-annotation-collapsed-show');
+		this.hidden = true;
 	}
 
 	// check if this is "our" autosaved comment
@@ -908,7 +928,7 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	public hide (): void {
-		if (this.isEdit()) {
+		if (this.hidden === true || this.isEdit()) {
 			return;
 		}
 
@@ -1092,6 +1112,7 @@ export class Comment extends CanvasSectionObject {
 			return;
 		}
 		if (!this.sectionProperties.commentContainerRemoved) {
+			this.cachedIsEdit = false;
 			$(this.sectionProperties.container).removeClass('annotation-active reply-annotation-container modify-annotation-container');
 			this.removeLastBRTag(this.sectionProperties.nodeModifyText);
 			if (this.sectionProperties.contentText.origText !== this.sectionProperties.nodeModifyText.innerText ||
@@ -1129,6 +1150,8 @@ export class Comment extends CanvasSectionObject {
 		}
 		else {
 			this.sectionProperties.nodeReply.style.display = 'none';
+			if (!this.sectionProperties.nodeModify || this.sectionProperties.nodeModify.style.display === 'none')
+				this.cachedIsEdit = false;
 		}
 	}
 
@@ -1155,6 +1178,7 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.contentNode.style.display = '';
 		this.sectionProperties.nodeModify.style.display = 'none';
 		this.sectionProperties.nodeReply.style.display = '';
+		this.cachedIsEdit = true;
 		return this;
 	}
 
@@ -1165,12 +1189,12 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.nodeReply.style.display = 'none';
 		this.sectionProperties.container.style.visibility = '';
 		this.sectionProperties.contentNode.style.display = 'none';
+		this.cachedIsEdit = true;
 		return this;
 	}
 
 	public isEdit (): boolean {
-		return !this.pendingInit && ((this.sectionProperties.nodeModify && this.sectionProperties.nodeModify.style.display !== 'none') ||
-		       (this.sectionProperties.nodeReply && this.sectionProperties.nodeReply.style.display !== 'none'));
+		return this.cachedIsEdit;
 	}
 
 	public isModifying(): boolean {
@@ -1536,8 +1560,13 @@ export class Comment extends CanvasSectionObject {
 		return 1; // Comment list not fully initialized but we know we are not root
 	}
 
-	public getCommentHeight(): number {
-		return this.sectionProperties.container.getBoundingClientRect().height  - this.sectionProperties.childLinesNode.getBoundingClientRect().height;
+	public getCommentHeight(invalidateCache: boolean = true): number {
+		if (invalidateCache)
+			this.cachedCommentHeight = null;
+		if (this.cachedCommentHeight === null)
+			this.cachedCommentHeight = this.sectionProperties.container.getBoundingClientRect().height
+			- this.sectionProperties.childLinesNode.getBoundingClientRect().height;
+		return this.cachedCommentHeight;
 	}
 
 	public setCollapsed(): void {

--- a/browser/src/dom/PosAnimation.js
+++ b/browser/src/dom/PosAnimation.js
@@ -16,6 +16,17 @@ L.PosAnimation = L.Class.extend({
 
 		this.fire('start');
 
+		// Skip some work if the duration is zero
+		if (duration <= 0) {
+			el.style[L.DomUtil.TRANSITION] = '';
+			L.DomUtil.setPosition(el, newPos);
+			this._el._leaflet_pos = newPos;
+			this._inProgress = false;
+			this.fire('step').fire('end');
+			this._el.dataset.transitioning = false;
+			return;
+		}
+
 		el.style[L.DomUtil.TRANSITION] = 'all ' + (isNaN(duration) ? 0.25 : 0) +
 		        's cubic-bezier(0,0,' + (easeLinearity || 0.5) + ',1)';
 


### PR DESCRIPTION
* Resolves: #10748
* Target version: master 

### Summary

It is desirable for comments to scroll in sync with the document instead of lagging behind the scroll position. The first commit in this branch anchors comments directly to the scroll position and the second commit fixes various performance issues doing this exposes.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

