### PR TITLE
wsd: do not complain if process is reaped already

### DIFF
--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -179,7 +179,7 @@ void requestShutdown()
                 return std::make_pair(ret, WTERMSIG(status));
             }
         }
-        else if (pid > 0)
+        else if (pid > 0 && errno != 0) // Don't complain if the process is reaped already.
         {
             // Log errno if we had a child pid we expected to reap.
             LOG_WRN("Failed to reap child process " << pid << " (" << Util::symbolicErrno(errno)


### PR DESCRIPTION
When a process is already reaped, waitpid(3) will
fail with errno == 0 (success). Instead of blindly
warning, we for success in errno and therefore
have nothing to warn about.

Change-Id: I4d2d35a58eb3cfe6b70b0d2593e62f4ee1015581
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
