### PR TITLE
UserList: do not render when not changed

### DIFF
--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -127,14 +127,14 @@ class UserList extends L.Control {
 	followUser(viewId: number, instantJump: boolean = true) {
 		const myViewId = this.map._docLayer._viewId;
 		const followingViewId = app.getFollowedViewId();
-		const followMyself = viewId === followingViewId;
+		const followMyself = viewId === myViewId;
+
+		if (followingViewId === viewId) return;
 
 		app.setFollowingUser(viewId);
 
 		if (followMyself) {
 			this.map._setFollowing(true, myViewId, instantJump);
-			this.renderAll();
-			return;
 		} else if (viewId !== -1) {
 			this.map._setFollowing(true, viewId, instantJump);
 		} else {


### PR DESCRIPTION
We seems to rerender avatars (in DOM) on every key press. Do it only if selected user was changed.

see:
Map.Keyboard.js     : _handleKeyEvent
Control.UserList.ts : selectUser