### PR TITLE
UI log: small fixes, and extra addons

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3946,6 +3946,10 @@ LogUiCommands::~LogUiCommands()
                     return;
                 actCmd = (*_tokens)[0];
                 actSubCmd = (*_tokens)[1];
+                std::size_t pos = actSubCmd.find_first_of ('?');
+                if (pos != std::string::npos) {
+                    actSubCmd = actSubCmd.substr (0,pos);
+                }
             }
             else if (_tokens->equals(0, "mouse"))
             {

--- a/test/data/empty-chart.fods
+++ b/test/data/empty-chart.fods
@@ -207,14 +207,14 @@
     <style:text-properties fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
    <style:style style:name="ce3" style:family="table-cell" style:parent-style-name="Default">
-   <style:table-cell-properties style:rotation-angle="90" fo:wrap-option="wrap" style:max-height="2in"/>
+   <style:table-cell-properties style:rotation-angle="45" fo:wrap-option="wrap" style:max-height="2in"/>
    <style:text-properties fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
   </style:style>
   <style:style style:name="co1" style:family="table-column">
    <style:table-column-properties fo:break-before="auto" style:column-width="1.3in"/>
   </style:style>
   <style:style style:name="co2" style:family="table-column">
-   <style:table-column-properties fo:break-before="auto" style:column-width="1.3in"/>
+   <style:table-column-properties fo:break-before="auto" style:column-width="0.6in"/>
   </style:style>
   <style:style style:name="ro1" style:family="table-row">
    <style:table-row-properties style:row-height="0.1783in" fo:break-before="auto" style:use-optimal-row-height="true"/>
@@ -289,6 +289,11 @@
          </style:style>
          <style:style style:name="ch5" style:family="chart" style:data-style-name="N0">
           <style:chart-properties chart:display-label="true" chart:logarithmic="false" chart:reverse-direction="false" text:line-break="false" loext:try-staggering-first="false" chart:link-data-style-to-source="true" chart:axis-position="0"/>
+          <style:graphic-properties svg:stroke-color="#b3b3b3"/>
+          <style:text-properties fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
+         </style:style>
+         <style:style style:name="ch5log" style:family="chart" style:data-style-name="N0">
+          <style:chart-properties chart:display-label="true" chart:logarithmic="true" chart:reverse-direction="false" text:line-break="false" loext:try-staggering-first="false" chart:link-data-style-to-source="true" chart:axis-position="0"/>
           <style:graphic-properties svg:stroke-color="#b3b3b3"/>
           <style:text-properties fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
          </style:style>
@@ -448,7 +453,7 @@
       </draw:image>
      </draw:frame></table:shapes>
     <table:table-column table:style-name="co1" table:default-cell-style-name="Default"/>
-    <table:table-column table:style-name="co2" table:number-columns-repeated="2" table:default-cell-style-name="Default"/>
+    <table:table-column table:style-name="co2" table:number-columns-repeated="100" table:default-cell-style-name="Default"/>
     <table:table-row table:style-name="ro1">
      <table:table-cell table:number-columns-repeated="3"/>
     </table:table-row>


### PR DESCRIPTION
delete ?params from the end of uno commands, before logging The script delete them too... to be sure... (if we have old log)

Added char/sec type speed to statistics.
Fixed a bug with uno command connection... (a list was not deleted) found a problem: some cases undo-count-change not happens therefore some undo may not connectable to an undo-count-change made a new "unknown" command .. and count these wrong cases.

Made other statistics a bit better:
-added 45 degree rotattion
-added logarithmical scaling to uno commands
(maybe soem other charts will need it too)
-wrote text to A1 ..and fixed the code to not use that for charts -added new groups: "Single viewer", "Single Editor"


Change-Id: I6bfa40e3505971bd6fb7f77da618f76410ebf87a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

