### PR TITLE
fix(mobileWizard): stop highlighting on close

### DIFF
--- a/browser/src/control/Control.MobileWizard.js
+++ b/browser/src/control/Control.MobileWizard.js
@@ -132,17 +132,17 @@ L.Control.MobileWizard = L.Control.extend({
 	},
 
 	_updateToolbarItemStateByClose: function() {
-		var toolbar = app.map.mobileTopBar;
-		if (toolbar)
-		{
-			//if (window.mobileWizard === false && toolbar.get('mobile_wizard').checked)
-			//	toolbar.uncheck('mobile_wizard');
+		const mobileWizard = document.getElementById('mobile_wizard');
+		if (window.mobileWizard === false && mobileWizard && mobileWizard.classList.contains('selected'))
+			mobileWizard.classList.remove('selected');
 
-			//if (window.insertionMobileWizard === false && toolbar.get('insertion_mobile_wizard').checked)
-			//	toolbar.uncheck('insertion_mobile_wizard');
-			//if (window.commentWizard === false && toolbar.get('comment_wizard').checked)
-			//	toolbar.uncheck('comment_wizard');
-		}
+		const insertionMobileWizard = document.getElementById('insertion_mobile_wizard');
+		if (window.insertionMobileWizard === false && insertionMobileWizard && insertionMobileWizard.classList.contains('selected'))
+			insertionMobileWizard.classList.remove('selected');
+
+		const commentWizard = document.getElementById('comment_wizard');
+		if (window.commentWizard === false && commentWizard && commentWizard.classList.contains('selected'))
+			commentWizard.classList.remove('selected');
 	},
 
 	goLevelDown: function(contentToShow, options) {


### PR DESCRIPTION
Way-back-when, we deselected the toolbar button when the mobile wizard was closed. We stopped doing this during the leaflet migration because the functions we previously used to do it no longer existed (I652a163ea0c831b47ce7725ffd0f9f190a98d9bf). Instead, we can use whether the 'selected' class is on our elements in the DOM to see if they should be unchecked.

That change had far more '.uncheck(...)' and '.check(...)' than I've set up here, and some of those may be necessary, but this was the bug I knew about and I didn't want to poke around with things that I wasn't completely sure where I was changing.


Change-Id: I737693f6db96c8298c07b195aa374a1bbb670108


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

