### PR TITLE
Buttons in presenter console does not have border radius until be we hover on it

### DIFF
--- a/browser/src/slideshow/PresenterConsole.js
+++ b/browser/src/slideshow/PresenterConsole.js
@@ -334,6 +334,7 @@ class PresenterConsole {
 			button.style.backgroundColor = 'transparent';
 			button.style.color = this.slideShowColor;
 			button.style.border = 'none';
+			button.style.borderRadius = this.PresenterConsoleBtnRadius;
 		});
 
 		elem = this._proxyPresenter.document.querySelector('#title-current');


### PR DESCRIPTION


- all the btn (ex: Notes, Slider sorter etc) should have border radius on initialization
- this patch will fix the inconsistency of border radius around btn in PresenterConsole


Change-Id: I880159a69cf5c20ac914785ca12c826c257b6c96


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

