### PR TITLE
jsdialog: allow to open links inside treeview

### DIFF
--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -787,8 +787,6 @@ class TreeViewControl {
 					entry.row,
 					builder,
 				);
-
-			if (e) e.preventDefault();
 		};
 	}
 


### PR DESCRIPTION
This is used in Audit dialog to open SDK help