### PR TITLE
impress: fix navigator sidebar icon missing width and height

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -321,7 +321,7 @@
 	background-position: right;
 	background-repeat: no-repeat;
 }
-.unospan-optionstoolboxdown .unobutton > img {
+#optionstoolboxdown .unotoolbutton .unobutton > img {
 	width: var(--btn-img-size);
 	height: var(--btn-img-size);
 }


### PR DESCRIPTION
Change-Id: I84239134f959e62fb6cfe7bea62bba782593bf29

* Target version: master 

### Summary
These properties were missing making the branding icon invisible in light mode

### Before
![Screenshot from 2025-02-12 12-47-28](https://github.com/user-attachments/assets/ea61a255-d9da-456e-9ae7-d2f40980e4aa)

### After change
![Screenshot from 2025-02-12 13-10-37](https://github.com/user-attachments/assets/695e63bf-592a-4f67-88a4-8caa21d6440f)


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

