### PR TITLE
css: make treeview in stylelist sidebar full height

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -438,7 +438,7 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	flex-grow: 1;
 }
 
-#TemplatePanel > div:nth-child(2),
-#TemplatePanel > div:nth-child(3) {
+#TemplatePanel > div:nth-child(4),
+#TemplatePanel > div:nth-child(5) {
 	height: inherit;
 }


### PR DESCRIPTION
Change-Id: I3f9949029940491f9fd72e0fec0c3f2eaf68a65f

* Target version: master 
* Regression #11100 

### Summary
 After change in information hierarchy in the style list the height on n-th div was applied to setting and filter instead of treeviews

### CURRENT
![Screenshot from 2025-02-10 14-44-07](https://github.com/user-attachments/assets/56eb30d4-1618-4c42-b2a4-41e73d54d9b1)

### NEW CHANGE
![Screenshot from 2025-02-10 14-46-32](https://github.com/user-attachments/assets/5e27df78-87bf-4d07-9947-feca8df9a500)





