### PR TITLE
Fix for #10885 : uncaught typeerror when leaving

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1675,10 +1675,8 @@ app.definitions.Socket = L.Class.extend({
 		if (this._map._docLayer) {
 			this._map._docLayer.removeAllViews();
 			this._map._docLayer._resetClientVisArea();
-			if (GraphicSelection.hasActiveSelection()) {
+			if (GraphicSelection.hasActiveSelection())
 				GraphicSelection.rectangle = null;
-				this._map._docLayer._onUpdateGraphicSelection();
-			}
 			if (this._map._docLayer._docType === 'presentation')
 				app.file.textCursor.visible = false;
 


### PR DESCRIPTION
Possibly regression from commit 4512fc8f4064c1472c3c134e7e76cb1377fe6064 Move graphic selection related logic to its own file.

Socket.js:1680 Uncaught TypeError: this._map._docLayer._onUpdateGraphicSelection is not a function
    at NewClass._onSocketClose (Socket.js:1680:25)
_onSocketClose	@	Socket.js:1680

we don't have that function anymore
