### PR TITLE
Do not fail install when /opt/cool is not fully deletable

### DIFF
--- a/coolwsd.spec.in
+++ b/coolwsd.spec.in
@@ -131,7 +131,7 @@ if [ $COOLWSD_IS_ACTIVE == "1" ]; then systemctl stop coolwsd; fi
 lokitroot=/opt/collaboraoffice
 coolparent=`cd ${lokitroot} && cd .. && /bin/pwd`
 
-rm -rf ${coolparent}/cool
+rm -rf ${coolparent}/cool || true
 mkdir -p ${coolparent}/cool/child-roots ${coolparent}/cool/cache
 chown cool:cool ${coolparent}/cool
 chown cool:cool ${coolparent}/cool/child-roots

--- a/debian/coolwsd.postinst.in
+++ b/debian/coolwsd.postinst.in
@@ -23,7 +23,7 @@ case "$1" in
 	# and installs in @LO_PATH@, and that /opt/cool is
 	# on the same file system
 
-	rm -rf /opt/cool
+	rm -rf /opt/cool || true
 	mkdir -p /opt/cool/child-roots /opt/cool/cache
 	chown cool: /opt/cool
 	chown cool: /opt/cool/child-roots


### PR DESCRIPTION
Backstory:
Our client has set up an EDR on their servers.
Recently Collabora could not be updated.

On the configuration step of the coolwsd package, the script tries to remove "/opt/cool/systemplate/etc/hosts" . Because it's a hard-link of the "/etc/hosts", the EDR disallow any modification, including removal.

The client doesn't want to set an exception to allow a package to modify a sensible file like "hosts". Can Collabora avoid a removal on this file ?

--

I hope this helps...


Change-Id: Id4c1d72b705dee460a709a5a22312bc3d692a5a6

