### PR TITLE
Improve URL popup positioning.

### DIFF
--- a/browser/src/canvas/sections/URLPopUpSection.ts
+++ b/browser/src/canvas/sections/URLPopUpSection.ts
@@ -146,26 +146,27 @@ class URLPopUpSection extends HTMLObjectSection {
 	}
 
 	public static resetPosition(section: URLPopUpSection) {
-		if (!section)
-			section = app.sectionContainer.getSectionWithName(URLPopUpSection.sectionName);
+		if (!section) section = app.sectionContainer.getSectionWithName(URLPopUpSection.sectionName);
+		if (!section) return;
 
 		let left = section.sectionProperties.documentPosition.pX - section.getPopUpWidth() * 0.5 * app.dpiScale;
 		let top = section.sectionProperties.documentPosition.pY - (section.getPopUpHeight() + URLPopUpSection.popupVerticalMargin) * app.dpiScale;
 
-		if (section) {
-			let arrowAtTop = false;
-			if (top < 0) {
-				top = section.sectionProperties.documentPosition.pY + (URLPopUpSection.popupVerticalMargin * 2 * app.dpiScale);
-				arrowAtTop = true;
-			}
+		const checkLeft = (section.sectionProperties.documentPosition.pX - section.containerObject.getDocumentTopLeft()[0]) - section.getPopUpWidth() * 0.5 * app.dpiScale;
+		const checkTop = (section.sectionProperties.documentPosition.pY - section.containerObject.getDocumentTopLeft()[1]) - (section.getPopUpHeight() + URLPopUpSection.popupVerticalMargin) * app.dpiScale;
 
-			if (left < 0) left = 0;
-
-			section.setPosition(left, top);
-			section.adjustHTMLObjectPosition();
-			section.reLocateArrow(arrowAtTop);
-			section.containerObject.requestReDraw();
+		let arrowAtTop = false;
+		if (checkTop < 0) {
+			top = section.sectionProperties.documentPosition.pY + (URLPopUpSection.popupVerticalMargin * 2 * app.dpiScale);
+			arrowAtTop = true;
 		}
+
+		if (checkLeft < 0) left = section.documentTopLeft[0];
+
+		section.setPosition(left, top);
+		section.adjustHTMLObjectPosition();
+		section.reLocateArrow(arrowAtTop);
+		section.containerObject.requestReDraw();
 	}
 
 	public static showURLPopUP(url: string, documentPosition: cool.SimplePoint, linkPosition?: cool.SimplePoint) {

--- a/browser/src/canvas/sections/URLPopUpSection.ts
+++ b/browser/src/canvas/sections/URLPopUpSection.ts
@@ -149,21 +149,21 @@ class URLPopUpSection extends HTMLObjectSection {
 		if (!section) section = app.sectionContainer.getSectionWithName(URLPopUpSection.sectionName);
 		if (!section) return;
 
-		let left = section.sectionProperties.documentPosition.pX - section.getPopUpWidth() * 0.5 * app.dpiScale;
-		let top = section.sectionProperties.documentPosition.pY - (section.getPopUpHeight() + URLPopUpSection.popupVerticalMargin) * app.dpiScale;
+		let originalLeft = section.sectionProperties.documentPosition.pX - section.getPopUpWidth() * 0.5 * app.dpiScale;
+		let originalTop = section.sectionProperties.documentPosition.pY - (section.getPopUpHeight() + URLPopUpSection.popupVerticalMargin) * app.dpiScale;
 
-		const checkLeft = (section.sectionProperties.documentPosition.pX - section.containerObject.getDocumentTopLeft()[0]) - section.getPopUpWidth() * 0.5 * app.dpiScale;
-		const checkTop = (section.sectionProperties.documentPosition.pY - section.containerObject.getDocumentTopLeft()[1]) - (section.getPopUpHeight() + URLPopUpSection.popupVerticalMargin) * app.dpiScale;
+		const checkLeft = originalLeft - section.containerObject.getDocumentTopLeft()[0];
+		const checkTop = originalTop - section.containerObject.getDocumentTopLeft()[1];
 
 		let arrowAtTop = false;
 		if (checkTop < 0) {
-			top = section.sectionProperties.documentPosition.pY + (URLPopUpSection.popupVerticalMargin * 2 * app.dpiScale);
+			originalTop = section.sectionProperties.documentPosition.pY + (URLPopUpSection.popupVerticalMargin * 2 * app.dpiScale);
 			arrowAtTop = true;
 		}
 
-		if (checkLeft < 0) left = section.documentTopLeft[0];
+		if (checkLeft < 0) originalLeft = section.documentTopLeft[0];
 
-		section.setPosition(left, top);
+		section.setPosition(originalLeft, originalTop);
 		section.adjustHTMLObjectPosition();
 		section.reLocateArrow(arrowAtTop);
 		section.containerObject.requestReDraw();


### PR DESCRIPTION
In Writer, it was not performing well. Document position is also taken into account.

Issue:
* Open a Writer file.
* Add some text and a hyperlink.
* Scroll down the document and let the hyperlink be the first visible row.
* If you click on the text part with the link, hyperlink popup will be shown in the invisible area.


Change-Id: Idfd01a0486bf0ce0f072472c3ca6dfe26d1f6014


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

