### PR TITLE
ssl termination: debug page is available on http

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -690,8 +690,7 @@ inline std::string getLaunchBase(bool asAdmin = false)
 {
     std::ostringstream oss;
     oss << "    ";
-    oss << ((ConfigUtil::isSslEnabled() || ConfigUtil::isSSLTermination()) ? "https://"
-                                                                           : "http://");
+    oss << (ConfigUtil::isSslEnabled() ? "https://" : "http://");
 
     if (asAdmin)
     {


### PR DESCRIPTION
with coolwsd.xml settings:
ssl.enable = false
ssl.termination = true

I expect: BROWSER <-- SSL --> PROXY <-- HTTP --> COOL

But I get in the console links with HTTPS for cool (which don't work)