### PR TITLE
Replace hardcoded canvas comment color with CSS variable

### DIFF
--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -56,6 +56,7 @@
 	--color-text-calc-header-selected: var(--color-text-darker);
 	--color-border-calc-header: #c0c0c0;
 	--color-calc-header-hover: #fff;
+	--color-calc-comment: #BF819E;
 
 	--color-grid-helper-line-solid: #e6e6e6;
 	--color-grid-helper-line-dashed: #191919;

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -1364,7 +1364,8 @@ export class Comment extends CanvasSectionObject {
 					// this.size may currently have an artifically wide size if mouseEnter without moveLeave seen
 					// so fetch the real size
 					var x = isRTL ? margin : cellSize[0] - squareDim - margin;
-					this.context.fillStyle = '#BF819E';
+					var commentColor = getComputedStyle(document.body).getPropertyValue('--color-calc-comment');
+					this.context.fillStyle = commentColor;
 					var region = new Path2D();
 					region.moveTo(x, 0);
 					region.lineTo(x + squareDim, 0);


### PR DESCRIPTION
Change-Id: Ib1db1e122c91e74a7477b18cd920e7e01424dceb


* Resolves: #10762 
* Target version: master 

### Summary
 Replaced the hardcoded color `#BF819E` in the canvas context with the CSS variable `--color-calc-comment`, defined in `color-palette.css` for consistent theming.
 
 This is a regression that resolves  "The color should come from the palette or dark palette css instead (css var)"  from #10762  

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

