### PR TITLE
a11y: treeview get current entry focused

### DIFF
--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -732,6 +732,7 @@ class TreeViewControl {
 		L.DomUtil.addClass(span, 'selected');
 		span.setAttribute('aria-selected', 'true');
 		span.tabIndex = 0;
+		span.focus();
 		if (checkbox) checkbox.removeAttribute('tabindex');
 	}
 

--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -352,7 +352,11 @@ class TreeViewControl {
 		level: number,
 		parent: HTMLElement,
 	) {
-		const tr = L.DomUtil.create('div', 'ui-treeview-entry', parent);
+		const tr = L.DomUtil.create(
+			'div',
+			builder.options.cssClass + ' ui-treeview-entry',
+			parent,
+		);
 		let dummyColumns = 0;
 		if (this._hasState) dummyColumns++;
 		tr.style.gridColumn = '1 / ' + (this._columns + dummyColumns + 1);


### PR DESCRIPTION
This hack removes the need to press the `tab` key in order to get a tree entry
focused after clicking on it.

That improves usability for the Navigation pane and also for gridview such as
the one for the 'font' tab in the Format cell dialog.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I1be820367f935c8460ab5a60ef74cc648230ac64
