### PR TITLE
Reinit CornerHeader on modechange.

### DIFF
--- a/browser/src/control/Control.CornerHeader.ts
+++ b/browser/src/control/Control.CornerHeader.ts
@@ -36,13 +36,9 @@ export class CornerHeader extends app.definitions.canvasSectionObject {
 
 	onInitialize():void {
 		this._map = L.Map.THIS;
-
-		const baseElem = document.getElementsByTagName('body')[0];
-		const elem = L.DomUtil.create('div', 'spreadsheet-header-row', baseElem);
-		this._textColor = L.DomUtil.getStyle(elem, 'color');
-		this.backgroundColor = L.DomUtil.getStyle(elem, 'background-color'); // This is a section property.
-		this.borderColor = L.DomUtil.getStyle(elem, 'border-top-color'); // This is a section property.
-		L.DomUtil.remove(elem);
+		
+		this._map.on('darkmodechanged', this._initCornerHeaderStyle, this);
+		this._initCornerHeaderStyle();
 	}
 
 	onClick(): void {
@@ -65,6 +61,15 @@ export class CornerHeader extends app.definitions.canvasSectionObject {
 
 	onMouseLeave(): void {
 		this.containerObject.getCanvasStyle().cursor = 'default';
+	}
+
+	_initCornerHeaderStyle(): void {
+		const baseElem = document.getElementsByTagName('body')[0];
+		const elem = L.DomUtil.create('div', 'spreadsheet-header-row', baseElem);
+		this._textColor = L.DomUtil.getStyle(elem, 'color');
+		this.backgroundColor = L.DomUtil.getStyle(elem, 'background-color'); // This is a section property.
+		this.borderColor = L.DomUtil.getStyle(elem, 'border-top-color'); // This is a section property.
+		L.DomUtil.remove(elem);
 	}
 }
 


### PR DESCRIPTION
Change-Id: I2f855273bc8824ac9d4b999ca8ecef4974c5d570


* Target version: master 

### Summary

Updates the style of the corner entry when switching between dark/light mode.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

