### PR TITLE
Fix regression from c0e53f04741987b70

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -180,15 +180,15 @@ bool isConfigAuthOk(const std::string& userProvidedUsr, const std::string& userP
             return false;
         }
 
-        auto userProvidedPwdHash = static_cast<unsigned char*>(alloca(tokens[4].size() / 2));
+        std::vector<unsigned char> userProvidedPwdHash(tokens[4].size() / 2);
         PKCS5_PBKDF2_HMAC(userProvidedPwd.c_str(), -1,
                           saltData.data(), saltData.size(),
                           std::stoi(tokens[2]),
                           EVP_sha512(),
-                          sizeof userProvidedPwdHash, userProvidedPwdHash);
+                          userProvidedPwdHash.size(), userProvidedPwdHash.data());
 
         std::stringstream stream;
-        for (unsigned long j = 0; j < sizeof userProvidedPwdHash; ++j)
+        for (unsigned long j = 0; j < userProvidedPwdHash.size(); ++j)
             stream << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(userProvidedPwdHash[j]);
 
         // now compare the hashed user-provided pwd against the stored hash


### PR DESCRIPTION
The intent was to avoid VLA, but later in the code the sizeof operator returned 16 and the length of token[4] was 256. This mismatch caused a regression, admin console's secure password was not accepted.
I decided to use std::vector instead of alloca. It's more readable and C++-like to me.


Change-Id: I3cbbce5c4ac568735b2b44dad2fb20e143bf4c75
