### PR TITLE
CheckFileInfo created without std::shared_ptr

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1032,9 +1032,9 @@ bool DocumentBroker::download(
             std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
             auto poller = std::make_shared<TerminatingPoll>("CFISynReqPoll");
             poller->runOnClientThread();
-            CheckFileInfo checkFileInfo(poller, session->getPublicUri(), [](CheckFileInfo&) {});
-            checkFileInfo.checkFileInfoSync(HTTP_REDIRECTION_LIMIT);
-            wopiFileInfo = checkFileInfo.wopiFileInfo(session->getPublicUri());
+            auto checkFileInfo = std::make_shared<CheckFileInfo>(poller, session->getPublicUri(), [](CheckFileInfo&) {});
+            checkFileInfo->checkFileInfoSync(HTTP_REDIRECTION_LIMIT);
+            wopiFileInfo = checkFileInfo->wopiFileInfo(session->getPublicUri());
             if (!wopiFileInfo)
             {
                 throw std::runtime_error(


### PR DESCRIPTION
and since:

commit e0ca4a82328a6750c5ab99dde64b3000b4e11f17
CommitDate: Tue Jan 14 08:31:11 2025 +0000

    use std::weak_ptr's of CheckFileInfo to detect callbacks after end of life

we rely upon creation via std::shared_ptr to detect callbacks that outlive CheckFileInfo

and so richdocumentscode didn't work


Change-Id: I1feb7859cc9d078ac70833a230c49ed964ef43e7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

