### PR TITLE
Update gitignore for mocha files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ test/unithttplib
 test/*.csv
 test/data/presets/user/browsersettings.json
 jsstress
+browser/mocha_tests/*.test.js
 
 *.o
 *.exe


### PR DESCRIPTION
to not show transpiled files like:
        browser/mocha_tests/CBounds.test.js
	browser/mocha_tests/CPointSet.test.js
	browser/mocha_tests/CanvasSectionContainer.test.js
	browser/mocha_tests/Rectangle.test.js
	browser/mocha_tests/SheetGeometry.test.js