### PR TITLE
Align jsdialog bottons not to take up more space

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -748,6 +748,15 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 }
 /* checkbox */
 
+#box1 #buttonbox1.jsdialog {
+	display: flex !important;
+}
+
+#box1 .d-flex.justify-content-center:has(.ui-pushbutton.hidden),
+#box1 .d-flex.justify-content-center:has(.ui-pushbutton[disabled]) {
+	display: none;
+}
+
 .jsdialog.checkbutton {
 	white-space: nowrap;
 	display: flex;


### PR DESCRIPTION
Change-Id: I823594b14ea15bf2fbee32a5302c64f9dd268564


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Hide elements that are not part of the jsdialog 
- Align elements/buttons to fit within the allocated space

### TODO
- Add class to active selection of the jsdialog Area or background

![Screenshot from 2025-01-28 11-31-10](https://github.com/user-attachments/assets/4dc549a5-32f1-4e89-88f6-164d07e9c136)



![Screenshot from 2025-01-28 11-30-36](https://github.com/user-attachments/assets/d48a5ddb-37b9-4879-ad21-2c3022adb505)
