### PR TITLE
Fixed same kid-id reorder problem in UI-log-script

### DIFF
--- a/scripts/undoStatistics.py
+++ b/scripts/undoStatistics.py
@@ -52,6 +52,7 @@ def reorderLogFile(oldFilename):
     fileLines = []
     kitStartLine = {}
     kitEndLine = {}
+    kitCount = {}
     i = 0
 
     for line in f:
@@ -60,16 +61,24 @@ def reorderLogFile(oldFilename):
             endOfKit = line[numbKit:].find(" ")
             if endOfKit >= 0:
                 endOfKit += numbKit
-                kit = int(line[numbKit+4:endOfKit],16)
+                kit = line[numbKit+4:endOfKit]
             else:
-                kit = int(line[numbKit+4:],16)
+                kit = line[numbKit+4:-1]
 
-            fileLines.append(FileLine(kit,line))
+            if kit not in kitCount:
+                kitCount[kit] = 0
 
-            if kit not in kitStartLine:
-                kitStartLine[kit] = i
-            kitEndLine[kit] = i
+            kit2 = kit + "/" + str(kitCount[kit])
+
+            fileLines.append(FileLine(kit2,line))
+
+            if kit2 not in kitStartLine:
+                kitStartLine[kit2] = i
+            kitEndLine[kit2] = i
             i += 1
+
+            if line.startswith("log-end-time:"):
+                kitCount[kit] += 1
 
     fOut = open(newFileName, "w")
 


### PR DESCRIPTION
Changed the reorder, so after a "log-end-time:"
new lines with same kit-ID will be handled as different kit-id.


Change-Id: Ib36aec7f7add53b75e377c0c40bfd0cfdd946d3d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

