### PR TITLE
Hide scaling handles of shapes when text cursor is visible.

### DIFF
--- a/browser/src/canvas/sections/ShapeHandleRotationSubSection.ts
+++ b/browser/src/canvas/sections/ShapeHandleRotationSubSection.ts
@@ -30,6 +30,19 @@ class ShapeHandleRotationSubSection extends CanvasSectionObject {
 		this.sectionProperties.mapPane = (<HTMLElement>(document.querySelectorAll('.leaflet-map-pane')[0]));
 		this.sectionProperties.previousCursorStyle = null;
 		this.sectionProperties.cursorStyle = 'pointer';
+
+		app.events.on('TextCursorVisibility', this.onTextCursorVisibility.bind(this));
+	}
+
+	onTextCursorVisibility(event: any): void {
+		if (event.detail.visible) {
+			this.setShowSection(false);
+			this.interactable = false;
+		}
+		else {
+			this.setShowSection(true);
+			this.interactable = true;
+		}
 	}
 
 	calculateAngle(center: cool.SimplePoint, target: cool.SimplePoint): number {

--- a/browser/src/canvas/sections/ShapeHandleScalingSubSection.ts
+++ b/browser/src/canvas/sections/ShapeHandleScalingSubSection.ts
@@ -37,10 +37,23 @@ class ShapeHandleScalingSubSection extends CanvasSectionObject {
 		this.sectionProperties.mapPane = (<HTMLElement>(document.querySelectorAll('.leaflet-map-pane')[0]));
 
 		this.setMousePointerType();
+
+		app.events.on('TextCursorVisibility', this.onTextCursorVisibility.bind(this));
 	}
 
 	onInitialize(): void {
 		this.setPosition(this.sectionProperties.position.pX, this.sectionProperties.position.pY);
+	}
+
+	onTextCursorVisibility(event: any): void {
+		if (event.detail.visible) {
+			this.setShowSection(false);
+			this.interactable = false;
+		}
+		else {
+			this.setShowSection(true);
+			this.interactable = true;
+		}
 	}
 
 	onDraw(frameCount?: number, elapsedTime?: number, subsetBounds?: cool.Bounds): void {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1959,6 +1959,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		app.file.textCursor.visible = command ? true : false;
 		this._removeSelection();
 		this._onUpdateCursor();
+		app.events.fire('TextCursorVisibility', { visible: app.file.textCursor.visible });
 	},
 
 	_setCursorVisible: function() {

--- a/cypress_test/integration_tests/common/impress_helper.js
+++ b/cypress_test/integration_tests/common/impress_helper.js
@@ -199,13 +199,12 @@ function editTextInShape() {
 function dblclickOnSelectedShape() {
 	cy.log('>> dblclickOnSelectedShape - start');
 
-	cy.cGet('#test-div-shape-handle-rotation')
+	cy.cGet('#document-container')
 		.then(function(items) {
 			expect(items).to.have.length(1);
-			var XPos = (items[0].getBoundingClientRect().left + items[0].getBoundingClientRect().right) / 2;
-			var YPos = items[0].getBoundingClientRect().bottom + 50;
-			cy.cGet('body')
-				.dblclick(XPos, YPos);
+			var XPos = (items[0].getBoundingClientRect().left + items[0].getBoundingClientRect().width) / 2;
+			var YPos = (items[0].getBoundingClientRect().top + items[0].getBoundingClientRect().height) / 2;
+			cy.cGet('body').dblclick(XPos, YPos);
 		});
 
 	cy.cGet('.leaflet-cursor.blinking-cursor')


### PR DESCRIPTION
Issue:
* Open an Impress file and start editing a textbox.
* See that handles are visible.
* Try to re-scale the selected shape.
* It doesn't work but the preview is shown.
* When text editing is active, scaling is not enabled.
* We need to hide the handles in that case.


Change-Id: I0ebf20270fc08f8553c1985456836711369407e4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

