### PR TITLE
css: make style tree in sidebar full height

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -428,3 +428,8 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 #TemplatePanel > div:nth-child(4) {
 	flex-grow: 1;
 }
+
+#TemplatePanel > div:nth-child(2),
+#TemplatePanel > div:nth-child(3) {
+	height: inherit;
+}


### PR DESCRIPTION
visible in Calc where not always we have that much content inside the tree