### PR TITLE
widget: on demand rendering also sends separators

### DIFF
--- a/browser/src/control/jsdialog/Widget.IconView.ts
+++ b/browser/src/control/jsdialog/Widget.IconView.ts
@@ -196,7 +196,9 @@ JSDialog.iconView = function (
 	};
 
 	container.updateRenders = (pos: number) => {
-		const dropdown = container.querySelectorAll('.ui-iconview-entry');
+		const dropdown = container.querySelectorAll(
+			'.ui-iconview-entry, .ui-iconview-separator',
+		);
 		if (dropdown[pos]) {
 			let container = dropdown[pos];
 			const entry = data.entries[pos];


### PR DESCRIPTION
problem:
not including separators in messes up indexing and misplaces the inconview widget


Change-Id: I663b01271cd375177a6a573bf77cb9b90f772cc5

* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

