### PR TITLE
mocha: store the compiled js files in a separate folder away from the typescript files

### DIFF
--- a/browser/.gitignore
+++ b/browser/.gitignore
@@ -9,7 +9,7 @@ bower.json
 component.json
 
 mocha.log
-mocha_tests/*.js
+mocha_tests/workdir/
 tscompile.done
 duplication.log
 

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -50,11 +50,12 @@ QUIET_ECHO_ = $(QUIET_ECHO_$(AM_DEFAULT_VERBOSITY))
 QUIET_ECHO_0 = @echo "  ECHO    " $@;
 
 MOCHA_DIR = $(srcdir)/mocha_tests
+MOCHA_JS_DIR = $(MOCHA_DIR)/workdir
 MOCHA_TS_FILES = $(wildcard $(MOCHA_DIR)/*.ts)
-MOCHA_TS_JS_FILES := $(MOCHA_TS_FILES:.ts=.js)
+MOCHA_TS_JS_FILES = $(patsubst $(MOCHA_DIR)/%.ts,$(MOCHA_JS_DIR)/%.js,$(MOCHA_TS_FILES))
 # tsc can report a failure, but still create a .js and a second make attempt will succeed,
 # so if this returns an error then delete the target
-$(MOCHA_TS_JS_FILES): %.js: %.ts
+$(MOCHA_JS_DIR)/%.js: $(MOCHA_DIR)/%.ts
 	$(QUIET_TSC) $(builddir)/node_modules/typescript/bin/tsc $< --outfile $@ --module none --lib dom,es2016 --target ES5 || (rm -f $@ && false)
 
 JQUERY_LIGHTNESS_IMAGE_PATH = $(srcdir)/images/jquery-ui-lightness

--- a/browser/package.json
+++ b/browser/package.json
@@ -57,7 +57,7 @@
     "nan": "^2.22.0"
   },
   "scripts": {
-    "test": "mocha 'mocha_tests/**/*.js'",
+    "test": "mocha 'mocha_tests/workdir/**/*.js'",
     "test-single": "mocha",
     "duplication": "jscpd --ignore src/layer/tile/CanvasTileWorker.js ./src/ --exitCode 1 --min-lines 17"
   }


### PR DESCRIPTION
Store the compiled mocha js files in a separate folder away from the source typescript files.

Change-Id: Ibc1ecd263f53b2e6db736d9c6f1330998d4e2bf8

* Target version: master 

### Summary
Store the compiled mocha js files in a separate folder away from the source typescript files.

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

