### PR TITLE
UX iprovements on server audit dialog

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2250,6 +2250,42 @@ kbd,
 	height: 16px;
 }
 
+#ServerAuditDialog #ServerAuditDialog-mainbox label {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	color: #000;
+	border-radius: 30px;
+	width: fit-content;
+	height: 16px;
+	margin-top: 8px;
+	padding-right: 10px;
+}
+
+#ServerAuditDialog #ServerAuditDialog-mainbox label#auditsuccess {
+	background-color: #c4f7cc;
+	color: #1c4f26;
+}
+
+#ServerAuditDialog #ServerAuditDialog-mainbox label#auditerror {
+	background-color: #ffd6d9;
+	color: #d42314;
+}
+
+#ServerAuditDialog #ServerAuditDialog-mainbox label#auditsuccess::before {
+	background: url('images/circle-check.svg') no-repeat center/18px;
+	content: '';
+	width: 16px;
+	height: 16px;
+}
+
+#ServerAuditDialog #ServerAuditDialog-mainbox label#auditerror::before {
+	background: url('images/monochrome-x-cross.svg') no-repeat center;
+	content: '';
+	width: 16px;
+	height: 16px;
+}
+
 /* text-area overflow on function wizard window */
 
 #FormulaDialog #ed_formula.ui-textarea {

--- a/browser/images/circle-check.svg
+++ b/browser/images/circle-check.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" fill="#2bc545" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10" fill="#2bc545"/>
+  <path d="M7 12l3 3 6-6" stroke="#fafafa" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/browser/images/monochrome-x-cross.svg
+++ b/browser/images/monochrome-x-cross.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="45" fill="#fafafa" stroke="#d42314" stroke-width="6"/>
+  <line x1="30" y1="30" x2="70" y2="70" stroke="#d42314" stroke-width="8" stroke-linecap="round"/>
+  <line x1="70" y1="30" x2="30" y2="70" stroke="#d42314" stroke-width="8" stroke-linecap="round"/>
+</svg>

--- a/browser/src/control/Control.ServerAuditDialog.ts
+++ b/browser/src/control/Control.ServerAuditDialog.ts
@@ -176,8 +176,18 @@ class ServerAuditDialog {
 		return hasErrors;
 	}
 
+	private countErrors(): number {
+		return (
+			(app.serverAudit?.filter((entry: AuditEntry) => entry.status !== 'ok')
+				.length ?? 0) +
+			(app.clientAudit?.filter((entry: AuditEntry) => entry.status !== 'ok')
+				.length ?? 0)
+		);
+	}
+
 	private getJSON(entries: Array<any>): JSDialogJSON {
 		const hasErrors = this.hasErrors();
+		const countErrors = this.countErrors();
 
 		return {
 			id: this.id,
@@ -198,13 +208,6 @@ class ServerAuditDialog {
 					type: 'container',
 					vertical: true,
 					children: [
-						!hasErrors
-							? {
-									id: 'auditsuccess',
-									type: 'fixedtext',
-									text: _('No issues found'),
-								}
-							: {},
 						{
 							id: 'auditlist',
 							type: 'treelistbox',
@@ -215,6 +218,23 @@ class ServerAuditDialog {
 							entries: entries,
 							enabled: entries.length > 0,
 						},
+						!hasErrors
+							? {
+									id: 'auditsuccess',
+									type: 'fixedtext',
+									text: _('No issues found'),
+								}
+							: {
+									id: 'auditerror',
+									type: 'fixedtext',
+									text:
+										countErrors === 1
+											? _('1 issue found')
+											: _('%COUNT% issues found').replaceAll(
+													'%COUNT%',
+													countErrors,
+												),
+								},
 						{
 							id: this.id + '-buttonbox',
 							type: 'buttonbox',


### PR DESCRIPTION
Change-Id: I6c91fb915d6abd6dfd93536fdde6a2835091b6f5


* Improves: https://github.com/CollaboraOnline/online/pull/10925#issuecomment-2601894287
* Target version: master 

### Summary
- Added new stylings to the indicator to make it distinct
- Added both cases for no issues and errors plus count of issues
- Added new check-mark icon for audit success


### Screenshots
![Screenshot from 2025-01-28 09-58-39](https://github.com/user-attachments/assets/25fb0221-46af-4e5b-ae68-3e63819fdb2b)
![Screenshot from 2025-01-28 09-58-21](https://github.com/user-attachments/assets/c913f03b-a25a-4782-b23f-997721b9941d)

With no Issues
![Screenshot from 2025-01-28 13-52-51](https://github.com/user-attachments/assets/284282c6-17e8-491f-a710-4ad0ab263411)
![Screenshot from 2025-01-28 14-18-06](https://github.com/user-attachments/assets/c701b75b-e3d1-4ef9-8cc3-deda95567088)


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

