### PR TITLE
clang complains about unused function generated by STATE_ENUM macro

### DIFF
--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -16,7 +16,6 @@
 #endif
 
 #include <common/Anonymizer.hpp>
-#include <common/StateEnum.hpp>
 #include <Admin.hpp>
 #include <COOLWSD.hpp>
 #include <ClientSession.hpp>
@@ -1100,25 +1099,6 @@ bool ClientRequestDispatcher::handleWopiDiscoveryRequest(
     LOG_INF("Sent discovery.xml successfully.");
     return true;
 }
-
-
-// NB: these names are part of the published API, and should not be renamed or altered but can be expanded
-STATE_ENUM(CheckStatus,
-    Ok,
-    NotHttpSucess,
-    HostNotFound,
-    WopiHostNotAllowed,
-    HostUnReachable,
-    UnspecifiedError,
-    ConnectionAborted,
-    ConnectionRefused,
-    CertificateValidation,
-    SSLHandshakeFail,
-    MissingSsl,
-    NotHttps,
-    NoScheme,
-    Timeout,
-);
 
 bool ClientRequestDispatcher::handleWopiAccessCheckRequest(const Poco::Net::HTTPRequest& request,
                                                            Poco::MemoryInputStream& message,

--- a/wsd/ClientRequestDispatcher.hpp
+++ b/wsd/ClientRequestDispatcher.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <common/StateEnum.hpp>
 #include <RequestVettingStation.hpp>
 #include <RequestDetails.hpp>
 #include <Socket.hpp>
@@ -24,6 +25,24 @@
 /// Handles incoming connections and dispatches to the appropriate handler.
 class ClientRequestDispatcher final : public SimpleSocketHandler
 {
+    // NB: these names are part of the published API, and should not be renamed or altered but can be expanded
+    STATE_ENUM(CheckStatus,
+        Ok,
+        NotHttpSucess,
+        HostNotFound,
+        WopiHostNotAllowed,
+        HostUnReachable,
+        UnspecifiedError,
+        ConnectionAborted,
+        ConnectionRefused,
+        CertificateValidation,
+        SSLHandshakeFail,
+        MissingSsl,
+        NotHttps,
+        NoScheme,
+        Timeout,
+    );
+
 public:
     ClientRequestDispatcher() {}
 


### PR DESCRIPTION
When build with -werror switch clang complains about unused functions:
toString, toStringShort, and the unused variable CheckStatusMax.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I0f6bca7219dfae351750ee270776bbbb1807ba1a
