### PR TITLE
Fuzzing and Misc Improvements

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,3 @@
-Checks: 'clang-diagnostic-*,performance-*,unused-*,misc-*,-misc-macro-parentheses,readability-redundant-*,-readability-redundant-declaration'
+Checks: 'clang-diagnostic-*,performance-*,unused-*,misc-*,-misc-macro-parentheses,-misc-static-assert,readability-redundant-*,-readability-redundant-declaration'
 WarningsAsErrors: '*'
 

--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -13,6 +13,7 @@
 
 #include "SigUtil.hpp"
 #include "SigHandlerTrap.hpp"
+#include "Util.hpp"
 
 #if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
 #  include <execinfo.h>
@@ -91,8 +92,12 @@ bool getTerminationFlag() { return RunStateFlag >= RunState::Terminate; }
 
 void setTerminationFlag()
 {
-    // Set the forced-termination flag.
-    RunStateFlag = RunState::Terminate;
+    // While fuzzing, we never want to terminate.
+    if constexpr (!Util::isFuzzing())
+    {
+        // Set the forced-termination flag.
+        RunStateFlag = RunState::Terminate;
+    }
 
     if constexpr (!Util::isMobileApp())
     {

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -215,7 +215,7 @@ namespace Util
 
     bool kitInProcess = false;
     void setKitInProcess(bool value) { kitInProcess = value; }
-    bool isKitInProcess() { return kitInProcess || isFuzzing() || isMobileApp(); }
+    bool isKitInProcess() { return isFuzzing() || isMobileApp() || kitInProcess; }
 
     std::string replace(std::string result, const std::string& a, const std::string& b)
     {

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -631,15 +631,6 @@ namespace Util
         return ss.str();
     }
 
-    bool isFuzzing()
-    {
-#if LIBFUZZER
-        return true;
-#else
-        return false;
-#endif
-    }
-
     std::map<std::string, std::string> stringVectorToMap(const std::vector<std::string>& strvector, const char delimiter)
     {
         std::map<std::string, std::string> result;

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1360,7 +1360,14 @@ int main(int argc, char**argv)
      * Avoid using the configuration layer and rely on defaults which is only useful for special
      * test tool targets (typically fuzzing) where start-up speed is critical.
      */
-    bool isFuzzing();
+    constexpr bool isFuzzing()
+    {
+#if LIBFUZZER
+        return true;
+#else
+        return false;
+#endif
+    }
 
     constexpr bool isMobileApp()
     {

--- a/fuzzer/Common.hpp
+++ b/fuzzer/Common.hpp
@@ -8,6 +8,20 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+#include <cassert>
+#include <cstdio>
+
+#define CHECK(X)                                                                                   \
+    do                                                                                             \
+    {                                                                                              \
+        if (!(X))                                                                                  \
+        {                                                                                          \
+            fprintf(stderr, "Assertion: %s\n", #X);                                                \
+            assert(!(X));                                                                          \
+            __builtin_trap();                                                                      \
+        }                                                                                          \
+    } while (0)
+
 namespace fuzzer
 {
 bool DoInitialization();

--- a/fuzzer/HttpEcho.cpp
+++ b/fuzzer/HttpEcho.cpp
@@ -110,17 +110,6 @@ public:
     };
 };
 
-#define CHECK(X)                                                                                   \
-    do                                                                                             \
-    {                                                                                              \
-        if (!(X))                                                                                  \
-        {                                                                                          \
-            fprintf(stderr, "Assertion: %s\n", #X);                                                \
-            assert(!(X));                                                                          \
-            __builtin_trap();                                                                      \
-        }                                                                                          \
-    } while (0)
-
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     static bool initialized = fuzzer::DoInitialization();

--- a/fuzzer/HttpEcho.cpp
+++ b/fuzzer/HttpEcho.cpp
@@ -8,18 +8,14 @@
 #include <config.h>
 
 #include <cstdlib>
-#include <iostream>
 
-#include "ConfigUtil.hpp"
 #include "Socket.hpp"
 #include <test/HttpTestServer.hpp>
 
 #include <Poco/URI.h>
 
 #include <chrono>
-#include <condition_variable>
 #include <memory>
-#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <test/lokassert.hpp>

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -545,7 +545,8 @@ bool ChildSession::_handleInput(const char *buffer, int length)
         // All other commands are such that they always require a LibreOfficeKitDocument session,
         // i.e. need to be handled in a child process.
 
-        assert(tokens.equals(0, "clientzoom") ||
+        assert(Util::isFuzzing() ||
+               tokens.equals(0, "clientzoom") ||
                tokens.equals(0, "clientvisiblearea") ||
                tokens.equals(0, "outlinestate") ||
                tokens.equals(0, "downloadas") ||
@@ -849,7 +850,7 @@ bool ChildSession::_handleInput(const char *buffer, int length)
         }
         else
         {
-            assert(false && "Unknown command token.");
+            assert(Util::isFuzzing() && "Unknown command token.");
         }
     }
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2394,7 +2394,8 @@ void Document::drainQueue()
             }
             else if (tokens.equals(0, "tile") || tokens.equals(0, "tilecombine"))
             {
-                assert(false && "Should not have incoming tile requests in message queue");
+                assert(Util::isFuzzing() &&
+                       "Should not have incoming tile requests in message queue");
             }
             else if (tokens.startsWith(0, "child-"))
             {
@@ -2409,7 +2410,7 @@ void Document::drainQueue()
             }
             else if (tokens.equals(0, "callback"))
             {
-                assert(false && "callbacks cannot now appear on the incoming queue");
+                assert(Util::isFuzzing() && "callbacks cannot now appear on the incoming queue");
             }
             else
             {

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3006,7 +3006,7 @@ int pollCallback(void* data, int timeoutUs)
 bool anyInputCallback(void* data)
 {
     auto kitSocketPoll = reinterpret_cast<KitSocketPoll*>(data);
-    std::shared_ptr<Document> document = kitSocketPoll->getDocument();
+    const std::shared_ptr<Document>& document = kitSocketPoll->getDocument();
 
     return document && document->hasQueueItems();
 }

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3153,7 +3153,8 @@ void lokit_main(
     const std::string LogLevelStartup = logLevelStartup ? logLevelStartup : "trace";
 
     const bool bTraceStartup = (std::getenv("COOL_TRACE_STARTUP") != nullptr);
-    Log::initialize("kit", bTraceStartup ? LogLevelStartup : logLevel, logColor, logToFile, logProperties, logToFileUICmd, logPropertiesUICmd);
+    Log::initialize("kit", bTraceStartup ? LogLevelStartup : LogLevel, logColor, logToFile,
+                    logProperties, logToFileUICmd, logPropertiesUICmd);
     if (bTraceStartup && LogLevel != LogLevelStartup)
     {
         LOG_INF("Setting log-level to [" << LogLevelStartup << "] and delaying "

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2089,7 +2089,7 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
 
 bool Document::forwardToChild(const std::string& prefix, const std::vector<char>& payload)
 {
-    assert(payload.size() > prefix.size());
+    assert(Util::isFuzzing() || payload.size() > prefix.size());
 
     // Remove the prefix and trim.
     std::size_t index = prefix.size();

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -171,7 +171,7 @@ public:
 #endif
     int kitPoll(int timeoutMicroS);
     void setDocument(std::shared_ptr<Document> document) { _document = std::move(document); }
-    std::shared_ptr<Document> getDocument() const { return _document; }
+    const std::shared_ptr<Document>& getDocument() const { return _document; }
 
     // unusual LOK event from another thread, push into our loop to process.
     static bool pushToMainThread(LibreOfficeKitCallback callback, int type, const char* p,

--- a/kit/KitWebSocket.cpp
+++ b/kit/KitWebSocket.cpp
@@ -99,8 +99,7 @@ void KitWebSocketHandler::handleMessage(const std::vector<char>& data)
             LOG_DBG("CreateSession failed.");
         }
     }
-
-    else if (tokens.equals(0, "exit"))
+    else if (!Util::isFuzzing() && tokens.equals(0, "exit"))
     {
         if constexpr (!Util::isMobileApp())
         {
@@ -143,7 +142,7 @@ void KitWebSocketHandler::handleMessage(const std::vector<char>& data)
             LOG_WRN("No document while processing " << tokens[0] << " request.");
         }
     }
-    else if (tokens.size() == 3 && tokens.equals(0, "setconfig"))
+    else if (!Util::isFuzzing() && tokens.size() == 3 && tokens.equals(0, "setconfig"))
     {
 #if !MOBILEAPP && !defined(BUILDING_TESTS)
         // Currently only rlimit entries are supported.
@@ -153,7 +152,7 @@ void KitWebSocketHandler::handleMessage(const std::vector<char>& data)
         }
 #endif
     }
-    else if (tokens.equals(0, "setloglevel"))
+    else if (!Util::isFuzzing() && tokens.equals(0, "setloglevel"))
     {
         Log::setLevel(tokens[1]);
     }

--- a/kit/KitWebSocket.cpp
+++ b/kit/KitWebSocket.cpp
@@ -30,6 +30,7 @@
 #include "Kit.hpp"
 #include "ChildSession.hpp"
 #include "SigUtil.hpp"
+#include "Util.hpp"
 #include "KitWebSocket.hpp"
 
 using Poco::Exception;
@@ -156,7 +157,7 @@ void KitWebSocketHandler::handleMessage(const std::vector<char>& data)
     {
         Log::setLevel(tokens[1]);
     }
-    else
+    else if (!Util::isFuzzing())
     {
         LOG_ERR("Bad or unknown token [" << tokens[0] << ']');
     }


### PR DESCRIPTION
- **fuzz: include cleanup in HttpEcho.cpp**
- **wsd: constexpr Util::isFuzzing()**
- **wsd: short-circuit isKitInProcess() where possible**
- **clang-tidy: ignore static-assert**
- **fuzz: move CHECK to Common.hpp**
- **fuzz: no error logging while fuzzing**
- **fuzz: disable some assertions during fuzzing**
- **fuzz: disable precondition assertion during fuzzing**
- **fuzz: disable handling of some commands**
- **fuzz: disable asserting for valid commands**
- **fuzz: never terminate**
- **wsd: use the sanitized LogLevel**
- **wsd: avoid copying shared_ptr**
- **wsd: optimize resolveDNS eviction**
