### PR TITLE
Comment section: Use int for part hash.

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -769,7 +769,8 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 			// Make sure that comment is not transitioning and comment menu is not open.
 			var tempFunction = function() {
 				setTimeout(function() {
-					if (String(annotation.sectionProperties.container.dataset.transitioning) === 'true' || annotation.sectionProperties.contextMenu === true) {
+					if (annotation.sectionProperties.container && annotation.sectionProperties.contextMenu === true
+					) {
 						tempFunction();
 					}
 					else {
@@ -1305,8 +1306,11 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 	}
 
 	public add (comment: any): cool.Comment {
-		if (!comment.sectionProperties)
-			comment = new cool.Comment(comment, comment.id === 'new' ? {noMenu: true} : {}, this);
+		if (!comment.sectionProperties) {
+			const temp = new cool.Comment(comment, comment.id === 'new' ? {noMenu: true} : {}, this);
+			temp.sectionProperties.data = comment;
+			comment = temp;
+		}
 
 		comment.sectionProperties.noMenu  = comment.sectionProperties.data.id === 'new' ? true : false;
 
@@ -1751,7 +1755,7 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 	private adjustCommentFileBasedView (comment: any): void {
 		// Below calculations are the same with the ones we do while drawing tiles in fileBasedView.
 		var partHeightTwips = app.map._docLayer._partHeightTwips + app.map._docLayer._spaceBetweenParts;
-		var index = app.impress.getIndexFromSlideHash(comment.parthash);
+		var index = app.impress.getIndexFromSlideHash(parseInt(comment.parthash));
 		var yAddition = index * partHeightTwips;
 		comment.yAddition = yAddition; // We'll use this while we save the new position of the comment.
 

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -120,7 +120,7 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.showSelectedCoordinate = true; // Writer.
 
 		if (app.map._docLayer._docType === 'presentation' || app.map._docLayer._docType === 'drawing') {
-			this.sectionProperties.parthash = this.sectionProperties.data.parthash;
+			this.sectionProperties.parthash = parseInt(this.sectionProperties.data.parthash);
 			this.sectionProperties.partIndex = app.impress.getIndexFromSlideHash(this.sectionProperties.parthash);
 		}
 
@@ -735,7 +735,7 @@ export class Comment extends CanvasSectionObject {
 		if (this.sectionProperties.data.rectangle === null)
 			return;
 
-		const showMarker = app.impress.partList[app.map._docLayer._selectedPart].hash === parseInt(this.sectionProperties.data.parthash) ||
+		const showMarker = app.impress.partList[app.map._docLayer._selectedPart].hash === this.sectionProperties.data.parthash ||
 							app.file.fileBasedView;
 
 		this.sectionProperties.commentMarkerSubSection = new CommentMarkerSubSection(


### PR DESCRIPTION
Check container existence before setting edit mode. This fixes a bug:
- open Impress
- insert comment on second slide
- delete the comment
- insert again
- notice it was inserted on the first slide not second as expected

change from @gokaysatir 