### PR TITLE
Fix clang warning about unused functions

### DIFF
--- a/common/StateEnum.hpp
+++ b/common/StateEnum.hpp
@@ -60,7 +60,7 @@
         return NAME##_names[static_cast<int>(e)];                                                  \
     }                                                                                              \
     /* Returns the state name only, without the namespace, as a std::string. */                    \
-    static inline std::string toStringShort(NAME e)                                                \
+    [[maybe_unused]] static inline std::string toStringShort(NAME e)                                                \
     {                                                                                              \
         return nameShort(e);                                                                       \
     }                                                                                              \
@@ -73,11 +73,11 @@
         return NAME##_names[static_cast<int>(e)];                                                  \
     }                                                                                              \
     /* Returns the state name, with the namespace, as a std::string. */                            \
-    static inline std::string toString(NAME e)                                                     \
+    [[maybe_unused]] static inline std::string toString(NAME e)                                                     \
     {                                                                                              \
         return name(e);                                                                            \
     }                                                                                              \
-    static const size_t NAME##Max = COUNT_ARGS(__VA_ARGS__);                                       \
+    [[maybe_unused]] static const size_t NAME##Max = COUNT_ARGS(__VA_ARGS__);                                       \
     enum class NAME : char                                                                         \
     {                                                                                              \
         __VA_ARGS__                                                                                \


### PR DESCRIPTION
wsd/ClientRequestDispatcher.cpp:1106:1: error: unused function 'toStringShort' [-Werror,-Wunused-function] STATE_ENUM(CheckStatus,
^
./common/StateEnum.hpp:63:31: note: expanded from macro 'STATE_ENUM'
    static inline std::string toStringShort(NAME e)                                                \
                              ^
wsd/ClientRequestDispatcher.cpp:1106:1: error: unused function 'toString' [-Werror,-Wunused-function]
./common/StateEnum.hpp:76:31: note: expanded from macro 'STATE_ENUM'
    static inline std::string toString(NAME e)                                                     \
                              ^
wsd/ClientRequestDispatcher.cpp:1106:1: error: unused variable 'CheckStatusMax' [-Werror,-Wunused-const-variable]
./common/StateEnum.hpp:80:25: note: expanded from macro 'STATE_ENUM'
    static const size_t NAME##Max = COUNT_ARGS(__VA_ARGS__);                                       \
                        ^
<scratch space>:107:1: note: expanded from here
CheckStatusMax
^
3 errors generated.

introduced by commit e116ee8f0a4e16ad5b74918a9c1bce57d18a3377 Add an endpoint to check connectivity to WOPI server