### PR TITLE
jsdialog: no padding in treeview context menu

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -54,6 +54,7 @@
 .jsdialog.one-child-popup {
 	border: 0;
 	margin: 0 !important;
+	padding: 0 !important;
 }
 
 div#autoFillPreviewTooltip {
@@ -487,6 +488,10 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	line-height: var(--default-height);
 	align-content: start;
 	justify-content: stretch;
+}
+
+.ui-treeview * {
+	border-radius: initial;
 }
 
 .jsdialog:not(.sidebar).ui-treeview {

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -229,6 +229,14 @@ L.Control.JSDialog = L.Control.extend({
 		instance.overlay = overlay;
 	},
 
+	isOnlyChild: function(instance) {
+		const isMenu = instance.children && instance.children.length
+			&& instance.children[0].id === '__MENU__';
+		const isOnlyChild = instance.children && instance.children.length &&
+			instance.children[0].children && instance.children[0].children.length === 1;
+		return isMenu || isOnlyChild;
+	},
+
 	createContainer: function(instance, parentContainer) {
 		// it has to be form to handle default button
 		instance.container = L.DomUtil.create('div', 'jsdialog-window', parentContainer);
@@ -252,8 +260,7 @@ L.Control.JSDialog = L.Control.extend({
 
 		instance.defaultButtonId = this._getDefaultButtonId(instance.children);
 
-		if (instance.children && instance.children.length &&
-			instance.children[0].children && instance.children[0].children.length === 1)
+		if (this.isOnlyChild(instance))
 			instance.isOnlyChild = true;
 
 		// it has to be first button in the form
@@ -288,7 +295,7 @@ L.Control.JSDialog = L.Control.extend({
 			L.DomUtil.addClass(instance.form, 'snackbar');
 		}
 
-		instance.content = L.DomUtil.create('div', 'lokdialog ui-dialog-content ui-widget-content', instance.form);
+		instance.content = L.DomUtil.create('div', 'jsdialog lokdialog ui-dialog-content ui-widget-content' + (instance.isOnlyChild ? ' one-child-popup' : ''), instance.form);
 
 		this.dialogs[instance.id] = {};
 	},


### PR DESCRIPTION
do not add additional margin or padding to context menu also don't round the borders in it's entries
example menu to test can be found in style sidebar Writer -> Format -> Style sidebar (experimental for now)

result:
![contextmenu](https://github.com/user-attachments/assets/d0d345c0-a989-4b7f-92ce-78550cc24696)
