### PR TITLE
kill saving thread with SIGABRT

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -175,11 +175,11 @@ static LokHookFunction2* initFunction = nullptr;
 class BackgroundSaveWatchdog
 {
 public:
-    BackgroundSaveWatchdog(unsigned mobileAppDocId)
+    BackgroundSaveWatchdog(unsigned mobileAppDocId, int savingTid)
         : _saveCompleted(false)
         , _watchdogThread(
             // mobileAppDocId is on the stack, so capture it by value.
-              [mobileAppDocId, this]()
+              [mobileAppDocId, savingTid, this]()
               {
                   Util::setThreadName("kitbgsv_" + Util::encodeId(mobileAppDocId, 3) + "_wdg");
 
@@ -201,7 +201,7 @@ public:
                       LOG_WRN("BgSave timed out and will self-destroy");
                       Log::shutdown(); // Flush logs.
                       // raise(3) will exit the current thread, not the process.
-                      ::kill(0, SIGKILL); // kill(2) is trapped by seccomp.
+                      Util::killThreadById(savingTid, SIGABRT);
                   }
               })
     {
@@ -1487,7 +1487,7 @@ bool Document::forkToSave(const std::function<void()> &childSave, int viewId)
         Util::sleepFromEnvIfSet("KitBackgroundSave", "SLEEPBACKGROUNDFORDEBUGGER");
 
         assert(!BgSaveWatchdog && "Unexpected to have BackgroundSaveWatchdog instance");
-        BgSaveWatchdog = std::make_unique<BackgroundSaveWatchdog>(_mobileAppDocId);
+        BgSaveWatchdog = std::make_unique<BackgroundSaveWatchdog>(_mobileAppDocId, Util::getThreadId());
 
         UnitKit::get().postBackgroundSaveFork();
 


### PR DESCRIPTION
so the the correct/main thread gets the signal so we can get a backtrace generated.


Change-Id: I64f8f374bad92964f42ba34e23011bf827d87bf9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

