### PR TITLE
Fix scrollbar color in darkmode for writer and draw

### DIFF
--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -417,8 +417,14 @@ export class ScrollSection extends CanvasSectionObject {
 
 	private drawVerticalScrollBar (): void {
 		var scrollProps: any = this.getVerticalScrollProperties();
+		const isDarkBackground = this.map.uiManager.isBackgroundDark();
+		const docType = this.sectionProperties.docLayer._docType;
 
 		var startX = this.isRTL() ? this.sectionProperties.edgeOffset : this.size[0] - this.sectionProperties.scrollBarThickness - this.sectionProperties.edgeOffset;
+
+		if (isDarkBackground && (docType === 'text' || docType === 'drawing')) {
+			this.sectionProperties.scrollBarRailwayColor = 'transparent';
+		}
 
 		if (this.sectionProperties.drawScrollBarRailway) {
 			this.context.globalAlpha = this.sectionProperties.scrollBarRailwayAlpha;


### PR DESCRIPTION
Change-Id: Ied41faf1bd078a72b23e6f1bc6ae26a2268b1b98


* Resolves: #10701 
* Target version: master 

### Summary and testing
Fix scrollbar color in darkmode for writer and draw
Writer|Draw -> View -> change between light and dark mode and move the scrollbars

### BEFORE
[Screencast from 02-01-25 22:58:08.webm](https://github.com/user-attachments/assets/8dc01630-4cdb-4273-85a3-443d8cf5b8c5)


### AFTER FIX
[Screencast from 02-01-25 22:54:33.webm](https://github.com/user-attachments/assets/671e3d21-61ab-4c5f-8b9c-ca9b48aec1a2)



### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

