### PR TITLE
cool#11002 kit: fix memory corruption in Document::handleSaveMessage()

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1375,6 +1375,16 @@ void Document::handleSaveMessage(const std::string &)
         if (_queue)
             _queue->clear();
 
+        // unregister the view callbacks
+        const int viewCount = getLOKitDocument()->getViewsCount();
+        std::vector<int> viewIds(viewCount);
+        getLOKitDocument()->getViewIds(viewIds.data(), viewCount);
+        for (const auto viewId : viewIds)
+        {
+            _loKitDocument->setView(viewId);
+            _loKitDocument->registerCallback(nullptr, nullptr);
+        }
+
         // cleanup any lingering file-system pieces
         _loKitDocument.reset();
 

--- a/wsd/CacheUtil.hpp
+++ b/wsd/CacheUtil.hpp
@@ -23,6 +23,13 @@ struct CacheQuery
     std::string _uri;
     std::string _stamp;
     std::string _dest;
+
+    CacheQuery(const std::string& uri, const std::string& stamp, const std::string& dest)
+        : _uri(uri)
+        , _stamp(stamp)
+        , _dest(dest)
+    {
+    }
 };
 
 class Cache


### PR DESCRIPTION
- **wsd: fix clang-15 build**
- **cool#11002 kit: fix memory corruption in Document::handleSaveMessage()**
