### PR TITLE
test, UnitTimeoutInactive: increase the timeout further

### DIFF
--- a/test/UnitTimeoutInactive.cpp
+++ b/test/UnitTimeoutInactive.cpp
@@ -37,7 +37,7 @@ class UnitTimeoutInactivity : public UnitTimeoutBase0
     void configure(Poco::Util::LayeredConfiguration& /* config */) override
     {
         // net::Defaults.inactivityTimeout = std::chrono::seconds(3600);
-        net::Defaults.inactivityTimeout = std::chrono::milliseconds(150);
+        net::Defaults.inactivityTimeout = std::chrono::milliseconds(360);
         //
         // The following WSPing setup would cause ping/pong packages avoiding the inactivity TO
         //   net::Defaults.wsPingAvgTimeout = std::chrono::microseconds(25);


### PR DESCRIPTION
Encouraged by commit 91a83bcacb7d1d181bb6e37a26e69920dfde912a (increase
UnitTimeoutInactive inactivityTimeout, 2025-01-30), looking at why a
core.git dbgutil + online.git debug build still fails here, it seems it
now passes fine with a bit more relaxed timeout.

The new value is still 10k times smaller than the default, so is meant
to be still minimal.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I04cc2e111ac86b4bb49e03ab73635796078f0a1a
