### PR TITLE
Add an initial COOL-specific clang plugin

### DIFF
--- a/clang/Makefile
+++ b/clang/Makefile
@@ -1,0 +1,18 @@
+# Build this without automake, so that the plugin is not used when building the plugin itself.
+
+CLANG_CXXFLAGS = $(shell llvm-config --cxxflags)
+
+plugin.so: plugin.o Makefile
+	clang++ -shared plugin.o -o plugin.so
+
+plugin.o: plugin.cpp Makefile
+	clang++ -O2 -g $(CLANG_CXXFLAGS) -Wall -Wextra -Werror plugin.cpp -fPIC -c -o plugin.o
+
+run:
+	clang++ -Werror -Xclang -load -Xclang ./plugin.so -Xclang -add-plugin -Xclang coplugin -c -o test/capture.o test/capture.cpp
+
+check:
+	clang++ -Werror -Xclang -verify -Xclang -load -Xclang ./plugin.so -Xclang -add-plugin -Xclang coplugin -c -o test/capture.o test/capture.cpp
+
+clean:
+	rm -f plugin.so plugin.o

--- a/clang/README.md
+++ b/clang/README.md
@@ -1,0 +1,28 @@
+# Collabora Online clang plugin
+
+## Building
+
+For configure: use the `--enable-coplugin` option.
+
+To build, first build the clang plugin using:
+
+```
+make -C clang
+```
+
+and only then build the actual code.
+
+## Testing
+
+To run the automated tests:
+
+```
+make -C clang check
+```
+
+## Resources
+
+- <https://clang.llvm.org/docs/LibASTMatchersReference.html> "AST Matcher Reference"
+- <https://firefox-source-docs.mozilla.org/code-quality/static-analysis/writing-new/index.html>
+  "Writing New Firefox-Specific Static Analysis Checks" suggests to use AST matchers instead of
+  `RecursiveASTVisitor`, so using that approach here

--- a/clang/plugin.cpp
+++ b/clang/plugin.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Frontend/FrontendPluginRegistry.h>
+
+using namespace clang;
+
+namespace
+{
+/// Finds uses of lambda captures where the variable is captured by reference, but the variable is a
+/// parameter of a function, so the capture should be by value, assuming the lambda will be
+/// long-living.
+class CaptureCheck : public clang::ast_matchers::MatchFinder::MatchCallback
+{
+public:
+    bool ignoreCapture(const clang::LambdaCapture& capture,
+                       const std::set<const clang::ParmVarDecl*>& functionParams)
+    {
+        if (!capture.capturesVariable())
+        {
+            return true;
+        }
+
+        if (capture.getCaptureKind() != clang::LCK_ByRef)
+        {
+            return true;
+        }
+
+        auto lambdaParm = llvm::dyn_cast<clang::ParmVarDecl>(capture.getCapturedVar());
+        if (!lambdaParm)
+        {
+            return true;
+        }
+
+        auto it = functionParams.find(lambdaParm);
+        if (it == functionParams.end())
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    void run(const clang::ast_matchers::MatchFinder::MatchResult& result) override
+    {
+        const clang::FunctionDecl* functionDecl =
+            result.Nodes.getNodeAs<clang::CXXConstructorDecl>("constructorDecl");
+        if (!functionDecl)
+        {
+            functionDecl = result.Nodes.getNodeAs<clang::CXXMethodDecl>("methodDecl");
+        }
+
+        std::set<const clang::ParmVarDecl*> functionParams;
+        for (const clang::ParmVarDecl* functionParm : functionDecl->parameters())
+        {
+            functionParams.insert(functionParm);
+        }
+
+        const auto lambdaExpr = result.Nodes.getNodeAs<clang::LambdaExpr>("lambdaExpr");
+        if (!lambdaExpr)
+        {
+            return;
+        }
+
+        for (auto captureIt = lambdaExpr->capture_begin(); captureIt != lambdaExpr->capture_end();
+             ++captureIt)
+        {
+            const clang::LambdaCapture& capture = *captureIt;
+            if (ignoreCapture(capture, functionParams))
+            {
+                continue;
+            }
+
+            clang::SourceManager& sourceManager = result.Context->getSourceManager();
+            if (sourceManager.isInSystemHeader(capture.getLocation()))
+            {
+                continue;
+            }
+
+            clang::SourceRange range(capture.getLocation());
+            clang::SourceLocation location(range.getBegin());
+            report(result.Context,
+                   "function parameter captured by reference, capture by value instead", location)
+                << range;
+        }
+    }
+
+    static clang::ast_matchers::StatementMatcher makeMatcher()
+    {
+        using namespace clang::ast_matchers;
+        return lambdaExpr(
+                   anyOf(hasAncestor(cxxConstructorDecl(isDefinition()).bind("constructorDecl")),
+                         hasAncestor(cxxMethodDecl(hasAncestor(lambdaExpr())).bind("methodDecl"))))
+            .bind("lambdaExpr");
+    }
+
+    clang::DiagnosticBuilder report(clang::ASTContext* context, const std::string& string,
+                                    clang::SourceLocation location) const
+    {
+        clang::DiagnosticsEngine& engine = context->getDiagnostics();
+        clang::DiagnosticIDs::Level level = clang::DiagnosticIDs::Level::Warning;
+        if (engine.getWarningsAsErrors())
+            level = clang::DiagnosticIDs::Level::Error;
+        std::string formatString = string + " [coplugin:capture]";
+        return engine.Report(location,
+                             engine.getDiagnosticIDs()->getCustomDiagID(level, formatString));
+    }
+};
+
+/// Builds a list of checks to be executed.
+class CheckRegistry
+{
+public:
+    CheckRegistry() { _finder.addMatcher(CaptureCheck::makeMatcher(), &_captureCheck); }
+
+    std::unique_ptr<ASTConsumer> makeASTConsumer() { return _finder.newASTConsumer(); }
+
+private:
+    clang::ast_matchers::MatchFinder _finder;
+    CaptureCheck _captureCheck;
+};
+
+/// Connects CheckRegistry to an already existing compiler instance.
+class COPluginAction : public PluginASTAction
+{
+public:
+    std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance& ci, llvm::StringRef) override
+    {
+        // Use placement new to keep this alive till the AST context is alive.
+        void* buf = ci.getASTContext().Allocate<CheckRegistry>();
+        auto registry = new (buf) CheckRegistry();
+        return registry->makeASTConsumer();
+    }
+
+    bool ParseArgs(const CompilerInstance&, const std::vector<std::string>&) override
+    {
+        return true;
+    }
+};
+
+} // namespace
+
+static FrontendPluginRegistry::Add<COPluginAction> X("coplugin", "COOL plugin");
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/clang/test/capture.cpp
+++ b/clang/test/capture.cpp
@@ -1,0 +1,37 @@
+#include <functional>
+
+class C
+{
+  public:
+    std::function<void()> f;
+    // expected-error@+1 {{function parameter captured by reference, capture by value instead [coplugin:capture]}}
+    C(unsigned id) : f([&]() { (void)id; }) {}
+};
+
+class D
+{
+  public:
+    std::function<void()> f;
+    // good
+    D(unsigned id) : f([id]() { (void)id; }) {}
+};
+
+void f1()
+{
+    auto l1 = [](unsigned id) {
+        // expected-error@+1 {{function parameter captured by reference, capture by value instead [coplugin:capture]}}
+        auto l2 = [&id]() {};
+    };
+}
+
+void f2()
+{
+    auto l1 = [](unsigned id) {
+        // good
+        auto l2 = [id]() {};
+    };
+}
+
+int main() { C c(0); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/configure.ac
+++ b/configure.ac
@@ -364,6 +364,11 @@ AC_ARG_WITH([compiler-plugins],
                 [Experimental! Unlikely to work for anyone except Noel! Enable compiler plugins that will perform additional checks during
                  building.]))
 
+AC_ARG_ENABLE(coplugin,
+    AS_HELP_STRING([--enable-coplugin],
+        [Enables building of a clang plugin that performs COOL-specific checks.])
+)
+
 AC_ARG_ENABLE([werror],
             AS_HELP_STRING([--disable-werror],
                           [Do not turn warnings into errors.]))
@@ -1530,6 +1535,15 @@ AS_IF([test `uname -s` = "FreeBSD"],
 # need this after the other stuff that uses the compiler because we don't want to run configure-tests with the plugins enabled
 AS_IF([test -n "$with_compiler_plugins"],
       [CPPFLAGS="$CPPFLAGS -Xclang -load -Xclang ${with_compiler_plugins}/compilerplugins/obj/plugin.so -Xclang -add-plugin -Xclang loplugin -Xclang -plugin-arg-loplugin -Xclang --cool-base-path=\${abs_top_srcdir}"])
+
+# Clang plugin.
+AC_MSG_CHECKING([whether to build a clang plugin])
+if test "$enable_coplugin" = "yes"; then
+    AC_MSG_RESULT([yes])
+    CPPFLAGS="$CPPFLAGS -Xclang -load -Xclang \${abs_top_srcdir}/clang/plugin.so -Xclang -add-plugin -Xclang coplugin"
+else
+    AC_MSG_RESULT([no])
+fi
 
 if test "x${prefix}" = "xNONE"; then
     prefix=/usr/local


### PR DESCRIPTION
As suggested at
<https://github.com/CollaboraOnline/online/pull/10838#pullrequestreview-2527339319>,
detect some cases where capturing variables by reference in a lambda is
not safe, assuming that most lambdas are long-lived in coolwsd.

It would fail without commit
19861a2d0bdc2db9825f9d4b953ce3e0a7a3539b (kit, BackgroundSaveWatchdog:
fix memory management in the ctor, 2024-11-20) with the following
output:

kit/Kit.cpp:183:67: error: function parameter captured by reference, capture by value instead
                  Util::setThreadName("kitbgsv_" + Util::encodeId(mobileAppDocId, 3) + "_wdg");
                                                                  ^~~~~~~~~~~~~~
1 error generated.

And it would fail without commit
92efdebaeb3dae25eedb02801ac395ad6abf95dd (Fix memory handling in
Session::asyncConnect(), 2025-01-03) with the folliwng output:

./net/HttpRequest.hpp:1734:107: error: function parameter captured by reference, capture by value instead
            poll.addCallback([selfLifecycle = shared_from_this(), this, &poll, socket=std::move(socket), &result]() {
                                                                                                          ^~~~~~
1 error generated.

The clang API is nominally unstable, but this simple plugin seems to
work with openSUSE clang 15 and Fedora clang 19 without any ifdefs so
far.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ic5b40198f9c6c192603395fec6d6522951cb535e
