### PR TITLE
wsd: fix memory corruption in cleanupDocBrokers()

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -472,7 +472,9 @@ void cleanupDocBrokers()
         // consider shutting down unused subforkits
         for (auto it = SubForKitProcs.begin(); it != SubForKitProcs.end(); )
         {
-            const std::string& configId = it->first;
+            // copy as it will be used after erase()
+            std::string configId = it->first;
+
             if (configId.empty()) {
                 // ignore primordial forkit
                 ++it;


### PR DESCRIPTION
Visible when running UnitMultiTenant:

    #0 0x563e36164273 in __interceptor_memcpy /home/abuild/rpmbuild/BUILD/llvm-15.0.7.src/build/../projects/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors.inc:899:5
...
    #3 0x7f41a250828a in UnitSubForKit::killSubForKit(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) test/UnitMultiTenant.cpp:65:9
    #4 0x563e36538c1b in cleanupDocBrokers() wsd/COOLWSD.cpp:493:32
    #5 0x563e365b1b93 in PrisonPoll::wakeupHook() wsd/COOLWSD.cpp:2676:9

Just make a copy if the iterator will be invalidated before the last use
of that config ID.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ie074d3ff282e228ffd8b96b3514068ec0b08e2a3
