### PR TITLE
Accessibility navigator: use an empty alt tag for the icons

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -406,8 +406,7 @@ L.Control.JSDialog = L.Control.extend({
 
 		} else {
 			// will directly set element of focusable element based on init focus id
-			// If init_id is not defined, select the first focusable element from the container
-			firstFocusableElement = instance.init_focus_id ? instance.container.querySelector('[id=\'' + instance.init_focus_id + '\']') : JSDialog.GetFocusableElements(instance.container);
+			firstFocusableElement = instance.init_focus_id ? instance.container.querySelector('[id=\'' + instance.init_focus_id + '\']') : null;
 		}
 
 		if (firstFocusableElement && document.activeElement !== firstFocusableElement && instance.canHaveFocus) {

--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -517,6 +517,7 @@ class TreeViewControl {
 				L.LOUtil.setImage(icon, iconName, builder.map);
 				L.DomUtil.addClass(span, 'ui-treeview-expandable-with-icon');
 				icon.tabIndex = -1;
+				icon.alt = ''; //In this case, it is advisable to use an empty alt tag for the icons, as the information of the function is available in text form
 			} else if (
 				entry.columns[index].link &&
 				!this.isSeparator(entry.columns[index])


### PR DESCRIPTION
- Navigator: Missing alt Attribute for Icons
    - The Icons do not have alt attributes.

- Solution : In this case, it is advisable to use an empty alt tag for the icons, as the information of the function is available in text form


Change-Id: Iac161fd9e096e6765ef5ee66aa55839dfa057b5b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

