### PR TITLE
wopi: add UserCanOnlyComment option

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1306,7 +1306,16 @@ DocumentBroker::updateSessionWithWopiInfo(const std::shared_ptr<ClientSession>& 
     // but this is more readily comprehensible and easier to reason about.
     session->setWritePermission(wopiFileInfo->getUserCanWrite());
 
-    if (!wopiFileInfo->getUserCanWrite())
+    if (wopiFileInfo->getUserCanOnlyComment())
+    {
+        LOG_DBG("Setting session ["
+                << sessionId << "] to readonly for UserCanOnlyComment=true and allowing comments");
+        session->setWritePermission(true);
+        session->setWritable(true);
+        session->setReadOnly(true);
+        session->setAllowChangeComments(true);
+    }
+    else if (!wopiFileInfo->getUserCanWrite())
     {
         // We can't write in the storage, so we can't even add comments.
         LOG_DBG("Setting session [" << sessionId << "] to readonly for UserCanWrite=false");

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -262,6 +262,7 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo, Poco::JSON::Ob
     JsonUtil::findJSONValue(object, "UserCanRename", _userCanRename);
     JsonUtil::findJSONValue(object, "BreadcrumbDocName", _breadcrumbDocName);
     JsonUtil::findJSONValue(object, "FileUrl", _fileUrl);
+    JsonUtil::findJSONValue(object, "UserCanOnlyComment", _userCanOnlyComment);
 
     // check if user is admin on the integrator side
     bool isAdminUser = false;

--- a/wsd/wopi/WopiStorage.hpp
+++ b/wsd/wopi/WopiStorage.hpp
@@ -84,6 +84,7 @@ public:
         bool getSupportsRename() const { return _supportsRename; }
         bool getSupportsLocks() const { return _supportsLocks; }
         bool getUserCanRename() const { return _userCanRename; }
+        bool getUserCanOnlyComment() const { return _userCanOnlyComment; }
 
         const std::optional<bool> getIsAdminUser() const { return _isAdminUser; }
         const std::string& getIsAdminUserError() const { return _isAdminUserError; }
@@ -171,6 +172,8 @@ public:
         bool _userCanRename = false;
         /// If user is considered as admin on the integrator side
         std::optional<bool> _isAdminUser = std::nullopt;
+        /// If user is limited to only writing/modifiyng comments
+        bool _userCanOnlyComment = false;
 
         /// error code if integration does not use isAdminUser field properly
         std::string _isAdminUserError;


### PR DESCRIPTION
If UserCanOnlyComment is set to true, the document is opened in comment
only mode. In that case, UserCanWrite is superseded by
UserCanOnlyComment.

If UserCanOnlyComment is false, everything works as before.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I3417aadc428e079bb1533e2432ea60a1e62d03fb
(cherry picked from commit 9baa71156a7cd30bc4cf01434c2d962693d962d6)
