### PR TITLE
Comment section: Use int for part hash.

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -2366,17 +2366,6 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 		this.disableLayoutAnimation = true;
 		var comment;
 		if (Comment.isAnyEdit()) {
-			this.map.uiManager.showConfirmModal(
-				'comments-update',
-				_('Comments Updated'),
-				_('Another user has updated comments. Would you like to proceed updating?'),
-				_('OK'),
-				() => {
-					CommentSection.pendingImport = false;
-					this.clearList();
-					this.importComments(commentList);
-				}
-			);
 			CommentSection.pendingImport = true;
 			return;
 		}


### PR DESCRIPTION
Check container existence before setting edit mode.


Fixes adding comment to wrong part in Impress.