### PR TITLE
Notebookbar: style previews: Reduce parent's border color contrast

### DIFF
--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -40,7 +40,7 @@
 	--color-btn-border: #b6b6b6;
 	--color-btn-border-dis: #c0bfbc;
 
-	--color-stylesview-border: var(--color-border);
+	--color-stylesview-border: var(--color-toolbar-border);
 	--color-toolbar-border: #e1dfdd;
 
 	--color-error: #e9322d;


### PR DESCRIPTION
Set style preview border color to match the toolbar border and
notebookbar's separators, reducing contrast while enhancing the
visibility of the selected/active child's border.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I786d32fa1b97ddbeb18c2205805a5666d9ca1765
