### PR TITLE
Fix error in onKeyDown handler

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -483,15 +483,16 @@ L.Map.Keyboard = L.Handler.extend({
 			return;
 		}
 
+		var docLayer = this._map._docLayer;
+
 		// if any key is pressed, we stop the following other users
-		this._map.userList.followUser(this._map._docLayer._viewId, false);
+		if (docLayer) this._map.userList.followUser(docLayer._viewId, false);
 
 		if (window.KeyboardShortcuts.processEvent(app.UI.language.fromURL, ev)) {
 			ev.shortCutActivated = true;
 			ev.preventDefault();
 			return;
 		}
-		var docLayer = this._map._docLayer;
 		if (!keyEventFn && docLayer && docLayer.postKeyboardEvent) {
 			// default is to post keyboard events on the document
 			keyEventFn = L.bind(docLayer.postKeyboardEvent, docLayer);
@@ -568,7 +569,7 @@ L.Map.Keyboard = L.Handler.extend({
 		}
 
 		if (this._map.isEditMode()) {
-			docLayer._resetPreFetching();
+			if (docLayer) docLayer._resetPreFetching();
 
 			if (this._ignoreKeyEvent(ev)) {
 				// key ignored

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -374,7 +374,7 @@ L.Map.Keyboard = L.Handler.extend({
 	// printable characters. Those are handled by TextInput.js.
 	_onKeyDown: function (ev) {
 		if (this._map.uiManager.isUIBlocked()
-			|| ((this._map._docLayer._docType === 'presentation' || this._map._docLayer._docType === 'drawing') && this._map._docLayer._preview.partsFocused === true)
+			|| (this._map._docLayer && (this._map._docLayer._docType === 'presentation' || this._map._docLayer._docType === 'drawing') && this._map._docLayer._preview.partsFocused === true)
 		)
 			return;
 


### PR DESCRIPTION
If we are in the state when we didn't load document (for example error appeared) - on key press we
got error in the console:

Map.Keyboard.js:377 Uncaught TypeError: Cannot read properties of undefined (reading '_docType')
    at NewClass._onKeyDown (Map.Keyboard.js:377:29)
    at HTMLDivElement.handler (DomEvent.js:51:14)Understand this errorAI
Map.KeyboardShortcuts.ts:113 Uncaught TypeError: Cannot read properties of null (reading 'dispatch')
    at KeyboardShortcuts.processEventImpl (Map.KeyboardShortcuts.ts:113:32)
    at KeyboardShortcuts.processEvent (Map.KeyboardShortcuts.ts:138:18)
    at NewClass._globalKeyEvent (Map.Keyboard.js:408:32)
    at HTMLDocument.handler (DomEvent.js:51:14)Understand this errorAI
Map.Keyboard.js:377 Uncaught TypeError: Cannot read properties of undefined (reading '_docType')
    at NewClass._onKeyDown (Map.Keyboard.js:377:29)
    at HTMLDivElement.handler (DomEvent.js:51:14)
