### PR TITLE
Backport SSL Improvements

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -149,18 +149,9 @@ std::string Socket::getStatsString(const std::chrono::steady_clock::time_point &
 
 std::ostream& Socket::streamImpl(std::ostream& os) const
 {
-    os << "Socket[#" << getFD()
-       << ", " << toString(type())
-       << " @ ";
-    if (Type::IPv6 == type())
-    {
-        os << "[" << clientAddress() << "]:" << clientPort();
-    }
-    else
-    {
-        os << clientAddress() << ":" << clientPort();
-    }
-    return os << "]";
+    os << "Socket[#" << getFD() << ", " << toString(type()) << " @ " << clientAddress() << ":"
+       << clientPort() << ']';
+    return os;
 }
 
 std::string Socket::toStringImpl() const

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1490,12 +1490,11 @@ bool StreamSocket::checkRemoval(std::chrono::steady_clock::time_point now)
             if (!isClosed())
             {
                 // Note: Ensure proper semantics of onDisconnect()
-                LOG_WRN("Socket still open post onDisconnect(), forced shutdown.");
-                shutdown(); // signal
-                closeConnection(); // real -> setClosed()
+                LOG_WRN("Socket still open post onDisconnect(), forcing shutdown");
             }
         }
-        else
+
+        if (!isClosed())
         {
             shutdown(); // signal
             closeConnection(); // real -> setClosed()

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -628,7 +628,7 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
                 // re-entrancy hazard
                 LOG_DBG("Unexpected socket poll resize");
             }
-            else if (!_pollSockets[i])
+            else if (!_pollSockets[i] || _pollSockets[i]->getFD() < 0)
             {
                 // removed in a callback
                 ++itemsErased;
@@ -682,11 +682,10 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
             LOG_TRC("Scanning to removing " << itemsErased << " defunct sockets from "
                     << _pollSockets.size() << " sockets");
 
-            _pollSockets.erase(
-                std::remove_if(_pollSockets.begin(), _pollSockets.end(),
-                    [](const std::shared_ptr<Socket>& s)->bool
-                    { return !s; }),
-                _pollSockets.end());
+            _pollSockets.erase(std::remove_if(_pollSockets.begin(), _pollSockets.end(),
+                                              [](const std::shared_ptr<Socket>& s) -> bool
+                                              { return !s || s->getFD() < 0; }),
+                               _pollSockets.end());
         }
     }
 

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -147,7 +147,6 @@ public:
         : _type(type)
         , _clientPort(0)
         , _fd(createSocket(type))
-        , _closed(_fd < 0)
         , _creationTime(creationTime)
         , _lastSeenTime(_creationTime)
         , _bytesSent(0)
@@ -172,8 +171,8 @@ public:
         }
     }
 
-    /// Returns true if this socket has been closed, i.e. rejected from polling and potentially shutdown
-    bool isClosed() const { return _closed; }
+    /// Returns true iff this socket has been closed or is invalid.
+    bool isClosed() const { return _fd < 0; }
 
     constexpr Type type() const { return _type; }
     constexpr bool isIPType() const { return Type::IPv4 == _type || Type::IPv6 == _type; }
@@ -221,11 +220,11 @@ public:
         if (!_noShutdown)
         {
             LOG_TRC("Socket shutdown RDWR. " << *this);
-            setClosed();
             if constexpr (!Util::isMobileApp())
                 ::shutdown(_fd, SHUT_RDWR);
             else
                 fakeSocketShutdown(_fd);
+            setClosed(); // Invalidate the FD.
         }
     }
 
@@ -418,7 +417,6 @@ protected:
         : _type(type)
         , _clientPort(0)
         , _fd(fd)
-        , _closed(_fd < 0)
         , _creationTime(creationTime)
         , _lastSeenTime(_creationTime)
         , _bytesSent(0)
@@ -438,7 +436,7 @@ protected:
     void setNoShutdown() { _noShutdown = true; }
 
     /// Explicitly marks this socket closed, i.e. rejected from polling and potentially shutdown
-    void setClosed() { _closed = true; }
+    void setClosed() { _fd = -1; }
 
     /// Explicitly marks this socket and the given SocketDisposition closed
     void setClosed(SocketDisposition &disposition) { setClosed(); disposition.setClosed(); }
@@ -478,9 +476,7 @@ private:
     std::string _clientAddress;
     const Type _type;
     unsigned int _clientPort;
-    const int _fd;
-    /// True if this socket is closed.
-    bool _closed;
+    int _fd; ///< The socket file-descriptor. Invalid/closed if < 0.
 
     const std::chrono::steady_clock::time_point _creationTime;
     std::chrono::steady_clock::time_point _lastSeenTime;

--- a/net/Ssl.cpp
+++ b/net/Ssl.cpp
@@ -199,8 +199,12 @@ SslContext::SslContext(const std::string& certFilePath, const std::string& keyFi
         SSL_CTX_set_verify_depth(_ctx, 9);
 
         // The write buffer may re-allocate, and we don't mind partial writes.
-        SSL_CTX_set_mode(_ctx, SSL_MODE_ENABLE_PARTIAL_WRITE |
-                               SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+        // Without auto-retry, when SSL_read processes non-application data,
+        // it would return with WANT_READ even when there is application data to
+        // process. This is reasonable for blocking sockets, but inefficient for
+        // non-blocking ones, wich we use. So we enable auto-retry.
+        SSL_CTX_set_mode(_ctx, SSL_MODE_ENABLE_PARTIAL_WRITE | SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER |
+                                   SSL_MODE_AUTO_RETRY);
         SSL_CTX_set_session_cache_mode(_ctx, SSL_SESS_CACHE_OFF);
 
         initDH();

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -368,7 +368,7 @@ private:
         const unsigned long bioError = ERR_peek_error();
         const std::string bioErrStr = getBioError(bioError);
 
-        LOG_TRC("SSL error (" << context << "): " << sslErrorToName(sslError) << " (" << sslError
+        LOG_DBG("SSL error (" << context << "): " << sslErrorToName(sslError) << " (" << sslError
                               << "), rc: " << rc << ", errno: " << last_errno << " ("
                               << Util::symbolicErrno(last_errno) << ": "
                               << std::strerror(last_errno) << ")" << ": " << bioErrStr);

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -305,6 +305,16 @@ private:
 
         if (rc > 0)
         {
+            const unsigned long bioError = ERR_peek_error();
+            if (bioError != 0)
+            {
+                LOG_DBG("Unexpected SSL error ("
+                        << bioError
+                        << ") after success implies uncleared earlier errors or "
+                           "a bug in the SSL library");
+                ERR_clear_error();
+            }
+
             // Success: Reset so we can do either.
             _sslWantsTo = SslWantsTo::Neither;
             return rc;

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -16,6 +16,7 @@
 #include <net/Socket.hpp>
 
 #include <openssl/ssl.h>
+#include <openssl/err.h>
 
 #include <cerrno>
 #include <sstream>
@@ -312,6 +313,8 @@ private:
         // Handle errors in the error-queue.
         const int ret = handleSslError(rc, last_errno, context);
         errno = last_errno; // Restore errno.
+
+        ERR_clear_error(); // Make sure we leave no errors in the queue.
 
         return ret;
     }

--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -461,8 +461,6 @@ private:
                     {
                         // Socket closed. Not an error.
                         oss << " (" << context << "): closed. " << bioErrStr;
-                        LOG_INF(oss.str());
-                        return 0;
                     }
                     else if (rc == -1)
                     {
@@ -479,9 +477,7 @@ private:
                 }
 
                 oss << bioErrStr;
-                const std::string msg = oss.str();
-                LOG_TRC("Throwing SSL Error ("
-                        << context << "): " << msg); // Locate the source of the exception.
+                LOG_DBG("SSL Error (" << context << "): " << oss.str());
 
                 handshakeFail();
 
@@ -490,13 +486,12 @@ private:
                 if (!sslVerifyResult.empty())
                     LOG_ERR("SSL verification warning (" << context << "): " << sslVerifyResult);
 
-                errno = last_errno; // Restore errno before throwing.
-                throw std::runtime_error(msg);
+                last_errno = last_errno ? last_errno : EPIPE; // Set errno if unset.
+                return 0; // EOF.
             }
             break;
         }
 
-        errno = last_errno; // Restore errno.
         return rc;
     }
 

--- a/tools/Stress.cpp
+++ b/tools/Stress.cpp
@@ -89,7 +89,7 @@ int Stress::main(const std::vector<std::string>& args)
     }
 #endif
 
-    std::string server = args[0];
+    const std::string& server = args[0];
 
     if (!strncmp(server.c_str(), "http", 4))
     {


### PR DESCRIPTION
- **wsd: cosmetics**
- **wsd: replace _closed member with invalidating the FD**
- **wsd: invalidate socket FD by negating**
- **wsd: simplify shutting down in checkRemoval**
- **wsd: simplify Socket::streamImpl()**
- **wsd: net: always process application-data if available**
- **wsd: net: log SSL errors at debug level**
- **wsd: net: handle unexpected closed-socket gracefully**
- **wsd: net: always clear SSL errors after failed IO**
- **wsd: net: check for unexpected errors in SSL**
