### PR TITLE
wsd: presets: pass xcu as json array instead of json object

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1569,8 +1569,11 @@ private:
 
             Poco::Path destDir(_presetsPath, groupName);
             Poco::File(destDir).createDirectories();
-            std::string fileName =
-                Poco::Path(destDir.toString(), Uri::getFilenameWithExtFromURL(uri)).toString();
+            std::string fileName;
+            if (groupName == "xcu")
+                fileName = Poco::Path(destDir.toString(), "config.xcu").toString();
+            else
+                fileName = Poco::Path(destDir.toString(), Uri::getFilenameWithExtFromURL(uri)).toString();
 
             queries.emplace_back(uri, stamp, fileName);
         }
@@ -1593,25 +1596,6 @@ private:
         const std::string stamp = JsonUtil::getJSONValue<std::string>(firstElem, "stamp");
 
         queries.emplace_back(uri, stamp, "browsersetting.json");
-    }
-
-    void addXcu(Poco::JSON::Object::Ptr settings, std::vector<CacheQuery>& queries)
-    {
-        if (!settings->has("xcu"))
-            return;
-
-        auto xcu = settings->get("xcu").extract<Poco::JSON::Object::Ptr>();
-        if (xcu.isNull())
-            return;
-
-        const std::string uri = JsonUtil::getJSONValue<std::string>(xcu, "uri");
-        const std::string stamp = JsonUtil::getJSONValue<std::string>(xcu, "stamp");
-
-        Poco::Path destDir(_presetsPath, "xcu");
-        Poco::File(destDir).createDirectories();
-        std::string fileName = Poco::Path(destDir, "config.xcu").toString();
-
-        queries.emplace_back(uri, stamp, fileName);
     }
 
 public:
@@ -1649,7 +1633,7 @@ public:
             addBrowserSetting(settings, presets);
             addGroup(settings, "autotext", presets);
             addGroup(settings, "wordbook", presets);
-            addXcu(settings, presets);
+            addGroup(settings, "xcu", presets);
         }
 
         Cache::supplyConfigFiles(_configId, presets);

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -581,6 +581,7 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
 
         Poco::JSON::Array::Ptr configAutoTexts = new Poco::JSON::Array();
         Poco::JSON::Array::Ptr configDictionaries = new Poco::JSON::Array();
+        Poco::JSON::Array::Ptr configXcu = new Poco::JSON::Array();
         for (const auto& item : items)
         {
             Poco::JSON::Object::Ptr configEntry = new Poco::JSON::Object();
@@ -596,10 +597,11 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
             else if (item.first == "wordbook")
                 configDictionaries->add(configEntry);
             else if (item.first == "xcu")
-                configInfo->set("xcu", configEntry);
+                configXcu->add(configEntry);
         }
         configInfo->set("autotext", configAutoTexts);
         configInfo->set("wordbook", configDictionaries);
+        configInfo->set("xcu", configXcu);
 
         if (serveBrowserSetttings)
         {


### PR DESCRIPTION
- this is done to make the json format consistent
- json format after this change
```json
{
  "autotext": [
    {
      "stamp": "\"780e98110c\"",
      "uri": "https://localhost:9980/wopi/settings/home/rashesh/work/collabora/online/master//test/data/presets/user/autotextuser.bau"
    }
  ],
  "browsersetting": [
    {
      "stamp": "\"780e98110c\"",
      "uri": "https://localhost:9980/wopi/settings/home/rashesh/work/collabora/online/master/test/data/presets/user/browsersetting.json"
    }
  ],
  "kind": "user",
  "wordbook": [
    {
      "stamp": "\"780e98110c\"",
      "uri": "https://localhost:9980/wopi/settings/home/rashesh/work/collabora/online/master//test/data/presets/user/dictionaryuser.dic"
    }
  ],
  "xcu": [
    {
      "stamp": "\"780e98110c\"",
      "uri": "https://localhost:9980/wopi/settings/home/rashesh/work/collabora/online/master//test/data/presets/user/configuser.xcu"
    }
  ]
}
```


Change-Id: I37058c647eea6f6d17ef76cde99c79a73273ea53