### PR TITLE
Accessibility: Navigator use an empty alt tag for the icons

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -406,7 +406,8 @@ L.Control.JSDialog = L.Control.extend({
 
 		} else {
 			// will directly set element of focusable element based on init focus id
-			firstFocusableElement = instance.init_focus_id ? instance.container.querySelector('[id=\'' + instance.init_focus_id + '\']') : null;
+			// If init_id is not defined, select the first focusable element from the container
+			firstFocusableElement = instance.init_focus_id ? instance.container.querySelector('[id=\'' + instance.init_focus_id + '\']') : JSDialog.GetFocusableElements(instance.container);
 		}
 
 		if (firstFocusableElement && document.activeElement !== firstFocusableElement && instance.canHaveFocus) {


### PR DESCRIPTION
Missing alt Attribute for Icons
The Icons do not have alt attributes.

Solution : In this case, it is advisable to use an empty alt tag for the icons, as the information of the funktion is available in text form


Change-Id: Ibdb1c7833477b9a020c1e77e5da6fe08a0f90336


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

