### PR TITLE
Add appropriate alt attributes to images within buttons for better accessibility

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2357,7 +2357,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				$(div).addClass('no-label');
 			}
 
-			if (buttonImage !== false) {
+			// for Accessibility : graphic elements are located within buttons, the img should receive an empty alt
+			if(button.getAttribute('aria-label')){ // if we already set the aria-label then do not go for image alt attr
+				buttonImage.alt = '';
+			}
+			else if (buttonImage !== false) {
 				if(data.aria) {
 					buttonImage.alt = data.aria.label;
 				} else {


### PR DESCRIPTION
- Ensured img elements within buttons receive an empty alt attribute when the button has a programmatic label (e.g., aria-label).
- Added descriptive alt attributes to img elements if the button lacks a programmatic label.
- This change improves screen reader support by avoiding redundant announcements and providing meaningful descriptions where needed.


Change-Id: I3317e5c0d192db493cd2928b2c63396d9df64e49


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

