### PR TITLE
cypress: check search with following off

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2507,6 +2507,10 @@ L.CanvasTileLayer = L.Layer.extend({
 			{
 				var _fillColor = '#CCCCCC';
 				var strTwips = result.twipsRectangles.match(/\d+/g);
+
+				if (!strTwips || !strTwips.length)
+					continue;
+
 				var rectangles = [];
 				for (var i = 0; i < strTwips.length; i += 4) {
 					var topLeftTwips = new L.Point(parseInt(strTwips[i]), parseInt(strTwips[i + 1]));

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1009,7 +1009,7 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	_isLatLngInView: function (position) {
 		var centerOffset = this._map._getCenterOffset(position);
-		var viewHalf = this._map._getCenterLayerPoint();
+		var viewHalf = this._map.getSize()._divideBy(2);
 		var positionInView =
 			centerOffset.x > -viewHalf.x && centerOffset.x < viewHalf.x &&
 			centerOffset.y > -viewHalf.y && centerOffset.y < viewHalf.y;
@@ -2474,7 +2474,15 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 		this._searchTerm = originalPhrase;
 		this._map.fire('search', {originalPhrase: originalPhrase, count: count, highlightAll: highlightAll, results: results});
-		app.setFollowingUser(this._viewId, /* instant jump */ true);
+
+		app.setFollowingUser(this._viewId);
+
+		// always jump to search result - we already received cell / text cursor before so we need
+		// to force it in case we had following OFF
+		if (app.file.textCursor.visible)
+			this._onUpdateCursor(/* scroll */ true);
+		else if (app.calc.cellCursorVisible)
+			this._onUpdateCellCursor(/* scroll */ true);
 	},
 
 	_clearSearchResults: function() {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4168,7 +4168,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			}
 
 			if (oldSize.x !== newSize.x || oldSize.y !== newSize.y) {
-				this._map.invalidateSize();
+				this._map.invalidateSize({}, oldSize);
 			}
 
 			var hasMobileWizardOpened = this._map.uiManager.mobileWizard ? this._map.uiManager.mobileWizard.isOpen() : false;

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -794,7 +794,9 @@ L.Map = L.Evented.extend({
 		return this.panTo(newCenter, options);
 	},
 
-	invalidateSize: function (options) {
+	// If map size has already been updated, invalidateSize needs the oldSize to work properly
+	// (e.g. if getSize() has already been called whith _sizeChanged === true)
+	invalidateSize: function (options, oldSize) {
 		if (!this._loaded) { return this; }
 
 		options = L.extend({
@@ -802,7 +804,9 @@ L.Map = L.Evented.extend({
 			pan: false
 		}, options === true ? {animate: true} : options);
 
-		var oldSize = this.getSize();
+		if (!oldSize) {
+			oldSize = this.getSize();
+		}
 		this._sizeChanged = true;
 
 		var newSize = this.getSize(),

--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -551,6 +551,15 @@ function scrollWriterDocumentToTop() {
 	assertScrollbarPosition('vertical', 0, 10);
 }
 
+function scrollViewDown() {
+	cy.getFrameWindow()
+		.its('L')
+		.then(function(L) {
+			L.Map.THIS.panBy({x: 0, y: 4000});
+			updateFollowingUsers();
+		});
+}
+
 function updateFollowingUsers() {
 	cy.getFrameWindow()
 		.its('app')
@@ -603,5 +612,6 @@ module.exports.switchUIToCompact = switchUIToCompact;
 module.exports.checkAccessibilityEnabledToBe = checkAccessibilityEnabledToBe;
 module.exports.setAccessibilityState = setAccessibilityState;
 module.exports.scrollWriterDocumentToTop = scrollWriterDocumentToTop;
+module.exports.scrollViewDown = scrollViewDown;
 module.exports.updateFollowingUsers = updateFollowingUsers;
 module.exports.assertVisiblePage = assertVisiblePage;

--- a/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
@@ -14,11 +14,11 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell
 	});
 
 	it('No jump on long merged cell', function() {
-		desktopHelper.assertScrollbarPosition('horizontal', 205, 315);
+		desktopHelper.assertScrollbarPosition('horizontal', 205, 320);
 		calcHelper.clickOnFirstCell(true, false, false);
 
 		cy.cGet(helper.addressInputSelector).should('have.value', 'A1:Z1');
-		desktopHelper.assertScrollbarPosition('horizontal', 205, 315);
+		desktopHelper.assertScrollbarPosition('horizontal', 205, 320);
 	});
 
 	it('Jump on address with not visible cursor', function() {
@@ -30,7 +30,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell
 	});
 
 	it('Jump on search with not visible cursor', function() {
-		desktopHelper.assertScrollbarPosition('horizontal', 205, 315);
+		desktopHelper.assertScrollbarPosition('horizontal', 205, 320);
 		cy.cGet('input#search-input').clear().type('FIRST{enter}');
 
 		cy.cGet(helper.addressInputSelector).should('have.value', 'A10');

--- a/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
@@ -50,7 +50,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		}
 
 		// Document should scroll
-		desktopHelper.assertScrollbarPosition('vertical', 250, 270);
+		desktopHelper.assertScrollbarPosition('vertical', 230, 250);
 		// Document should not scroll horizontally
 		desktopHelper.assertScrollbarPosition('horizontal', 48, 50);
 	});
@@ -73,6 +73,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		}
 
 		// Document should scroll
-		desktopHelper.assertScrollbarPosition('horizontal', 160, 190);
+		desktopHelper.assertScrollbarPosition('horizontal', 80, 110);
 	});
 });

--- a/cypress_test/integration_tests/desktop/calc/searchbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/searchbar_spec.js
@@ -1,6 +1,7 @@
-/* global describe it cy beforeEach require*/
+/* global describe it cy beforeEach expect require*/
 
 var helper = require('../../common/helper');
+var desktopHelper = require('../../common/desktop_helper');
 var searchHelper = require('../../common/search_helper');
 
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar.', function() {
@@ -33,6 +34,38 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar.'
 
 		searchHelper.searchNext();
 		cy.cGet(helper.addressInputSelector).should('have.value', 'A301');
+	});
+
+	it('Search existing word when not following own view', function() {
+		desktopHelper.assertScrollbarPosition('vertical', 10, 30);
+
+		cy.getFrameWindow().its('app').then((app) => {
+			expect(app.isFollowingOff()).to.be.false;
+		});
+
+		desktopHelper.scrollViewDown();
+
+		desktopHelper.assertScrollbarPosition('vertical', 175, 205);
+
+		cy.getFrameWindow().its('app').then((app) => {
+			expect(app.isFollowingOff()).to.be.true;
+		});
+
+		helper.setDummyClipboardForCopy();
+		searchHelper.typeIntoSearchField('a');
+
+		searchHelper.searchNext();
+
+		cy.cGet(helper.addressInputSelector).should('have.value', 'A1');
+		desktopHelper.assertScrollbarPosition('vertical', 10, 30);
+
+		desktopHelper.scrollViewDown();
+
+		searchHelper.typeIntoSearchField('c');
+		searchHelper.searchNext();
+
+		cy.cGet(helper.addressInputSelector).should('have.value', 'C1');
+		desktopHelper.assertScrollbarPosition('vertical', 10, 30);
 	});
 
 	it('Search not existing word.', function() {

--- a/cypress_test/integration_tests/desktop/calc/sheet_switch_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/sheet_switch_spec.js
@@ -30,12 +30,12 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Sheet switching tests', fu
 	it('Check view position on repeated selection of currently selected sheet', function() {
 		// initially we are on sheet 2 tab
 		cy.cGet(helper.addressInputSelector).should('have.prop', 'value', 'F720');
-		desktopHelper.assertScrollbarPosition('vertical', 330, 350);
+		desktopHelper.assertScrollbarPosition('vertical', 260, 300);
 
 		// click on sheet 2 tab (yes, current one)
 		cy.cGet('#spreadsheet-tab1').click();
 		cy.cGet(helper.addressInputSelector).should('have.prop', 'value', 'F720');
-		desktopHelper.assertScrollbarPosition('vertical', 330, 350);
+		desktopHelper.assertScrollbarPosition('vertical', 220, 285);
 
 		// go to different place in the spreadsheet
 		cy.cGet(helper.addressInputSelector).type('{selectAll}A2{enter}');

--- a/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require */
+/* global describe it cy beforeEach expect require */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -105,7 +105,13 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar' 
 	});
 
 	it('Search when cursor not visible', function() {
+		cy.wait(3000);
+
 		desktopHelper.assertScrollbarPosition('vertical', 0, 10);
+
+		cy.getFrameWindow().its('app').then((app) => {
+			expect(app.isFollowingOff()).to.be.false;
+		});
 
 		helper.setDummyClipboardForCopy();
 		searchHelper.typeIntoSearchField('sit');
@@ -115,19 +121,25 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar' 
 
 		helper.copy();
 		helper.expectTextForClipboard('sit');
-		desktopHelper.assertScrollbarPosition('vertical', 60, 75);
+		desktopHelper.assertScrollbarPosition('vertical', 55, 155);
 		desktopHelper.assertVisiblePage(1, 2, 6);
 
 		// Scroll document to the top so cursor is no longer visible, that turns following off
 		desktopHelper.scrollWriterDocumentToTop();
 		desktopHelper.updateFollowingUsers();
 
-		cy.cGet('#searchnext').click();
-		desktopHelper.assertScrollbarPosition('vertical', 135, 150);
-		desktopHelper.assertVisiblePage(2, 3, 6);
+		cy.getFrameWindow().its('app').then((app) => {
+			expect(app.isFollowingOff()).to.be.true;
+		});
+
+		desktopHelper.assertScrollbarPosition('vertical', 0, 30);
 
 		cy.cGet('#searchnext').click();
-		desktopHelper.assertScrollbarPosition('vertical', 215, 230);
+		desktopHelper.assertScrollbarPosition('vertical', 130, 230);
+		desktopHelper.assertVisiblePage(3, 4, 6);
+
+		cy.cGet('#searchnext').click();
+		desktopHelper.assertScrollbarPosition('vertical', 200, 300);
 		desktopHelper.assertVisiblePage(3, 4, 6);
 	});
 });

--- a/cypress_test/integration_tests/multiuser/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/cell_cursor_spec.js
@@ -22,7 +22,7 @@ describe(['tagmultiuser'], 'Check cell cursor and view behavior', function() {
 		cy.cSetActiveFrame('#iframe1');
 
 		cy.cGet(helper.addressInputSelector).type('{selectAll}A400{enter}');
-		desktopHelper.assertScrollbarPosition('vertical', 210, 240);
+		desktopHelper.assertScrollbarPosition('vertical', 185, 240);
 		cy.cGet('#sc_input_window .ui-custom-textarea-text-layer').click();
 		cy.cGet('#sc_input_window .ui-custom-textarea-text-layer').type('some text{enter}');
 
@@ -31,7 +31,7 @@ describe(['tagmultiuser'], 'Check cell cursor and view behavior', function() {
 		cy.cGet('#followingChip').click();
 
 		// verify that second view is scrolled to the: A400
-		desktopHelper.assertScrollbarPosition('vertical', 210, 240);
+		desktopHelper.assertScrollbarPosition('vertical', 185, 240);
 
 		// second view should still have cursor at the end: A588
 		cy.cGet(helper.addressInputSelector).should('have.prop', 'value', 'A588');
@@ -42,7 +42,7 @@ describe(['tagmultiuser'], 'Check cell cursor and view behavior', function() {
 
 		// verify that second view is still at the: A400
 		cy.cSetActiveFrame('#iframe2');
-		desktopHelper.assertScrollbarPosition('vertical', 210, 240);
+		desktopHelper.assertScrollbarPosition('vertical', 185, 240);
 
 		// second view should still have cursor at the previous cell: A588+1
 		cy.cGet(helper.addressInputSelector).should('have.prop', 'value', 'A589');
@@ -59,13 +59,13 @@ describe(['tagmultiuser'], 'Check cell cursor and view behavior', function() {
 		cy.cSetActiveFrame('#iframe1');
 
 		cy.cGet(helper.addressInputSelector).type('{selectAll}A400{enter}');
-		desktopHelper.assertScrollbarPosition('vertical', 210, 240);
+		desktopHelper.assertScrollbarPosition('vertical', 185, 240);
 		calcHelper.clickOnFirstCell(true, false, false);
 		cy.cGet('#map').type('abc{enter}');
 
 		// second view should jump there
 		cy.cSetActiveFrame('#iframe2');
-		desktopHelper.assertScrollbarPosition('vertical', 210, 240);
+		desktopHelper.assertScrollbarPosition('vertical', 185, 240);
 
 		// first view inserts sheet before current one
 		cy.cSetActiveFrame('#iframe1');
@@ -83,6 +83,6 @@ describe(['tagmultiuser'], 'Check cell cursor and view behavior', function() {
 		// first goes to second sheet and we should see A388
 		cy.cSetActiveFrame('#iframe1');
 		cy.cGet('#spreadsheet-tab1').click();
-		desktopHelper.assertScrollbarPosition('vertical', 210, 240);
+		desktopHelper.assertScrollbarPosition('vertical', 185, 240);
 	});
 });


### PR DESCRIPTION
Followup for https://github.com/CollaboraOnline/online/pull/10876:
- cell not fully visible if we scroll to it after search (thanks to [@jaumep](https://phabricator.collabora.com/p/jaumep/) )
- fix for turning off following ( regression )
- jump to found result always ( if have text cursor or cell cursor visible)
- added cypress tests