### PR TITLE
Add background color on following chip of user avatar

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1651,6 +1651,7 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	align-items: center;
 
 	color: var(--color-main-text);
+	background-color: var(--color-main-background);
 }
 
 #userListSummaryBackground > #userListSummary {


### PR DESCRIPTION
Change-Id: I5c801bbddfba1166030c8b0ca0cebabc576867f1

* Target version: master 

### Summary
Introduced a background color to the following chip to remove odd border over the user avatar 

### BEFORE
![Screenshot from 2024-12-28 00-20-06](https://github.com/user-attachments/assets/5dad2dbb-e06c-44bd-8621-bef6d7958659)
![Screenshot from 2024-12-28 00-20-15](https://github.com/user-attachments/assets/2f051546-5de1-4c86-b828-86b560eb4550)

### AFTER
![Screenshot from 2024-12-28 00-18-37](https://github.com/user-attachments/assets/4d1065df-695c-4e69-9987-0853df757e0d)
![Screenshot from 2024-12-28 00-18-20](https://github.com/user-attachments/assets/e48083f3-65c3-4154-afa3-010746d1a245)



### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

