### PR TITLE
tiles: combine also vertical columns of tiles

### DIFF
--- a/kit/KitQueue.cpp
+++ b/kit/KitQueue.cpp
@@ -459,7 +459,7 @@ TileCombined KitQueue::popTileQueue(float &priority)
 
         LOG_TRC("Combining candidate: " << it.serialize());
 
-        // Check if it's on the same row.
+        // Check if it's on the same row or column.
         if (tiles[0].canCombine(it))
         {
             tiles.emplace_back(it);

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -233,11 +233,14 @@ public:
         return true;
     }
 
+    bool onSameColumn(const TileDesc& other) const
+    {
+        return other.getTilePosX() + other.getTileWidth() >= getTilePosX() &&
+               other.getTilePosX() <= getTilePosX() + getTileWidth();
+    }
+
     bool onSameRow(const TileDesc& other) const
     {
-        if (!sameTileCombineParams(other))
-            return false;
-
         return other.getTilePosY() + other.getTileHeight() >= getTilePosY() &&
                other.getTilePosY() <= getTilePosY() + getTileHeight();
     }
@@ -247,7 +250,10 @@ public:
         if (isPreview() || other.isPreview())
             return false;
 
-        if (!onSameRow(other))
+        if (!sameTileCombineParams(other))
+            return false;
+
+        if (!onSameRow(other) || !onSameColumn(other))
             return false;
 
         const int gridX = getTilePosX() / getTileWidth();


### PR DESCRIPTION
Let's consider calc where we changed single column content. We need to redraw tiles in a single column probably. That was not possible to fetch in one go as we looked only for horizontal adjacent tiles. Let's try to combine also vertically.

Related to issue #10968 Preload more intelligently

After applying we can combine 2 tiles vertically:
```
kit-17619-17619 2025-01-24 18:38:40.239133 +0100 [ kitbroker_001 ] DBG  #21: child_ws: recv [tilecombine nviewid=1000 part=3 width=256 height=256 tileposx=49920,49920,49920,49920,49920 tileposy=207360,211200,215040,218880,222720 tilewidth=3840 tileheight=3840 ver=973,974,975,976,977 | kit/KitWebSocket.cpp:59
kit-17619-17619 2025-01-24 18:38:40.239167 +0100 [ kitbroker_001 ] TRC  KitQueue depth: 5| kit/KitQueue.cpp:424
kit-17619-17619 2025-01-24 18:38:40.239173 +0100 [ kitbroker_001 ] TRC  Combining candidate:  nviewid=1000 part=3 width=256 height=256 tileposx=49920 tileposy=211200 tilewidth=3840 tileheight=3840 ver=974| kit/KitQueue.cpp:460
kit-17619-17619 2025-01-24 18:38:40.239178 +0100 [ kitbroker_001 ] TRC  Combining candidate:  nviewid=1000 part=3 width=256 height=256 tileposx=49920 tileposy=215040 tilewidth=3840 tileheight=3840 ver=975| kit/KitQueue.cpp:460
kit-17619-17619 2025-01-24 18:38:40.239182 +0100 [ kitbroker_001 ] TRC  Combining candidate:  nviewid=1000 part=3 width=256 height=256 tileposx=49920 tileposy=218880 tilewidth=3840 tileheight=3840 ver=976| kit/KitQueue.cpp:460
kit-17619-17619 2025-01-24 18:38:40.239186 +0100 [ kitbroker_001 ] TRC  Combining candidate:  nviewid=1000 part=3 width=256 height=256 tileposx=49920 tileposy=222720 tilewidth=3840 tileheight=3840 ver=977| kit/KitQueue.cpp:460
kit-17619-17619 2025-01-24 18:38:40.239190 +0100 [ kitbroker_001 ] TRC  Combined 2 tiles, leaving 3 in queue.| kit/KitQueue.cpp:472
kit-17619-17619 2025-01-24 18:38:40.239196 +0100 [ kitbroker_001 ] TRC  KitQueue res:  nviewid=1000 part=3 width=256 height=256 tileposx=49920,49920 tileposy=207360,211200 tilewidth=3840 tileheight=3840 ver=973,974| kit/KitQueue.cpp:482
```

Change-Id: Ie564c79fb3a462d9df8a5bcd7eb4addc42a1fcbe
