### PR TITLE
net: fix clang-15 build

### DIFF
--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -132,6 +132,14 @@ struct DNSCacheEntry
     std::string queryPort;
     HostEntry hostEntry;
     std::chrono::steady_clock::time_point lookupTime;
+
+    DNSCacheEntry(const std::string& address, const std::string& port, const HostEntry& entry, const std::chrono::steady_clock::time_point& time)
+    : queryAddress(address)
+    , queryPort(port)
+    , hostEntry(entry)
+    , lookupTime(time)
+    {
+    }
 };
 
 static HostEntry resolveDNS(const std::string& addressToCheck,


### PR DESCRIPTION
In file included from net/NetUtil.cpp:14:
In file included from ./net/NetUtil.hpp:14:
In file included from /usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/chrono:41:
In file included from /usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/sstream:38:
In file included from /usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/istream:38:
In file included from /usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/ios:42:
In file included from /usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/ios_base.h:41:
In file included from /usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/locale_classes.h:40:
In file included from /usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/string:53:
In file included from /usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/basic_string.h:39:
In file included from /usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/ext/alloc_traits.h:34:
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/alloc_traits.h:518:4: error: no matching function for call to 'construct_at'
          std::construct_at(__p, std::forward<_Args>(__args)...);
          ^~~~~~~~~~~~~~~~~
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/vector.tcc:117:21: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<net::DNSCacheEntry>>::construct<net::DNSCacheEntry, const std::basic_string<char> &, const std::basic_string<char> &, net::HostEntry &, const std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<long, std::ratio<1, 1000000000>>> &>' requested here
            _Alloc_traits::construct(this->_M_impl, this->_M_impl._M_finish,
                           ^
net/NetUtil.cpp:170:16: note: in instantiation of function template specialization 'std::vector<net::DNSCacheEntry>::emplace_back<const std::basic_string<char> &, const std::basic_string<char> &, net::HostEntry &, const std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<long, std::ratio<1, 1000000000>>> &>' requested here
    querycache.emplace_back(addressToCheck, port, hostEntry, now);
               ^
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/stl_construct.h:94:5: note: candidate template ignored: substitution failure [with _Tp = net::DNSCacheEntry, _Args = <const std::basic_string<char> &, const std::basic_string<char> &, net::HostEntry &, const std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<long, std::ratio<1, 1000000000>>> &>]: no matching constructor for initialization of 'net::DNSCacheEntry'
    construct_at(_Tp* __location, _Args&&... __args)
    ^
1 error generated.

So add an explicit ctor to help the compiler.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ia3476cdb7a92345b32ad553c9ea15c0b54a16094
