### PR TITLE
calc: drag select outside the map

### DIFF
--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -191,7 +191,7 @@ export class ScrollSection extends CanvasSectionObject {
 				&& (<any>window).mode.isDesktop()
 				&& this.containerObject.isDraggingSomething()
 				&& L.Map.THIS._docLayer._docType === 'spreadsheet') {
-					var temp = this.containerObject.positionOnMouseDown;
+					var temp = [e.pos.x, e.pos.y];
 					var tempPos = [(this.isRTL() ? this.map._size.x - temp[0] : temp[0]) * app.dpiScale, temp[1] * app.dpiScale];
 					var docTopLeft = app.sectionContainer.getDocumentTopLeft();
 					tempPos = [tempPos[0] + docTopLeft[0], tempPos[1] + docTopLeft[1]];
@@ -221,7 +221,7 @@ export class ScrollSection extends CanvasSectionObject {
 			vx = -50;
 		}
 
-		this.onScrollVelocity({vx: vx, vy: vy});
+		this.onScrollVelocity({ vx: vx, vy: vy, pos: e.pos });
 	}
 
 	private getVerticalScrollLength (): number {

--- a/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
@@ -75,4 +75,27 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		// Document should scroll
 		desktopHelper.assertScrollbarPosition('horizontal', 80, 110);
 	});
+
+	it('Scroll while selecting with mouse', function () {
+		cy.cGet(helper.addressInputSelector).should('have.value', 'A2');
+
+		// Click on the bottom left cell and hold
+		cy.cGet('.leaflet-layer')
+			.then(function (items) {
+				expect(items).to.have.lengthOf(1);
+				var yPos = items[0].getBoundingClientRect().height - 60;
+				cy.cGet('.leaflet-layer').realMouseDown({ pointer: 'mouse', button: 'left', x: 30, y: yPos, scrollBehavior: false });
+			});
+		// Drag some cells to the right
+		cy.cGet('.leaflet-layer').realMouseMove(-280, -60, { position: 'bottomRight', scrollBehavior: false });
+		// Drag to the bottom edge
+		cy.cGet('.leaflet-layer').realMouseMove(-280, 0, { position: 'bottomRight', scrollBehavior: false });
+		// Wait for autoscroll and lift the button
+		cy.wait(500);
+		cy.cGet('.leaflet-layer').realMouseUp({ pointer: 'mouse', button: 'left' });
+
+		// Wihtout the fix, the selected range is of the form A17:A22, instead of A17:D22
+		// It's better not to check the exact range beacuse it can easily change in different executions
+		cy.cGet(helper.addressInputSelector).invoke('val').should('contain', 'D');
+	});
 });


### PR DESCRIPTION
In calc, when handling auto-scroll outside the map, the selected range
was updated using the mouse down position. This causes the selection to
shrink and expand when the mouse leaves and enters the map area.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I307b9e30f8a06333a034f18914b1322146358512
