### PR TITLE
wsd: Simplify HTTP request to use direct octet-stream content type

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -2024,23 +2024,15 @@ void FileServerRequestHandler::uploadFileToNextcloud(const Poco::Net::HTTPReques
         // TODO : Handle nextcloud wopi url dynamically
         // TODO : Extract nextcloud wopi fileupload stuff so we can re-use it
         Poco::URI wopiUri("http://nextcloud.local/index.php/apps/richdocuments/wopi/settings/upload");
-        wopiUri.addQueryParameter("fileId", "-1");
+        wopiUri.addQueryParameter("fileId", fileName);
         wopiUri.addQueryParameter("access_token", token);
 
         Authorization auth(Authorization::Type::Token, token);
         auto httpRequest = StorageConnectionManager::createHttpRequest(wopiUri, auth);
         httpRequest.setVerb(http::Request::VERB_POST);
 
-        const std::string boundary = "------BOUNDARY_STR";
-        std::ostringstream bodyStream;
-        bodyStream << boundary << "\r\n"
-                   << "Content-Disposition: form-data; name=\"file\"; filename=\"" << fileName << "\"\r\n"
-                   << "Content-Type: application/octet-stream\r\n\r\n"
-                   << fileContent << "\r\n"
-                   << boundary << "--\r\n";
-
-        httpRequest.header().set("Content-Type", "multipart/form-data; boundary=" + boundary.substr(2));
-        httpRequest.setBody(bodyStream.str());
+        httpRequest.header().set("Content-Type", "application/octet-stream");
+        httpRequest.setBody(fileContent);
 
         LOG_DBG("uploadFileToNextcloud: WOPI URI: " << wopiUri.toString());
         for (const auto& kv : httpRequest.header())


### PR DESCRIPTION
wsd: Simplify HTTP request to use direct octet-stream content type for files

Change-Id: I7a4f902582195b1cf0e0e4d1107254b42c5a0987


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

