### PR TITLE
fix: unnecessary UserSettingsUri set from wopi response

### DIFF
--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -240,8 +240,6 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo, Poco::JSON::Ob
     if (auto settingsJSON = object->getObject("UserSettings"))
         JsonUtil::findJSONValue(settingsJSON, "uri", _userSettingsUri);
 
-    JsonUtil::findJSONValue(object, "UserSettingsUri", _userSettingsUri);
-
     JsonUtil::findJSONValue(object, "WatermarkText", _watermarkText);
     JsonUtil::findJSONValue(object, "UserCanWrite", _userCanWrite);
     JsonUtil::findJSONValue(object, "PostMessageOrigin", _postMessageOrigin);


### PR DESCRIPTION
Change-Id: Icea911ea3a136602bf05f4051a0e3222e83de048


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

