### PR TITLE
Add xml parameters brandProductName and brandproductURL

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -47,6 +47,9 @@ m4_ifelse(MOBILEAPP, [true],
 ]
 )
 
+<input type="hidden" id="init-product-branding-name" value="%PRODUCT_BRANDING_NAME%" />
+<input type="hidden" id="init-product-branding-url" value="%PRODUCT_BRANDING_URL%" />
+
 <input type="hidden" id="init-uri-prefix" value="m4_ifelse(MOBILEAPP, [], [%SERVICE_ROOT%/browser/%VERSION%/])" />
 <input type="hidden" id="init-branding-name" value="%BRANDING_THEME%" />
 

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -281,6 +281,9 @@ class InitializerBase {
 			document.getElementById('content-keeper').remove();
 		}, false);
 
+		window.brandProductName = document.getElementById("init-product-branding-name").value;
+		window.brandProductURL = document.getElementById("init-product-branding-url").value;
+
 		this.initiateCoolParams();
 	}
 

--- a/browser/src/control/Control.AboutDialog.ts
+++ b/browser/src/control/Control.AboutDialog.ts
@@ -87,12 +87,12 @@ class AboutDialog {
 			productName = windowAny.MobileAppName;
 		} else {
 			productName =
-				typeof brandProductName !== 'undefined'
+				typeof brandProductName === 'string' && brandProductName.length > 0
 					? brandProductName
 					: 'Collabora Online Development Edition (unbranded)';
 		}
 		var productURL =
-			typeof brandProductURL !== 'undefined'
+			typeof brandProductURL === 'string' && brandProductURL.length > 0
 				? brandProductURL
 				: 'https://collaboraonline.github.io/';
 

--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -287,6 +287,8 @@ static const std::map<std::string, std::string> DefAppConfig = {
     { "user_interface.mode", "default" },
     { "user_interface.statusbar_save_indicator", "true" },
     { "user_interface.use_integration_theme", "true" },
+    { "user_interface.brandProductName", "" },
+    { "user_interface.brandProductURL", "" },
     { "wasm.enable", "false" },
     { "wasm.force", "false" },
     { "watermark.opacity", "0.2" },

--- a/configure.ac
+++ b/configure.ac
@@ -989,6 +989,7 @@ WELCOME_CONFIG_FRAGMENT=
 HOME_MODE_CONFIGURATION=
 ENABLE_WELCOME_MESSAGE=0
 WELCOME_URL=
+CONFIG_INTERFACE_FRAGMENT=
 if test -n "$with_welcome_url"; then
     WELCOME_URL=$with_welcome_url
     ENABLE_WELCOME_MESSAGE=1
@@ -999,12 +1000,16 @@ else
     WELCOME_CONFIG_FRAGMENT="<welcome>
       <enable type=\"bool\" desc=\"Controls whether the welcome screen should be shown to the users on new install and updates. When enabled, your custom welcome screen must be created at /usr/share/coolwsd/browser/dist/welcome/welcome.html.\" default=\"false\">false</enable>
     </welcome>"
+    CONFIG_INTERFACE_FRAGMENT="<brandProductName desc=\"Change the displayed name the application will have for the user.\" type=\"string\"></brandProductName>
+    <brandProductURL desc=\"Change the product URL, empty makes disable the link\" type=\"string\">https://www.collaboraonline.com</brandProductURL>"
 fi
 
 AC_SUBST([WELCOME_CONFIG_FRAGMENT])
 AM_SUBST_NOTMAKE(WELCOME_CONFIG_FRAGMENT)
 AC_SUBST([HOME_MODE_CONFIGURATION])
 AM_SUBST_NOTMAKE(HOME_MODE_CONFIGURATION)
+AC_SUBST([CONFIG_INTERFACE_FRAGMENT])
+AM_SUBST_NOTMAKE(CONFIG_INTERFACE_FRAGMENT)
 AC_DEFINE_UNQUOTED([ENABLE_WELCOME_MESSAGE],$ENABLE_WELCOME_MESSAGE,[Should the Release notes message be shown on upgrade])
 AM_CONDITIONAL([ENABLE_WELCOME_MESSAGE], [test "$ENABLE_WELCOME_MESSAGE" = "1"])
 AC_DEFINE_UNQUOTED([WELCOME_URL],["$WELCOME_URL"],[The welcome url of the build.])

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -259,6 +259,9 @@
       <mode type="string" desc="Controls the user interface style. The 'default' means: Take the value from ui_defaults, or decide for one of compact or tabbed (default|compact|tabbed)" default="default">default</mode>
       <use_integration_theme desc="Use theme from the integrator" type="bool" default="true">true</use_integration_theme>
       <statusbar_save_indicator desc="Show saving status indicator in the statusbar" type="bool" default="true">true</statusbar_save_indicator>
+
+      @CONFIG_INTERFACE_FRAGMENT@
+
     </user_interface>
 
     <storage desc="Backend storage">

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1718,6 +1718,11 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
     #else // configurable
         std::string enableWelcomeMessage = stringifyBoolFromConfig(config, "welcome.enable", false);
         std::string autoShowWelcome = stringifyBoolFromConfig(config, "welcome.enable", false);
+
+        std::string brandProductURL = ConfigUtil::getConfigValue<std::string>(config, "user_interface.brandProductURL", "");
+        std::string brandProductName = ConfigUtil::getConfigValue<std::string>(config, "user_interface.brandProductName", "");
+        Poco::replaceInPlace(preprocess, std::string("%PRODUCT_BRANDING_NAME%"), brandProductName);
+        Poco::replaceInPlace(preprocess, std::string("%PRODUCT_BRANDING_URL%"), brandProductURL);
     #endif
 
     Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG%"), enableWelcomeMessage);


### PR DESCRIPTION
In user_interface section.


Change-Id: If5033a3221de985cf82eace8dc7c28fec220c419


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

This allows to set a product name and product url.

The option is visible only in COOL.


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

