### PR TITLE
Add null safety check for controlPosition initialization

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -829,9 +829,9 @@ L.Control.JSDialog = L.Control.extend({
 		// focus on element outside view will move viewarea leaving blank space on the bottom
 		if (innerData.action_type === 'grab_focus') {
 			var control = dialogContainer.querySelector('[id=\'' + innerData.control_id + '\']');
-			var controlPosition = control.getBoundingClientRect();
-			if (controlPosition.bottom > window.innerHeight ||
-				controlPosition.right > window.innerWidth) {
+			var controlPosition = control ? control.getBoundingClientRect() : null;
+			if (controlPosition && (controlPosition.bottom > window.innerHeight ||
+				controlPosition.right > window.innerWidth)) {
 				this.centerDialogPosition(dialog); // will center it
 			}
 		}


### PR DESCRIPTION
- for undefined element we should add safe check here for controlPosition
- we are already showing error about absece of contolId element in `executeAction`` method (browser/src/control/Control.JSDialogBuilder.js#L2778)
- so no need to show JsError here.


Change-Id: I557e2c386408f0b9fe197fcf7a931152b31f9286


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

