### PR TITLE
Safer Socket Closed State

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1490,12 +1490,11 @@ bool StreamSocket::checkRemoval(std::chrono::steady_clock::time_point now)
             if (!isClosed())
             {
                 // Note: Ensure proper semantics of onDisconnect()
-                LOG_WRN("Socket still open post onDisconnect(), forced shutdown.");
-                shutdown(); // signal
-                closeConnection(); // real -> setClosed()
+                LOG_WRN("Socket still open post onDisconnect(), forcing shutdown");
             }
         }
-        else
+
+        if (!isClosed())
         {
             shutdown(); // signal
             closeConnection(); // real -> setClosed()

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -628,7 +628,7 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
                 // re-entrancy hazard
                 LOG_DBG("Unexpected socket poll resize");
             }
-            else if (!_pollSockets[i])
+            else if (!_pollSockets[i] || _pollSockets[i]->getFD() < 0)
             {
                 // removed in a callback
                 ++itemsErased;
@@ -682,11 +682,10 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
             LOG_TRC("Scanning to removing " << itemsErased << " defunct sockets from "
                     << _pollSockets.size() << " sockets");
 
-            _pollSockets.erase(
-                std::remove_if(_pollSockets.begin(), _pollSockets.end(),
-                    [](const std::shared_ptr<Socket>& s)->bool
-                    { return !s; }),
-                _pollSockets.end());
+            _pollSockets.erase(std::remove_if(_pollSockets.begin(), _pollSockets.end(),
+                                              [](const std::shared_ptr<Socket>& s) -> bool
+                                              { return !s || s->getFD() < 0; }),
+                               _pollSockets.end());
         }
     }
 

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -147,7 +147,6 @@ public:
         : _type(type)
         , _clientPort(0)
         , _fd(createSocket(type))
-        , _closed(_fd < 0)
         , _creationTime(creationTime)
         , _lastSeenTime(_creationTime)
         , _bytesSent(0)
@@ -172,8 +171,8 @@ public:
         }
     }
 
-    /// Returns true if this socket has been closed, i.e. rejected from polling and potentially shutdown
-    bool isClosed() const { return _closed; }
+    /// Returns true iff this socket has been closed or is invalid.
+    bool isClosed() const { return _fd < 0; }
 
     constexpr Type type() const { return _type; }
     constexpr bool isIPType() const { return Type::IPv4 == _type || Type::IPv6 == _type; }
@@ -221,11 +220,11 @@ public:
         if (!_noShutdown)
         {
             LOG_TRC("Socket shutdown RDWR. " << *this);
-            setClosed();
             if constexpr (!Util::isMobileApp())
                 ::shutdown(_fd, SHUT_RDWR);
             else
                 fakeSocketShutdown(_fd);
+            setClosed(); // Invalidate the FD.
         }
     }
 
@@ -418,7 +417,6 @@ protected:
         : _type(type)
         , _clientPort(0)
         , _fd(fd)
-        , _closed(_fd < 0)
         , _creationTime(creationTime)
         , _lastSeenTime(_creationTime)
         , _bytesSent(0)
@@ -438,7 +436,7 @@ protected:
     void setNoShutdown() { _noShutdown = true; }
 
     /// Explicitly marks this socket closed, i.e. rejected from polling and potentially shutdown
-    void setClosed() { _closed = true; }
+    void setClosed() { _fd = -1; }
 
     /// Explicitly marks this socket and the given SocketDisposition closed
     void setClosed(SocketDisposition &disposition) { setClosed(); disposition.setClosed(); }
@@ -478,9 +476,7 @@ private:
     std::string _clientAddress;
     const Type _type;
     unsigned int _clientPort;
-    const int _fd;
-    /// True if this socket is closed.
-    bool _closed;
+    int _fd; ///< The socket file-descriptor. Invalid/closed if < 0.
 
     const std::chrono::steady_clock::time_point _creationTime;
     std::chrono::steady_clock::time_point _lastSeenTime;


### PR DESCRIPTION
This combines the _closed member of Socket
with the _fd, such that we invalidate the
_fd and don't need a separate flag. This
is safer and reduces duplication.

This fixes a possible bug where we
inadvertently close _another_ socket
when we call shutdown(2) on the already
closed FD after the FD gets recycled.

For example, StreamSocket::checkRemoval()
has a case where we unconditionally call
Socket::shutdown(), via closeConnection(),
which calls shutdown(2). There could
easily be other cases where we close a
socket that can later be reused by
accept(2) before we call shutdown(2) on
this recylced FD again, closing the
recently accepted connection.

If this has been happening in the wild,
it probably is rather rare, otherwise
we should have seen more issues related
to closed sockets. Still, there have
been numerous cases over the years of
unexplained reports with closed sockets
(discounting those that were proven to be
due to external components).

It is the prudent thing to invalidate any
and all FD's post closing.


- **wsd: replace _closed member with invalidating the FD**
- **wsd: invalidate socket FD by negating**
- **wsd: simplify shutting down in checkRemoval**
