### PR TITLE
cool#10630 doc electronic sign: 4 fixes for the non-first-page case

### DIFF
--- a/browser/src/app/GraphicSelectionMiddleware.ts
+++ b/browser/src/app/GraphicSelectionMiddleware.ts
@@ -151,14 +151,8 @@ class GraphicSelection {
 
 	/// Push down the graphic selection on non-first pages of scrolling PDF view.
 	static transformGraphicSelection(messageJSON: any) {
-		if (!app.file.fileBasedView) {
-			return;
-		}
-
 		const docLayer = app.map._docLayer;
-		const additionPerPart =
-			docLayer._partHeightTwips + docLayer._spaceBetweenParts;
-		const verticalOffset = additionPerPart * docLayer._selectedPart;
+		const verticalOffset = docLayer.getFiledBasedViewVerticalOffset();
 		if (!verticalOffset) {
 			return;
 		}

--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -697,6 +697,14 @@ class ShapeHandlesSection extends CanvasSectionObject {
 		if (!y) y = this.sectionProperties.lastDragDistance[1] + this.position[1];
 		else y = this.adjustSnapTransformCoordinate(null, y);
 
+		let yTwips = y * app.pixelsToTwips;
+		const docLayer = app.map._docLayer;
+		const verticalOffset = docLayer.getFiledBasedViewVerticalOffset();
+		if (verticalOffset) {
+			// Transform from canvas twips to core twips.
+			yTwips -= verticalOffset;
+		}
+
 		const parameters = {
 			'TransformPosX': {
 				'type': 'long',
@@ -704,7 +712,7 @@ class ShapeHandlesSection extends CanvasSectionObject {
 			},
 			'TransformPosY': {
 				'type': 'long',
-				'value': Math.round(y * app.pixelsToTwips)
+				'value': Math.round(yTwips)
 			}
 		};
 

--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -717,6 +717,8 @@ class ShapeHandlesSection extends CanvasSectionObject {
 		};
 
 		app.map.sendUnoCommand('.uno:TransformDialog', parameters);
+
+		docLayer.requestNewFiledBasedViewTiles();
 	}
 
 	onMouseUp(point: number[], e: MouseEvent): void {

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2028,6 +2028,14 @@ L.Control.Menubar = L.Control.extend({
 			} else {
 				app.map.sendUnoCommand('.uno:InsertSignatureLine');
 			}
+
+			if (app.file.fileBasedView) {
+				// The file based view is primarily to view multi-page PDF files, so
+				// it doesn't seem to have precise tracking of invalidations, just
+				// request new tiles for now.
+				app.map._docLayer._requestNewTiles();
+				app.map._docLayer.redraw();
+			}
 		} else if (id === 'insertgraphic') {
 			L.DomUtil.get('insertgraphic').click();
 		} else if (id === 'insertgraphicremote') {

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2029,13 +2029,10 @@ L.Control.Menubar = L.Control.extend({
 				app.map.sendUnoCommand('.uno:InsertSignatureLine');
 			}
 
-			if (app.file.fileBasedView) {
-				// The file based view is primarily to view multi-page PDF files, so
-				// it doesn't seem to have precise tracking of invalidations, just
-				// request new tiles for now.
-				app.map._docLayer._requestNewTiles();
-				app.map._docLayer.redraw();
-			}
+			// The file based view is primarily to view multi-page PDF files, so
+			// it doesn't seem to have precise tracking of invalidations, just
+			// request new tiles for now.
+			app.map._docLayer.requestNewFiledBasedViewTiles();
 		} else if (id === 'insertgraphic') {
 			L.DomUtil.get('insertgraphic').click();
 		} else if (id === 'insertgraphicremote') {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3106,6 +3106,18 @@ L.CanvasTileLayer = L.Layer.extend({
 		return verticalOffset;
 	},
 
+	// If viewing multi-page PDF files, no precise tracking of invalidations is implemented yet,
+	// so this allows requesting new tiles when we know a viewed PDF changes for some special
+	// reason.
+	requestNewFiledBasedViewTiles: function() {
+		if (!app.file.fileBasedView) {
+			return;
+		}
+
+		this._requestNewTiles();
+		this.redraw();
+	},
+
 	// Given a character code and a UNO keycode, send a "key" message to coolwsd.
 	//
 	// "type" is either "input" for key presses (akin to the DOM "keypress"

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3076,6 +3076,11 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		this._sendClientVisibleArea();
 
+		const verticalOffset = this.getFiledBasedViewVerticalOffset();
+		if (verticalOffset) {
+			y -= verticalOffset;
+		}
+
 		app.socket.sendMessage('mouse type=' + type +
 				' x=' + x + ' y=' + y + ' count=' + count +
 				' buttons=' + buttons + ' modifier=' + modifier);
@@ -3086,6 +3091,19 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		if (this._map && this._map._docLayer && (type === 'buttondown' || type === 'buttonup'))
 			app.setFollowingUser(this._map._docLayer._getViewId());
+	},
+
+	// If viewing multi-page PDF files, get the twips offset of the current part. This is
+	// needed, because core has multiple draw pages in such a case, but we have just one canvas.
+	getFiledBasedViewVerticalOffset: function() {
+		if (!app.file.fileBasedView) {
+			return;
+		}
+
+		const additionPerPart = this._partHeightTwips + this._spaceBetweenParts;
+		const verticalOffset = additionPerPart * this._selectedPart;
+
+		return verticalOffset;
 	},
 
 	// Given a character code and a UNO keycode, send a "key" message to coolwsd.


### PR DESCRIPTION
- **cool#10630 doc electronic sign: fix no SVG in graphic selection on 2nd page**
- **cool#10630 doc electronic sign: fix outgoing mouse messages on 2nd page**
- **cool#10630 doc electronic sign: fix outgoing transform pos on 2nd page**
- **cool#10630 doc electronic sign: fix outdated tile for shape move on 2nd page**
