### PR TITLE
Sanitization

### DIFF
--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -12,11 +12,13 @@
 #include <config.h>
 
 #include <ConfigUtil.hpp>
+
 #include <Util.hpp>
 
 #include <cassert>
 #include <string>
 #include <sstream>
+#include <unordered_map>
 
 #include <Poco/Util/AbstractConfiguration.h>
 #include <Poco/Util/XMLConfiguration.h>
@@ -42,7 +44,7 @@ RuntimeConstant<bool> SslTermination;
 // NOTE: This is sorted, please keep it sorted as it's friendlier to readers,
 //       except for properties, which are sorted before the value, e.g.
 //       "setting[@name]" before "setting", which is more readable.
-static const std::map<std::string, std::string> DefAppConfig = {
+static const std::unordered_map<std::string, std::string> DefAppConfig = {
     { "accessibility.enable", "false" },
     { "admin_console.enable", "true" },
     { "admin_console.enable_pam", "false" },
@@ -319,7 +321,7 @@ void initialize(const std::string& xml)
 
 bool isInitialized() { return Config != nullptr; }
 
-const std::map<std::string, std::string>& getDefaultAppConfig() { return DefAppConfig; }
+const std::unordered_map<std::string, std::string>& getDefaultAppConfig() { return DefAppConfig; }
 
 /// Recursively extract the sub-keys of the given parent key.
 void extract(const std::string& parentKey, const Poco::Util::AbstractConfiguration& config,

--- a/common/ConfigUtil.hpp
+++ b/common/ConfigUtil.hpp
@@ -26,6 +26,7 @@
 #include <atomic>
 #include <string>
 #include <map>
+#include <unordered_map>
 
 namespace ConfigUtil
 {
@@ -33,7 +34,8 @@ namespace ConfigUtil
 class AppConfigMap final : public Poco::Util::MapConfiguration
 {
 public:
-    AppConfigMap(const std::map<std::string, std::string>& map)
+    AppConfigMap() = default;
+    AppConfigMap(const std::unordered_map<std::string, std::string>& map)
     {
         for (const auto& pair : map)
         {
@@ -109,7 +111,7 @@ void initialize(const Poco::Util::AbstractConfiguration* config);
 bool isInitialized();
 
 /// Returns the default config.
-const std::map<std::string, std::string>& getDefaultAppConfig();
+const std::unordered_map<std::string, std::string>& getDefaultAppConfig();
 
 /// Extract all entries as key-value pairs. We use map to have the entries sorted.
 std::map<std::string, std::string> extractAll(const Poco::Util::AbstractConfiguration& config);

--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -189,10 +189,10 @@ namespace FileUtil
     {
     public:
         /// Stat the given path. Symbolic links are stat'ed when @link is true.
-        Stat(const std::string& file, bool link = false)
-            : _path(file)
+        Stat(std::string file, bool link = false)
+            : _path(std::move(file))
             , _sb{}
-            , _res(link ? lstat(file.c_str(), &_sb) : stat(file.c_str(), &_sb))
+            , _res(link ? lstat(_path.c_str(), &_sb) : stat(_path.c_str(), &_sb))
             , _stat_errno(errno)
         {
         }
@@ -201,7 +201,7 @@ namespace FileUtil
         bool bad() const { return !good(); }
         const struct ::stat& sb() const { return _sb; }
 
-        const std::string path() const { return _path; }
+        const std::string& path() const { return _path; }
 
         bool isDirectory() const { return S_ISDIR(_sb.st_mode); }
         bool isFile() const { return S_ISREG(_sb.st_mode); }

--- a/common/Protocol.hpp
+++ b/common/Protocol.hpp
@@ -311,8 +311,8 @@ namespace COOLProtocol
         std::string ret(message, abbrevLen);
         for (size_t i = abbrevLen; i < messageLen; ++i)
         {
-            const uint8_t unit = message[i];
-            const bool continuation = (unit & 0xC0) == 0x80;
+            const char unit = message[i];
+            const bool continuation = (static_cast<uint8_t>(unit) & 0xC0) == 0x80;
             if (!continuation) // likely
                 break;
             ret.push_back(unit);

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -406,16 +406,16 @@ static void cleanupChildren()
 
     // Now delete the jails.
     auto i = cleanupJailPaths.size();
-    while (i-- > 0)
+    while (i > 0)
     {
+        --i;
         const std::string path = cleanupJailPaths[i];
 
-        // don't delete jails where there was a crash until it ~3 minutes old
-        std::string noteCrashFile(path + "/tmp/kit-crashed");
-        auto noteStat = FileUtil::Stat(noteCrashFile);
+        // Don't delete jails where there was a crash until it's ~3 minutes old.
+        const FileUtil::Stat noteStat(path + "/tmp/kit-crashed");
         if (noteStat.good())
         {
-            time_t modifiedTimeSec = noteStat.modifiedTimeMs() / 1000;
+            const time_t modifiedTimeSec = noteStat.modifiedTimeMs() / 1000;
             if (time(nullptr) < modifiedTimeSec + 180)
                 continue;
         }

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1312,7 +1312,7 @@ public:
                     _inBuffer.append(&buf[0], len);
                 }
                 // else poll will handle errors.
-            } while (len == (sizeof(buf)));
+            } while (len == static_cast<ssize_t>(sizeof(buf)));
 
             // Restore errno from the read call.
             errno = last_errno;

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -749,22 +749,22 @@ protected:
         char scratch[16];
 
         // All unfragmented frames must have the Fin bit.
-        scratch[slen++] = WSFrameMask::Fin | flags;
+        scratch[slen++] = static_cast<char>(WSFrameMask::Fin | flags);
 
         int maskFlag = _isMasking ? 0x80 : 0;
         if (len < 126)
         {
-            scratch[slen++] = (char)(len | maskFlag);
+            scratch[slen++] = static_cast<char>(len | maskFlag);
         }
         else if (len <= 0xffff)
         {
-            scratch[slen++] = (char)(126 | maskFlag);
+            scratch[slen++] = static_cast<char>(126 | maskFlag);
             scratch[slen++] = static_cast<char>((len >> 8) & 0xff);
             scratch[slen++] = static_cast<char>((len >> 0) & 0xff);
         }
         else
         {
-            scratch[slen++] = (char)(127 | maskFlag);
+            scratch[slen++] = static_cast<char>(127 | maskFlag);
             scratch[slen++] = static_cast<char>((len >> 56) & 0xff);
             scratch[slen++] = static_cast<char>((len >> 48) & 0xff);
             scratch[slen++] = static_cast<char>((len >> 40) & 0xff);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1274,10 +1274,11 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
     // Initialize the config subsystem.
     LayeredConfiguration& conf = config();
 
-    const std::map<std::string, std::string> DefAppConfig = ConfigUtil::getDefaultAppConfig();
+    const std::unordered_map<std::string, std::string> defAppConfig =
+        ConfigUtil::getDefaultAppConfig();
 
     // Set default values, in case they are missing from the config file.
-    Poco::AutoPtr<ConfigUtil::AppConfigMap> defConfig(new ConfigUtil::AppConfigMap(DefAppConfig));
+    Poco::AutoPtr<ConfigUtil::AppConfigMap> defConfig(new ConfigUtil::AppConfigMap(defAppConfig));
     conf.addWriteable(defConfig, PRIO_SYSTEM); // Lowest priority
 
 #if !MOBILEAPP
@@ -1712,7 +1713,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
 
     // Copy and serialize the config into XML to pass to forkit.
     KitXmlConfig.reset(new Poco::Util::XMLConfiguration);
-    for (const auto& pair : DefAppConfig)
+    for (const auto& pair : defAppConfig)
     {
         try
         {

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -310,7 +310,7 @@ private:
     virtual std::string getJailRoot(int pid) override;
 
     /// Settings passed from the command-line to override those in the config file.
-    std::map<std::string, std::string> _overrideSettings;
+    std::unordered_map<std::string, std::string> _overrideSettings;
 
 #if MOBILEAPP
 public:

--- a/wsd/ProofKey.cpp
+++ b/wsd/ProofKey.cpp
@@ -92,7 +92,7 @@ std::vector<unsigned char> Proof::Base64ToBytes(const std::string &str)
     char c = 0;
     std::vector<unsigned char> vec;
     while (decoder.get(c))
-        vec.push_back(c);
+        vec.push_back(static_cast<unsigned char>(c));
 
     return vec;
 }

--- a/wsd/RemoteConfig.hpp
+++ b/wsd/RemoteConfig.hpp
@@ -71,7 +71,7 @@ public:
         : RemoteJSONPoll(config, "remote_config.remote_url", "remoteconfig_poll", "configuration")
     {
         constexpr int PRIO_JSON = -200; // highest priority
-        _persistConfig = new ConfigUtil::AppConfigMap(std::map<std::string, std::string>{});
+        _persistConfig = new ConfigUtil::AppConfigMap();
         _conf.addWriteable(_persistConfig, PRIO_JSON);
     }
 


### PR DESCRIPTION
- **wsd: resolve race on ChildSpawnTimeoutMs**
- **wsd: use unordered_map for default config**
- **wsd: avoid overflowing cleanupWait**
- **wsd: signed-to-unsigned conversion**
- **wsd: avoid copying strings**
- **wsd: avoid overflowing unsigned index**
- **wsd: sign-to-unsigned conversion**
- **wsd: unsigned char to char conversion**
- **wsd: signed-to-unsigned char conversion**
