### PR TITLE
Calc: remove unused FormulaTooltip functions

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1173,40 +1173,6 @@ L.Control.UIManager = L.Control.extend({
 		}, {once: true});
 	},
 
-	// Calc function tooltip
-
-	/// Shows tooltip over the cell while typing a function in a cell.
-	/// tooltipInfo contains possible function list. If you type a valid
-	/// function it'll show the usage of the function.
-	showFormulaTooltip: function(tooltipInfo, pos) {
-		var elem = $('.leaflet-layer');
-		var pt = this.map.latLngToContainerPoint(pos);
-		pt.y -=35; //Show tooltip above the cursor.
-
-		if ($('.ui-tooltip').length > 0) {
-			this._setTooltipText(elem, tooltipInfo);
-		}
-		else {
-			elem.tooltip({
-				tooltipClass: 'functiontooltip',
-				content: tooltipInfo,
-				items: elem[0],
-				position: { my: 'left top', at: 'left+' + pt.x +  ' top+' +pt.y, collision: 'fit fit' }
-			});
-			elem.tooltip('option', 'customClass', 'functiontooltip');
-			elem.tooltip('open');
-			elem.off('mouseleave');
-		}
-	},
-
-	hideFormulaTooltip: function() {
-		var elem = $('.leaflet-layer');
-		if ($('.ui-tooltip').length > 0) {
-			elem.tooltip();
-			elem.tooltip('option', 'disabled', true);
-		}
-	},
-
 	// Snack bar
 
 	closeSnackbar: function() {


### PR DESCRIPTION
- showFormulaTooltip() and hideFormulaTooltip() are no longer in use -> removed.


Change-Id: I621e462f32470077215004b41aa82cb4fd16b829


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

