### PR TITLE
sc autofill: make cells selectable after first click - if autofill context menu is open

### DIFF
--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -1148,6 +1148,8 @@ export class ScrollSection extends CanvasSectionObject {
 	public onMouseWheel (point: Array<number>, delta: Array<number>, e: MouseEvent): void {
 		if (e.ctrlKey) return;
 
+		this.map.fire('closepopups'); // close all popups when scrolling
+
 		let hscroll = 0, vscroll = 0;
 		if (Math.abs(delta[1]) > Math.abs(delta[0])) {
 			if (e.shiftKey)

--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -109,6 +109,7 @@ L.Control.ContextMenu = L.Control.extend({
 
 	onAdd: function (map) {
 		this._prevMousePos = null;
+		this._autoFillContextMenu = false;
 
 		map._contextMenu = this;
 		map.on('locontextmenu', this._onContextMenu, this);
@@ -119,6 +120,12 @@ L.Control.ContextMenu = L.Control.extend({
 	},
 
 	_onClosePopup: function () {
+
+		if (this._autoFillContextMenu) {
+			this._autoFillContextMenu = false;
+			app.map._docLayer._resetReferencesMarks();
+		}
+
 		$.contextMenu('destroy', '.leaflet-layer');
 		this.hasContextMenu = false;
 	},
@@ -168,7 +175,7 @@ L.Control.ContextMenu = L.Control.extend({
 			} else if (menuItem.indexOf('.uno:AutoFill') !== -1) {
 				// we should close the autofill preview popup before open autofill context menu
 				map.fire('closeautofillpreviewpopup');
-				autoFillContextMenu = true;
+				this._autoFillContextMenu = autoFillContextMenu = true;
 				break;
 			}
 		}

--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -204,6 +204,12 @@ L.Control.ContextMenu = L.Control.extend({
 						var $menu = opt.$menu;
 						$menu.attr('tabindex', 0); // Make the context menu focusable
 					},
+					activated: function (opt) {
+						if (autoFillContextMenu) {
+							var $layer = opt.$layer;
+							$layer.css('pointer-events', 'none'); // disable mouse clicks for the layer
+						}
+					},
 					hide: function() {
 						if(autoFillContextMenu)
 							app.map._docLayer._resetReferencesMarks();

--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -635,6 +635,8 @@ export class Header extends app.definitions.canvasSectionObject {
 		L.DomUtil.enableImageDrag();
 		L.DomUtil.enableTextSelection();
 
+		this._map.fire('closepopups'); // close all popups if a row/column header is selected
+
 		if (this.containerObject.isDraggingSomething() && this._dragEntry) {
 			this.onDragEnd(this.containerObject.getDragDistance());
 			this._dragEntry = null;

--- a/browser/src/control/jsdialog/Util.Dropdown.js
+++ b/browser/src/control/jsdialog/Util.Dropdown.js
@@ -154,6 +154,9 @@ JSDialog.OpenDropdown = function (id, popupParent, entries, innerCallback, popup
 		};
 	};
 	L.Map.THIS.fire('jsdialog', {data: json, callback: generateCallback(entries)});
+
+	L.Map.THIS.fire('closepopups'); // close popups if a dropdown menu is opened
+	L.Map.THIS._docLayer._resetReferencesMarks();
 };
 
 JSDialog.CloseDropdown = function (id) {

--- a/browser/src/control/jsdialog/Util.Dropdown.js
+++ b/browser/src/control/jsdialog/Util.Dropdown.js
@@ -153,10 +153,8 @@ JSDialog.OpenDropdown = function (id, popupParent, entries, innerCallback, popup
 				JSDialog.CloseDropdown(id);
 		};
 	};
-	L.Map.THIS.fire('jsdialog', {data: json, callback: generateCallback(entries)});
-
 	L.Map.THIS.fire('closepopups'); // close popups if a dropdown menu is opened
-	L.Map.THIS._docLayer._resetReferencesMarks();
+	L.Map.THIS.fire('jsdialog', {data: json, callback: generateCallback(entries)});
 };
 
 JSDialog.CloseDropdown = function (id) {


### PR DESCRIPTION
- disable mouse clicks for context-menu-layer
- close popups if a dropdown menu is opened -> this only applies to the autofill context-menu. other context menus should not be affected.
- close all popups when scrolling and reset selection with _resetReferencesMarks() if autofill context menu is open
- close all popups if a row/column header is selected



Change-Id: Iaf7b5c09003291f27155ae9ab6787f2f871ac466


* Resolves: # <!-- related github issue -->
* Target version: master 

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

