### PR TITLE
CheckFileInfo: disconnect callbacks in dtor

### DIFF
--- a/wsd/wopi/CheckFileInfo.cpp
+++ b/wsd/wopi/CheckFileInfo.cpp
@@ -212,4 +212,13 @@ CheckFileInfo::wopiFileInfo(const Poco::URI& uriPublic) const
     return wopiFileInfo;
 }
 
+CheckFileInfo::~CheckFileInfo()
+{
+    if (_httpSession)
+    {
+        _httpSession->setConnectFailHandler(nullptr);
+        _httpSession->setFinishedHandler(nullptr);
+    }
+}
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/wopi/CheckFileInfo.hpp
+++ b/wsd/wopi/CheckFileInfo.hpp
@@ -73,6 +73,8 @@ public:
     /// In some scenarios we can't proceed without CheckFileInfo results.
     void checkFileInfoSync(int redirectionLimit);
 
+    ~CheckFileInfo();
+
     std::string getSslVerifyMessage()
     {
         if (_httpSession)


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Ensures the CheckFileInfo lambda using `this` can't be called after being destructed.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

