### PR TITLE
wsd: wopiAccessCheck, fix consistency in CheckStatus SslHandshake

### DIFF
--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1111,7 +1111,7 @@ STATE_ENUM(CheckStatus,
     UnspecifiedError,
     ConnectionAborted,
     CertificateValidation,
-    SSLHandshakeFail,
+    SslHandshakeFail,
     MissingSsl,
     NotHttps,
     NoScheme,
@@ -1270,7 +1270,7 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(const Poco::Net::HTTP
             }
 
             if (result == net::AsyncConnectResult::SSLHandShakeFailure) {
-                status = CheckStatus::SSLHandshakeFail;
+                status = CheckStatus::SslHandshakeFail;
             }
 
             if (!probeSession->getSslVerifyMessage().empty())


### PR DESCRIPTION
Change-Id: I3f04b7877c5ac87f00c75f8326767a4aadd228eb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

