### PR TITLE
Align comments indicator and add hover state to comments avatar

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -589,20 +589,22 @@ body {
 }
 
 .cool-annotation-info-collapsed {
-	text-align: center;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 	margin: 0;
 	padding: 0;
 	background-color: var(--color-primary);
 	color: var(--color-primary-text);
 	font-weight: bold;
 	font-family: var(--cool-font);
-	font-size: 20px;
+	font-size: var(--default-font-size);
 	border: 1px solid var(--color-primary);
 	border-radius: 50%;
 	z-index: 10;
 	position: relative;
-	width: var(--btn-size);
-	height: var(--btn-size);
+	width: var(--btn-size-s);
+	height: var(--btn-size-s);
 	left: -6px;
 	top: -15px;
 }
@@ -701,7 +703,15 @@ body {
 	height: 32px;
 	width: 32px;
 	padding: 0;
+	opacity: 0.9;
 }
+
+.cool-annotation.collapsed-comment .cool-annotation-img:hover {
+	cursor: pointer;
+	opacity: 1;
+	box-shadow: 0px 4px 10px var(--color-box-shadow);
+}
+
 .cool-annotation-img .avatar-img{
 	border: none;
 }

--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -259,6 +259,7 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 		for (var i: number = 0; i < this.sectionProperties.commentList.length; i++) {
 			if (this.sectionProperties.commentList[i].sectionProperties.data.id !== 'new')
 				this.sectionProperties.commentList[i].setCollapsed();
+				$(this.sectionProperties.commentList[i].sectionProperties.container).addClass('collapsed-comment');
 			if (this.sectionProperties.commentList[i].isRootComment())
 				this.collapseReplies(i, this.sectionProperties.commentList[i].sectionProperties.data.id);
 		}
@@ -268,6 +269,7 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 		this.isCollapsed = false;
 		for (var i: number = 0; i < this.sectionProperties.commentList.length; i++) {
 			this.sectionProperties.commentList[i].setExpanded();
+			$(this.sectionProperties.commentList[i].sectionProperties.container).removeClass('collapsed-comment');
 		}
 	}
 
@@ -784,6 +786,7 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 		while (rootIndex <= lastIndex) {
 			this.sectionProperties.commentList[rootIndex].sectionProperties.container.style.display = '';
 			this.sectionProperties.commentList[rootIndex].sectionProperties.container.style.visibility = '';
+			$(this.sectionProperties.commentList[rootIndex].sectionProperties.container).removeClass('collapsed-comment');
 			rootIndex++;
 		}
 		rootComment.updateThreadInfoIndicator();
@@ -792,8 +795,10 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 	private collapseReplies(rootIndex: number, rootId: number) {
 		var lastChild = this.getLastChildIndexOf(rootId);
 
+		$(this.sectionProperties.commentList[rootIndex].sectionProperties.container).addClass('collapsed-comment');
 		for (var i = lastChild; i > rootIndex; i--) {
 			this.sectionProperties.commentList[i].sectionProperties.container.style.display = 'none';
+			$(this.sectionProperties.commentList[i].sectionProperties.container).addClass('collapsed-comment');
 		}
 		this.sectionProperties.commentList[i].updateThreadInfoIndicator();
 	}


### PR DESCRIPTION
Change-Id: I4746de9d38ce016e0fdef2d0ef15d810474276b6


* Resolves: #10887 
* Target version: master 

### Summary
Fixes the alignment, size, and interactivity issues with the number of replies indicator in the comments section, resized to fit seamlessly within the circle, and includes a hover state

### Screenshot
[Screencast from 10-01-25 15:38:57.webm](https://github.com/user-attachments/assets/bed079eb-32fe-44e8-8846-5308a80c413a)


