### PR TITLE
Add tiny scrollbar for stylepreview in notebookbar

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -391,7 +391,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	border: 1px solid var(--color-stylesview-border);
 	border-radius: var(--border-radius);
 	border-collapse: separate; /*To use box-shadow in Internet Explorer 9 or later*/
-	scrollbar-width: none;
+	scrollbar-width: thin;
 	background-color: var(--color-stylesview-background);
 	filter: brightness(var(--brightness-stylesview));
 	box-sizing: border-box;
@@ -401,10 +401,6 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	filter: none;
 }
 
-#stylesview::-webkit-scrollbar {
-	width: 0;
-	height: 0;
-}
 
 #stylesview .ui-iconview-entry {
 	box-sizing: border-box;


### PR DESCRIPTION
- A small visible scrollbar should also be included in stylepreview.

Before:
![image](https://github.com/user-attachments/assets/22049f91-dddf-4e40-8660-f03f3bca55fa)


After:

![image](https://github.com/user-attachments/assets/31a48fde-aed7-47f2-87a4-6c8b924ebd42)

Change-Id: I73131ac6a6753cd8cc2907f7c8397f50948637ba


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

