### PR TITLE
Add aria label for pushbutton control

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -988,7 +988,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				tab.id = Number.isInteger(parseInt(item.id)) ? data.id + '-' + item.id : item.id;
 				tab.textContent = title;
 				tab.setAttribute('role', 'tab');
-				tab.setAttribute('aria-label', title);
+				builder._addAriaLabel(tab, item, builder);
 				builder._setAccessKey(tab, builder._getAccessKeyFromText(item.text));
 				builder._stressAccessKey(tab, tab.accessKey);
 
@@ -1597,6 +1597,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			pushbutton.onclick = builder.callback.bind(builder, 'responsebutton', 'click', { id: pushbutton.id }, builder._responses[pushbutton.id], builder);
 		else
 			pushbutton.onclick = builder.callback.bind(builder, 'pushbutton', data.isToggle ? 'toggle' : 'click', pushbutton, data.command, builder);
+	
+		builder._addAriaLabel(pushbutton, data, builder);
 
 		builder.map.hideRestrictedItems(data, wrapper, pushbutton);
 		builder.map.disableLockedItem(data, wrapper, pushbutton);
@@ -2224,6 +2226,13 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			return '';
 	},
 
+	_addAriaLabel(element, data, builder) {
+		if (data.aria)
+			element.setAttribute('aria-label', data.aria.label);
+		else if(data.text)
+			element.setAttribute('aria-label', builder._cleanText(data.text));
+	},
+
 	// Create a DOM node with an identifiable parent class
 	_createIdentifiable : function(type, classNames, parentContainer, data) {
 		return L.DomUtil.create(
@@ -2308,10 +2317,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 			JSDialog.SynchronizeDisabledState(div, [button]);
 
-			if(data.text)
-				button.setAttribute('aria-label', data.text);
-			else if (data.aria)
-				button.setAttribute('aria-label', data.aria.label);
+			builder._addAriaLabel(button, data, builder);
 
 			if (!data.accessKey)
 				builder._setAccessKey(button, builder._getAccessKeyFromText(data.text));

--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -184,6 +184,7 @@ JSDialog.combobox = function (parentContainer, data, builder) {
 	container.id = data.id;
 
 	var content = L.DomUtil.create('input', 'ui-combobox-content ' + builder.options.cssClass, container);
+	content.id = data.id + '-input';
 	content.value = data.text;
 	content.role = 'combobox';
 


### PR DESCRIPTION
- added aria-label for pushbutton control
- generic method to add aria label based on `aria` or `text` property


Change-Id: I80e1aaa132ed944d24223519e640fc56d01b9dcb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

