### PR TITLE
refactor: allow rescaling without projecting

### DIFF
--- a/browser/src/geo/crs/CRS.js
+++ b/browser/src/geo/crs/CRS.js
@@ -38,6 +38,16 @@ L.CRS = {
 		return Math.pow(1.2, zoom);
 	},
 
+	// equivalent to doing an unproject with oldZoom then a project with newZoom
+	// except that unproject is technically invalid (so possibly confusing) for any non-css-pixel
+	// but this function will work with any scaling (including twips or core pixels)
+	rescale: function (point, oldZoom, newZoom) {
+		return L.point(
+			point.x * this.scale(newZoom - oldZoom),
+			point.y * this.scale(newZoom - oldZoom),
+		);
+	},
+
 	distance: function (latlng1, latlng2) {
 		var dx = latlng2.lng - latlng1.lng,
 		    dy = latlng2.lat - latlng1.lat;

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -496,7 +496,7 @@ L.TileSectionManager = L.Class.extend({
 		return {
 			offset: this._offset,
 			topLeft: docTopLeft.add(this._offset),
-			center: this._map.project(this._map.unproject(newPaneCenter, this._map.getZoom()), this._map.getScaleZoom(scale))
+			center: this._map.rescale(newPaneCenter, this._map.getZoom(), this._map.getScaleZoom(scale)),
 		};
 	},
 

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -1058,6 +1058,15 @@ L.Map = L.Evented.extend({
 		return this.options.crs.pointToLatLng(L.point(point), zoom);
 	},
 
+	// rescaling
+
+	rescale: function(point, oldZoom, newZoom) {
+		oldZoom = oldZoom === undefined ? this.getZoom() : oldZoom;
+		newZoom = newZoom === undefined ? this.getZoom() : newZoom;
+
+		return this.options.crs.rescale(point, oldZoom, newZoom);
+	},
+
 	/**
 	 * Get LatLng coordinates after negating the X cartesian-coordinate.
 	 * This is useful in Calc RTL mode as mouse events have regular document


### PR DESCRIPTION
Previously, in order to change the scale of a coordinate we roundtripped through lat/lng. The conversion here, unproject with the old zoom and then re-project with the new zoom, is valid with all point types (core pixels, css pixels and twips) but the intermediate step (a lat/lng from the unproject) isn't valid for anything except CSS pixels. The new rescale function is a simplification of the project(unproject(x)), as a single step and with duplicate terms cancelled.


Change-Id: I65fec84d2160299d5edb2d5264bc3b8ce0c1d29f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

