### PR TITLE
fixes for log UI Commands (kit-id)

### DIFF
--- a/scripts/undoStatistics.py
+++ b/scripts/undoStatistics.py
@@ -59,9 +59,9 @@ def reorderLogFile(oldFilename):
             endOfKit = line[numbKit:].find(" ")
             if endOfKit >= 0:
                 endOfKit += numbKit
-                kit = int(line[numbKit+4:endOfKit])
+                kit = int(line[numbKit+4:endOfKit],16)
             else:
-                kit = int(line[numbKit+4:])
+                kit = int(line[numbKit+4:],16)
 
             fileLines.append(FileLine(kit,line))
 
@@ -158,7 +158,7 @@ if __name__ == "__main__":
     actIndex=-1
     f = open(newFileName, 'r')
     for line in f:
-        if line.startswith("time="):
+        if line.startswith("kit="):
             numbrep = line.find("rep=")
             cmdStart = line[numbrep:].find(" ")+numbrep+1
             repeat = int(line[numbrep+4:cmdStart])


### PR DESCRIPTION
fixed kit id parse, as it is a hexadecimal number not a decimal. fixed also undo command recheck part, as these lines start with "kit=" now, not with "time=".


Change-Id: I1e649efda96b2a728b1efd2d5bcfa84f1e1c5af2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

