### PR TITLE
wsd: wopiAccessCheck, use nameShort for Status

### DIFF
--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1203,7 +1203,7 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(const Poco::Net::HTTP
 
     const auto sendResult = [this, socket](CheckStatus result)
     {
-        const auto output = "{\"status\": \"" + JsonUtil::escapeJSONValue(name(result)) + "\"}\n";
+        const auto output = "{\"status\": \"" + JsonUtil::escapeJSONValue(nameShort(result)) + "\"}\n";
 
         http::Response jsonResponse(http::StatusCode::OK);
         FileServerRequestHandler::hstsHeaders(jsonResponse);
@@ -1212,7 +1212,7 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(const Poco::Net::HTTP
         jsonResponse.set("X-Content-Type-Options", "nosniff");
 
         socket->sendAndShutdown(jsonResponse);
-        LOG_INF("Wopi Access Check request, result" << name(result));
+        LOG_INF("Wopi Access Check request, result" << nameShort(result));
     };
 
     if (scheme.empty())


### PR DESCRIPTION
So in json response we have `Ok` instead of `CheckStatus::Ok`.

Amends #9202
Change-Id: I0d26ac1e098e8a6889248102d3baad5cd9a38bc1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

