### PR TITLE
tiles: duplicated rendering

### DIFF
--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -162,7 +162,7 @@ namespace RenderTiles
                            mode);
 
             // FIXME: prettify this.
-            bool forceKeyframe = tiles[tileIndex].getOldWireId() == 0;
+            bool forceKeyframe = tiles[tileIndex].isForcedKeyFrame();
 
             // FIXME: share the same wireId for all tiles concurrently rendered.
             TileWireId wireId = getCurrentWireId(true);

--- a/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
@@ -139,7 +139,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar' 
 		desktopHelper.assertVisiblePage(3, 4, 6);
 
 		cy.cGet('#searchnext').click();
-		desktopHelper.assertScrollbarPosition('vertical', 200, 300);
+		desktopHelper.assertScrollbarPosition('vertical', 200, 305);
 		desktopHelper.assertVisiblePage(3, 4, 6);
 	});
 });

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -3037,6 +3037,7 @@ void ClientSession::handleTileInvalidation(const std::string& message,
        _tileWidthTwips == 0 || _tileHeightTwips == 0 ||
        (_clientSelectedPart == -1 && !_isTextDocument))
     {
+        LOG_TRC("No visible area received yet - skip invalidation");
         return;
     }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4361,7 +4361,7 @@ void DocumentBroker::sendTileCombine(const TileCombined& newTileCombined)
     _childProcess->sendTextFrame(req);
 }
 
-void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined, bool forceKeyframe,
+void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined, bool canForceKeyframe,
                                                const std::shared_ptr<ClientSession>& session)
 {
     ASSERT_CORRECT_THREAD();
@@ -4369,7 +4369,7 @@ void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined, bool 
     assert(!tileCombined.hasDuplicates());
 
     LOG_TRC("TileCombined request for " << tileCombined.serialize() << " from " <<
-            (forceKeyframe ? "client" : "wsd"));
+            (canForceKeyframe ? "client" : "wsd"));
     if (!hasTileCache())
     {
         LOG_WRN("Combined tile request without a loaded document?");
@@ -4385,7 +4385,7 @@ void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined, bool 
         tile.setVersion(++_tileVersion);
 
         // client can force keyframe with an oldWid == 0 on tile
-        if (forceKeyframe && tile.getOldWireId() == 0)
+        if (canForceKeyframe && tile.getOldWireId() == 0)
         {
             // combinedtiles requests direct from the browser get flagged.
             // The browser may have dropped / cleaned its cache, so we can't
@@ -4403,9 +4403,14 @@ void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined, bool 
         bool tooLarge = cachedTile && cachedTile->tooLarge();
         if(!cachedTile || !cachedTile->isValid() || tooLarge)
         {
+            bool forceKeyFrame = false;
             if (!cachedTile || tooLarge)
+            {
+                forceKeyFrame = true;
                 tile.forceKeyframe();
-            requestTileRendering(tile, /*forceKeyFrame*/ true, now, tilesNeedsRendering, session);
+            }
+
+            requestTileRendering(tile, forceKeyFrame, now, tilesNeedsRendering, session);
         }
     }
     if (hasOldWireId)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4385,7 +4385,7 @@ void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined, bool 
         tile.setVersion(++_tileVersion);
 
         // client can force keyframe with an oldWid == 0 on tile
-        if (canForceKeyframe && tile.getOldWireId() == 0)
+        if (canForceKeyframe && tile.isForcedKeyFrame())
         {
             // combinedtiles requests direct from the browser get flagged.
             // The browser may have dropped / cleaned its cache, so we can't
@@ -4585,7 +4585,7 @@ bool DocumentBroker::requestTileRendering(TileDesc& tile, bool forceKeyframe,
         if (forceKeyframe)
         {
             LOG_TRC("Forcing keyframe for tile was oldwid " << tile.getOldWireId());
-            tile.setOldWireId(0);
+            tile.forceKeyframe();
         }
         allSamePartAndSize &= tilesNeedsRendering.empty() || tile.sameTileCombineParams(tilesNeedsRendering.back());
         tilesNeedsRendering.push_back(tile);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -416,7 +416,7 @@ public:
 
     void handleTileRequest(const StringVector &tokens, bool forceKeyframe,
                            const std::shared_ptr<ClientSession>& session);
-    void handleTileCombinedRequest(TileCombined& tileCombined, bool forceKeyframe,
+    void handleTileCombinedRequest(TileCombined& tileCombined, bool canForceKeyframe,
                                    const std::shared_ptr<ClientSession>& session);
     void sendRequestedTiles(const std::shared_ptr<ClientSession>& session);
     void sendTileCombine(const TileCombined& tileCombined);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -588,6 +588,13 @@ public:
 #endif // !MOBILEAPP
 
 private:
+    /// Checks if we really need to request tile rendering or it's in progress
+    /// returns true if all tiles are of the same part and size so can be grouped
+    inline bool requestTileRendering(TileDesc& tile, bool forceKeyFrame,
+                                     const std::chrono::steady_clock::time_point &now,
+                                     std::vector<TileDesc>& tilesNeedsRendering,
+                                     const std::shared_ptr<ClientSession>& session);
+
     /// Get the session that can write the document for save / locking / uploading.
     /// Note that if there is no loaded and writable session, the first will be returned.
     std::shared_ptr<ClientSession> getWriteableSession() const;

--- a/wsd/TileCache.cpp
+++ b/wsd/TileCache.cpp
@@ -277,7 +277,7 @@ Blob TileCache::lookupCachedStream(StreamType type, const std::string& name)
     return Blob();
 }
 
-void TileCache::invalidateTiles(int part, int mode, int x, int y, int width, int height, int normalizedViewId)
+bool TileCache::invalidateTiles(int part, int mode, int x, int y, int width, int height, int normalizedViewId)
 {
     LOG_TRC("Removing invalidated tiles: part: " << part << ", mode: " << mode <<
             ", x: " << x << ", y: " << y <<
@@ -286,6 +286,12 @@ void TileCache::invalidateTiles(int part, int mode, int x, int y, int width, int
             ", viewid: " << normalizedViewId);
 
     ASSERT_CORRECT_THREAD_OWNER(_owner);
+
+    if (_cache.empty())
+    {
+        LOG_TRC("Removing invalidated tiles: cache was empty");
+        return false;
+    }
 
     for (auto it = _cache.begin(); it != _cache.end();)
     {
@@ -307,15 +313,17 @@ void TileCache::invalidateTiles(int part, int mode, int x, int y, int width, int
             ++it;
         }
     }
+
+    return true;
 }
 
-void TileCache::invalidateTiles(const std::string& tiles, int normalizedViewId)
+bool TileCache::invalidateTiles(const std::string& tiles, int normalizedViewId)
 {
     int part = 0, mode = 0;
     TileWireId wireId = 0;
     const Util::Rectangle invalidateRect = TileCache::parseInvalidateMsg(tiles, part, mode, wireId);
 
-    invalidateTiles(part, mode, invalidateRect.getLeft(), invalidateRect.getTop(),
+    return invalidateTiles(part, mode, invalidateRect.getLeft(), invalidateRect.getTop(),
                     invalidateRect.getWidth(), invalidateRect.getHeight(), normalizedViewId);
 }
 

--- a/wsd/TileCache.hpp
+++ b/wsd/TileCache.hpp
@@ -268,8 +268,9 @@ public:
     /// Return the data if we have it, or nothing.
     Blob lookupCachedStream(StreamType type, const std::string& name);
 
-    // The tiles parameter is an invalidatetiles: message as sent by the child process
-    void invalidateTiles(const std::string& tiles, int normalizedViewId);
+    /// The tiles parameter is an invalidatetiles: message as sent by the child process
+    /// returns true if cache wasn't empty
+    bool invalidateTiles(const std::string& tiles, int normalizedViewId);
 
     /// Parse invalidateTiles message to rectangle and associated attributes of the invalidated area
     static Util::Rectangle parseInvalidateMsg(const std::string& tiles, int &part, int &mode, TileWireId &wid);
@@ -299,7 +300,9 @@ private:
     void ensureCacheSize();
     static size_t itemCacheSize(const Tile &tile);
 
-    void invalidateTiles(int part, int mode, int x, int y, int width, int height, int normalizedViewId);
+    /// Removes the invalid tiles from the cache
+    /// returns true if cache wasn't empty
+    bool invalidateTiles(int part, int mode, int x, int y, int width, int height, int normalizedViewId);
 
     /// Lookup tile in our cache.
     Tile findTile(const TileDesc &desc);

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -115,6 +115,7 @@ public:
     void setOldWireId(TileWireId id) { _oldWireId = id; }
     void forceKeyframe() { setOldWireId(0); }
     TileWireId getOldWireId() const { return _oldWireId; }
+    bool isForcedKeyFrame() const { return getOldWireId() == 0; }
     void setWireId(TileWireId id) { _wireId = id; }
     TileWireId getWireId() const { return _wireId; }
 


### PR DESCRIPTION
Related to #10980 
Check if we have pending rendering before requesting new one for the same tile.
Add some useful logging for rare cases in TRC.
Client only "can" request rendering keyframe by wid=0 when tile is not in cache.
Client cannot force it when we already have correct one.

Manual test:
1. open calc
2. open debug tools with tile overlays and invalidations
3. hold page down until reaching missing tiles (red color)
Check what we received, ideally would be to just get single tile as it wasn't edited.

![5-after-page-down](https://github.com/user-attachments/assets/943eeb38-b4c8-48b5-8bb7-964c0c6b1f05)
