### PR TITLE
fix: ensure documentAnchor is set in onResize

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1362,7 +1362,7 @@ class CanvasSectionContainer {
 		newWidth = Math.floor(newWidth * app.dpiScale);
 		newHeight = Math.floor(newHeight * app.dpiScale);
 
-		if (this.right === newWidth && this.bottom === newHeight)
+		if (this.right === newWidth && this.bottom === newHeight && this.documentAnchor)
 			return;
 
 		// Drawing may happen asynchronously so backup the old contents to avoid


### PR DESCRIPTION
in I6df1f36d6100857373686c6b57daaa805917df02, we early-exit from onResize to avoid it being called unnecessarily. Unfortunately, it also sets `documentAnchor`, which we missed when checking whether we needed to run through it. This caused an error on mobile web, leading to a failure to open documents in, say, the Nextcloud app.


Change-Id: I4938ade7f03be95b0f0ff3edd4e5805302f22036


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

