### PR TITLE
wsd: exit the bgsave process once saved

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1395,7 +1395,8 @@ void Document::handleSaveMessage(const std::string &)
         // cleanup any lingering file-system pieces
         _loKitDocument.reset();
 
-        // Next step in the chain is BgSaveChildWebSocketHandler::onDisconnect
+        UnitKit::get().preBackgroundSaveExit();
+        Util::forcedExit(EX_OK);
     }
 }
 


### PR DESCRIPTION
Once saving is complete, there little
point for the bgsave process to stick
around. Best to exit promptly.