### PR TITLE
browser: accessibility: remove jquery tooltip for buttons

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2312,7 +2312,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			} else if (builder.options.useInLineLabelsForUnoButtons === true) {
 				$(div).addClass('no-label');
 			} else {
-				builder.map.uiManager.enableTooltip(div);
 				$(div).addClass('no-label');
 			}
 


### PR DESCRIPTION
The jquery-ui tooltip is creating a instance for each toolbar
button, which creates unnecesary hidden elements

<div role="log" aria-live="assertive" aria-relevant="additions"
class="ui-helper-hidden-accessible"></div>

Anyway, the tooltip was replaced for a new Tooltip class.

Change-Id: I73368b3ce46ec72e4fa7efb94a772637b24e8541
Signed-off-by: Henry Castro <hcastro@collabora.com>
