### PR TITLE
Navigator: Allow text list items to wrap

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -345,6 +345,7 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 #NavigatorDeck .ui-treeview-cell-text {
 	/* good to move this into css var*/
 	font-size: 14px;
+	white-space: break-spaces;
 }
 #NavigatorDeck .ui-treeview-cell {
 	/* Move this whole block away and fix in the main control */


### PR DESCRIPTION
Otherwise the text gets cropped and impossible to read.

This commit also fixes or decreases the image diff in cypress test fail on "writer/navigator_spec.js" due to Visual Regression Plugin detecting a image mismatch.
- make -C cypress_test run-desktop spec=writer/navigator_spec.js


Change-Id: I4c90b6296b9d4b47490e7a46d8578c5485909b61


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

