### PR TITLE
For undefined init focus id we should focus on first focus able element in container

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -413,7 +413,8 @@ L.Control.JSDialog = L.Control.extend({
 
 		} else {
 			// will directly set element of focusable element based on init focus id
-			firstFocusableElement = instance.init_focus_id ? instance.container.querySelector('[id=\'' + instance.init_focus_id + '\']') : null;
+			// If init_id is not defined, select the first focusable element from the container
+			firstFocusableElement = instance.init_focus_id ? instance.container.querySelector('[id=\'' + instance.init_focus_id + '\']') : JSDialog.GetFocusableElements(instance.container);
 		}
 
 		if (firstFocusableElement && document.activeElement !== firstFocusableElement && instance.canHaveFocus) {

--- a/cypress_test/integration_tests/desktop/calc/focus_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/focus_spec.js
@@ -53,4 +53,11 @@ describe(['tagdesktop'], 'Calc focus tests', function() {
 		cy.cGet('#input-modal-input').should('have.focus');
 	});
 
+	it('On color palette dialog open', function() {
+		cy.cGet('#Home').click();
+		cy.cGet('#Home-container .unoBackgroundColor .arrowbackground').click();
+		// focus should be on first element which is Automatic color button
+		cy.cGet('#transparent-color-button').should('have.focus');
+	});
+
 });

--- a/cypress_test/integration_tests/desktop/calc/focus_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/focus_spec.js
@@ -60,4 +60,11 @@ describe(['tagdesktop'], 'Calc focus tests', function() {
 		cy.cGet('#transparent-color-button').should('have.focus');
 	});
 
+	it('On Tabcontrol dialog open', function() {
+		cy.cGet('#Layout-tab-label').click();
+		cy.cGet('#Layout-container .unoPageFormatDialog').click();
+		// focus should be on selected tab if current dialog is tabcontrol dialog
+		cy.cGet('.ui-tab.jsdialog.selected').should('have.focus');
+	});
+
 });

--- a/cypress_test/integration_tests/desktop/calc/focus_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/focus_spec.js
@@ -47,4 +47,10 @@ describe(['tagdesktop'], 'Calc focus tests', function() {
 		helper.expectTextForClipboard(text1+text2);
 		calcHelper.typeIntoFormulabar('{enter}');
 	});
+
+	it('On Rename-sheet modal dialog open', function() {
+		cy.cGet('.spreadsheet-tab.spreadsheet-tab-selected').dblclick();
+		cy.cGet('#input-modal-input').should('have.focus');
+	});
+
 });


### PR DESCRIPTION


- in current case we did not have any fallback for cases like undefined init focus
- it is simple that if no focus-able id defined then we will add focus on first focus-able element


Change-Id: Ib46a1c7a3366933e8b01ca831798d92bf96797e0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

