### PR TITLE
Improved comment menu item wording 

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -1202,7 +1202,7 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 							}.bind(this)
 						},
 						showBigger: docLayer._docType !== 'text' || (<any>window).mode.isMobile() ? undefined : {
-							name: isShownBig ? _('Show on the side') : _('Show comment bigger'),
+							name: isShownBig ? _('Show on the side') : _('Open in full view'),
 							callback: function (key: any, options: any) {
 								this.toggleShowBigger.call(this, options.$trigger[0].annotation);
 							}.bind(this)


### PR DESCRIPTION
Change-Id: I82dd343fdfe6b5fc389320c4b95d6808de4f3e6f

* Resolves: #11057
* Target version: master 

### Summary
 Changed wording from "Show comment bigger" as it was a bit  of odd (grammar) to "Open in full view" 

### Screenshot
![Screenshot from 2025-01-30 16-50-08](https://github.com/user-attachments/assets/3412bb69-5458-4e23-ab60-4b94516a7ddf)


