### PR TITLE
annotation: avoid autosaving empty comments

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -455,7 +455,7 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.contentText.innerHTML = this.sanitize(linkedText);
 		// Original unlinked text
 		this.sectionProperties.contentText.origText = this.sectionProperties.data.text ? this.sectionProperties.data.text: '';
-		this.sectionProperties.contentText.origHTML = this.sectionProperties.data.html;
+		this.sectionProperties.contentText.origHTML = this.sectionProperties.data.html ? this.sectionProperties.data.html: '';
 		this.sectionProperties.nodeModifyText.innerText = this.sectionProperties.data.text ? this.sectionProperties.data.text: '';
 		if (this.sectionProperties.data.html) {
 			this.sectionProperties.nodeModifyText.innerHTML = this.sanitize(this.sectionProperties.data.html);


### PR DESCRIPTION
problem:
comment HTML being undefined caused some conditions to evaluate to true ie:
in function onLostFocus
this.sectionProperties.contentText.origHTML !== this.sectionProperties.nodeModifyText.innerHTML


Change-Id: Ibeaf20618a9f47b4f3833459c120d6e5155f4fa0


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

