### PR TITLE
Update highlight mode without waiting cursor invalidation

### DIFF
--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -459,6 +459,7 @@ class Dispatcher {
 		this.actionsMap['columnrowhighlight'] = function () {
 			var newState = !app.map.uiManager.getHighlightMode();
 			app.map.uiManager.setHighlightMode(newState);
+			app.map._docLayer.updateHighlight();
 		};
 	}
 

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -1053,9 +1053,29 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			this._resetReferencesMarks();
 	},
 
+	updateHighlight: function () {
+		if ( this._map) {
+			if (this._map.uiManager.getHighlightMode()) {
+				var updateMsg = 'updateHighlight';
+				this._highlightColAndRow(updateMsg);
+			}
+			else
+				this._resetReferencesMarks();
+		}
+	},
+
 	_highlightColAndRow: function (textMsg) {
+		var strTwips = [];
+		if(textMsg.startsWith('updateHighlight')) {
+			strTwips[0] = app.calc.cellCursorTopLeftTwips.x;
+			strTwips[1] = app.calc.cellCursorTopLeftTwips.y;
+			strTwips[2] = app.calc.cellCursorOffset.x;
+			strTwips[3] = app.calc.cellCursorOffset.y;
+		}
+		else
+			strTwips = textMsg.match(/\d+/g);
+
 		this._resetReferencesMarks();
-		var strTwips = textMsg.match(/\d+/g);
 		var references = [];
 		this._referencesAll = [];
 		var rectangles = [];
@@ -1077,7 +1097,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			} else {
 				// Row rectangle
 				topLeftTwips = new L.Point(parseInt(0), parseInt(strTwips[1]));
-				offset = new L.Point(parseInt(maxRow), parseInt(strTwips[4]));
+				offset = new L.Point(parseInt(maxRow), parseInt(strTwips[3]));
 				boundsTwips = this._convertToTileTwipsSheetArea(
 					new L.Bounds(topLeftTwips, topLeftTwips.add(offset)));
 				rectangles.push([boundsTwips.getBottomLeft(), boundsTwips.getBottomRight(),

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2080,13 +2080,14 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 		else {
 			var strTwips = textMsg.match(/\d+/g);
-
 			var topLeftTwips = new L.Point(parseInt(strTwips[0]), parseInt(strTwips[1]));
 			var offset = new L.Point(parseInt(strTwips[2]), parseInt(strTwips[3]));
 			var bottomRightTwips = topLeftTwips.add(offset);
 			let _cellCursorTwips = this._convertToTileTwipsSheetArea(new L.Bounds(topLeftTwips, bottomRightTwips));
 
 			app.calc.cellAddress = new app.definitions.simplePoint(parseInt(strTwips[4]), parseInt(strTwips[5]));
+			app.calc.cellCursorTopLeftTwips = topLeftTwips;
+			app.calc.cellCursorOffset = offset;
 			let tempRectangle = _cellCursorTwips.toRectangle();
 			app.calc.cellCursorRectangle = new app.definitions.simpleRectangle(tempRectangle[0], tempRectangle[1], tempRectangle[2], tempRectangle[3]);
 			this._cellCursorSection.setPosition(app.calc.cellCursorRectangle.pX1, app.calc.cellCursorRectangle.pY1);


### PR DESCRIPTION
Pressing Column Row Highlight button wasn't switching the highlight mode quickly. We had to wait cursor invalidation to see highlight. Now pressing button triggers the mode quickly.


Change-Id: Ic5c84e625a3f96f6cc9858dfb84d14474bd9e773


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

