### PR TITLE
Drop the config url query params from identifier

### DIFF
--- a/wsd/CacheUtil.cpp
+++ b/wsd/CacheUtil.cpp
@@ -53,8 +53,8 @@ std::string Cache::getConfigId(const std::string& uri)
     Poco::URI settingsUri(uri);
     std::string sourcePrefix = settingsUri.getScheme() +
                                '_' + settingsUri.getAuthority();
-    std::string sourcePathEtc = settingsUri.getPathEtc();
-    return sourcePrefix + sourcePathEtc;
+    std::string sourcePath = settingsUri.getPath();
+    return sourcePrefix + sourcePath;
 }
 
 void Cache::cacheConfigFile(const std::string& configId, const std::string& uri,

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -556,6 +556,7 @@ public:
 
 #if !MOBILEAPP
     void asyncInstallPresets(const std::shared_ptr<ClientSession>& session,
+                             const std::string& configId,
                              const std::string& userSettingsUri,
                              const std::string& presetsPath);
 
@@ -569,7 +570,9 @@ public:
 
     /// Start an asynchronous Installation of the user presets, e.g. autotexts etc, as
     /// described at userSettingsUri for installation into presetsPath
-    static std::shared_ptr<PresetsInstallTask> asyncInstallPresets(SocketPoll& poll, const std::string& userSettingsUri,
+    static std::shared_ptr<PresetsInstallTask> asyncInstallPresets(SocketPoll& poll,
+                                    const std::string& configId,
+                                    const std::string& userSettingsUri,
                                     const std::string& presetsPath,
                                     const std::shared_ptr<ClientSession>& session,
                                     const std::function<void(bool)>& finishedCB);

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -157,7 +157,7 @@ public:
         if (auto settingsJSON = wopiInfo->getObject("SharedSettings"))
         {
             JsonUtil::findJSONValue(settingsJSON, "uri", _uri);
-            _configId = Cache::getConfigId(_uri);
+            _configId = "shared-" + Cache::getConfigId(_uri);
 
             std::string stamp;
             JsonUtil::findJSONValue(settingsJSON, "stamp", stamp);
@@ -215,7 +215,8 @@ void RequestVettingStation::launchInstallPresets()
     // if this wopi server has some shared settings we want to have a subForKit for those settings
     std::string presetsPath = Poco::Path(COOLWSD::ChildRoot, JailUtil::CHILDROOT_TMP_SHARED_PRESETS_PATH).toString();
     // ensure the server config is downloaded and populate a subforkit when config is available
-    DocumentBroker::asyncInstallPresets(*_poll, sharedSettings.getUri(), presetsPath, nullptr, finishedCallback);
+    DocumentBroker::asyncInstallPresets(*_poll, configId, sharedSettings.getUri(), presetsPath,
+                                        nullptr, finishedCallback);
 }
 
 #endif


### PR DESCRIPTION
Unescaped and used in subforkit announce they get parsed as additional arguments. Escaped, they end up doubly unescaped elsewhere. Just drop them entirely and disambiguate where necessary.


Change-Id: Ia57f14f7cb3aa7c4f77f2dc536996bdcaa38db78


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

