### PR TITLE
Do not jump on uno command to cursor

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -418,7 +418,7 @@ L.Map.include({
 			app.socket.sendMessage('uno ' + command + (json ? ' ' + JSON.stringify(json) : ''));
 			// user interaction turns off the following of other users
 			if (map.userList && map._docLayer && map._docLayer._viewId)
-				map.userList.followUser(map._docLayer._viewId);
+				map.userList.followUser(map._docLayer._viewId, /* do instant scroll */ false);
 		}
 	},
 

--- a/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
@@ -56,4 +56,24 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		helper.typeIntoDocument('{end}{home}{end}');
 		desktopHelper.assertScrollbarPosition('horizontal', 430, 653);
 	});
+
+	it('Check if we jump the view on change of formatting mark', function() {
+		desktopHelper.switchUIToNotebookbar();
+
+		desktopHelper.selectZoomLevel('40');
+		helper.typeIntoDocument('{ctrl}{home}');
+		desktopHelper.pressKey(2, 'pagedown');
+		desktopHelper.pressKey(1, 'pagedown');
+		desktopHelper.assertScrollbarPosition('vertical', 220, 240);
+
+		// cursor on the bottom, scroll to top
+		desktopHelper.scrollWriterDocumentToTop();
+		desktopHelper.assertScrollbarPosition('vertical', 0, 10);
+
+		cy.cGet('.notebookbar #View-tab-label').click();
+		cy.cGet('.notebookbar #View-container .unoControlCodes').click();
+
+		cy.cGet('.notebookbar #View-container .unoControlCodes').should('have.class', 'selected');
+		desktopHelper.assertScrollbarPosition('vertical', 0, 10);
+	});
 });


### PR DESCRIPTION
Fixes regression from commit 03b42ad45d4ce1774530be55d47e2f092da7ab1a following: reset on user interaction by uno command

BEFORE REGRESSION:
1735648839262 OUTGOING: uno .uno:ControlCodes
global.js:566 1735648839296 INCOMING: canonicalidchange: viewid=4 canonicalid=1001 viewrenderedstate=PS;Light global.js:566 1735648839297 OUTGOING: tilecombine ...

AFTER REGRESSION:
1735648643409 OUTGOING: uno .uno:ControlCodes
global.js:566 1735648643409 OUTGOING: clientvisiblearea x=-4995 y=0 width=22455 height=9765 splitx=0 splity=0 global.js:566 1735648643410 OUTGOING: clientzoom tilepixelwidth=256 tilepixelheight=256 tiletwipwidth=3840 tiletwipheight=3840 dpiscale=1 zoom=10 global.js:566 1735648643473 INCOMING: invalidatetiles: EMPTY, 0, 0 wid=344 global.js:566 1735648643473 INCOMING: canonicalidchange: viewid=4 canonicalid=1001 viewrenderedstate=PS;Light global.js:566 1735648643474 OUTGOING: tilecombine ...

_sendClientVisibleArea (CanvasTileLayer.js:4911)
_update (CanvasTileLayer.js:4852)
_reset (CanvasTileLayer.js:903)
_viewReset (CanvasTileLayer.js:4451)
fire (Events.js:152)
_resetView (Map.js:1310)
panBy (Map.PanAnimation.js:51)
scrollTop (Scroll.js:36)
ScrollSection.onScrollTo (ScrollSection.ts:140)
fire (Events.js:152)
scrollToPos (CanvasTileLayer.js:3224)
_onUpdateCursor (CanvasTileLayer.js:3268)
goToViewCursor (CanvasTileLayer.js:3358)
_goToViewId (Map.js:1693)
_setFollowing (Map.js:1716)
UserList.followUser (Control.UserList.ts:135)
sendUnoCommand (Toolbar.js:421)

When we send uno comand it means user did interaction with the app -> we want to foolow own cursor then and stop following others. But do not do instant jump to cursor.
