### PR TITLE
tile: avoid rendering beyond document boundary

### DIFF
--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -548,6 +548,7 @@ export class Header extends app.definitions.canvasSectionObject {
 			this._prevMouseOverEntry = this._mouseOverEntry;
 			this._mouseOverEntry = result.entry;
 		}
+		else return;
 
 		if (!this.containerObject.isDraggingSomething()) { // If we are not dragging anything.
 			this._dragDistance = null;

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -13,7 +13,7 @@
  * Calc tile layer is used to display a spreadsheet document
  */
 
-/* global app CPolyUtil CPolygon */
+/* global app CPolyUtil CPolygon $ */
 
 L.CalcTileLayer = L.CanvasTileLayer.extend({
 	options: {
@@ -107,6 +107,9 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		if (typeof this._prevSelectedPart === 'number' && !e.source) {
 			this.refreshViewData(undefined, false /* compatDataSrcOnly */, true /* sheetGeometryChanged */);
 			this._switchSplitPanesContext();
+			setTimeout(() => {
+				this._syncTileContainerSize();
+			}, 500);
 		}
 	},
 
@@ -311,7 +314,6 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		this._map.setMaxBounds(new L.LatLngBounds(topLeft, bottomRight));
 
 		this._map.fire('scrolllimits', newSizePx.clone());
-		this._syncTileContainerSize();
 
 		if (limitWidth || limitHeight || extendedLimit)
 			app.sectionContainer.requestReDraw();
@@ -384,7 +386,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		}
 	},
 
-	syncTileContainerSize: function() {
+	_syncTileContainerSize: function() {
 		if (!this._map) return;
 
 		var tileContainer = this._container;
@@ -392,58 +394,66 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			// Document container size is up to date as of now.
 			var documentContainerSize = document.getElementById('document-container');
 			documentContainerSize = documentContainerSize.getBoundingClientRect();
-			documentContainerSize = [documentContainerSize.width, documentContainerSize.height];
+			documentContainerSize = [documentContainerSize.width * app.dpiScale, documentContainerSize.height * app.dpiScale];
 
-			var mapElement = document.getElementById('map'); // map's size = tiles section's size.
+			// Size has changed. Our map and canvas are not resized yet.
+			// But the row header, row group, column header and column group sections don't need to be resized.
+			// We can get their width and height from the sections' properties.
+			const rowHeaderSection = app.sectionContainer.getSectionWithName(L.CSections.RowHeader.name);
+			const columnHeaderSection = app.sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name);
+			const rowGroupSection = app.sectionContainer.getSectionWithName(L.CSections.RowGroup.name);
+			const columnGroupSection = app.sectionContainer.getSectionWithName(L.CSections.ColumnGroup.name);
+			const scrollSection = app.sectionContainer.getSectionWithName(L.CSections.Scroll.name);
+			const scrollBarThickness = scrollSection ? scrollSection.sectionProperties.scrollBarThickness : 0;
 
-			var oldSize = [mapElement.clientWidth, mapElement.clientHeight];
+			const marginLeft = (rowHeaderSection ? rowHeaderSection.size[0] : 0) + (rowGroupSection ? rowGroupSection.size[0] : 0);
+			const marginTop = (columnHeaderSection ? columnHeaderSection.size[1] : 0) + (columnGroupSection ? columnGroupSection.size[1] : 0);
 
-			var rectangle = this._getTilesSectionRectangle();
-			mapElement.style.left = rectangle.getPxX1() + 'px';
-			mapElement.style.top = rectangle.getPxY1() + 'px';
-			var mapSize = [rectangle.getPxWidth(), rectangle.getPxHeight()];
+			// Available for tiles section.
+			const availableSpace = [documentContainerSize[0] - marginLeft - scrollBarThickness, documentContainerSize[1] - marginTop - scrollBarThickness];
+			let newMapSize = availableSpace.slice();
+			let newCanvasSize = documentContainerSize.slice();
 
-			if (app.file.size.pixels[0] < documentContainerSize[0] || app.file.size.pixels[1] < documentContainerSize[1]) {
-				var additionalHeight = 0;
-				var additionalWidth = 0;
-				var rowHeader = app.sectionContainer.getSectionWithName(L.CSections.RowHeader.name);
-				var columnHeader = app.sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name);
-				var scroll = app.sectionContainer.getSectionWithName(L.CSections.Scroll.name);
-				if (scroll) {
-					additionalHeight += scroll.sectionProperties.scrollBarThickness;
-					additionalWidth += scroll.sectionProperties.scrollBarThickness;
-				}
+			const fileSizePixels = [app.file.size.pixels[0], app.file.size.pixels[1]];
 
-				if (rowHeader) {
-					additionalWidth += rowHeader.size[0];
-				}
-				if (columnHeader) {
-					additionalHeight += columnHeader.size[1];
-				}
-				documentContainerSize = [Math.min(documentContainerSize[0], app.file.size.pixels[0])+ additionalWidth, Math.min(documentContainerSize[1], app.file.size.pixels[1])+additionalHeight];
-
-				mapSize = [Math.min(mapSize[0], app.file.size.pixels[0]), Math.min(mapSize[1], app.file.size.pixels[1])];
+			// If we don't need that much space.
+			if (fileSizePixels[0] < availableSpace[0]) {
+				newMapSize[0] = fileSizePixels[0];
+				newCanvasSize[0] = fileSizePixels[0] + marginLeft + scrollBarThickness;
 			}
 
-			app.sectionContainer.onResize(documentContainerSize[0], documentContainerSize[1]); // Canvas's size = documentContainer's size.
+			if (fileSizePixels[1] < availableSpace[1]) {
+				newMapSize[1] = fileSizePixels[1];
+				newCanvasSize[1] = fileSizePixels[1] + marginTop + scrollBarThickness;
+			}
 
-			mapElement.style.width = mapSize[0] + 'px';
-			mapElement.style.height = mapSize[1] + 'px';
+			newMapSize = [Math.round(newMapSize[0] / app.dpiScale), Math.round(newMapSize[1] / app.dpiScale)];
+			newCanvasSize = [Math.round(newCanvasSize[0] / app.dpiScale), Math.round(newCanvasSize[1] / app.dpiScale)];
 
-			tileContainer.style.width = rectangle.getPxWidth() + 'px';
-			tileContainer.style.height = rectangle.getPxHeight() + 'px';
+			const mapElement = document.getElementById('map'); // map's size = tiles section's size.
 
-			var newSize = this._getRealMapSize();
-			var heightIncreased = oldSize[1] < newSize.y;
-			var widthIncreased = oldSize[0] < newSize.x;
+			const oldMapSize = [mapElement.clientWidth, mapElement.clientHeight];
+
+			mapElement.style.left = Math.round(marginLeft / app.dpiScale) + 'px';
+			mapElement.style.top = Math.round(marginTop / app.dpiScale) + 'px';
+			mapElement.style.width = newMapSize[0] + 'px';
+			mapElement.style.height = newMapSize[1] + 'px';
+
+			tileContainer.style.width = newMapSize[0] + 'px';
+			tileContainer.style.height = newMapSize[1] + 'px';
+
+			app.sectionContainer.onResize(newCanvasSize[0], newCanvasSize[1]); // Canvas's size = documentContainer's size.
+
+			var widthIncreased = oldMapSize[0] < newMapSize[0];
+			var heightIncreased = oldMapSize[1] < newMapSize[1];
 
 			if (app.sectionContainer.doesSectionExist(L.CSections.RowHeader.name)) {
 				app.sectionContainer.getSectionWithName(L.CSections.RowHeader.name)._updateCanvas();
 				app.sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name)._updateCanvas();
 			}
 
-			if (oldSize[0] !== newSize.x || oldSize[1] !== newSize.y) {
-				this._map.invalidateSize({}, new L.Point(oldSize[0], oldSize[1]));
+			if (oldMapSize[0] !== newMapSize[0] || oldMapSize[1] !== newMapSize[1]) {
+				this._map.invalidateSize({}, new L.Point(oldMapSize[0], oldMapSize[1]));
 			}
 
 			var hasMobileWizardOpened = this._map.uiManager.mobileWizard ? this._map.uiManager.mobileWizard.isOpen() : false;
@@ -457,8 +467,6 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				} else
 					this._onUpdateCursor(true);
 			}
-
-			this._fitWidthZoom();
 
 			// Center the view w.r.t the new map-pane position using the current zoom.
 			this._map.setView(this._map.getCenter());
@@ -1063,7 +1071,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 
 			this._oldSheetGeomMsg = textMsg;
 			this._handleSheetGeometryDataMsg(values, differentSheet);
-
+			this._syncTileContainerSize();
 		} else if (values.comments) {
 			app.sectionContainer.getSectionWithName(L.CSections.CommentList.name).importComments(values.comments);
 		} else if (values.commentsPos) {

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -311,6 +311,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		this._map.setMaxBounds(new L.LatLngBounds(topLeft, bottomRight));
 
 		this._map.fire('scrolllimits', newSizePx.clone());
+		this._syncTileContainerSize();
 
 		if (limitWidth || limitHeight || extendedLimit)
 			app.sectionContainer.requestReDraw();

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4177,16 +4177,41 @@ L.CanvasTileLayer = L.Layer.extend({
 			documentContainerSize = documentContainerSize.getBoundingClientRect();
 			documentContainerSize = [documentContainerSize.width, documentContainerSize.height];
 
-			app.sectionContainer.onResize(documentContainerSize[0], documentContainerSize[1]); // Canvas's size = documentContainer's size.
-
 			var oldSize = this._getRealMapSize();
 
 			var rectangle = this._getTilesSectionRectangle();
 			var mapElement = document.getElementById('map'); // map's size = tiles section's size.
 			mapElement.style.left = rectangle.getPxX1() + 'px';
 			mapElement.style.top = rectangle.getPxY1() + 'px';
-			mapElement.style.width = rectangle.getPxWidth() + 'px';
-			mapElement.style.height = rectangle.getPxHeight() + 'px';
+			var mapSize = [rectangle.getPxWidth(), rectangle.getPxHeight()];
+
+			if (this.isCalc() && (app.file.size.pixels[0] < documentContainerSize[0] || app.file.size.pixels[1] < documentContainerSize[1])) {
+
+				var additionalHeight = 0;
+				var additionalWidth = 0;
+				var rowHeader = app.sectionContainer.getSectionWithName(L.CSections.RowHeader.name);
+				var columnHeader = app.sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name);
+				var scroll = app.sectionContainer.getSectionWithName(L.CSections.Scroll.name);
+				if (scroll) {
+					additionalHeight += scroll.sectionProperties.scrollBarThickness;
+					additionalWidth += scroll.sectionProperties.scrollBarThickness;
+				}
+
+				if (rowHeader) {
+					additionalWidth += rowHeader.size[0];
+				}
+				if (columnHeader) {
+					additionalHeight += columnHeader.size[1];
+				}
+				documentContainerSize = [Math.min(documentContainerSize[0], app.file.size.pixels[0])+ additionalWidth, Math.min(documentContainerSize[1], app.file.size.pixels[1])+additionalHeight];
+
+				mapSize = [Math.min(mapSize[0], app.file.size.pixels[0]), Math.min(mapSize[1], app.file.size.pixels[1])];
+			}
+
+			app.sectionContainer.onResize(documentContainerSize[0], documentContainerSize[1]); // Canvas's size = documentContainer's size.
+
+			mapElement.style.width = mapSize[0] + 'px';
+			mapElement.style.height = mapSize[1] + 'px';
 
 			tileContainer.style.width = rectangle.getPxWidth() + 'px';
 			tileContainer.style.height = rectangle.getPxHeight() + 'px';

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -941,6 +941,9 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		app.twipsToPixels = app.tile.size.pixels[0] / app.tile.size.twips[0];
 		app.pixelsToTwips = app.tile.size.twips[0] / app.tile.size.pixels[0];
+
+		if (this._docType === 'spreadsheet')
+			this._syncTileContainerSize();
 	},
 
 	_checkSpreadSheetBounds: function (newZoom) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4177,41 +4177,16 @@ L.CanvasTileLayer = L.Layer.extend({
 			documentContainerSize = documentContainerSize.getBoundingClientRect();
 			documentContainerSize = [documentContainerSize.width, documentContainerSize.height];
 
+			app.sectionContainer.onResize(documentContainerSize[0], documentContainerSize[1]); // Canvas's size = documentContainer's size.
+
 			var oldSize = this._getRealMapSize();
 
 			var rectangle = this._getTilesSectionRectangle();
 			var mapElement = document.getElementById('map'); // map's size = tiles section's size.
 			mapElement.style.left = rectangle.getPxX1() + 'px';
 			mapElement.style.top = rectangle.getPxY1() + 'px';
-			var mapSize = [rectangle.getPxWidth(), rectangle.getPxHeight()];
-
-			if (this.isCalc() && (app.file.size.pixels[0] < documentContainerSize[0] || app.file.size.pixels[1] < documentContainerSize[1])) {
-
-				var additionalHeight = 0;
-				var additionalWidth = 0;
-				var rowHeader = app.sectionContainer.getSectionWithName(L.CSections.RowHeader.name);
-				var columnHeader = app.sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name);
-				var scroll = app.sectionContainer.getSectionWithName(L.CSections.Scroll.name);
-				if (scroll) {
-					additionalHeight += scroll.sectionProperties.scrollBarThickness;
-					additionalWidth += scroll.sectionProperties.scrollBarThickness;
-				}
-
-				if (rowHeader) {
-					additionalWidth += rowHeader.size[0];
-				}
-				if (columnHeader) {
-					additionalHeight += columnHeader.size[1];
-				}
-				documentContainerSize = [Math.min(documentContainerSize[0], app.file.size.pixels[0])+ additionalWidth, Math.min(documentContainerSize[1], app.file.size.pixels[1])+additionalHeight];
-
-				mapSize = [Math.min(mapSize[0], app.file.size.pixels[0]), Math.min(mapSize[1], app.file.size.pixels[1])];
-			}
-
-			app.sectionContainer.onResize(documentContainerSize[0], documentContainerSize[1]); // Canvas's size = documentContainer's size.
-
-			mapElement.style.width = mapSize[0] + 'px';
-			mapElement.style.height = mapSize[1] + 'px';
+			mapElement.style.width = rectangle.getPxWidth() + 'px';
+			mapElement.style.height = rectangle.getPxHeight() + 'px';
 
 			tileContainer.style.width = rectangle.getPxWidth() + 'px';
 			tileContainer.style.height = rectangle.getPxHeight() + 'px';
@@ -4219,13 +4194,6 @@ L.CanvasTileLayer = L.Layer.extend({
 			var newSize = this._getRealMapSize();
 			var heightIncreased = oldSize.y < newSize.y;
 			var widthIncreased = oldSize.x < newSize.x;
-
-			if (this._docType === 'spreadsheet') {
-				if (app.sectionContainer.doesSectionExist(L.CSections.RowHeader.name)) {
-					app.sectionContainer.getSectionWithName(L.CSections.RowHeader.name)._updateCanvas();
-					app.sectionContainer.getSectionWithName(L.CSections.ColumnHeader.name)._updateCanvas();
-				}
-			}
 
 			if (oldSize.x !== newSize.x || oldSize.y !== newSize.y) {
 				this._map.invalidateSize({}, oldSize);

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -977,11 +977,6 @@ L.Map = L.Evented.extend({
 			this._sizeChanged = false;
 		}
 
-		// do this only for calc as writer and impress renders area around the document too
-		if (app.file.size.pixels[0] !== 0 && app.file.size.pixels[1] !== 0 && this._docLayer.isCalc()) {
-			this._size.x = this._size.x > app.file.size.pixels[0] ? app.file.size.pixels[0] : this._size.x;
-			this._size.y = this._size.y > app.file.size.pixels[1] ? app.file.size.pixels[1] : this._size.y;
-		}
 		return this._size.clone();
 	},
 

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -976,6 +976,12 @@ L.Map = L.Evented.extend({
 
 			this._sizeChanged = false;
 		}
+
+		// do this only for calc as writer and impress renders area around the document too
+		if (app.file.size.pixels[0] !== 0 && app.file.size.pixels[1] !== 0 && this._docLayer.isCalc()) {
+			this._size.x = this._size.x > app.file.size.pixels[0] ? app.file.size.pixels[0] : this._size.x;
+			this._size.y = this._size.y > app.file.size.pixels[1] ? app.file.size.pixels[1] : this._size.y;
+		}
 		return this._size.clone();
 	},
 


### PR DESCRIPTION
problem:
i.e: if calc sheet has most of row hidden and remaining rows don't cover the canvas area then
1. canvas center was incorrectly calculated based on available area instead the required doc area
2. grids were drawn beyond the last visible raw


Change-Id: I1f43e37e104c693b8f070271dac620385c0a2dd0


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

