### PR TITLE
Fix: Prevent cursor position reference issue

### DIFF
--- a/browser/src/control/Control.Mention.ts
+++ b/browser/src/control/Control.Mention.ts
@@ -122,7 +122,7 @@ class Mention extends L.Control.AutoCompletePopup {
 		// It happens when user is typing mention at the end where there is no
 		// horizontal space and whole '@mention' goes to new line
 		const currentPos = this.getCursorPosition();
-		let cursorPos = this.cursorPosAtStart;
+		let cursorPos = { ...this.cursorPosAtStart }; // Make a copy so changes to cursorPos don’t affect the original position
 		if (this.cursorPosAtStart.y !== currentPos.y) {
 			cursorPos = currentPos;
 			this.cursorPosAtStart = currentPos;


### PR DESCRIPTION
- Created a separate copy of cursorPosAtStart to avoid modifying the original values when adjusting `cursorPos.y`.
- this will fix the popup moves when user types mention name
- popup should be at start and do not move


Change-Id: I09fad05d742cec7f735648e4f0a5e5217d0d2434


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

