### PR TITLE
doc_memory_used_bytes should be in bytes not in kilobytes (fixes #10984)

### DIFF
--- a/browser/admin/src/Util.js
+++ b/browser/admin/src/Util.js
@@ -22,7 +22,7 @@ var Util = Base.extend({
 }, { // class interface
 
 	humanizeMem: function (kbytes) {
-		var unit = 1000;
+		var unit = 1024;
 		var units = [_('kB'), _('MB'), _('GB'), _('TB'), _('PB'), _('EB'), _('ZB'), _('YB'), _('BB')];
 		for (var i = 0; Math.abs(kbytes) >= unit && i < units.length; i++) {
 			kbytes /= unit;

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -1251,7 +1251,7 @@ void AdminModel::getMetrics(std::ostringstream &oss)
         oss << "doc_views" << suffix << doc.getViews().size() << "\n";
         oss << "doc_views_active" << suffix << doc.getActiveViews() << "\n";
         oss << "doc_is_modified" << suffix << doc.getModifiedStatus() << "\n";
-        oss << "doc_memory_used_bytes" << suffix << doc.getMemoryDirty() << "\n";
+        oss << "doc_memory_used_bytes" << suffix << doc.getMemoryDirty() * 1024 << "\n";
         oss << "doc_cpu_used_seconds" << suffix << ((double)doc.getLastJiffies()/tick_per_sec) << "\n";
         oss << "doc_open_time_seconds" << suffix << doc.getOpenTime() << "\n";
         oss << "doc_idle_time_seconds" << suffix << doc.getIdleTime() << "\n";


### PR DESCRIPTION
Change-Id: I562a7eacdb04bae7745c5f92502c21ef88bf9627


* Resolves: #10984
* Target version: master 
