### PR TITLE
slideshow: followup: exit  from notes view before starting

### DIFF
--- a/browser/src/slideshow/PresenterConsole.js
+++ b/browser/src/slideshow/PresenterConsole.js
@@ -193,7 +193,7 @@ class PresenterConsole {
 		if (this._waitForExitingNotesMode && e.mode === 0) {
 			this._waitForExitingNotesMode = false;
 			this._map.off('impressmodechanged', this._onImpressModeChanged, this);
-			this._onPresentInConsole();
+			setTimeout(this._onPresentInConsole.bind(this), 500);
 		}
 	}
 

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -547,7 +547,8 @@ class SlideShowPresenter {
 			const startSlide = {
 				startSlideNumber: this._startSlide,
 			};
-			inWindow ? this._onStartInWindow(startSlide) : this._onStart(startSlide);
+			const startSlideshow = inWindow ? this._onStartInWindow : this._onStart;
+			setTimeout(startSlideshow.bind(this, startSlide), 500);
 		}
 	}
 


### PR DESCRIPTION
This is a follow up since previous patch has a problem when presenter console is
started in Firefox when Impress is in notes view mode.
Oddly, it seems that presentation information are requested but the reply with
the info never reaches CanvasTileLayer._onMessage.
Anyway I can see that the reply is sent by the core.
Since I'm not able to understand the root cause, I implemented a simple
workaround by delay the presenter console start by 500ms.
In order to be safer I decided to apply the same delay also when we present
without the console.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I941419b3d33095608973af18aab9df2b767a02f4
