### PR TITLE
Delay setting layoutIsRtl to ensure correct section positioning

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -687,8 +687,12 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 
 			this._setAnchor('tilesSection', tilesSection,
 				[[L.CSections.ColumnHeader.name, 'bottom', 'top'], [L.CSections.RowHeader.name, '-left', 'right']]);
-
-			this._layoutIsRTL = true;
+			
+			// Do not set layoutIsRtl to true prematurely. If set before all sections are defined 
+			// (e.g., during load with onStatusMsg), some sections may not update to their correct positions. 
+			// Ensure all sections are adjusted first, then set layoutIsRtl to true to show that they have moved.
+			if (rowHeaderSection)
+				this._layoutIsRTL = true;
 
 			sectionContainer.reNewAllSections(true);
 			this._syncTileContainerSize();
@@ -696,7 +700,6 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		} else if (!sheetIsRTL && this._layoutIsRTL === true) {
 
 			console.log('debug: in RTL -> LTR canvas section adjustments');
-			this._layoutIsRTL = false;
 			var sectionContainer = app.sectionContainer;
 
 			var tilesSection = sectionContainer.getSectionWithName(L.CSections.Tiles.name);
@@ -725,6 +728,9 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 
 			columnHeaderSection.anchor = [[L.CSections.ColumnGroup.name, 'bottom', 'top'], [L.CSections.CornerHeader.name, 'right', 'left']];
 			columnHeaderSection.expand = ['right'];
+
+			if (rowHeaderSection)
+				this._layoutIsRTL = false;
 
 			tilesSection.anchor = [[L.CSections.ColumnHeader.name, 'bottom', 'top'], [L.CSections.RowHeader.name, 'right', 'left']];
 


### PR DESCRIPTION
Prevent premature setting of layoutIsRtl, which can cause some sections to remain in incorrect positions if they are not defined before calling _adjustCanvasSectionsForLayoutChange. Fix this by ensuring all sections are adjusted before setting layoutIsRtl.


Change-Id: I13f9e18c185e61265503d413a77a2a8151bb6857


* Resolves: #10814 
* Target version: master 

### Summary

Right now, an early call to _adjustCanvasSectionsForLayoutChange will set the sheet's layoutIsRTL to true before adjusting the anchor position of all of the sections. 

I'm not sure if this is the correct fix.  What I can think of is if "status" messages and w/e calls into _adjustCanvasSectionsForLayoutChange should be delayed further (set is_ready after we render). Any comments on this would be appreciated.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check` (This fails on unit-synthetic-lok, which seems unrelated)
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

