### PR TITLE
only call short cuts once for a shortcut combination

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -400,6 +400,11 @@ L.Map.Keyboard = L.Handler.extend({
 		if (this._map.uiManager.isUIBlocked())
 			return;
 
+		if (ev.shortCutActivated === true) {
+			window.app.console.log('Shortcut for: ' + ev.code + ' already handled');
+			return;
+		}
+
 		if (window.KeyboardShortcuts.processEvent(app.UI.language.fromURL, ev)) {
 			ev.preventDefault();
 			return;
@@ -482,6 +487,7 @@ L.Map.Keyboard = L.Handler.extend({
 		this._map.userList.followUser(this._map._docLayer._viewId, false);
 
 		if (window.KeyboardShortcuts.processEvent(app.UI.language.fromURL, ev)) {
+			ev.shortCutActivated = true;
 			ev.preventDefault();
 			return;
 		}

--- a/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
@@ -12,6 +12,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'PDF View Tests', function(
 
 	it('PDF page down', { env: { 'pdf-view': true } }, function() {
 		cy.cGet('#map').type('{pagedown}');
+		cy.cGet('#map').type('{pagedown}');
 		cy.cGet('#preview-frame-part-1').should('have.attr', 'style', 'border: 2px solid darkgrey;');
 		cy.cGet('#map').type('{pageup}');
 		cy.cGet('#map').type('{pageup}');


### PR DESCRIPTION
e.g. pressing F1 will dispatch help twice, so tag that the event dispatched a shortcut in _handleKeyEvent to not handle it again in _globalKeyEvent

1st
_handleKeyEvent
_onKeyDown
handler

2nd

_globalKeyEvent
handler

the ev.preventDefault to make the browser ignore the event is used in multiple places where we don't immediately dispatch the event in _handleKeyEvent but explicitly leave it to be handled later by _globalKeyEvent, e.g. Ctrl+S, so doesn't work as a proxy that a shortcut was already handled


Change-Id: I7c025ba4a8a883982ddf5ea0bf741e7b66d3cae5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

