### PR TITLE
Fix width of Thesaurus left arrow button

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -170,6 +170,11 @@ button.has-img {
 	min-width: auto !important;
 }
 
+/* Thesaurus <- button */
+button#left.has-img > img {
+	width: 16px;
+}
+
 /* Calc Auto-Filter buttons coming from core */
 [data-theme='dark'] button#select_current.has-img > img {
 	filter: invert(.9)


### PR DESCRIPTION
SVG images may not have an intrinsic width and height defined. This can cause max-content to behave unexpectedly since it relies on the size of the content, and an SVG without dimensions may not contribute to the content's width.

We set width explicitely in this case.


Change-Id: I5ebed738bd4f3a12a96596ddac07341097e43bc3

Before:
![image](https://github.com/user-attachments/assets/4787b53e-3479-4a15-a97f-003911a8560f)

After:
![image](https://github.com/user-attachments/assets/f49a77d0-937c-4546-89d3-8312d587971e)
