### PR TITLE
add missing "Screen Reading" menu

### DIFF
--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -1061,6 +1061,8 @@ class Menubar extends L.Control {
 				{name: MenubarShortcuts.addShortcut(_('Keyboard shortcuts'), MenubarShortcuts.shortcuts.KEYBOARD_SHORTCUTS), id: 'keyboard-shortcuts', type: 'action', iosapp: false},
 				{name: _('Report an issue'), id: 'report-an-issue', type: 'action', iosapp: false},
 				{name: _('Latest Updates'), id: 'latestupdates', type: 'action', iosapp: false},
+				window.enableAccessibility ?
+					{name: _('Screen Reading'), id: 'togglea11ystate', type: 'action'} : {},
 				{name: _('Send Feedback'), id: 'feedback', type: 'action', mobileapp: false},
 				{name: _('Server audit'), id: 'serveraudit', type: 'action', mobileapp: false},
 				{name: _('About'), id: 'about', type: 'action'}]

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1769,7 +1769,7 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
 
     // default to the notebookbar if the value is "default" or whatever
     // nonsensical
-    if (enableAccessibility == "true" || (userInterfaceMode != "classic" && userInterfaceMode != "notebookbar"))
+    if (enableAccessibility == "true" && userInterfaceMode != "classic" && userInterfaceMode != "notebookbar")
         userInterfaceMode = "notebookbar";
 
     Poco::replaceInPlace(preprocess, std::string("%USER_INTERFACE_MODE%"), userInterfaceMode);


### PR DESCRIPTION
- **wsd: accessbility: fix the compact user interface settings.**
- **browser: accessibility: add missing "Screen Reading" menu for calc**
