### PR TITLE
validate BaseFileName requirements

### DIFF
--- a/wsd/wopi/CheckFileInfo.cpp
+++ b/wsd/wopi/CheckFileInfo.cpp
@@ -211,6 +211,12 @@ CheckFileInfo::wopiFileInfo(const Poco::URI& uriPublic) const
         JsonUtil::findJSONValue(_wopiInfo, "BaseFileName", filename);
         JsonUtil::findJSONValue(_wopiInfo, "LastModifiedTime", modifiedTime);
 
+        if (filename.find_first_of('/') != std::string::npos)
+        {
+            LOG_ERR("BaseFileName should be the name of the file without a path, but is: " << filename);
+            filename.clear();
+        }
+
         Poco::JSON::Object::Ptr wopiInfo = _wopiInfo;
         wopiFileInfo = std::make_unique<WopiStorage::WOPIFileInfo>(
             StorageBase::FileInfo(size, std::move(filename), std::move(ownerId),


### PR DESCRIPTION
https://sdk.collaboraonline.com/docs/advanced_integration.html

See: CheckFileInfo response properties

BaseFileName:
A string containing the base name of the file, omitting its path.


Change-Id: Ia861aef80fe2d89a6953628ef7557b2488d24323


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

