### PR TITLE
COOL_JS.m4 constantly grows in size (backport co-24.04)

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -757,10 +757,9 @@ $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist: $(COOL_JS_DST)
 	if cmp -s $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist.tmp $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist; then rm $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist.tmp; else mv $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist.tmp $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist; fi
 
 $(INTERMEDIATE_DIR)/COOL_JS.m4: $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist
-	@rm -f COOL_JS.m4
-	$(foreach file,$(NODE_MODULES_JS) $(COOL_LIBS_JS) $(patsubst %.ts,%.js,$(COOL_JS_WEBORDER)), $(shell echo -n $(file), >> $(INTERMEDIATE_DIR)/COOL_JS.m4))
-# remove last ","
-	@truncate -s -1 $(INTERMEDIATE_DIR)/COOL_JS.m4
+	$(foreach file,$(NODE_MODULES_JS) $(COOL_LIBS_JS) $(patsubst %.ts,%.js,$(COOL_JS_WEBORDER)), $(shell echo -n $(file), >> $(INTERMEDIATE_DIR)/COOL_JS.m4.tmp))
+	@truncate -s -1 $(INTERMEDIATE_DIR)/COOL_JS.m4.tmp
+	@mv $(INTERMEDIATE_DIR)/COOL_JS.m4.tmp $(INTERMEDIATE_DIR)/COOL_JS.m4
 
 $(DIST_FOLDER)/cool.html: $(srcdir)/html/cool.html.m4 \
 	$(COOL_HTML_DST) \


### PR DESCRIPTION
and gets multiple duplicates of "script src=" lines in it

and on switching branches, etc there can be entries in it that doesn't exist, which then causes unit-integration to fail on the Fileserver not able to provide all files referenced in cool.html

presumably since:

commit e30367d6344a87787b816a9efd92294711e8c5ba
CommitDate: Wed Aug 28 12:44:57 2024 +0200

    input file to m4 macro through intermediate file, not parameter


Change-Id: Id48ff3b420649532740958e7fed86daf9fa64e99

-----------------------------------------------------------------------------------------
This is backport. I assume see problems with building release branch in CI after container was used for master branch.
eg. https://github.com/CollaboraOnline/online/pull/10835