### PR TITLE
SSL Improvements (2)

### DIFF
--- a/common/ConfigUtil.hpp
+++ b/common/ConfigUtil.hpp
@@ -23,6 +23,7 @@
 
 #include <Util.hpp>
 
+#include <atomic>
 #include <string>
 #include <map>
 

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -409,12 +409,16 @@ private:
             // Unexpected: happens only with SSL_CTX_set_client_cert_cb().
             case SSL_ERROR_WANT_X509_LOOKUP: // 4
             case SSL_ERROR_WANT_CLIENT_HELLO_CB: // 11
+                LOG_ASSERT_MSG(!"Unhandled use of SSL_CTX_set_client_cert_cb()",
+                               "Unhandled " << sslErrorToName(sslError)
+                                            << " with SSL_CTX_set_client_cert_cb()");
                 errno = last_errno; // Restore errno.
                 return rc;
 
             case SSL_ERROR_WANT_ASYNC: // 9
             case SSL_ERROR_WANT_ASYNC_JOB: // 10
-                LOG_ASSERT(!"SSL_MODE_ASYNC is unsupported");
+                LOG_ASSERT_MSG(!"Unhandled use of SSL_MODE_ASYNC",
+                               "Unhandled " << sslErrorToName(sslError) << " with SSL_MODE_ASYNC");
                 errno = last_errno; // Restore errno.
                 return rc;
 

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -11,8 +11,11 @@
 
 #pragma once
 
+#include <common/Log.hpp>
 #include <net/Ssl.hpp>
 #include <net/Socket.hpp>
+
+#include <openssl/ssl.h>
 
 #include <cerrno>
 #include <sstream>
@@ -429,6 +432,10 @@ private:
             case SSL_ERROR_SSL: // 1
             default:
             {
+                // We should know what errors we handle here.
+                LOG_ASSERT_MSG(sslError == SSL_ERROR_SYSCALL || sslError == SSL_ERROR_SSL,
+                               "Unexpected SSL error " << sslErrorToName(sslError));
+
                 // Effectively an EAGAIN error at the BIO layer
                 if (BIO_should_retry(_bio))
                 {

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -351,14 +351,12 @@ private:
         const int sslError = SSL_get_error(_ssl, rc);
         LOG_ASSERT_MSG(sslError != SSL_ERROR_NONE, "Expected an SSL error to handle but have none");
 
-#define SSL_LOG_PREFIX(CONTEXT, SSL_ERR, RC, ERRNO)                                                \
-    "SSL error (" << CONTEXT << "): " << sslErrorToName(SSL_ERR) << " (" << SSL_ERR                \
-                  << "), rc: " << RC << ", errno: " << ERRNO << " ("                               \
-                  << Util::symbolicErrno(last_errno) << ": " << std::strerror(last_errno) << ")"
-
         // Handle non-fatal cases first.
         const std::string bioErrStr = getBioError();
-        LOG_TRC(SSL_LOG_PREFIX(context, sslError, rc, last_errno) << ": " << bioErrStr);
+        LOG_TRC("SSL error (" << context << "): " << sslErrorToName(sslError) << " (" << sslError
+                              << "), rc: " << rc << ", errno: " << last_errno << " ("
+                              << Util::symbolicErrno(last_errno) << ": "
+                              << std::strerror(last_errno) << ")" << ": " << bioErrStr);
 
         switch (sslError)
         {
@@ -482,8 +480,6 @@ private:
             }
             break;
         }
-
-#undef SSL_LOG_PREFIX
 
         errno = last_errno; // Restore errno.
         return rc;


### PR DESCRIPTION
More non-functional error-handling improvements.
This greatly simplifies error handling, _without_ introducing any functional changes.
Functional changes will follow.

- **wsd: net: simplify ssl error handling**
- **wsd: net: unify SSL error logging**
- **wsd: net: remove single-use macro**
- **wsd: net: conditional use of SSL_ERROR_WANT_RETRY_VERIFY**
- **wsd: include missing atomic header**
- **wsd: net: assert catch-all SSL errors**
- **wsd: net: peek the error only once**
- **wsd: net: assert on unexpected SSL errors**
- **wsd: net: hoist restoring errno**
