### PR TITLE
UILog save/load statistics

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -128,7 +128,7 @@
 
     <logging_ui_cmd>
         <merge type="bool" desc="If true, repeated commands after each other will be merged into 1 line. If false, every command will be 1 new line." default="true">true</merge>
-        <merge_display_end_time type="bool" desc="If true, the duration of the merged command will also be logged." default="false">false</merge_display_end_time>
+        <merge_display_end_time type="bool" desc="If true, the duration of the merged command will also be logged." default="false">true</merge_display_end_time>
         <file enable="@COOLWSD_LOG_UICMD_TO_FILE@">
             <!-- If you use other path than /var/log and you run coolwsd from systemd, make sure that you enable that path in coolwsd.service (ReadWritePaths). Also the log file path must be writable by the 'cool' user. -->
             <property name="path" desc="Log file path.">@COOLWSD_LOGFILE_UICMD@</property>

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -304,11 +304,16 @@ bool ChildSession::_handleInput(const char *buffer, int length)
             return false;
         }
 
+        std::chrono::steady_clock::time_point timeStart = std::chrono::steady_clock::now();
+
         // Disable processing of other messages while loading document
         InputProcessingManager processInput(getProtocol(), false);
         // disable watchdog while loading
         WatchdogGuard watchdogGuard;
         _isDocLoaded = loadDocument(tokens);
+
+        LogUiCommands uiLog(this);
+        uiLog.logSaveLoad("load", Poco::URI(getJailedFilePath()).getPath(), timeStart);
 
         LOG_TRC("isDocLoaded state after loadDocument: " << _isDocLoaded);
         return _isDocLoaded;
@@ -719,7 +724,14 @@ bool ChildSession::_handleInput(const char *buffer, int length)
                 // disable watchdog while saving
                 WatchdogGuard watchdogGuard;
 
-                return unoCommand(unoSave);
+                std::chrono::steady_clock::time_point timeStart = std::chrono::steady_clock::now();
+                bool result = unoCommand(unoSave);
+                if (result)
+                {
+                    LogUiCommands uiLog(this);
+                    uiLog.logSaveLoad("save", Poco::URI(getJailedFilePath()).getPath(), timeStart);
+                }
+                return result;
             }
             else
                 return true;
@@ -742,11 +754,25 @@ bool ChildSession::_handleInput(const char *buffer, int length)
         }
         else if (tokens.equals(0, "saveas"))
         {
-            return saveAs(tokens);
+            std::chrono::steady_clock::time_point timeStart = std::chrono::steady_clock::now();
+            bool result = saveAs(tokens);
+            if (result)
+            {
+                LogUiCommands uiLog(this);
+                uiLog.logSaveLoad("saveas", Poco::URI(getJailedFilePath()).getPath(), timeStart);
+            }
+            return result;
         }
         else if (tokens.equals(0, "exportas"))
         {
-            return exportAs(tokens);
+            std::chrono::steady_clock::time_point timeStart = std::chrono::steady_clock::now();
+            bool result = exportAs(tokens);
+            if (result)
+            {
+                LogUiCommands uiLog(this);
+                uiLog.logSaveLoad("exportas", Poco::URI(getJailedFilePath()).getPath(), timeStart);
+            }
+            return result;
         }
         else if (tokens.equals(0, "useractive"))
         {
@@ -1026,6 +1052,7 @@ bool ChildSession::saveDocumentBackground([[maybe_unused]] const StringVector& t
     return false;
 #else
     LOG_TRC("Attempting background save");
+    _logUiSaveBackGroundTimeStart = std::chrono::steady_clock::now();
 
     // Keep the session alive over the lifetime of an async save
     if (!_docManager->forkToSave([this, tokens]{
@@ -3855,6 +3882,12 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
     }
 }
 
+void ChildSession::saveLogUiBackground()
+{
+    LogUiCommands uiLog(this);
+    uiLog.logSaveLoad("savebg", Poco::URI(getJailedFilePath()).getPath(), _logUiSaveBackGroundTimeStart);
+}
+
 void LogUiCommands::logLine(LogUiCommandsLine &line, bool isUndoChange)
 {
     // log command
@@ -3899,9 +3932,38 @@ void LogUiCommands::logLine(LogUiCommandsLine &line, bool isUndoChange)
     }
 }
 
+void LogUiCommands::logSaveLoad(std::string cmd, const std::string & path, std::chrono::steady_clock::time_point timeStart)
+{
+    LogUiCommandsLine uiLogLine;
+    uiLogLine._timeStart = timeStart;
+    uiLogLine._timeEnd = std::chrono::steady_clock::now();
+    uiLogLine._repeat = 1;
+    uiLogLine._cmd = cmd;
+
+    std::size_t size = 0;
+    const auto st = FileUtil::Stat(path);
+    if (st.exists() && st.good())
+    {
+        size = st.size();
+    }
+
+    std::set<std::string> fileExtensions = { "sxw", "odt", "fodt", "sxc", "ods", "fods", "sxi", "odp", "fodp", "sxd", "odg", "fodg", "doc", "xls", "ppt", "docx", "xlsx", "pptx" };
+    std::string extension = Poco::Path(path).getExtension();
+    if (fileExtensions.find(extension) == fileExtensions.end())
+        extension = "unknown";
+
+    std::stringstream strToLog;
+    strToLog << "size=" << size;
+    strToLog << " ext=" << extension;
+
+    uiLogLine._subCmd = strToLog.str();
+
+    logLine(uiLogLine);
+}
+
 LogUiCommands::~LogUiCommands()
 {
-    if (_session->_isDocLoaded && Log::isLogUIEnabled() && _session->_clientVisibleArea.getWidth() != 0)
+    if (!_skipDestructor && _session->_isDocLoaded && Log::isLogUIEnabled() && _session->_clientVisibleArea.getWidth() != 0)
     {
         if (_tokens->size() > 0 && _cmdToLog.find((*_tokens)[0]) != _cmdToLog.end())
         {

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -43,14 +43,17 @@ public:
     ChildSession* _session;
     int _lastUndoCount = 0;
     const StringVector* _tokens;
+    bool _skipDestructor = false;
     LogUiCommands(ChildSession* session, const StringVector* tokens) : _session(session),_tokens(tokens) {}
+    LogUiCommands(ChildSession* session) : _session(session),_tokens(nullptr),_skipDestructor(true) {}
     ~LogUiCommands();
+    void logSaveLoad(std::string cmd, const std::string & path, std::chrono::steady_clock::time_point timeStart);
 private:
     // list the commands to log here.
     std::set<std::string> _cmdToLog = {
         "uno", "key", "mouse", "textinput", "removetextcontext",
         "paste", "insertfile", "dialogevent" };
-    // list the the uno commands here, that are not to log. It will serach these strings as a prefixes
+    // list the the uno commands here, that are not to log. It will search these strings as a prefixes
     std::set<std::string> _unoCmdToNotLog = {
         ".uno:SidebarShow", ".uno:ToolbarMode" };
     void logLine(LogUiCommandsLine &line, bool isUndoChange=false);
@@ -155,6 +158,13 @@ public:
     std::string getViewRenderState() { return _viewRenderState; }
 
     float getTilePriority(const std::chrono::steady_clock::time_point &now, const TileDesc &desc) const;
+
+    void saveLogUiBackground()
+#if defined(BUILDING_TESTS)
+    {}
+#else
+    ;
+#endif
 
 private:
     bool loadDocument(const StringVector& tokens);
@@ -341,6 +351,7 @@ private:
     friend class LogUiCommands;
     int _lastUiCmdLinesLoggedCount = 0;
     LogUiCommandsLine _lastUiCmdLinesLogged[2];
+    std::chrono::steady_clock::time_point _logUiSaveBackGroundTimeStart;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/kit/KitWebSocket.cpp
+++ b/kit/KitWebSocket.cpp
@@ -309,8 +309,10 @@ void BgSaveParentWebSocketHandler::handleMessage(const std::vector<char>& data)
             object->get("commandName").toString() == ".uno:Save")
         {
             if (object->get("success").toString() == "true")
+            {
                 _document->notifySyntheticUnmodifiedState();
-
+                _session->saveLogUiBackground();
+            }
             else
             {
                 _document->updateModifiedOnFailedBgSave();


### PR DESCRIPTION
load / save is logged with time duration, filesize, and extension like this:

kit=001 time=0.594 dur=0.534 user=4 rep=1 cmd:load size=10377 ext=docx

there are some separarate "save" for different saving: "save"
"savebg" - save in background
"saveas"
"exportas"

reporting script is not final, it just list all the load/save It will need a better statistics with better charts, but that can be done later.


Change-Id: I67ab4bf4591aca4ec03d9167a26b13cbc6b6aa07


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

