### PR TITLE
Fix mousewheel scrolling sometimes not working in one direction

### DIFF
--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -732,6 +732,8 @@ export class ScrollSection extends CanvasSectionObject {
 	}
 
 	public scrollVerticalWithOffset (offset: number): boolean {
+		this.calculateYMinMax();
+
 		if (offset > 0) {
 			if (this.documentTopLeft[1] + offset > this.sectionProperties.yMax)
 				offset = this.sectionProperties.yMax - this.documentTopLeft[1];
@@ -756,6 +758,8 @@ export class ScrollSection extends CanvasSectionObject {
 	}
 
 	public scrollHorizontalWithOffset (offset: number): void {
+		this.calculateXMinMax();
+
 		if (this.isRTL()) {
 			offset = -offset;
 		}


### PR DESCRIPTION
Scroll extents were not being recalculated when attempting to scroll in ScrollSection, causing scrolling initiated with the mouse not to work sometimes. This was especially noticeable with Impress notes view as scroll extents weren't otherwise recalculated elsewhere.