### PR TITLE
Avoid redundant `getpresentationinfo` call when `startPresentation` parameter is used

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -129,6 +129,7 @@ class SlideShowPresenter {
 	private _cypressSVGPresentationTest: boolean = false;
 	private _onKeyDownHandler: (e: KeyboardEvent) => void;
 	private _onImpressModeChanged: any = null;
+	private _startingPresentation: boolean = false;
 
 	constructor(map: any) {
 		this._cypressSVGPresentationTest =
@@ -172,7 +173,8 @@ class SlideShowPresenter {
 	}
 
 	private onUpdateParts() {
-		if (this._checkAlreadyPresenting()) this.onSlideShowInfoChanged();
+		if (this._checkAlreadyPresenting() && !this._startingPresentation)
+			this.onSlideShowInfoChanged();
 	}
 
 	public getNavigator() {
@@ -407,6 +409,7 @@ class SlideShowPresenter {
 		}
 
 		this._canvasLoader.startLoader();
+		this._startingPresentation = false;
 	}
 
 	public stopLoader(): void {
@@ -705,7 +708,7 @@ class SlideShowPresenter {
 			return;
 		// disable slide sorter or it will receive key events
 		this._map._docLayer._preview.partsFocused = false;
-
+		this._startingPresentation = true;
 		app.socket.sendMessage('getpresentationinfo');
 	}
 
@@ -717,6 +720,7 @@ class SlideShowPresenter {
 			return;
 		// disable present in console onStartInWindow
 		this._enablePresenterConsole(true);
+		this._startingPresentation = true;
 		app.socket.sendMessage('getpresentationinfo');
 	}
 


### PR DESCRIPTION
- Added a `_startingPresentation` flag to track the state of the presentation startup.
- Modified the `onUpdateParts` method to prevent redundant `getpresentationinfo` calls during initialization.
- Updated the presentation start logic to set the flag when the presentation begins, ensuring the request is sent only once.


* Resolves: #10198 

Change-Id: Ib1edc8b57a3ec879db93cffbd649b5b96d0004f4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

