### PR TITLE
SSL Improvements (1)

### DIFF
--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -358,7 +358,7 @@ private:
                   << Util::symbolicErrno(last_errno) << ": " << std::strerror(last_errno) << ")"
 
         // Handle non-fatal cases first.
-        const std::string bioErrStr = getBioError(rc);
+        const std::string bioErrStr = getBioError();
         switch (sslError)
         {
             // Not an error; should be handled elsewhere.
@@ -530,13 +530,13 @@ private:
         return rc;
     }
 
-    std::string getBioError(const int rc) const
+    std::string getBioError() const
     {
         // The error is coming from BIO. Find out what happened.
         const long bioError = ERR_peek_error();
 
         std::ostringstream oss;
-        oss << "BIO error: " << bioError << ", rc: " << rc;
+        oss << "BIO error: " << bioError;
 
         char buf[512];
         ERR_error_string_n(bioError, buf, sizeof(buf));

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -300,6 +300,17 @@ private:
             return rc;
         }
 
+        // Handle errors in the error-queue.
+        const int ret = handleSslError(rc, last_errno, context);
+
+        return ret;
+    }
+
+    /// Handle SSL errors after read or write. Called from handleSslState().
+    int handleSslError(const int rc, const int last_errno, const char* context)
+    {
+        assert(rc <= 0 && "Expected SSL failure to handle but have success");
+
         // Last operation failed. Find out if SSL was trying
         // to do something different that failed, or not.
         const int sslError = SSL_get_error(_ssl, rc);

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -414,11 +414,19 @@ private:
                                           << bioErrStr);
 #if OPENSSL_VERSION_NUMBER > 0x10100000L
                 else if (sslError == SSL_ERROR_WANT_ASYNC)
-                    LOG_TRC("SSL error (" << context << "): WANT_ASYNC (" << sslError << ") "
+                {
+                    LOG_WRN("SSL error (" << context << "): WANT_ASYNC (" << sslError << ") "
                                           << bioErrStr);
+                    LOG_ASSERT_MSG(sslError != SSL_ERROR_WANT_ASYNC,
+                                   "Unexpected WANT_ASYNC; SSL_MODE_ASYNC is unsupported");
+                }
                 else if (sslError == SSL_ERROR_WANT_ASYNC_JOB)
-                    LOG_TRC("SSL error (" << context << "): WANT_ASYNC_JOB (" << sslError << ") "
+                {
+                    LOG_WRN("SSL error (" << context << "): WANT_ASYNC_JOB (" << sslError << ") "
                                           << bioErrStr);
+                    LOG_ASSERT_MSG(sslError != SSL_ERROR_WANT_ASYNC_JOB,
+                                   "Unexpected WANT_ASYNC_JOB; SSL_MODE_ASYNC is unsupported");
+                }
 #endif
                 else
                     LOG_TRC("SSL error (" << context << "): UNKNOWN (" << sslError << ") "

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -315,17 +315,19 @@ private:
         // to do something different that failed, or not.
         const int sslError = SSL_get_error(_ssl, rc);
         LOG_ASSERT_MSG(sslError != SSL_ERROR_NONE, "Expected an SSL error to handle but have none");
+
+        const std::string bioErrStr = getBioError(rc);
         switch (sslError)
         {
             case SSL_ERROR_NONE:
                 LOG_TRC("SSL error (" << context << "): ERROR_NONE (" << sslError
-                                      << "): " << getBioError(rc));
+                                      << "): " << bioErrStr);
                 return rc;
 
             case SSL_ERROR_ZERO_RETURN:
                 // Shutdown complete, we're disconnected.
                 LOG_TRC("SSL error (" << context << "): ZERO_RETURN (" << sslError
-                                      << "): " << getBioError(rc));
+                                      << "): " << bioErrStr);
                 errno = last_errno; // Restore errno.
                 return 0;
 
@@ -334,7 +336,7 @@ private:
                 LOG_TRC("SSL error (" << context << "): WANT_READ (" << sslError << ") has "
                                       << (SSL_has_pending(_ssl) ? "" : "no")
                                       << " pending data to read: " << SSL_pending(_ssl) << ". "
-                                      << getBioError(rc));
+                                      << bioErrStr);
 #else
                 LOG_TRC("SSL error (" << context << "): WANT_READ (" << sslError << ").");
 #endif
@@ -347,7 +349,7 @@ private:
                 LOG_TRC("SSL error (" << context << "): WANT_WRITE (" << sslError << ") has "
                                       << (SSL_has_pending(_ssl) ? "" : "no")
                                       << " pending data to read: " << SSL_pending(_ssl) << ". "
-                                      << getBioError(rc));
+                                      << bioErrStr);
 #else
                 LOG_TRC("SSL error: WANT_WRITE (" << sslError << ").");
 #endif
@@ -357,20 +359,20 @@ private:
 
             case SSL_ERROR_WANT_CONNECT:
                 LOG_TRC("SSL error (" << context << "): WANT_CONNECT (" << sslError
-                                      << "): " << getBioError(rc));
+                                      << "): " << bioErrStr);
                 errno = last_errno; // Restore errno.
                 return rc;
 
             case SSL_ERROR_WANT_ACCEPT:
                 LOG_TRC("SSL error (" << context << "): WANT_ACCEPT (" << sslError
-                                      << "): " << getBioError(rc));
+                                      << "): " << bioErrStr);
                 errno = last_errno; // Restore errno.
                 return rc;
 
             case SSL_ERROR_WANT_X509_LOOKUP:
                 // Unexpected.
                 LOG_TRC("SSL error (" << context << "): WANT_X509_LOOKUP (" << sslError
-                                      << "): " << getBioError(rc));
+                                      << "): " << bioErrStr);
                 errno = last_errno; // Restore errno.
                 return rc;
 
@@ -380,7 +382,7 @@ private:
                     // Posix API error, let the caller handle.
                     LOG_TRC("SSL error (" << context << "): SYSCALL error " << sslError << " ("
                                           << Util::symbolicErrno(last_errno) << ": "
-                                          << std::strerror(last_errno) << "): " << getBioError(rc));
+                                          << std::strerror(last_errno) << "): " << bioErrStr);
                     errno = last_errno; // Restore errno.
                     return rc;
                 }
@@ -395,10 +397,10 @@ private:
                     LOG_TRC("BIO asks for retry - underlying EAGAIN? ("
                             << context << "): " << SSL_get_error(_ssl, rc) << " has_pending "
                             << SSL_has_pending(_ssl) << " bytes: " << SSL_pending(_ssl) << ". "
-                            << getBioError(rc));
+                            << bioErrStr);
 #else
                     LOG_TRC("BIO asks for retry - underlying EAGAIN? " << SSL_get_error(_ssl, rc)
-                                                                       << ". " << getBioError(rc));
+                                                                       << ". " << bioErrStr);
 #endif
                     errno = last_errno ? last_errno : EAGAIN; // Restore errno.
                     return -1; // poll is used to detect real errors.
@@ -406,21 +408,21 @@ private:
 
                 if (sslError == SSL_ERROR_SSL)
                     LOG_TRC("SSL error (" << context << "): SSL (" << sslError << ") "
-                                          << getBioError(rc));
+                                          << bioErrStr);
                 else if (sslError == SSL_ERROR_SYSCALL)
                     LOG_TRC("SSL error (" << context << "): SYSCALL (" << sslError << ") "
-                                          << getBioError(rc));
+                                          << bioErrStr);
 #if OPENSSL_VERSION_NUMBER > 0x10100000L
                 else if (sslError == SSL_ERROR_WANT_ASYNC)
                     LOG_TRC("SSL error (" << context << "): WANT_ASYNC (" << sslError << ") "
-                                          << getBioError(rc));
+                                          << bioErrStr);
                 else if (sslError == SSL_ERROR_WANT_ASYNC_JOB)
                     LOG_TRC("SSL error (" << context << "): WANT_ASYNC_JOB (" << sslError << ") "
-                                          << getBioError(rc));
+                                          << bioErrStr);
 #endif
                 else
                     LOG_TRC("SSL error (" << context << "): UNKNOWN (" << sslError << ") "
-                                          << getBioError(rc));
+                                          << bioErrStr);
 
                 // The error is coming from BIO. Find out what happened.
                 const long bioError = ERR_peek_error();
@@ -433,7 +435,7 @@ private:
                     if (rc == 0)
                     {
                         // Socket closed. Not an error.
-                        oss << " (" << context << "): closed. " << getBioError(rc);
+                        oss << " (" << context << "): closed. " << bioErrStr;
                         LOG_INF(oss.str());
                         errno = last_errno; // Restore errno.
                         return 0;
@@ -452,7 +454,7 @@ private:
                     oss << " (" << context << "): unknown. ";
                 }
 
-                oss << getBioError(rc);
+                oss << bioErrStr;
                 const std::string msg = oss.str();
                 LOG_TRC("Throwing SSL Error ("
                         << context << "): " << msg); // Locate the source of the exception.

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -314,8 +314,14 @@ private:
         // Last operation failed. Find out if SSL was trying
         // to do something different that failed, or not.
         const int sslError = SSL_get_error(_ssl, rc);
+        LOG_ASSERT_MSG(sslError != SSL_ERROR_NONE, "Expected an SSL error to handle but have none");
         switch (sslError)
         {
+            case SSL_ERROR_NONE:
+                LOG_TRC("SSL error (" << context << "): ERROR_NONE (" << sslError
+                                      << "): " << getBioError(rc));
+                return rc;
+
             case SSL_ERROR_ZERO_RETURN:
                 // Shutdown complete, we're disconnected.
                 LOG_TRC("SSL error (" << context << "): ZERO_RETURN (" << sslError

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -306,6 +306,42 @@ private:
         return ret;
     }
 
+    /// Maps SSL Error codes to their respective string form.
+    constexpr std::string_view sslErrorToName(int sslError)
+    {
+        switch (sslError)
+        {
+            case SSL_ERROR_NONE:
+                return "NONE";
+            case SSL_ERROR_SSL:
+                return "SSL";
+            case SSL_ERROR_WANT_READ:
+                return "WANT_READ";
+            case SSL_ERROR_WANT_WRITE:
+                return "WANT_WRITE";
+            case SSL_ERROR_WANT_X509_LOOKUP:
+                return "WANT_X509_LOOKUP";
+            case SSL_ERROR_SYSCALL:
+                return "SYSCALL";
+            case SSL_ERROR_ZERO_RETURN:
+                return "ZERO_RETURN";
+            case SSL_ERROR_WANT_CONNECT:
+                return "WANT_CONNECT";
+            case SSL_ERROR_WANT_ACCEPT:
+                return "WANT_ACCEPT";
+            case SSL_ERROR_WANT_ASYNC:
+                return "WANT_ASYNC";
+            case SSL_ERROR_WANT_ASYNC_JOB:
+                return "WANT_ASYNC_JOB";
+            case SSL_ERROR_WANT_CLIENT_HELLO_CB:
+                return "WANT_CLIENT_HELLO_CB";
+            case SSL_ERROR_WANT_RETRY_VERIFY:
+                return "WANT_RETRY_VERIFY";
+        }
+
+        return "UNKNOWN";
+    }
+
     /// Handle SSL errors after read or write. Called from handleSslState().
     int handleSslError(const int rc, const int last_errno, const char* context)
     {
@@ -316,33 +352,35 @@ private:
         const int sslError = SSL_get_error(_ssl, rc);
         LOG_ASSERT_MSG(sslError != SSL_ERROR_NONE, "Expected an SSL error to handle but have none");
 
+#define SSL_LOG_PREFIX(CONTEXT, SSL_ERR, RC, ERRNO)                                                \
+    "SSL error (" << CONTEXT << "): " << sslErrorToName(SSL_ERR) << " (" << SSL_ERR                \
+                  << "), rc: " << RC << ", errno: " << ERRNO << " ("                               \
+                  << Util::symbolicErrno(last_errno) << ": " << std::strerror(last_errno) << ")"
+
         // Handle non-fatal cases first.
         const std::string bioErrStr = getBioError(rc);
         switch (sslError)
         {
             // Not an error; should be handled elsewhere.
             case SSL_ERROR_NONE: // 0
-                LOG_TRC("SSL error (" << context << "): ERROR_NONE (" << sslError
-                                      << "): " << bioErrStr);
+                LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
                 return rc;
 
             // Peer stopped writing. We have nothing more to read, but can write.
             case SSL_ERROR_ZERO_RETURN: // 6
                 // Shutdown complete, we're disconnected.
-                LOG_TRC("SSL error (" << context << "): ZERO_RETURN (" << sslError
-                                      << "): " << bioErrStr);
+                LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
                 errno = last_errno; // Restore errno.
                 return 0;
 
             // Retry: Need to read data.
             case SSL_ERROR_WANT_READ: // 2
 #if OPENSSL_VERSION_NUMBER > 0x10100000L
-                LOG_TRC("SSL error (" << context << "): WANT_READ (" << sslError << ") has "
-                                      << (SSL_has_pending(_ssl) ? "" : "no")
-                                      << " pending data to read: " << SSL_pending(_ssl) << ". "
-                                      << bioErrStr);
+                LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno)
+                        << " has " << (SSL_has_pending(_ssl) ? "" : "no")
+                        << " pending data to read: " << SSL_pending(_ssl) << ". " << bioErrStr);
 #else
-                LOG_TRC("SSL error (" << context << "): WANT_READ (" << sslError << ").");
+                LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
 #endif
                 _sslWantsTo = SslWantsTo::Read;
                 errno = last_errno; // Restore errno.
@@ -351,12 +389,11 @@ private:
             // Retry: Need to write data.
             case SSL_ERROR_WANT_WRITE: // 3
 #if OPENSSL_VERSION_NUMBER > 0x10100000L
-                LOG_TRC("SSL error (" << context << "): WANT_WRITE (" << sslError << ") has "
-                                      << (SSL_has_pending(_ssl) ? "" : "no")
-                                      << " pending data to read: " << SSL_pending(_ssl) << ". "
-                                      << bioErrStr);
+                LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno)
+                        << " has " << (SSL_has_pending(_ssl) ? "" : "no")
+                        << " pending data to read: " << SSL_pending(_ssl) << ". " << bioErrStr);
 #else
-                LOG_TRC("SSL error: WANT_WRITE (" << sslError << ").");
+                LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
 #endif
                 _sslWantsTo = SslWantsTo::Write;
                 errno = last_errno; // Restore errno.
@@ -364,29 +401,25 @@ private:
 
             // Retry.
             case SSL_ERROR_WANT_CONNECT: // 7
-                LOG_TRC("SSL error (" << context << "): WANT_CONNECT (" << sslError
-                                      << "): " << bioErrStr);
+                LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
                 errno = last_errno; // Restore errno.
                 return rc;
 
             // Retry.
             case SSL_ERROR_WANT_ACCEPT: // 8
-                LOG_TRC("SSL error (" << context << "): WANT_ACCEPT (" << sslError
-                                      << "): " << bioErrStr);
+                LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
                 errno = last_errno; // Restore errno.
                 return rc;
 
             // Unexpected: happens only with SSL_CTX_set_client_cert_cb().
             case SSL_ERROR_WANT_X509_LOOKUP: // 4
-                LOG_TRC("SSL error (" << context << "): WANT_X509_LOOKUP (" << sslError
-                                      << "): " << bioErrStr);
+                LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
                 errno = last_errno; // Restore errno.
                 return rc;
 
             // Unexpected: happens only with SSL_CTX_set_client_cert_cb().
             case SSL_ERROR_WANT_CLIENT_HELLO_CB: // 11
-                LOG_TRC("SSL error (" << context << "): WANT_X509_LOOKUP (" << sslError
-                                      << "): " << bioErrStr);
+                LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
                 errno = last_errno; // Restore errno.
                 return rc;
 
@@ -396,9 +429,7 @@ private:
                 if (last_errno != 0)
                 {
                     // Posix API error, let the caller handle.
-                    LOG_TRC("SSL error (" << context << "): SYSCALL error " << sslError << " ("
-                                          << Util::symbolicErrno(last_errno) << ": "
-                                          << std::strerror(last_errno) << "): " << bioErrStr);
+                    LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
                     errno = last_errno; // Restore errno.
                     return rc;
                 }
@@ -425,30 +456,25 @@ private:
                 // Non-recoverable, fatal I/O error occurred.
                 // SSL_shutdown() must not be called.
                 if (sslError == SSL_ERROR_SSL) // 1
-                    LOG_TRC("SSL error (" << context << "): SSL (" << sslError << ") "
-                                          << bioErrStr);
+                    LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
                 else if (sslError == SSL_ERROR_SYSCALL) // 5
-                    LOG_TRC("SSL error (" << context << "): SYSCALL (" << sslError << ") "
-                                          << bioErrStr);
+                    LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
 #if OPENSSL_VERSION_NUMBER > 0x10100000L
                 else if (sslError == SSL_ERROR_WANT_ASYNC) // 9
                 {
-                    LOG_WRN("SSL error (" << context << "): WANT_ASYNC (" << sslError << ") "
-                                          << bioErrStr);
+                    LOG_WRN(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
                     LOG_ASSERT_MSG(sslError != SSL_ERROR_WANT_ASYNC,
                                    "Unexpected WANT_ASYNC; SSL_MODE_ASYNC is unsupported");
                 }
                 else if (sslError == SSL_ERROR_WANT_ASYNC_JOB) // 10
                 {
-                    LOG_WRN("SSL error (" << context << "): WANT_ASYNC_JOB (" << sslError << ") "
-                                          << bioErrStr);
+                    LOG_WRN(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
                     LOG_ASSERT_MSG(sslError != SSL_ERROR_WANT_ASYNC_JOB,
                                    "Unexpected WANT_ASYNC_JOB; SSL_MODE_ASYNC is unsupported");
                 }
 #endif
                 else
-                    LOG_TRC("SSL error (" << context << "): UNKNOWN (" << sslError << ") "
-                                          << bioErrStr);
+                    LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
 
                 // The error is coming from BIO. Find out what happened.
                 const long bioError = ERR_peek_error();
@@ -497,6 +523,8 @@ private:
             }
             break;
         }
+
+#undef SSL_LOG_PREFIX
 
         errno = last_errno; // Restore errno.
         return rc;

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -316,22 +316,26 @@ private:
         const int sslError = SSL_get_error(_ssl, rc);
         LOG_ASSERT_MSG(sslError != SSL_ERROR_NONE, "Expected an SSL error to handle but have none");
 
+        // Handle non-fatal cases first.
         const std::string bioErrStr = getBioError(rc);
         switch (sslError)
         {
-            case SSL_ERROR_NONE:
+            // Not an error; should be handled elsewhere.
+            case SSL_ERROR_NONE: // 0
                 LOG_TRC("SSL error (" << context << "): ERROR_NONE (" << sslError
                                       << "): " << bioErrStr);
                 return rc;
 
-            case SSL_ERROR_ZERO_RETURN:
+            // Peer stopped writing. We have nothing more to read, but can write.
+            case SSL_ERROR_ZERO_RETURN: // 6
                 // Shutdown complete, we're disconnected.
                 LOG_TRC("SSL error (" << context << "): ZERO_RETURN (" << sslError
                                       << "): " << bioErrStr);
                 errno = last_errno; // Restore errno.
                 return 0;
 
-            case SSL_ERROR_WANT_READ:
+            // Retry: Need to read data.
+            case SSL_ERROR_WANT_READ: // 2
 #if OPENSSL_VERSION_NUMBER > 0x10100000L
                 LOG_TRC("SSL error (" << context << "): WANT_READ (" << sslError << ") has "
                                       << (SSL_has_pending(_ssl) ? "" : "no")
@@ -344,7 +348,8 @@ private:
                 errno = last_errno; // Restore errno.
                 return rc;
 
-            case SSL_ERROR_WANT_WRITE:
+            // Retry: Need to write data.
+            case SSL_ERROR_WANT_WRITE: // 3
 #if OPENSSL_VERSION_NUMBER > 0x10100000L
                 LOG_TRC("SSL error (" << context << "): WANT_WRITE (" << sslError << ") has "
                                       << (SSL_has_pending(_ssl) ? "" : "no")
@@ -357,26 +362,37 @@ private:
                 errno = last_errno; // Restore errno.
                 return rc;
 
-            case SSL_ERROR_WANT_CONNECT:
+            // Retry.
+            case SSL_ERROR_WANT_CONNECT: // 7
                 LOG_TRC("SSL error (" << context << "): WANT_CONNECT (" << sslError
                                       << "): " << bioErrStr);
                 errno = last_errno; // Restore errno.
                 return rc;
 
-            case SSL_ERROR_WANT_ACCEPT:
+            // Retry.
+            case SSL_ERROR_WANT_ACCEPT: // 8
                 LOG_TRC("SSL error (" << context << "): WANT_ACCEPT (" << sslError
                                       << "): " << bioErrStr);
                 errno = last_errno; // Restore errno.
                 return rc;
 
-            case SSL_ERROR_WANT_X509_LOOKUP:
-                // Unexpected.
+            // Unexpected: happens only with SSL_CTX_set_client_cert_cb().
+            case SSL_ERROR_WANT_X509_LOOKUP: // 4
                 LOG_TRC("SSL error (" << context << "): WANT_X509_LOOKUP (" << sslError
                                       << "): " << bioErrStr);
                 errno = last_errno; // Restore errno.
                 return rc;
 
-            case SSL_ERROR_SYSCALL:
+            // Unexpected: happens only with SSL_CTX_set_client_cert_cb().
+            case SSL_ERROR_WANT_CLIENT_HELLO_CB: // 11
+                LOG_TRC("SSL error (" << context << "): WANT_X509_LOOKUP (" << sslError
+                                      << "): " << bioErrStr);
+                errno = last_errno; // Restore errno.
+                return rc;
+
+            // Non-recoverable, fatal I/O error occurred.
+            // Check errno *and* the error queue.
+            case SSL_ERROR_SYSCALL: // 5
                 if (last_errno != 0)
                 {
                     // Posix API error, let the caller handle.
@@ -406,21 +422,23 @@ private:
                     return -1; // poll is used to detect real errors.
                 }
 
-                if (sslError == SSL_ERROR_SSL)
+                // Non-recoverable, fatal I/O error occurred.
+                // SSL_shutdown() must not be called.
+                if (sslError == SSL_ERROR_SSL) // 1
                     LOG_TRC("SSL error (" << context << "): SSL (" << sslError << ") "
                                           << bioErrStr);
-                else if (sslError == SSL_ERROR_SYSCALL)
+                else if (sslError == SSL_ERROR_SYSCALL) // 5
                     LOG_TRC("SSL error (" << context << "): SYSCALL (" << sslError << ") "
                                           << bioErrStr);
 #if OPENSSL_VERSION_NUMBER > 0x10100000L
-                else if (sslError == SSL_ERROR_WANT_ASYNC)
+                else if (sslError == SSL_ERROR_WANT_ASYNC) // 9
                 {
                     LOG_WRN("SSL error (" << context << "): WANT_ASYNC (" << sslError << ") "
                                           << bioErrStr);
                     LOG_ASSERT_MSG(sslError != SSL_ERROR_WANT_ASYNC,
                                    "Unexpected WANT_ASYNC; SSL_MODE_ASYNC is unsupported");
                 }
-                else if (sslError == SSL_ERROR_WANT_ASYNC_JOB)
+                else if (sslError == SSL_ERROR_WANT_ASYNC_JOB) // 10
                 {
                     LOG_WRN("SSL error (" << context << "): WANT_ASYNC_JOB (" << sslError << ") "
                                           << bioErrStr);


### PR DESCRIPTION
Non-functional SSL error handling and logging improvements.
Functional changes will follow separately.

- **wsd: net: breakout handleSslError() from handleSslState()**
- **wsd: net: handle SSL_ERROR_NONE**
- **wsd: net: hoist getBioError() and call it once**
- **wsd: net: assert and error on unsupported async encryption**
- **wsd: net: document the error conditions**
- **wsd: net: unify SSL error logging**
- **wsd: net: remove duplicate logging of rc**
