### PR TITLE
js: move disabling AutoText dialog shortcut logic to Map.KeyboardShortcuts.ts

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -671,11 +671,6 @@ L.Map.Keyboard = L.Handler.extend({
 			return true;
 		}
 
-		// Control + F3, ignore Autotext dialog
-		if (this._isCtrlKey(e) && e.keyCode === this.keyCodes.F3) {
-			return true;
-		}
-
 		// Control + Shift + I, open browser developper tools
 		if (this._isCtrlKey(e) && e.shiftKey && e.keyCode === this.keyCodes.I) {
 			return true;

--- a/browser/src/map/handler/Map.KeyboardShortcuts.ts
+++ b/browser/src/map/handler/Map.KeyboardShortcuts.ts
@@ -175,6 +175,7 @@ keyboardShortcuts.definitions.set('default', new Array<ShortcutDescriptor>(
 
     new ShortcutDescriptor('text', 'keydown', 0, 'F2', null, null, null),
     new ShortcutDescriptor('text', 'keydown', 0, 'F3', '.uno:ExpandGlossary', null, null),
+    new ShortcutDescriptor('text', 'keydown', Mod.CTRL, 'F3', null, null, null),
     new ShortcutDescriptor('text', 'keydown', 0, 'F5', null, null, null),
 
 


### PR DESCRIPTION
Change-Id: I28e1583b0ba3cb3e0e2bf85bfd482392e3ea04d8

* Target version: master 
