### PR TITLE
Calc toolbar/statusbar: fix scroll button issues on horizontal scroll

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -227,6 +227,7 @@
 }
 .ui-scroll-right::after {
 	rotate: 270deg;
+	left: 0px;
 }
 .ui-scroll-left:hover,
 .ui-scroll-right:hover {

--- a/browser/src/control/jsdialog/Util.ScrollableBar.ts
+++ b/browser/src/control/jsdialog/Util.ScrollableBar.ts
@@ -48,7 +48,8 @@ function showArrow(arrow: HTMLElement, show: boolean) {
 function setupResizeHandler(container: Element, scrollable: Element) {
 	const left = container.querySelector('.ui-scroll-left') as HTMLElement;
 	const right = container.querySelector('.ui-scroll-right') as HTMLElement;
-	var isRTL = document.documentElement.dir === 'rtl';
+	var isRTL: boolean = document.documentElement.dir === 'rtl';
+	var timer: any; // for shift + mouse wheel up/down
 
 	const handler = function () {
 		const rootContainer = scrollable.querySelector('div');
@@ -77,8 +78,24 @@ function setupResizeHandler(container: Element, scrollable: Element) {
 		}
 	}.bind(this);
 
+	// handler for toolbar and statusbar
+	// runs if shift + mouse wheel up/down are used
+	const shiftHandler = function (e: MouseEvent) {
+		const rootContainer = scrollable.querySelector('div');
+		if (!rootContainer || !e.shiftKey) return;
+
+		clearTimeout(timer);
+		// wait until mouse wheel stops scrolling
+		timer = setTimeout(function () {
+			JSDialog.RefreshScrollables();
+		}, 350);
+	}.bind(this);
+
 	window.addEventListener('resize', handler);
 	window.addEventListener('scroll', handler);
+	document
+		.querySelector('.ui-scrollable-content')
+		.addEventListener('wheel', shiftHandler);
 }
 
 JSDialog.MakeScrollable = function (parent: Element, scrollable: Element) {

--- a/browser/src/control/jsdialog/Util.ScrollableBar.ts
+++ b/browser/src/control/jsdialog/Util.ScrollableBar.ts
@@ -48,26 +48,28 @@ function showArrow(arrow: HTMLElement, show: boolean) {
 function setupResizeHandler(container: Element, scrollable: Element) {
 	const left = container.querySelector('.ui-scroll-left') as HTMLElement;
 	const right = container.querySelector('.ui-scroll-right') as HTMLElement;
+	var isRTL = document.documentElement.dir === 'rtl';
+
 	const handler = function () {
 		const rootContainer = scrollable.querySelector('div');
 		if (!rootContainer) return;
 
 		if (rootContainer.scrollWidth > window.innerWidth) {
 			// we have overflowed content
-			const direction = this._RTL ? -1 : 1;
+			const direction = isRTL ? -1 : 1;
 			if (direction * scrollable.scrollLeft > 0) {
-				if (this._RTL) showArrow(right, true);
+				if (isRTL) showArrow(right, true);
 				else showArrow(left, true);
-			} else if (this._RTL) showArrow(right, false);
+			} else if (isRTL) showArrow(right, false);
 			else showArrow(left, false);
 
 			if (
 				direction * scrollable.scrollLeft <
 				rootContainer.scrollWidth - window.innerWidth - 1
 			) {
-				if (this._RTL) showArrow(left, true);
+				if (isRTL) showArrow(left, true);
 				else showArrow(right, true);
-			} else if (this._RTL) showArrow(left, false);
+			} else if (isRTL) showArrow(left, false);
 			else showArrow(right, false);
 		} else {
 			showArrow(left, false);

--- a/browser/src/control/jsdialog/Util.ScrollableBar.ts
+++ b/browser/src/control/jsdialog/Util.ScrollableBar.ts
@@ -80,7 +80,7 @@ function setupResizeHandler(container: Element, scrollable: Element) {
 
 	// handler for toolbar and statusbar
 	// runs if shift + mouse wheel up/down are used
-	const shiftHandler = function (e: MouseEvent) {
+	const shiftHandler = (e: MouseEvent) => {
 		const rootContainer = scrollable.querySelector('div');
 		if (!rootContainer || !e.shiftKey) return;
 
@@ -89,13 +89,11 @@ function setupResizeHandler(container: Element, scrollable: Element) {
 		timer = setTimeout(function () {
 			JSDialog.RefreshScrollables();
 		}, 350);
-	}.bind(this);
+	};
 
 	window.addEventListener('resize', handler);
 	window.addEventListener('scroll', handler);
-	document
-		.querySelector('.ui-scrollable-content')
-		.addEventListener('wheel', shiftHandler);
+	scrollable.addEventListener('wheel', shiftHandler);
 }
 
 JSDialog.MakeScrollable = function (parent: Element, scrollable: Element) {


### PR DESCRIPTION
- fixed "this._RTL always returns undefined" issue. scroll buttons are now correctly visible/hidden when scrolling horizontally with right/left scroll buttons.

- aligned scroll-right button arrows on RTL docs
    - scroll-right button arrows of statusbar and toolbar were misaligned to the left. This is fixed with 'left: 0px'

-  Calc: show/hide scroll buttons correctly with shift + mouse wheel
    - Fixed: "Scrolling toolbar and statusbar with Shift + mouseWheelUp/Down does not hide/show the scroll right/left buttons correctly. Therefore, right/left buttons overlap with other elements." 

Change-Id: Ieeb124df61ba0e2dea94ea256ec1daa2f87b220b


* Resolves: #10942 
* Target version: master 

### TODO

**LTR docs:**
- [x] Scrolling toolbar and statusbar with `Shift` + `mouseWheelUp/Down` does not hide/show the scroll right/left buttons correctly. Therefore right/left buttons overlap with other elements

**RTL docs:**
- [x] all LTR issues exist.
- [x] scrolling with clicking on the buttons sometimes does not show/hide buttons. (this works well on LTR docs.)
  - the reason: `this._RTL` always returns `undefined`. So we couldn't know if the doc is RTL or LTR.
- [x] scroll-right buttons' arrows are not aligned well. 


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

