### PR TITLE
Correct text vertical alignment of checkboxes in show sheets dialog

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -605,6 +605,7 @@ input[type='checkbox'].autofilter, .jsdialog input[type='checkbox'] {
 	appearance: none;
 	width: 20px;
 	height: 20px;
+	vertical-align: middle;
 	background: url('images/lc_checkboxoff.svg') no-repeat center;
 	margin: 1px 8px;
 }


### PR DESCRIPTION
Change-Id: I4edf2311bf225483bfad59676d0e764385fde4b9


* Resolves: #10813 
* Target version: master 

### Summary
Fixes the misalignment of text labels relative to checkboxes in the "Show Sheets" dialog for improved visual consistency.

### TODO
![Screenshot from 2024-12-27 16-34-46](https://github.com/user-attachments/assets/2c112cc7-5398-42ba-b474-1c5fc93e98d3)


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

