### PR TITLE
Add font size to the jsdialog Push button to ensure it is consistent with other buttons 

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -132,6 +132,7 @@ button.jsdialog img {
 
 .ui-button-box .jsdialog.ui-pushbutton:not(.hidden) {
 	display: initial !important;
+	font-size: var(--default-font-size);
 }
 
 .ui-pushbutton[disabled] {

--- a/browser/css/device-desktop.css
+++ b/browser/css/device-desktop.css
@@ -32,4 +32,5 @@ button:not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-
 .button-primary:hover {
 	background-color: var(--color-primary-lighter);
 	color: var(--color-primary-dark);
+	cursor: pointer;
 }


### PR DESCRIPTION
Change-Id: I2b03d7e241618a75b97e8712c01c94e5c264b2ba


* Resolves: #10859 
* Target version: master 

### Summary
Fixes the font size of the "Push" button to ensure it is consistent with other buttons in the dialog

### Screenshots
![Screenshot from 2025-01-07 14-38-37](https://github.com/user-attachments/assets/d094119c-c7d0-4b3a-86d7-8c46d2974459)


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

