### PR TITLE
Fix an issue in LOUtil._doRectanglesIntersect() caught by mocha

### DIFF
--- a/browser/mocha_tests/LOUtil.test.ts
+++ b/browser/mocha_tests/LOUtil.test.ts
@@ -121,19 +121,19 @@ describe('LOUtil static class members', function () {
 		});
 
 		it('A meets B tangentially (vertical)', function () {
-			assert.ok(LOUtil._doRectanglesIntersect([10, 20, 100, 200], [110, 20, 10, 200]));
+			assert.ok(LOUtil._doRectanglesIntersect([10, 20, 100, 200], [109, 20, 10, 200]));
 		});
 
 		it('A meets B tangentially (horizontal)', function () {
-			assert.ok(LOUtil._doRectanglesIntersect([10, 20, 100, 200], [10, 220, 100, 20]));
+			assert.ok(LOUtil._doRectanglesIntersect([10, 20, 100, 200], [10, 219, 100, 20]));
 		});
 
 		it('A meets B tangentially (single point)', function () {
-			assert.ok(LOUtil._doRectanglesIntersect([10, 20, 100, 200], [110, 220, 10, 20]));
+			assert.ok(LOUtil._doRectanglesIntersect([10, 20, 100, 200], [109, 219, 10, 20]));
 		});
 
-		it('disjoint (bug in the function)', function () {
-			assert.ok(LOUtil._doRectanglesIntersect([10, 20, 100, 200], [111, 221, 100, 200]));
+		it('disjoint ([x2, y2] of first rectangle is away from the [x1, y1] of the second by a pixel)', function () {
+			assert.ok(!LOUtil._doRectanglesIntersect([10, 20, 100, 200], [110, 220, 100, 200]));
 		});
 
 		it('disjoint (rectangles very far away)', function () {

--- a/browser/mocha_tests/LOUtil.test.ts
+++ b/browser/mocha_tests/LOUtil.test.ts
@@ -141,4 +141,47 @@ describe('LOUtil static class members', function () {
 		});
 	});
 
+	describe('_getIntersectionRectangle', function () {
+
+		it('rectangle intersects with itself', function () {
+			const expected = [10, 20, 100, 200];
+			assert.deepEqual(expected, LOUtil._getIntersectionRectangle([10, 20, 100, 200], [10, 20, 100, 200]));
+		});
+
+		it('A contains B, there is intersection', function () {
+			const expected = [11, 21, 90, 190];
+			assert.deepEqual(expected, LOUtil._getIntersectionRectangle([10, 20, 100, 200], [11, 21, 90, 190]));
+		});
+
+		it('B contains A, there is intersection', function () {
+			const expected = [11, 21, 90, 190];
+			assert.deepEqual(expected, LOUtil._getIntersectionRectangle([11, 21, 90, 190], [10, 20, 100, 200]));
+		});
+
+		it('A meets B tangentially (vertical)', function () {
+			const expected = [109, 20, 1, 200];
+			assert.deepEqual(expected, LOUtil._getIntersectionRectangle([10, 20, 100, 200], [109, 20, 10, 200]));
+		});
+
+		it('A meets B tangentially (horizontal)', function () {
+			const expected = [10, 219, 100, 1];
+			assert.deepEqual(expected, LOUtil._getIntersectionRectangle([10, 20, 100, 200], [10, 219, 100, 20]));
+		});
+
+		it('A meets B tangentially (single point)', function () {
+			const expected = [109, 219, 1, 1];
+			assert.deepEqual(expected, LOUtil._getIntersectionRectangle([10, 20, 100, 200], [109, 219, 10, 20]));
+		});
+
+		it('disjoint ([x2, y2] of first rectangle is away from the [x1, y1] of the second by a pixel)', function () {
+			const expected: number[] = null;
+			assert.deepEqual(expected, LOUtil._getIntersectionRectangle([10, 20, 100, 200], [110, 220, 100, 200]));
+		});
+
+		it('disjoint (rectangles very far away)', function () {
+			const expected: number[] = null;
+			assert.deepEqual(expected ,LOUtil._getIntersectionRectangle([10, 20, 10, 20], [400, 500, 10, 20]));
+		});
+	});
+
 });

--- a/browser/src/app/LOUtil.ts
+++ b/browser/src/app/LOUtil.ts
@@ -395,7 +395,7 @@ class LOUtil {
 					rectangle1[2] * 0.5 -
 					(rectangle2[0] + rectangle2[2] * 0.5),
 			) <
-			rectangle1[2] + rectangle2[2]
+			0.5 * (rectangle1[2] + rectangle2[2])
 		) {
 			if (
 				Math.abs(
@@ -403,7 +403,7 @@ class LOUtil {
 						rectangle1[3] * 0.5 -
 						(rectangle2[1] + rectangle2[3] * 0.5),
 				) <
-				rectangle1[3] + rectangle2[3]
+				0.5 * (rectangle1[3] + rectangle2[3])
 			)
 				return true;
 			else return false;


### PR DESCRIPTION
* Target version: master 

### Summary
Fix an issue in LOUtil._doRectanglesIntersect() caught by mocha. Also introduce unit tests for LOUtil._getIntersectionRectangle().

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

