### PR TITLE
Change following chip dimensions on user avatars

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1607,14 +1607,14 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 
 #followingChipBackground,
 #userListSummaryBackground {
-	border-radius: var(--btn-size); /* We expect the height to be --btn-size, give a bit for a border. To fully round the corners, this needs to be at least 50% of the height so --btn-size should do */
+	border-radius: var(--btn-img-size); /* We expect the height to be --btn-img-size, give a bit for a border. To fully round the corners, this needs to be at least 50% of the height so --btn-img-size should do */
 	padding: 2px; /* This will become the grey border around the inner elements */
 
 	display: none;
 }
 
 #followingChipBackground {
-	transform: translateX(calc(4px /* border widths */ + 4px /* background paddings */ + var(--btn-size) - 0.6px /* browser rendering fudge */));
+	transform: translateX(calc(2.5px /* border widths */ + 2.5px /* background paddings */ + var(--btn-img-size) - 0.6px /* browser rendering fudge */));
 	/* We'd like this to flow over the first item of the userListSummary. I've added a fudge because browser rendering seems to have subpixel errors here and it's far better to
 	 * render the border marginally too far left than leave a gap. */
 }
@@ -1639,11 +1639,11 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 #followingChipBackground > #followingChip {
 	border-style: solid;
 	border-width: 2px;
-	border-radius: calc(var(--btn-size));
+	border-radius: calc(var(--btn-img-size));
 
-	height: var(--btn-size);
-	padding-left: calc(var(--btn-size) * 0.4);
-	padding-right: calc(var(--btn-size) * 1.2);
+	height: var(--btn-img-size);
+	padding-left: calc(var(--btn-img-size) * 0.4);
+	padding-right: calc(var(--btn-img-size) * 1.2);
 
 	display: flex;
 	flex-direction: column;
@@ -1652,6 +1652,7 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 
 	color: var(--color-main-text);
 	background-color: var(--color-main-background);
+	box-sizing: border-box;
 }
 
 #userListSummaryBackground > #userListSummary {


### PR DESCRIPTION
Change-Id: I4ad71e2935a17275b6fa1f2ef1568cf6d68adcc0

* Target version: master 

### Summary
Fixes regression from https://github.com/CollaboraOnline/online/pull/10686

Since user avatar icons are now using --btn-img-size, the following chip dimensions have to be adjusted from --btn-size to --btn-img-size and use "box-sizing: border-box" to ensure avatar icons align properly within the chip without overlap or layout issues

### BEFORE REGRESSION
![Screenshot from 2025-01-01 10-39-07](https://github.com/user-attachments/assets/9772a722-8e42-442a-be47-f11eef123c56)

## REGRESSION
![image01](https://github.com/user-attachments/assets/b77be074-62d5-4b0b-bc9d-91ba0f6e440a)

### CURRENT FIX
![Screenshot from 2025-01-01 09-06-20](https://github.com/user-attachments/assets/f12a346e-7d34-4561-a24d-1f4c3bf5f22a)
![Screenshot from 2025-01-01 10-47-47](https://github.com/user-attachments/assets/be097a8a-59fd-414d-919b-a066ef46c0ca)


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

