### PR TITLE
Update all custom button style rules during insert new one

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -697,19 +697,25 @@ L.Control.UIManager = L.Control.extend({
 				newButton[0].text = newButton[0].hint;
 				topToolbar.insertItem(insertBefore, newButton);
 
-				// add the css rule for the image
-				const item = document.querySelector(".w2ui-icon." + encodeURIComponent(button.id));
-				if (item) {
-					item.style.background = 'url("' + encodeURI(button.imgurl) + '")';
-					item.style.backgroundRepeat = 'no-repeat';
-					item.style.backgroundPosition = 'center';
-				}
+				// updated css rules to show custom button images
+				this.setCssRulesForCustomButtons();
 			}
 		}
 
 		if (this.map.isReadOnlyMode()) {
 			// Just add a menu entry for it
 			this.map.fire('addmenu', {id: button.id, label: button.hint});
+		}
+	},
+
+	setCssRulesForCustomButtons: function() {
+		for (var button of this.customButtons) {
+			const item = document.querySelector(".w2ui-icon." + encodeURIComponent(button.id));
+			if (item) {
+				item.style.background = 'url("' + encodeURI(button.imgurl) + '")';
+				item.style.backgroundRepeat = 'no-repeat';
+				item.style.backgroundPosition = 'center';
+			}
 		}
 	},
 


### PR DESCRIPTION
When we add a new custom button it resets all top toolbar and builds again. So we lost the style changes of the old custom buttons and have only last inserted one.

To fix that we have to update old custom button style too.


Change-Id: I26188ff8af99dfe07484fd4c8b00edeed81c562e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

