### PR TITLE
calc: allow multi-selection of functions in statusbar

### DIFF
--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -196,19 +196,25 @@ class StatusBar extends JSDialog.Toolbar {
 		};
 	}
 
-	_generateStateTableCellMenuItem(value, visible) {
+	_generateStateMenuEntry(id, text, selection) {
+		return {id: id, text: text, selected: !!(selection & parseInt(id))};
+	}
+
+	_generateStateTableCellMenuItem(selection, visible) {
 		var submenu = [
-			{id: '2', text: _('Average')},
-			{id: '8', text: _('CountA')},
-			{id: '4', text: _('Count')},
-			{id: '16', text: _('Maximum')},
-			{id: '32', text: _('Minimum')},
-			{id: '512', text: _('Sum')},
-			{id: '8192', text: _('Selection count')},
-			{id: '1', text: _('None')}
+			this._generateStateMenuEntry('2', _('Average'), selection),
+			this._generateStateMenuEntry('8', _('CountA'), selection),
+			this._generateStateMenuEntry('4', _('Count'), selection),
+			this._generateStateMenuEntry('16', _('Maximum'), selection),
+			this._generateStateMenuEntry('32', _('Minimum'), selection),
+			this._generateStateMenuEntry('512', _('Sum'), selection),
+			this._generateStateMenuEntry('8192', _('Selection count'), selection),
+			this._generateStateMenuEntry('1', _('None'), selection)
 		];
-		var selected = submenu.filter((item) => { return item.id === value; });
-		var text = selected.length ? selected[0].text : _('None');
+		var selected = submenu
+			.filter((item) => { return item.selected; })
+			.map((item) => { return item.text; });
+		var text = selected.length ? selected.join('; ') : _('None');
 		return {type: 'menubutton', id: 'StateTableCellMenu', text: text, image: false, menu: submenu, visible: visible};
 	}
 
@@ -254,7 +260,7 @@ class StatusBar extends JSDialog.Toolbar {
 			{type: 'menubutton', id: 'languagestatus:LanguageStatusMenu'},	// spreadsheet, text, presentation
 			{type: 'separator', id: 'languagestatusbreak', orientation: 'vertical', visible: false}, // spreadsheet
 			this._generateHtmlItem('statetablecell'),					// spreadsheet
-			this._generateStateTableCellMenuItem('2', false),			// spreadsheet
+			this._generateStateTableCellMenuItem(2, false),			// spreadsheet
 			{type: 'separator', id: 'statetablebreak', orientation: 'vertical', visible: false}, // spreadsheet
 			this._generateHtmlItem('permissionmode'),					// spreadsheet, text, presentation
 			{type: 'toolitem', id: 'signstatus', command: '.uno:Signature', w2icon: '', text: _UNO('.uno:Signature'), visible: false},
@@ -480,6 +486,10 @@ class StatusBar extends JSDialog.Toolbar {
 			// Check 'None' even when state is 0
 			if (state === '0')
 				state = '1';
+
+			try {
+				state = parseInt(state);
+			} catch (e) { console.error(e); state = 1; }
 
 			this.builder.updateWidget(this.parentContainer, this._generateStateTableCellMenuItem(state, true));
 			JSDialog.RefreshScrollables();

--- a/cypress_test/integration_tests/desktop/calc/statusbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/statusbar_spec.js
@@ -12,6 +12,9 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Statubar tests.', function
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
 			desktopHelper.showStatusBarIfHidden();
 		}
+
+		cy.cGet(helper.addressInputSelector).should('have.value', 'A3');
+		cy.wait(100);
 	});
 
 	it('Selected sheet.', function() {
@@ -44,6 +47,12 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Statubar tests.', function
 		cy.cGet('#StateTableCell').should('have.text', 'Average: 15.5; Sum: 31');
 		helper.typeIntoInputField(helper.addressInputSelector, 'A1');
 		cy.cGet('#StateTableCell').should('have.text', 'Average: 10; Sum: 10');
+
+		desktopHelper.makeZoomItemsVisible();
+		cy.cGet('#StateTableCellMenu .unolabel').contains('Average; Sum');
+		cy.cGet('#StateTableCellMenu .arrowbackground').click();
+		cy.cGet('.jsdialog-overlay').should('exist');
+		cy.cGet('.ui-combobox-entry.selected').contains(/Average|Sum/g);
 	});
 
 	it('Change zoom level.', function() {


### PR DESCRIPTION
not possible to mark multiple entries yet, but it is visible if core has it activated

AFTER FIX:
![funccalc](https://github.com/user-attachments/assets/222d1267-905c-4d36-9d9d-cd2410c51e8d)

multiple entries are selected