### PR TITLE
Add new sections to setting iframe

### DIFF
--- a/browser/admin/adminIntegratorSettings.html
+++ b/browser/admin/adminIntegratorSettings.html
@@ -28,36 +28,7 @@
   </head>
   <body>
     <div id="fileControls">
-      <div id="sharedConfigs">
-        <div class="section">
-          <h3>Autotext</h3>
-          <ul id="autotextList"></ul>
-          <input type="file" class="hidden" id="autotextFile" accept=".bau" />
-          <button
-            id="uploadAutotextButton"
-            type="submit"
-            class="inline-button button button--size-normal button--text-only button--vue-secondary"
-          >
-            <span class="button__wrapper">
-              <span class="button__text"> Upload Autotext </span>
-            </span>
-          </button>
-        </div>
-        <div class="section">
-          <h3>Wordbook</h3>
-          <input type="file" class="hidden" id="wordbookFile" accept=".dic" />
-          <ul id="wordbookList"></ul>
-          <button
-            id="uploadWordbookButton"
-            type="submit"
-            class="inline-button button button--size-normal button--text-only button--vue-secondary"
-          >
-            <span class="button__wrapper">
-              <span class="button__text">   Upload Wordbook </span>
-            </span>
-          </button>
-        </div>
-      </div>
+      <div id="allConfigSection"></div>
       <input
         type="hidden"
         id="initial-variables"

--- a/browser/admin/css/adminIntegratorSettings.css
+++ b/browser/admin/css/adminIntegratorSettings.css
@@ -114,7 +114,6 @@ body {
 
   padding-left: 0px;
   margin-left: 0px;
-  overflow: hidden;
   display: block;
 }
 

--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -28,6 +28,7 @@ interface ConfigData {
 	autotext: ConfigItem[] | null;
 	wordbook: ConfigItem[] | null;
 	browsersetting: ConfigItem[] | null;
+	xcu: ConfigItem[] | null;
 }
 
 interface SectionConfig {
@@ -53,6 +54,7 @@ const PATH = {
 	autoTextUpload: () => settingConfigBasePath() + '/autotext/',
 	wordBookUpload: () => settingConfigBasePath() + '/wordbook/',
 	browserSettingsUpload: () => settingConfigBasePath() + '/browsersetting/',
+	XcuUpload: () => settingConfigBasePath() + '/xcu/',
 };
 
 function settingConfigBasePath(): string {
@@ -145,6 +147,15 @@ function insertConfigSections(): void {
 			buttonText: 'Upload Browser Setting',
 			uploadPath: PATH.browserSettingsUpload(),
 			enabledFor: 'userconfig',
+		},
+		{
+			sectionTitle: 'Xcu',
+			listId: 'XcuList',
+			inputId: 'XcuFile',
+			buttonId: 'uploadXcuButton',
+			fileAccept: '.xcu',
+			buttonText: 'Upload Xcu',
+			uploadPath: PATH.XcuUpload(),
 		},
 	];
 
@@ -432,26 +443,36 @@ function populateList(
 }
 
 function populateSharedConfigUI(data: ConfigData): void {
-	// todo: dynamically generate this list too from configSections
-	if (data.autotext) populateList('autotextList', data.autotext, '/autotext');
-	if (data.wordbook) populateList('wordbookList', data.wordbook, '/wordbook');
-
 	const browserSettingButton = document.getElementById(
 		'uploadBrowserSettingsButton',
 	) as HTMLButtonElement | null;
 
-	if (!browserSettingButton) {
-		console.error('Something went wrong');
-		return;
+	if (browserSettingButton) {
+		if (data.browsersetting && data.browsersetting.length > 0) {
+			browserSettingButton.style.display = 'none';
+		} else {
+			browserSettingButton.style.removeProperty('display');
+		}
 	}
 
-	if (data.browsersetting && data.browsersetting.length > 0) {
-		browserSettingButton.style.display = 'none';
-	} else {
-		browserSettingButton.style.removeProperty('display');
+	const xcuSettingButton = document.getElementById(
+		'uploadXcuButton',
+	) as HTMLButtonElement | null;
+
+	if (xcuSettingButton) {
+		if (data.xcu && data.xcu.length > 0) {
+			xcuSettingButton.style.display = 'none';
+		} else {
+			xcuSettingButton.style.removeProperty('display');
+		}
 	}
+
+	// todo: dynamically generate this list too from configSections
+	if (data.autotext) populateList('autotextList', data.autotext, '/autotext');
+	if (data.wordbook) populateList('wordbookList', data.wordbook, '/wordbook');
 	if (data.browsersetting)
 		populateList('BrowserSettingsList', data.browsersetting, '/browsersetting');
+	if (data.xcu) populateList('XcuList', data.xcu, '/xcu');
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -27,6 +27,7 @@ interface ConfigData {
 	kind: 'shared' | 'user';
 	autotext: ConfigItem[] | null;
 	wordbook: ConfigItem[] | null;
+	browsersetting: ConfigItem[] | null;
 }
 
 interface SectionConfig {
@@ -37,6 +38,7 @@ interface SectionConfig {
 	fileAccept: string;
 	buttonText: string;
 	uploadPath: string;
+	enabledFor?: string;
 }
 
 const API_ENDPOINTS = {
@@ -50,6 +52,7 @@ const API_ENDPOINTS = {
 const PATH = {
 	autoTextUpload: () => settingConfigBasePath() + '/autotext/',
 	wordBookUpload: () => settingConfigBasePath() + '/wordbook/',
+	browserSettingsUpload: () => settingConfigBasePath() + '/browsersetting/',
 };
 
 function settingConfigBasePath(): string {
@@ -133,9 +136,23 @@ function insertConfigSections(): void {
 			buttonText: 'Upload Wordbook',
 			uploadPath: PATH.wordBookUpload(),
 		},
+		{
+			sectionTitle: 'Browser Settings',
+			listId: 'BrowserSettingsList',
+			inputId: 'BrowserSettingsFile',
+			buttonId: 'uploadBrowserSettingsButton',
+			fileAccept: '.json',
+			buttonText: 'Upload Browser Setting',
+			uploadPath: PATH.browserSettingsUpload(),
+			enabledFor: 'userconfig',
+		},
 	];
 
 	configSections.forEach((cfg) => {
+		if (cfg.enabledFor && cfg.enabledFor !== getConfigType()) {
+			return;
+		}
+
 		const sectionEl = createConfigSection(cfg);
 
 		const fileInput = sectionEl.querySelector<HTMLInputElement>(
@@ -416,8 +433,19 @@ function populateList(
 }
 
 function populateSharedConfigUI(data: ConfigData): void {
+	// todo: dynamically generate this list too from configSections
 	if (data.autotext) populateList('autotextList', data.autotext, '/autotext');
 	if (data.wordbook) populateList('wordbookList', data.wordbook, '/wordbook');
+	if (data.browsersetting && data.browsersetting.length > 0) {
+		const button = document.getElementById(
+			'uploadBrowserSettingsButton',
+		) as HTMLButtonElement | null;
+		if (button) {
+			button.disabled = true;
+		}
+
+		populateList('BrowserSettingsList', data.browsersetting, '/browsersetting');
+	}
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -417,8 +417,7 @@ function populateList(
 					throw new Error(`Delete failed: ${response.statusText}`);
 				}
 
-				// On success - remove li
-				listEl.removeChild(li);
+				await fetchAndPopulateSharedConfigs();
 			} catch (error: unknown) {
 				console.error('Error deleting file:', error);
 			}
@@ -436,16 +435,23 @@ function populateSharedConfigUI(data: ConfigData): void {
 	// todo: dynamically generate this list too from configSections
 	if (data.autotext) populateList('autotextList', data.autotext, '/autotext');
 	if (data.wordbook) populateList('wordbookList', data.wordbook, '/wordbook');
-	if (data.browsersetting && data.browsersetting.length > 0) {
-		const button = document.getElementById(
-			'uploadBrowserSettingsButton',
-		) as HTMLButtonElement | null;
-		if (button) {
-			button.disabled = true;
-		}
 
-		populateList('BrowserSettingsList', data.browsersetting, '/browsersetting');
+	const browserSettingButton = document.getElementById(
+		'uploadBrowserSettingsButton',
+	) as HTMLButtonElement | null;
+
+	if (!browserSettingButton) {
+		console.error('Something went wrong');
+		return;
 	}
+
+	if (data.browsersetting && data.browsersetting.length > 0) {
+		browserSettingButton.style.display = 'none';
+	} else {
+		browserSettingButton.style.removeProperty('display');
+	}
+	if (data.browsersetting)
+		populateList('BrowserSettingsList', data.browsersetting, '/browsersetting');
 }
 
 document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Generate a configuration section using JavaScript to reduce code repetition.
- Add a browser settings section with the following conditions: 
  - Only one file can be uploaded. If a file is already uploaded, the upload button should be disabled.
  - Applicable only for user configurations.
- Add an XCU section similar to browser settings:
  - Only one file can be uploaded at a time.

![nextcloud local_index php_settings_user_richdocuments (5)](https://github.com/user-attachments/assets/f551a01f-bd9b-47eb-9724-ce6f05f9c459)
![nextcloud local_index php_settings_user_richdocuments (4)](https://github.com/user-attachments/assets/9d88a1b9-70c2-4d8d-bfee-9fd15ef4281f)
