### PR TITLE
cool#11064 kit: check for callbacks & wsd socket in the anyInput callback

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -793,7 +793,7 @@ public:
     /// Poll the sockets for available data to read or buffer to write.
     /// Returns the return-value of poll(2): 0 on timeout,
     /// -1 for error, and otherwise the number of events signalled.
-    int poll(std::chrono::microseconds timeoutMax) { return poll(timeoutMax.count()); }
+    int poll(std::chrono::microseconds timeoutMax, bool justPoll = false) { return poll(timeoutMax.count(), justPoll); }
 
     /// Poll the sockets for available data to read or buffer to write.
     /// Returns the return-value of poll(2): 0 on timeout,
@@ -962,7 +962,7 @@ private:
     }
 
     /// Actual poll implementation
-    int poll(int64_t timeoutMaxMicroS);
+    int poll(int64_t timeoutMaxMicroS, bool justPoll = false);
 
     /// Initialize the poll fds array with the right events
     void setupPollFds(std::chrono::steady_clock::time_point now,


### PR DESCRIPTION
Open the 300 pages bugdoc, go to the end of page 1 (before a page
break), press enter, a page 2 is inserted and we get new tiles after a
delay:
15:08:33.803 global.js:566 1738073313803 OUTGOING: key type=up char=0 key=1280
...
15:08:34.249 global.js:566 1738073314249 INCOMING: delta: nviewid=1000 part=0 ...
-> 446 ms.

The reason this happens is because our anyInput callback tells core to
finish the idle Writer layout first and only then render the tiles for
the visible area, which is a problem similar to what commit
930cd616fb6defd8c0de0163bd92e637c7b6b76f (Related: cool#9735 kit: use
the new registerAnyInputCallback() LOK API, 2024-08-26) fixed.

Fix this problem by improving the anyInput callbacks to take 2 more
"inputs" into account:
1) LOK_CALLBACK_INVALIDATE_TILES went to KitQueue::_callbacks and this
   was only processed in the next main loop iteration, so checks for
  this in the anyInput callback, which partly reverts commit
  2823933a2111136e14a8605cf5698dff40835e72 (anyInput - should only depend
  on incoming messages from coolwsd., 2024-12-10).
2) Now that the invalidation is processed, it's sent to the wsd process
   and we get a tile request on the wsd -> kit socket, in the kit
  process. Fix this problem by doing a poll() on that socket as the
  already existing FIXME comment suggested.

With this, we paint tiles for the visible area before calculating pages
3..300 in Writer:
10:15:47.441 global.js:566 1738314947441 OUTGOING: key type=input char=13 key=1280
...
10:15:47.476 global.js:566 1738314947476 INCOMING: delta: nviewid=1000 part=0 ...
-> 24ms

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I668d2ebf341b628841e0a637fee9e476eeddd179
