### PR TITLE
accessibility: missing labelledBy attribute for pushbutton

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1546,6 +1546,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			pushbutton.innerText = pushbuttonText;
 			builder._stressAccessKey(pushbutton, pushbutton.accessKey);
 		}
+		if (image)
+			image.alt = '';
+
 		if (data.enabled === 'false' || data.enabled === false)
 			$(pushbutton).prop('disabled', true);
 
@@ -1555,8 +1558,13 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			pushbutton.onclick = builder.callback.bind(builder, 'responsebutton', 'click', { id: pushbutton.id }, builder._responses[pushbutton.id], builder);
 		else
 			pushbutton.onclick = builder.callback.bind(builder, 'pushbutton', data.isToggle ? 'toggle' : 'click', pushbutton, data.command, builder);
-	
-		builder._addAriaLabel(pushbutton, data, builder);
+
+
+		if (data.labelledBy) {
+			pushbutton.setAttribute('aria-labelledby', data.labelledBy);
+		} else {
+			builder._addAriaLabel(pushbutton, data, builder);
+		}
 
 		builder.map.hideRestrictedItems(data, wrapper, pushbutton);
 		builder.map.disableLockedItem(data, wrapper, pushbutton);


### PR DESCRIPTION
Missing Alt Attribute for push button like Input Range Buttons
The controls do not have alt attributes, which results in screen readers and
other assistive technologies being unable to adequately describe the icons.

The problem has been solved by checking for available labelledBy attribute
beyond aria.label.
The alt attribute is set empty for button image.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I6187cb03fffed960c098e51448b705dd1c787e4b
