### PR TITLE
Notebookbar: Shorten "Find and replace" Translatable string

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -848,7 +848,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 								{
 									'id': 'home-search-dialog',
 									'type': 'toolitem',
-									'text': _UNO('.uno:SearchDialog'),
+									'text': _('Replace'),
 									'command': '.uno:SearchDialog',
 									'accessibility': { focusBack: false, 	combination: 'FD',	de: null }
 								}

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -997,7 +997,7 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 								{
 									'id': 'home-search-dialog',
 									'type': 'toolitem',
-									'text': _UNO('.uno:SearchDialog'),
+									'text': _('Replace'),
 									'command': '.uno:SearchDialog',
 									'accessibility': { focusBack: false, 	combination: 'FD',	de: null }
 								}

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1061,7 +1061,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 								{
 									'id': 'home-search-dialog',
 									'type': 'toolitem',
-									'text': _UNO('.uno:SearchDialog'),
+									'text': _('Replace'),
 									'command': '.uno:SearchDialog',
 									'accessibility': { focusBack: false, 	combination: 'FD',	de: null }
 								}

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -902,7 +902,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								{
 									'id': 'home-search-dialog',
 									'type': 'toolitem',
-									'text': _UNO('.uno:SearchDialog'),
+									'text': _('Replace'),
 									'command': '.uno:SearchDialog',
 									'accessibility': { focusBack: false, 	combination: 'FD',	de: 'US' }
 								}


### PR DESCRIPTION
"Find and replace" button in the notebookbar can be:

- Too long: Requiring additional scrolling in narrower windows can
become particularly frustrating when dealing with certain long-form
languages."
- Too hard for first eye scanning: Since the button is placed within
the Search group ("Search" btn at the top and "Find and replace" btn
at the bottom) it can be difficult to spot "replace" when user tries
to find it but at the first sight sees only "Search" and then "Find".
- A bit unexpected, specially when the user is used to see "Replace"
in other workflows and Office suites.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I3e875191490610df5fbf717e259cf7c7bb85d61a
