### PR TITLE
Calc: Rename Column/Row Highlighting to Focus Cell

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -768,7 +768,7 @@ L.Control.Menubar = L.Control.extend({
 				   {uno: '.uno:Navigator', id: 'navigator'},
 				   {type: 'separator'},
 				   {name: _UNO('.uno:ToggleSheetGrid', 'spreadsheet', true), uno: '.uno:ToggleSheetGrid', id: 'sheetgrid'},
-				   {name: _UNO('.uno:ViewColumnRowHighlighting', 'spreadsheet', true), type:'action', id: 'columnrowhighlight'},
+				   {name: _('Focus Cell'), type:'action', id: 'columnrowhighlight'},
 				   {name: _UNO('.uno:FreezePanes', 'spreadsheet', true), id: 'FreezePanes', type: 'action', uno: '.uno:FreezePanes'},
 				   {name: _UNO('.uno:FreezeCellsMenu', 'spreadsheet', true), id: 'FreezeCellsMenu', type: 'menu', uno: '.uno:FreezeCellsMenu', menu: [
 					   {name: _UNO('.uno:FreezePanesColumn', 'spreadsheet', true), id: 'FreezePanesColumn', type: 'action', uno: '.uno:FreezePanesColumn'},

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1172,7 +1172,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'colrowhighlight',
 				'type': 'bigcustomtoolitem',
-				'text': _UNO('.uno:ViewColumnRowHighlighting', 'spreadsheet', true),
+				'text': _('Focus Cell'),
 				'command': 'columnrowhighlight',
 				'accessibility': { focusBack: true,	combination: 'HL', de: null }
 			},


### PR DESCRIPTION
As initially written in 2022
https://github.com/CollaboraOnline/online/issues/4738 and later
https://github.com/CollaboraOnline/online/issues/9566, in non
technical terms user should be able to navigate with cell cursor
through lengthly sheets without getting lost when attempting to
read/scan distant cells from the same row or column.

- Use a more concise "Focus Cell" term that is more reminiscent of a
mode and that describes better the desired intent.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I47b3e6e06aacc7f9fd42c57edb6acade63a125f9
