### PR TITLE
fix(calc): Improve zoom view-jumping

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -383,8 +383,8 @@ window.L.TileSectionManager = window.L.Class.extend({
 			newCenter = newTopLeftP.multiplyBy(app.dpiScale).add(paneBounds.getSize().subtract(splitPos).divideBy(2));
 		} else {
 			const newPaneCenter = new cool.Point(
-				(docTopLeft.x - splitPos.x + (paneSize.x + splitPos.x) * 0.5 / scale),
-				(docTopLeft.y - splitPos.y + (paneSize.y + splitPos.y) * 0.5 / scale));
+				(docTopLeft.x - paneSize.x * 0.5 / scale),
+				(docTopLeft.y - paneSize.y * 0.5 / scale));
 			newCenter = this._map.rescale(newPaneCenter, this._map.getZoom(), newZoom);
 		}
 

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -372,14 +372,26 @@ window.L.TileSectionManager = window.L.Class.extend({
 			return { offset: this._offset, topLeft: docTopLeft };
 		}
 
-		const newPaneCenter = new cool.Point(
-			(docTopLeft.x - splitPos.x + (paneSize.x + splitPos.x) * 0.5 / scale),
-			(docTopLeft.y - splitPos.y + (paneSize.y + splitPos.y) * 0.5 / scale));
+		let newCenter;
+
+		const newZoom = this._map.getScaleZoom(scale);
+		if (this._layer.isCalc()) {
+			const zoomScaleAbs = this._map.zoomToFactor(newZoom);
+
+			const newTopLeftP = this._layer.sheetGeometry
+				.getCorePixelsAtZoom(docTopLeft, zoomScaleAbs);
+			newCenter = newTopLeftP.multiplyBy(app.dpiScale).add(paneBounds.getSize().subtract(splitPos).divideBy(2));
+		} else {
+			const newPaneCenter = new cool.Point(
+				(docTopLeft.x - splitPos.x + (paneSize.x + splitPos.x) * 0.5 / scale),
+				(docTopLeft.y - splitPos.y + (paneSize.y + splitPos.y) * 0.5 / scale));
+			newCenter = this._map.rescale(newPaneCenter, this._map.getZoom(), newZoom);
+		}
 
 		return {
 			offset: this._offset,
-			topLeft: docTopLeft.add(this._offset),
-			center: this._map.rescale(newPaneCenter, this._map.getZoom(), this._map.getScaleZoom(scale)),
+			topLeft: docTopLeft,
+			center: newCenter,
 		};
 	},
 

--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -376,15 +376,20 @@ function actionOnSelector(name, func) {
 	});
 }
 
+function cygetScrollbarPosition(type) {
+	return cy.cGet('#test-div-' + type + '-scrollbar').then(function($item) {
+		cy.wrap(parseInt($item.text()));
+	});
+}
+
 //type represent horizontal/vertical scrollbar
 //arr : In both cypress GUI and CLI the scrollposition are slightly different
 //so we are passing both in array and assert using oneOf
 function assertScrollbarPosition(type, lowerBound, upperBound) {
 	cy.log('>> assertScrollbarPosition - start');
 
-	cy.cGet('#test-div-' + type + '-scrollbar')
-		.should(function($item) {
-			const x = parseInt($item.text());
+	cygetScrollbarPosition(type)
+		.should(function(x) {
 			expect(x).to.be.within(lowerBound, upperBound);
 		});
 

--- a/cypress_test/integration_tests/desktop/calc/zoom_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/zoom_spec.js
@@ -1,0 +1,157 @@
+// Zooming isn't perfect for not causing view jumps yet - it's only "much better than before"
+// Therefore, we'll assert that it has to be at somewhere that isn't quite the right position (but is similarly "much better than before")
+// If you fix zoom properly, you should update these tests to match
+/* global describe it cy beforeEach expect require */
+
+var helper = require('../../common/helper');
+var desktopHelper = require('../../common/desktop_helper');
+
+const zoomLevels = {
+  20: { expectedHorizontal: 760, expectedVertical: 540 },
+  25: { expectedHorizontal: 760, expectedVertical: 540 },
+  30: { expectedHorizontal: 760, expectedVertical: 540 },
+  35: { expectedHorizontal: 760, expectedVertical: 540 },
+  40: { expectedHorizontal: 760, expectedVertical: 540 },
+  50: { expectedHorizontal: 760, expectedVertical: 540 },
+  60: { expectedHorizontal: 760, expectedVertical: 540 },
+  70: { expectedHorizontal: 760, expectedVertical: 540 },
+  85: { expectedHorizontal: 760, expectedVertical: 540 },
+  100: { expectedHorizontal: 760, expectedVertical: 540 },
+  120: { expectedHorizontal: 760, expectedVertical: 524 },
+  150: { expectedHorizontal: 760, expectedVertical: 520 },
+  170: { expectedHorizontal: 760, expectedVertical: 520 },
+  200: { expectedHorizontal: 760, expectedVertical: 520 },
+  235: { expectedHorizontal: 760, expectedVertical: 500 },
+  280: { expectedHorizontal: 740, expectedVertical: 500 },
+  335: { expectedHorizontal: 740, expectedVertical: 500 },
+  400: { expectedHorizontal: 740, expectedVertical: 500 },
+}; // Record<zoom, { expectedHortizontal, expectedVertical }>
+
+const acceptableDrift = 10; // FIXME: there is no "acceptable drift", but there was a change that introduced drift but was otherwise considerably better, so we make this tradeoff. Ideally this would be changed to be a static tolerance
+
+describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell selectionTest zooming on cells far away from the top left', function() {
+  beforeEach(function() {
+    helper.setupAndLoadDocument('calc/cell_cursor.ods');
+    desktopHelper.switchUIToCompact();
+    cy.cGet('#toolbar-up .ui-scroll-right').click();
+    cy.cGet('#sidebar').click({ force: true });
+  });
+
+  it("doesn't jump when zooming at a high cell index", function() {
+    helper.typeIntoInputField(helper.addressInputSelector, 'SKY3665');
+
+    desktopHelper.assertScrollbarPosition('horizontal', 540, 560);
+    desktopHelper.assertScrollbarPosition('vertical', 360, 380);
+
+    desktopHelper.zoomIn();
+
+    desktopHelper.assertScrollbarPosition('horizontal', 540, 560);
+    desktopHelper.assertScrollbarPosition('vertical', 360, 380);
+
+    desktopHelper.zoomOut();
+
+    desktopHelper.assertScrollbarPosition('horizontal', 540, 560);
+    desktopHelper.assertScrollbarPosition('vertical', 360, 380);
+  });
+
+  it("doesn't jump even when zooming a long way", function() {
+    helper.typeIntoInputField(helper.addressInputSelector, 'SKY3665');
+
+    desktopHelper.assertScrollbarPosition('horizontal', 520, 560);
+    desktopHelper.assertScrollbarPosition('vertical', 320, 380);
+
+    desktopHelper.selectZoomLevel(20);
+
+    desktopHelper.assertScrollbarPosition('horizontal', 520, 560);
+    desktopHelper.assertScrollbarPosition('vertical', 320, 380);
+
+    desktopHelper.selectZoomLevel(400);
+
+    desktopHelper.assertScrollbarPosition('horizontal', 520, 560);
+    desktopHelper.assertScrollbarPosition('vertical', 320, 380);
+
+    desktopHelper.selectZoomLevel(100);
+
+    desktopHelper.assertScrollbarPosition('horizontal', 520, 560);
+    desktopHelper.assertScrollbarPosition('vertical', 320, 380);
+  });
+
+  it("doesn't lose precision on repeated zooms", function() {
+    helper.typeIntoInputField(helper.addressInputSelector, 'SKY3665');
+
+    desktopHelper.assertScrollbarPosition('horizontal', 740, 770);
+    desktopHelper.assertScrollbarPosition('vertical', 450, 540);
+
+    cy.log("Zooming in")
+
+    const zoomEntries = Array.from(zoomLevels.entries());
+    let prevZoom = 100;
+
+    for (const [zoomLevel, { expectedHorizontal, expectedVertical }] of zoomEntries.filter(([level, _]) => level > 100)) {
+      const expectedHorizontalDifference = expectedHorizontal - zoomLevels[prevZoom].expectedHorizontal;
+      const expectedVerticalDifference = expectedVertical - zoomLevels[prevZoom].expectedVertical;
+
+      cy.log(`Zooming to ${zoomLevel}`);
+
+      desktopHelper.cygetScrollbarPosition('horizontal').then((oldHorizontalPosition) => {
+        desktopHelper.cygetScrollbarPosition('vertical').then((oldVerticalPosition) => {
+          // This has to be nested because cypress queues operations and then runs them all at once - it has no equivalent of await either
+
+          desktopHelper.zoomIn();
+          desktopHelper.shouldHaveZoomLevel(zoomLevel);
+
+          desktopHelper.assertScrollbarPosition('horizontal', oldHorizontalPosition + expectedHorizontalDifference - acceptableDrift, oldHorizontalPosition - expectedHorizontalDifference + acceptableDrift);
+          desktopHelper.assertScrollbarPosition('vertical', oldVerticalPosition + expectedVerticalDifference - acceptableDrift, oldVerticalPosition - expectedVerticalDifference + acceptableDrift);
+        });
+      });
+
+      prevZoom = zoomLevel;
+    }
+
+    cy.log("Zooming out")
+
+    for (const [zoomLevel, { expectedHorizontal, expectedVertical }] of zoomEntries.toReversed().slice(1)) {
+      const expectedHorizontalDifference = expectedHorizontal - zoomLevels[prevZoom].expectedHorizontal;
+      const expectedVerticalDifference = expectedVertical - zoomLevels[prevZoom].expectedVertical;
+
+      cy.log(`Zooming to ${zoomLevel}`);
+
+      desktopHelper.cygetScrollbarPosition('horizontal').then((oldHorizontalPosition) => {
+        desktopHelper.cygetScrollbarPosition('vertical').then((oldVerticalPosition) => {
+          // This has to be nested because cypress queues operations and then runs them all at once - it has no equivalent of await either
+
+          desktopHelper.zoomIn();
+          desktopHelper.shouldHaveZoomLevel(zoomLevel);
+
+          desktopHelper.assertScrollbarPosition('horizontal', oldHorizontalPosition + expectedHorizontalDifference - acceptableDrift, oldHorizontalPosition - expectedHorizontalDifference + acceptableDrift);
+          desktopHelper.assertScrollbarPosition('vertical', oldVerticalPosition + expectedVerticalDifference - acceptableDrift, oldVerticalPosition - expectedVerticalDifference + acceptableDrift);
+        });
+      });
+
+      prevZoom = zoomLevel;
+    }
+
+    cy.log("Zooming in")
+
+    for (const [zoomLevel, { expectedHorizontal, expectedVertical }] of zoomEntries.filter(([level, _]) => level <= 100).slice(1)) {
+      const expectedHorizontalDifference = expectedHorizontal - zoomLevels[prevZoom].expectedHorizontal;
+      const expectedVerticalDifference = expectedVertical - zoomLevels[prevZoom].expectedVertical;
+
+      cy.log(`Zooming to ${zoomLevel}`);
+
+      desktopHelper.cygetScrollbarPosition('horizontal').then((oldHorizontalPosition) => {
+        desktopHelper.cygetScrollbarPosition('vertical').then((oldVerticalPosition) => {
+          // This has to be nested because cypress queues operations and then runs them all at once - it has no equivalent of await either
+
+          desktopHelper.zoomIn();
+          desktopHelper.shouldHaveZoomLevel(zoomLevel);
+
+          desktopHelper.assertScrollbarPosition('horizontal', oldHorizontalPosition + expectedHorizontalDifference - acceptableDrift, oldHorizontalPosition - expectedHorizontalDifference + acceptableDrift);
+          desktopHelper.assertScrollbarPosition('vertical', oldVerticalPosition + expectedVerticalDifference - acceptableDrift, oldVerticalPosition - expectedVerticalDifference + acceptableDrift);
+        });
+      });
+
+      prevZoom = zoomLevel;
+    }
+  });
+});


### PR DESCRIPTION
Previously, we got significant view jumps in calc by virtue of an incorrect center position. To fix this, I've melded together the old formula (from before commit d6f375c501690370e41ceeec18200599bd33490c) with the new formula. I've gated this to calc as the old formula is calc specific. More testing will be needed to determine if there is any jumping in writer/impress.

This old formula had some pitfalls, as it was made to deal with zooming from the top left of the screen rather than an arbitrary point. Particularly notably, the old formula doesn't deal with anything that is not on the edge of a cell. Therefore, there is still some view jumping, there's just likely to be less-of-it and it'll be a bit more consistent rather than having huge jumps every time on higher positions.

This code still doesn't work in some cases, which I will continue to fix:
- It doesn't work on my iPad, it's unclear why but the symptoms are no change in zoom level. It's possible that tablets use YetAnotherZoomFormula
- It doesn't work on my Mac. The symptoms are being *nearly there* but ever-so-slightly off


Change-Id: I7127d8f0a3156ed9dfb04bdd5fb801c318531269


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

