### PR TITLE
Fix wrong custom button image URL

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -336,15 +336,18 @@ L.Control.Notebookbar = L.Control.extend({
 		}
 
 		var isUnoCommand = button.unoCommand && button.unoCommand.indexOf('.uno:') >= 0;
+		var forceToUseDefaultIcon = false;
 		if (button.unoCommand && !isUnoCommand)
 			button.unoCommand = '.uno:' + button.unoCommand;
+		if (isUnoCommand && button.imgurl.indexOf('http') === -1)
+			forceToUseDefaultIcon = true;
 
 		this.additionalShortcutButtons.push(
 			{
 				id: button.id,
 				type: 'toolitem',
 				text: button.label ? button.label : (button.hint ? _(button.hint) : ' '),
-				icon: button.imgurl,
+				icon: forceToUseDefaultIcon ? undefined : button.imgurl,
 				command: button.unoCommand,
 				accessKey: button.accessKey ? button.accessKey: null,
 				postmessage: button.unoCommand ? undefined : true,


### PR DESCRIPTION
Button image URL was like:
"http://localhost:9980/browser/b776c533b4/images/images/lc_save.svg" That causes the missing icon when new inserted custom buttons After fix, new URL will be like
"http://localhost:9980/browser/b776c533b4/images/lc_save.svg"


Change-Id: Ide8f6df68018fcac98ce95f1a5c4a9317cff3473


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

