### PR TITLE
Add white space nowrap to radio button label

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -784,6 +784,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 
 .jsdialog .radiobutton > label {
 	vertical-align: middle;
+	white-space: nowrap;
 }
 
 .jsdialog input[type='radio'][disabled='disabled'] ~ label {


### PR DESCRIPTION
Change-Id: Ia5993bfbad217bc51780b155b80feab4bcaf4684


* Resolves: #10860 
* Target version: master 

### Summary
The radio button labels were wrapping to the next line in cases of limited space, causing misalignment and poor readability. Adding white-space: nowrap ensures the labels remain on a single line, maintaining a consistent and professional appearance across all layouts.

### Before
![400545651-8876626e-b66b-4ca9-b4ff-77fecc49f01b](https://github.com/user-attachments/assets/0558c1f1-7e7a-4ac9-ba89-986054215319)


### AFTER
![Screenshot from 2025-01-08 00-28-01](https://github.com/user-attachments/assets/1dd59078-6228-43f4-a7f1-a744d163ad55)


- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

