### PR TITLE
jsdialog: no padding in treeview context menu (mobile)

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -52,6 +52,7 @@
 .jsdialog.one-child-popup {
 	border: 0;
 	margin: 0 !important;
+	padding: 0 !important;
 }
 
 div#autoFillPreviewTooltip {
@@ -482,6 +483,10 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	line-height: var(--default-height);
 	align-content: start;
 	justify-content: stretch;
+}
+
+.ui-treeview * {
+	border-radius: initial;
 }
 
 .jsdialog:not(.sidebar).ui-treeview {

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -229,6 +229,14 @@ L.Control.JSDialog = L.Control.extend({
 		instance.overlay = overlay;
 	},
 
+	isOnlyChild: function(instance) {
+		const isMenu = instance.children && instance.children.length
+			&& instance.children[0].id === '__MENU__';
+		const isOnlyChild = instance.children && instance.children.length &&
+			instance.children[0].children && instance.children[0].children.length === 1;
+		return isMenu || isOnlyChild;
+	},
+
 	createContainer: function(instance, parentContainer) {
 		// it has to be form to handle default button
 		instance.container = L.DomUtil.create('div', 'jsdialog-window', parentContainer);
@@ -252,8 +260,7 @@ L.Control.JSDialog = L.Control.extend({
 
 		instance.defaultButtonId = this._getDefaultButtonId(instance.children);
 
-		if (instance.children && instance.children.length &&
-			instance.children[0].children && instance.children[0].children.length === 1)
+		if (this.isOnlyChild(instance))
 			instance.isOnlyChild = true;
 
 		// it has to be first button in the form
@@ -288,7 +295,7 @@ L.Control.JSDialog = L.Control.extend({
 			L.DomUtil.addClass(instance.form, 'snackbar');
 		}
 
-		instance.content = L.DomUtil.create('div', 'lokdialog ui-dialog-content ui-widget-content', instance.form);
+		instance.content = L.DomUtil.create('div', 'jsdialog lokdialog ui-dialog-content ui-widget-content' + (instance.isOnlyChild ? ' one-child-popup' : ''), instance.form);
 
 		this.dialogs[instance.id] = {};
 	},


### PR DESCRIPTION
do not add additional margin or padding to context menu also don't round the borders in it's entries
example menu to test can be found in style sidebar Writer -> Format -> Style sidebar (experimental for now)

Change-Id: I2b70ad0742bbb6a815768894f148de1d9cd3c21e

--------------- we did duplicate with the same changeId so adding manual port here -------------------
see:
https://github.com/CollaboraOnline/online/pull/10823/commits/c81e4d558f142ead7049619d9e6c5d5039254ae1
and
https://github.com/CollaboraOnline/online/commit/bbe11a084df36da9beb28cf378571d6cdc1869ba
