### PR TITLE
fd leak: just revert instead of an invasive fix for now

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -619,7 +619,7 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
                 // re-entrancy hazard
                 LOG_DBG("Unexpected socket poll resize");
             }
-            else if (!_pollSockets[i] || _pollSockets[i]->getFD() < 0)
+            else if (!_pollSockets[i])
             {
                 // removed in a callback
                 ++itemsErased;
@@ -673,10 +673,11 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS)
             LOG_TRC("Scanning to removing " << itemsErased << " defunct sockets from "
                     << _pollSockets.size() << " sockets");
 
-            _pollSockets.erase(std::remove_if(_pollSockets.begin(), _pollSockets.end(),
-                                              [](const std::shared_ptr<Socket>& s) -> bool
-                                              { return !s || s->getFD() < 0; }),
-                               _pollSockets.end());
+            _pollSockets.erase(
+                std::remove_if(_pollSockets.begin(), _pollSockets.end(),
+                    [](const std::shared_ptr<Socket>& s)->bool
+                    { return !s; }),
+                _pollSockets.end());
         }
     }
 

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -217,7 +217,7 @@ public:
     /// TODO: Support separate read/write shutdown.
     virtual void shutdown()
     {
-        if (!_noShutdown && !isClosed())
+        if (!_noShutdown)
         {
             LOG_TRC("Socket shutdown RDWR. " << *this);
             if constexpr (!Util::isMobileApp())
@@ -436,14 +436,7 @@ protected:
     void setNoShutdown() { _noShutdown = true; }
 
     /// Explicitly marks this socket closed, i.e. rejected from polling and potentially shutdown
-    /// Note: to preserve the original FD post closing (f.e. in logs and debugger), we negate it.
-    void setClosed()
-    {
-        if (_fd > 0)
-            _fd = -_fd;
-        else if (_fd == 0) // Unlikely, but technically possible.
-            _fd = -1;
-    }
+    void setClosed() { _fd = -1; }
 
     /// Explicitly marks this socket and the given SocketDisposition closed
     void setClosed(SocketDisposition &disposition) { setClosed(); disposition.setClosed(); }


### PR DESCRIPTION
- **Revert "wsd: shutdown and close sockets early"**
- **Revert "wsd: invalidate socket FD by negating"**
- **Revert "wsd: replace _closed member with invalidating the FD"**
