### PR TITLE
Fix memory handling in Session::asyncConnect()

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1731,7 +1731,7 @@ private:
         _socket.reset(); // Reset to make sure we are disconnected.
 
         auto pushConnectCompleteToPoll = [this, &poll](std::shared_ptr<StreamSocket> socket, net::AsyncConnectResult result ) {
-            poll.addCallback([selfLifecycle = shared_from_this(), this, &poll, socket=std::move(socket), &result]() {
+            poll.addCallback([selfLifecycle = shared_from_this(), this, &poll, socket=std::move(socket), result]() {
                 asyncConnectCompleted(poll, socket, result);
             });
         };


### PR DESCRIPTION
`result` is allocated on the stack, don't capture its address in a
lambda.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I2d6dad1f76002559e400c57cd5b4ffa0b6e0f0d6
