### PR TITLE
fix: custom logo doesn't persist sometimes

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -410,9 +410,7 @@ L.Control.UIManager = L.Control.extend({
 
 		this.map.on('changeuimode', this.onChangeUIMode, this);
 
-		if (typeof window.initializedUI === 'function') {
-			window.initializedUI();
-		}
+		this.refreshTheme();
 
 		var startPresentationGet = this.map.isPresentationOrDrawing() && window.coolParams.get('startPresentation');
 		// check for "presentation" dispatch event only after document gets fully loaded
@@ -1059,6 +1057,14 @@ L.Control.UIManager = L.Control.extend({
 			this.refreshNotebookbar();
 		else
 			this.refreshMenubar();
+
+		this.refreshTheme();
+	},
+
+	refreshTheme: function () {
+		if (typeof window.initializedUI === 'function') {
+			window.initializedUI();
+		}
 	},
 
 	onUpdateViews: function () {

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1581,8 +1581,7 @@ app.definitions.Socket = L.Class.extend({
 			this._map.setPermission(app.file.permission);
 			window.migrating = false;
 			this._map.uiManager.initializeSidebar();
-			if (typeof window.initializedUI === 'function')
-				window.initializedUI();
+			this._map.uiManager.refreshTheme();
 		}
 
 		this._map.fire('docloaded', {status: true});


### PR DESCRIPTION
- when UI is refreshed old html is deleted which consist of overwritten css background-image
- this patch makes sure to update document header after '#document-header' is re-created

Change-Id: I6b2723ada4319f9139be8ff8d29b463401540969