### PR TITLE
wsd: better CheckFileInfo validation

### DIFF
--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -651,6 +651,26 @@ http::Request WopiStorage::initHttpRequest(const Poco::URI& uri, const Authoriza
     return httpRequest;
 }
 
+static bool parseResponseAndValidate(const std::string& response, Poco::JSON::Object::Ptr& wopiInfo)
+{
+    if (JsonUtil::parseJSON(response, wopiInfo))
+    {
+        // Validate the filename is sane.
+        std::string filename;
+        if (JsonUtil::findJSONValue(wopiInfo, "BaseFileName", filename) &&
+            filename.find_first_of('/') == std::string::npos)
+        {
+            return true; // We're good.
+        }
+
+        LOG_ERR("BaseFileName should be the name of the file without a path, but is: [" << filename
+                                                                                        << ']');
+    }
+
+    wopiInfo.reset(); // Clear the parsed JSON, if any.
+    return false;
+}
+
 std::unique_ptr<WopiStorage::WOPIFileInfo>
 WopiStorage::getWOPIFileInfoForUri(Poco::URI uriObject, const Authorization& auth,
                                    LockContext& lockCtx, unsigned redirectLimit)
@@ -743,7 +763,7 @@ WopiStorage::getWOPIFileInfoForUri(Poco::URI uriObject, const Authorization& aut
     }
 
     Poco::JSON::Object::Ptr object;
-    if (JsonUtil::parseJSON(wopiResponse, object))
+    if (parseResponseAndValidate(wopiResponse, object))
     {
         if (COOLWSD::AnonymizeUserData)
             LOG_DBG("WOPI::CheckFileInfo (" << callDurationMs << "): anonymizing...");
@@ -757,6 +777,9 @@ WopiStorage::getWOPIFileInfoForUri(Poco::URI uriObject, const Authorization& aut
         JsonUtil::findJSONValue(object, "OwnerId", ownerId);
         JsonUtil::findJSONValue(object, "BaseFileName", filename);
         JsonUtil::findJSONValue(object, "LastModifiedTime", lastModifiedTime);
+
+        assert(filename.find_first_of('/') == std::string::npos &&
+               "Invalid BaseFileName, which had passed prior validation");
 
         FileInfo fileInfo = FileInfo({filename, ownerId, lastModifiedTime});
         setFileInfo(fileInfo);


### PR DESCRIPTION
We now validate the CheckFileInfo response
immediately after receiving it, and we mark
it as Fail if it doesn't pass.

This results in the prompt closing of the
client connection, with an equally immediate
"Document loading failed" message to the user
with "Unauthorized" in the message (though the
message refers to the host).


Change-Id: I1e706c7d12e66452476a90631b1521fc93d44e63


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

