### PR TITLE
Fix Presenter Console gets close in case of repeat slideshow after x sec

### DIFF
--- a/browser/src/slideshow/PresenterConsole.js
+++ b/browser/src/slideshow/PresenterConsole.js
@@ -788,7 +788,8 @@ class PresenterConsole {
 			}
 			case 'next': {
 				this._presenter.getNavigator().dispatchEffect();
-				if (isLastSlide) {
+				// if repeat after sec is set then do not close on last slide
+				if (isLastSlide && !this._presenter._presentationInfo.isEndless) {
 					this._onWindowClose();
 					break;
 				}


### PR DESCRIPTION
- handled the case where we do enable the repeat slide show & PC should not get closed
- isEndless will make sure we do not terminate the window


Change-Id: I6e7f5bb11e784195acc2e8dbb4918875c829e7f3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

