### PR TITLE
cool#11064 kit: send the client's visible area during file load

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1684,6 +1684,14 @@ function getInitializerClass() {
 		return global.makeDocAndWopiSrcUrl(httpURI, docUrlParams, suffix, wopiSrcParam);
 	};
 
+	global.makeClientVisibleArea = function() {
+		// An approximation till we don't yet have CanvasTileLayer, which would properly use
+		// map.getPixelBounds() and pixelsToTwips().
+		const width = window.innerWidth * 15;
+		const height = window.innerHeight * 15;
+		return '0;0;' + width + ';' + height;
+	};
+
 	// Encode a string to hex.
 	global.hexEncode = function (string) {
 		var bytes = new TextEncoder().encode(string);
@@ -1802,6 +1810,7 @@ function getInitializerClass() {
 				msg += ' darkBackground=' + darkBackground;
 
 				msg += ' timezone=' + Intl.DateTimeFormat().resolvedOptions().timeZone;
+				msg += ' clientvisiblearea=' + window.makeClientVisibleArea();
 
 				global.socket.send(msg);
 			}

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -257,6 +257,8 @@ app.definitions.Socket = L.Class.extend({
 
 		msg += ' accessibilityState=' + window.getAccessibilityState();
 
+		msg += ' clientvisiblearea=' + window.makeClientVisibleArea();
+
 		this._doSend(msg);
 		for (var i = 0; i < this._msgQueue.length; i++) {
 			this._doSend(this._msgQueue[i]);

--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -229,6 +229,11 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
             _macroSecurityLevel = std::move(value);
             ++offset;
         }
+        else if (name == "clientvisiblearea")
+        {
+            _initialClientVisibleArea = std::move(value);
+            ++offset;
+        }
         else if (name == "accessibilityState")
         {
             _accessibilityState = value == "true";

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -296,6 +296,8 @@ public:
 
     const std::string& getMacroSecurityLevel() const { return _macroSecurityLevel; }
 
+    const std::string& getInitialClientVisibleArea() const { return _initialClientVisibleArea; }
+
     bool getAccessibilityState() const { return _accessibilityState; }
 
     void setAccessibilityState(bool val) { _accessibilityState = val; }
@@ -435,6 +437,8 @@ private:
 
     /// Level of Macro security.
     std::string _macroSecurityLevel;
+
+    std::string _initialClientVisibleArea;
 
     /// Specifies whether accessibility support is enabled for this session.
     bool _accessibilityState;

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1874,6 +1874,7 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
     const std::string& batchMode = session->getBatchMode();
     const std::string& enableMacrosExecution = session->getEnableMacrosExecution();
     const std::string& macroSecurityLevel = session->getMacroSecurityLevel();
+    const std::string& clientVisibleArea = session->getInitialClientVisibleArea();
     const bool accessibilityState = session->getAccessibilityState();
     const std::string& userTimezone = session->getTimezone();
     const std::string& userPrivateInfo = session->getUserPrivateInfo();
@@ -1896,6 +1897,9 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
 
     if (!macroSecurityLevel.empty())
         options += ",MacroSecurityLevel=" + macroSecurityLevel;
+
+    if (!clientVisibleArea.empty())
+        options += ",ClientVisibleArea=" + clientVisibleArea;
 
     if (!userTimezone.empty())
         options += ",Timezone=" + userTimezone;

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1591,6 +1591,11 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
                 << ConfigUtil::getConfigValue<int>("security.macro_security_level", 1);
         }
 
+        if (!getInitialClientVisibleArea().empty())
+        {
+            oss << " clientvisiblearea=" << getInitialClientVisibleArea();
+        }
+
         if (ConfigUtil::getConfigValue<bool>("accessibility.enable", false))
         {
             oss << " accessibilityState=" << std::boolalpha << getAccessibilityState();


### PR DESCRIPTION
Large enough documents load significantly faster in desktop Writer than
in COOL for some reason.

Investigating the reason, it turns out that the layout mechanism to
layout the visible area (first page, typically) of the document as part
of doc load goes wrong in the LOK case, where nominally the entire
document is visible.

Fix the problem by sending the approximate client visible area (in
twips, assuming 100% zoom) to core as a file load parameter.

This helps a lot for a 300 pages long document.
lok::Office::documentLoad() cost for the bugdoc:
- before: 540 ms
- after: 112 ms

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I10acbc571ee5119f6e69b5e8012cb2d422a8de4b
