### PR TITLE
net: fixed enum misspelling and missing value

### DIFF
--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -389,7 +389,7 @@ asyncConnect(const std::string& host, const std::string& port, const bool isSSL,
     if (isSSL)
     {
         LOG_ERR("Error: isSSL socket requested but SSL is not compiled in.");
-        asyncCb(nullptr, asyncConnectResult::MissingSSLError);
+        asyncCb(nullptr, AsyncConnectResult::MissingSSLError);
         return;
     }
 #endif

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -96,6 +96,7 @@ enum class AsyncConnectResult{
     HostNameError,
     UnknownHostError,
     SSLHandShakeFailure,
+    MissingSSLError
 };
 
 typedef std::function<void(std::shared_ptr<StreamSocket>, AsyncConnectResult result)> asyncConnectCB;


### PR DESCRIPTION
Change-Id: I392458e2c455df0a81f0f5c541f5f5a231e60692


* Target version: master 



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

