### PR TITLE
Clipboard Response Is Not Cacheable

### DIFF
--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -28,7 +28,7 @@
 namespace HttpHelper
 {
 void sendError(http::StatusCode errorCode, const std::shared_ptr<StreamSocket>& socket,
-               const std::string& body, const std::string& extraHeader)
+               std::string_view body, std::string_view extraHeader)
 {
     std::ostringstream oss;
     oss << "HTTP/1.1 " << errorCode << "\r\n"
@@ -40,7 +40,7 @@ void sendError(http::StatusCode errorCode, const std::shared_ptr<StreamSocket>& 
 }
 
 void sendErrorAndShutdown(http::StatusCode errorCode, const std::shared_ptr<StreamSocket>& socket,
-                          const std::string& body, const std::string& extraHeader)
+                          std::string_view body, const std::string& extraHeader)
 {
     sendError(errorCode, socket, body, extraHeader + "Connection: close\r\n");
     socket->shutdown();

--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -27,26 +27,6 @@
 
 namespace HttpHelper
 {
-void sendError(http::StatusCode errorCode, const std::shared_ptr<StreamSocket>& socket,
-               std::string_view body, std::string_view extraHeader)
-{
-    std::ostringstream oss;
-    oss << "HTTP/1.1 " << errorCode << "\r\n"
-        << "Date: " << Util::getHttpTimeNow() << "\r\n"
-        << "Content-Length: " << body.size() << "\r\n"
-        << extraHeader << "\r\n"
-        << body;
-    socket->send(oss.str());
-}
-
-void sendErrorAndShutdown(http::StatusCode errorCode, const std::shared_ptr<StreamSocket>& socket,
-                          std::string_view body, const std::string& extraHeader)
-{
-    sendError(errorCode, socket, body, extraHeader + "Connection: close\r\n");
-    socket->shutdown();
-    socket->ignoreInput();
-}
-
 void sendUncompressedFileContent(const std::shared_ptr<StreamSocket>& socket,
                                  const std::string& path, const int bufferSize)
 {

--- a/net/HttpHelper.hpp
+++ b/net/HttpHelper.hpp
@@ -23,12 +23,12 @@ namespace HttpHelper
 {
 /// Write headers and body for an error response.
 void sendError(http::StatusCode errorCode, const std::shared_ptr<StreamSocket>& socket,
-               const std::string& body = std::string(),
-               const std::string& extraHeader = std::string());
+               std::string_view body = std::string_view(),
+               std::string_view extraHeader = std::string_view());
 
 /// Write headers and body for an error response. Afterwards, shutdown the socket.
 void sendErrorAndShutdown(http::StatusCode errorCode, const std::shared_ptr<StreamSocket>& socket,
-                          const std::string& body = std::string(),
+                          std::string_view body = std::string_view(),
                           const std::string& extraHeader = std::string());
 
 /// Sends file as HTTP response and shutdown the socket.

--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -68,17 +68,18 @@ public:
                                                 http::StatusCode expected)
     {
         LOG_TST("getClipboard: connect to " << clipURIstr);
-        Poco::URI clipURI(clipURIstr);
+        const Poco::URI clipURI(clipURIstr);
+        const std::string clipPathAndQuery = clipURI.getPathAndQuery();
 
         auto httpSession = http::Session::create(clipURIstr);
         std::shared_ptr<const http::Response> httpResponse =
-            httpSession->syncRequest(http::Request(Poco::URI(clipURIstr).getPathAndQuery()));
+            httpSession->syncRequest(http::Request(clipPathAndQuery));
 
         // Note that this is expected for both living and closed documents.
         // This failed when either case didn't add the custom header.
         LOK_ASSERT_EQUAL(std::string("true"), httpResponse->get("X-COOL-Clipboard"));
 
-        LOG_TST("getClipboard: sent request: " << clipURI.getPathAndQuery());
+        LOG_TST("getClipboard: sent request: " << clipPathAndQuery);
 
         try {
             LOG_TST("getClipboard: HTTP get request returned: "

--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -79,6 +79,9 @@ public:
         // This failed when either case didn't add the custom header.
         LOK_ASSERT_EQUAL(std::string("true"), httpResponse->get("X-COOL-Clipboard"));
 
+        // We should mark clipboard responses as non-cacheable.
+        LOK_ASSERT_EQUAL(std::string("no-cache"), httpResponse->get("Cache-Control"));
+
         LOG_TST("getClipboard: sent request: " << clipPathAndQuery);
 
         try {

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1797,10 +1797,7 @@ bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
         {
             LOG_WRN(
                 "Conversion requests not allowed from this address: " << socket->clientAddress());
-            http::Response httpResponse(http::StatusCode::Forbidden);
-            httpResponse.set("Content-Length", "0");
-            socket->sendAndShutdown(httpResponse);
-            socket->ignoreInput();
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::Forbidden, socket);
             return true;
         }
 

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -294,12 +294,7 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
             LOG_ERR("Unsupported Clipboard Request from socket #" << socket->getFD()
                                                                   << ". Terminating connection.");
 
-            http::Response httpResponse(http::StatusCode::Forbidden);
-            httpResponse.set("Content-Length", "0");
-            httpResponse.set("Connection", "close");
-            socket->send(httpResponse);
-            socket->closeConnection(); // Shutdown socket.
-            socket->ignoreInput();
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::Forbidden, socket);
             return;
         }
 

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2250,6 +2250,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
             httpResponse.add("Content-Type", "application/octet-stream");
             httpResponse.add("X-Content-Type-Options", "nosniff");
             httpResponse.add("X-COOL-Clipboard", "true");
+            httpResponse.add("Cache-Control", "no-cache");
             httpResponse.set("Connection", "close");
             socket->send(httpResponse);
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3858,6 +3858,7 @@ bool DocumentBroker::lookupSendClipboardTag(const std::shared_ptr<StreamSocket> 
                 << "Content-Type: application/octet-stream\r\n"
                 << "X-Content-Type-Options: nosniff\r\n"
                 << "X-COOL-Clipboard: true\r\n"
+                << "Cache-Control: no-cache\r\n"
                 << "Connection: close\r\n"
                 << "\r\n";
             oss.write(saved->c_str(), saved->length());
@@ -3888,7 +3889,7 @@ void DocumentBroker::handleClipboardRequest(ClipboardRequest type,  const std::s
                                             const std::string &viewId, const std::string &tag,
                                             const std::shared_ptr<std::string> &data)
 {
-    for (auto& it : _sessions)
+    for (const auto& it : _sessions)
     {
         if (it.second->matchesClipboardKeys(viewId, tag))
         {


### PR DESCRIPTION
- **wsd: string -> string_view in HttpHelper**
- **wsd: reuse HttpHelper::sendErrorAndShutdown**
- **wsd: test: simplify UnitCopyPaste**
- **wsd: send clipboard response with no-cache header**
