### PR TITLE
fix: sending browsersetting update after reconnect fails

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -726,7 +726,8 @@ function getInitializerClass() {
 			value = String(value); // NOT "new String(...)". We cannot use .toString here because value could be null/undefined
 			if (global.prefs.useBrowserSetting) {
 				global.prefs._userBrowserSetting[key] = value;
-				global.socket.send('browsersetting action=update key=' + key + ' value=' + value);
+				if (global.socket && (global.socket instanceof WebSocket) && global.socket.readyState === 1)
+					global.socket.send('browsersetting action=update key=' + key + ' value=' + value);
 			}
 			if (global.prefs.canPersist) {
 				global.localStorage.setItem(key, value);

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -63,6 +63,7 @@ app.definitions.Socket = L.Class.extend({
 		} else	{
 			try {
 				this.socket = window.createWebSocket(this.getWebSocketBaseURI(map));
+				window.socket = this.socket;
 			} catch (e) {
 				this._map.fire('error', {msg: _('Oops, there is a problem connecting to {productname}: ').replace('{productname}', (typeof brandProductName !== 'undefined' ? brandProductName : 'Collabora Online Development Edition (unbranded)')) + e, cmd: 'socket', kind: 'failed', id: 3});
 				return;


### PR DESCRIPTION
- global.socket instance is not updated after reconnection therefore state shown when sending browsersettings using global.socket.send is from previous instance of websocket


Change-Id: Ie07cf1c98ea8b3e27575348deba938a2bdf15663


* Resolves: # <!-- related github issue -->
* Target version: master 