### PR TITLE
UnitKitSyntheticLok can pass and finish earlier than UnitSyntheticLok…

### DIFF
--- a/test/UnitPerf.cpp
+++ b/test/UnitPerf.cpp
@@ -29,7 +29,6 @@
 #include <string>
 #include <thread>
 
-/// Save torture testcase.
 class UnitPerf : public UnitWSD
 {
     void testPerf(std::string testType, std::string fileType, std::string tracesStr);

--- a/test/UnitSyntheticLok.cpp
+++ b/test/UnitSyntheticLok.cpp
@@ -33,7 +33,8 @@ namespace {
     }
 }
 
-/// Save torture testcase.
+bool testCompletedSuccess = false;
+
 class UnitSyntheticLok : public UnitWSD
 {
     void loadAndSynthesize(const std::string& name, const std::string& docName);
@@ -41,6 +42,7 @@ class UnitSyntheticLok : public UnitWSD
 public:
     UnitSyntheticLok();
     void invokeWSDTest() override;
+    void endTest(const std::string& reason) override;
 };
 
 void UnitSyntheticLok::loadAndSynthesize(
@@ -57,7 +59,11 @@ void UnitSyntheticLok::loadAndSynthesize(
     poll->startThread();
 
     Poco::URI uri(helpers::getTestServerURI());
-    auto wsSession = helpers::loadDocAndGetSession(poll, docName, uri, testname);
+    auto wsSession = helpers::loadDocAndGetSession(poll, docName, uri, testname, true, false);
+
+    // If we have already exitTest successfully when this returns, then that's fine.
+    if (testCompletedSuccess)
+        return;
 
     std::vector<char> message
         = wsSession->waitForMessage("status:", timeout, name);
@@ -86,6 +92,12 @@ void UnitSyntheticLok::invokeWSDTest()
         loadAndSynthesize(name, "empty.ods");
     }
     // wait for result from the Kit process
+}
+
+void UnitSyntheticLok::endTest(const std::string& reason)
+{
+    UnitWSD::endTest(reason);
+    testCompletedSuccess = !failed();
 }
 
 class UnitKitSyntheticLok;


### PR DESCRIPTION
… expects

It seems that UnitKitSyntheticLok regularly finishes successfully, setting TestResult::Ok, before UnitSyntheticLok even gets to see that the document is loaded.

UnitKitSyntheticLok flags UnitSyntheticLok that the test passed, so presumably if we see that the test passed, then we are done don't need to do anything else except exit.


Change-Id: I1111a195943789c5e31da814c8713e2b7b0070b3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

