### PR TITLE
Require OpenSSL 3.x

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -52,9 +52,6 @@
 /* User feedback URL. */
 #undef FEEDBACK_URL
 
-/* Whether OpenSSL has PKCS5_PBKDF2_HMAC() */
-#undef HAVE_PKCS5_PBKDF2_HMAC
-
 /* Define to 1 if you have the `ppoll' function. */
 #define HAVE_PPOLL 0
 

--- a/configure.ac
+++ b/configure.ac
@@ -1447,18 +1447,17 @@ AS_IF([test "$ENABLE_IOSAPP" != "true" -a "$ENABLE_ANDROIDAPP" != "true" -a "$ho
        fi
 
        PKG_CHECK_MODULES([OPENSSL], [openssl])
-       AC_MSG_CHECKING([Whether OpenSSL has PKCS5_PBKDF2_HMAC()])
+       AC_MSG_CHECKING([Whether OpenSSL is recent enough])
        AC_COMPILE_IFELSE([AC_LANG_SOURCE([
        #include <openssl/opensslv.h>
-       #if OPENSSL_VERSION_NUMBER < 0x10001000L
-       #error PKCS5_PBKDF2_HMAC() is in OpenSSL 1.0.1 or newer
+
+       /* OpenSSL 3.0.0 is the current mainline. */
+       #if OPENSSL_VERSION_NUMBER < 0x30000000
+       #error OpenSSL 3.0.0 or newer is required, override at your own risk
        #endif
        ])],
-                         [AC_MSG_RESULT([yes])
-                          AC_DEFINE([HAVE_PKCS5_PBKDF2_HMAC],1,[whether OpenSSL has PKCS5_PBKDF2_HMAC()])],
-                         [AC_MSG_RESULT([no])
-                          AC_MSG_WARN([OpenSSL is too old. Secure password storage for Admin Console is not supported.])
-                          AC_DEFINE([HAVE_PKCS5_PBKDF2_HMAC],0,[Whether OpenSSL has PKCS5_PBKDF2_HMAC()])])
+                         AC_MSG_RESULT([yes]),
+                         [AC_MSG_ERROR([OpenSSL is too old. Please use a more recent version.])])
 
        AC_MSG_CHECKING([POCO version])
        AC_COMPILE_IFELSE([AC_LANG_SOURCE([

--- a/ios/config.h.in
+++ b/ios/config.h.in
@@ -49,9 +49,6 @@
 /* Define to 1 if you have the <memory.h> header file. */
 #define HAVE_MEMORY_H 1
 
-/* Whether OpenSSL has PKCS5_PBKDF2_HMAC() */
-#define HAVE_PKCS5_PBKDF2_HMAC 0
-
 /* Define to 1 if you have the <Poco/Net/WebSocket.h> header file. */
 #define HAVE_POCO_NET_WEBSOCKET_H 1
 

--- a/tools/Config.cpp
+++ b/tools/Config.cpp
@@ -291,7 +291,6 @@ int Config::main(const std::vector<std::string>& args)
 
     if (args[0] == "set-admin-password")
     {
-#if HAVE_PKCS5_PBKDF2_HMAC
         std::vector<unsigned char> pwdhash(_adminConfig.getPwdHashLength());
         std::vector<unsigned char> salt(_adminConfig.getPwdSaltLength());
         RAND_bytes(salt.data(), _adminConfig.getPwdSaltLength());
@@ -364,10 +363,6 @@ int Config::main(const std::vector<std::string>& args)
         _coolConfig.setString("admin_console.secure_password", pwdConfigValue.str());
 
         changed = true;
-#else
-        std::cerr << "This application was compiled with old OpenSSL. Operation not supported. You can use plain text password in /etc/coolwsd/coolwsd.xml." << std::endl;
-        return EX_UNAVAILABLE;
-#endif
     }
     else if (ConfigUtil::isSupportKeyEnabled() && args[0] == "set-support-key")
     {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -571,7 +571,7 @@ void DocumentBroker::pollThread()
                         LOG_ERR(
                             "Failed to store the document and reached maximum retry count of "
                             << limStoreFailures
-                            << "Save failures: " << _saveManager.saveFailureCount()
+                            << " Save failures: " << _saveManager.saveFailureCount()
                             << ", Upload failures: " << _storageManager.uploadFailureCount()
 #if !MOBILEAPP
                             << ". Giving up"

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -167,7 +167,6 @@ bool isConfigAuthOk(const std::string& userProvidedUsr, const std::string& userP
             return false;
         }
 
-#if HAVE_PKCS5_PBKDF2_HMAC
         // Extract the salt from the config
         std::vector<unsigned char> saltData;
         StringVector tokens = StringVector::tokenize(securePass, '.');
@@ -193,14 +192,6 @@ bool isConfigAuthOk(const std::string& userProvidedUsr, const std::string& userP
 
         // now compare the hashed user-provided pwd against the stored hash
         return tokens.equals(4, stream.str());
-#else
-        const std::string pass = config.getString("admin_console.password", "");
-        LOG_ERR("The config file has admin_console.secure_password setting, "
-                << "but this application was compiled with old OpenSSL version, "
-                << "and this setting cannot be used." << (!pass.empty()? " Falling back to plain text password.": ""));
-
-        // careful, a fall-through!
-#endif
     }
 
     const std::string pass = config.getString("admin_console.password", "");


### PR DESCRIPTION
This bumps the minimum OpenSSL version requirements to 3.x.

I believe gitpod uses 1.1.1 and will need to be updated before we merge this, lest we break it.
CC: @Darshan-upadhyay1110

- **configure: require OpenSSL 3.0.11 or newer**
- **wsd: logging**
