### PR TITLE
Correct text and icon alignments in server audit dialog

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -541,6 +541,12 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	white-space: nowrap;
 }
 
+#ServerAuditDialog .ui-treeview-entry {
+	display: grid;
+	grid-template-columns: var(--btn-img-size-m) 6fr 3fr;
+	white-space: normal;
+}
+
 .ui-treeview-expanded-content {
 	display: grid;
 }
@@ -566,6 +572,21 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	display: grid;
 	grid-auto-flow: column;
 	/* grid-column: '1 / ' + (this._columns + 1) - set inside JS */
+}
+
+#ServerAuditDialog .ui-treeview-headers {
+	display: grid;
+	grid-column-end: 4 !important;
+	grid-template-columns: 0fr 6fr 3fr;
+	margin-inline-start: 4px;
+}
+
+#ServerAuditDialog .ui-treeview-headers div.ui-treeview-icon-column {
+	width: 0px /* prevent display of ui-treeview-icon-column in ui-treeview-header */
+}
+
+#ServerAuditDialog .ui-treeview-headers > div:nth-last-child(1) {
+	margin-inline-start: 7px;
 }
 
 .ui-treeview-header {
@@ -2209,11 +2230,12 @@ kbd,
 }
 
 #ServerAuditDialog #ServerAuditDialog-mainbox {
-	min-width: calc(min(800px, 80vw));
+	min-width: calc(min(600px, 80vw));
 }
 
 #ServerAuditDialog .ui-treeview {
 	border-color: transparent;
+	max-height: max-content;
 }
 #ServerAuditDialog .ui-treeview td[role='gridcell'] {
 	padding-inline-start: 0;


### PR DESCRIPTION
Change-Id: Id4b45e9097b8ba77df5280bedf1635693fce72fc


* Resolves: #10841 
* Target version: master 

### Summary
Improvements in alignment of icons and text in the server audit dialog

###  IN (COOLWSD version: 24.04.8.1(git hash: 8475197 (E))
![image (2)](https://github.com/user-attachments/assets/a42633f2-0678-4984-917d-4da9f73fb38d)

### AFTER: https://github.com/CollaboraOnline/online/pull/10870
![Screenshot from 2025-01-14 03-29-37](https://github.com/user-attachments/assets/1897200a-ef0b-46ed-beda-9d16f7dbe5da)

### CURRENT FIX AND IMPROVEMENT
![Screenshot from 2025-01-13 16-05-13](https://github.com/user-attachments/assets/2074343c-72f5-49c3-bef3-32944b91d3a6)


![Screenshot from 2025-01-14 02-20-31](https://github.com/user-attachments/assets/edecded5-d28d-4a50-8097-e7ae4a659199)


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

