### PR TITLE
Add  aria-labelledby with appropriate description and set role="dialog" for all form modal

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -232,10 +232,11 @@ L.Control.JSDialog = L.Control.extend({
 	createContainer: function(instance, parentContainer) {
 		// it has to be form to handle default button
 		instance.container = L.DomUtil.create('div', 'jsdialog-window', parentContainer);
-		instance.container.setAttribute('role', 'dialog');
 		instance.container.id = instance.id;
 
 		instance.form = L.DomUtil.create('form', 'jsdialog-container ui-dialog ui-widget-content lokdialog_container', instance.container);
+		instance.form.setAttribute('role', 'dialog');
+		instance.form.setAttribute('aria-labelledby', instance.title);
 
 		// Prevent overlay from getting the click, except if we want click to dismiss
 		// Like in the case of the inactivity message.


### PR DESCRIPTION

    - Enhance dialog accessibility: Add aria-labelledby, set role="dialog", and ensure meaningful titles.
    - Improve dialog accessibility: Add aria-labelledby and set role="dialog" for semantic clarity.


Change-Id: I815db1a23b9331e4de4e34ba57851364c081f320


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

