### PR TITLE
Fix toggle status of show all comments button

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -2359,9 +2359,8 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 			this.checkSize();
 			this.update();
 		}
-
-		var show = this.map.stateChangeHandler.getItemValue('showannotations');
-		this.setView(show === true || show === 'true');
+		var initalShowAnnotations = commentList.length > 0;
+		app.map.showComments(initalShowAnnotations);
 
 		var showResolved = this.map.stateChangeHandler.getItemValue('ShowResolvedAnnotations');
 		this.setViewResolved(showResolved === true || showResolved === 'true');

--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -173,11 +173,11 @@ class StatusBar extends JSDialog.Toolbar {
 	onShowCommentsChange(e) {
 		var state = e.state;
 		var statemsg;
-		if (state === 'true')
+		if (state === 'true' || state === true)
 			statemsg = _UNO('.uno:ShowAnnotations') +': ' + _('On');
-		else if (state === 'false')
+		else if (state === 'false' || state === false)
 			statemsg = _UNO('.uno:ShowAnnotations') +': ' + _('Off');
-		this.updateHtmlItem('ShowComments', state ? statemsg : ' ');
+		this.updateHtmlItem('ShowComments', statemsg);
 	}
 
 	_generateHtmlItem(id) {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -398,9 +398,6 @@ L.Control.UIManager = L.Control.extend({
 			var showResolved = this.getBooleanDocTypePref('ShowResolved', true);
 			if (showResolved === false || showResolved === 'false')
 				this.map.sendUnoCommand('.uno:ShowResolvedAnnotations');
-			// Notify the inital status of comments
-			var initialCommentState = this.map['stateChangeHandler'].getItemValue('showannotations');
-			this._map.fire('commandstatechanged', {commandName : 'showannotations', state : initialCommentState});
 			this.map.mention = L.control.mention(this.map);
 		}
 


### PR DESCRIPTION
Before initial state was always true.
Now we decide to initial state according to document have comments or not. If document have comments, default initial state is comments on, if not comments off.


Change-Id: If3e8eb5eeff29c8a72658d0afafc7379444d62ab


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

