### PR TITLE
wsd: better CheckFileInfo validation

### DIFF
--- a/wsd/wopi/CheckFileInfo.hpp
+++ b/wsd/wopi/CheckFileInfo.hpp
@@ -89,6 +89,9 @@ private:
         }
     }
 
+    /// Parses the CheckFileInfo response and validates it.
+    bool parseResponseAndValidate(const std::string& response);
+
     std::shared_ptr<TerminatingPoll> _poll;
     Poco::URI _url; ///< Sanitized URL to the document. Can change through redirection.
     const std::string _docKey; ///< Unique DocKey.


### PR DESCRIPTION
We now validate the CheckFileInfo response
immediately after receiving it, and we mark
it as Fail if it doesn't pass.

This results in the prompt closing of the
client connection, with an equally immediate
"Document loading failed" message to the user
with "Unauthorized" in the message (though the
message refers to the host).

The logs show:
```
ERR  #30: BaseFileName should be the name of the file without a path, but is: ../../about21.odt
ERR  #30: WOPI::CheckFileInfo (24ms) failed or no valid JSON payload returned. Access denied.
DBG  #31: WOPI::CheckFileInfo failed, sending error and closing connection now
```

And the connection is closed via sendUnauthorizedErrorAndShutdown().

Change-Id: I1e706c7d12e66452476a90631b1521fc93d44e63
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
