### PR TITLE
context menu: Don't show items for hidden commands

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -249,6 +249,11 @@ L.Control.ContextMenu = L.Control.extend({
 				continue;
 			}
 
+			// If the command was hidden with the Hide_Command postmessage...
+			if (this._map.uiManager.hiddenCommands[item.command]) {
+				continue;
+			}
+
 			// reduce Paste Special submenu
 			if (item.type === 'menu' && item.text && item.text.replace('~', '') === 'Paste Special'
 				&& item.menu && item.menu.length) {


### PR DESCRIPTION
Change-Id: I15f62cbdfc69d9ba4c1c7e53f2238d13b65285e5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

If the postmessage command Hide_Command was sent, also hide the command from the context menu.

See #10351 for a related change.

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

