### PR TITLE
coplugin: add refcounting check

### DIFF
--- a/clang/Makefile
+++ b/clang/Makefile
@@ -12,7 +12,8 @@ run:
 	clang++ -Werror -Xclang -load -Xclang ./plugin.so -Xclang -add-plugin -Xclang coplugin -c -o test/capture.o test/capture.cpp
 
 check:
-	clang++ -Werror -Xclang -verify -Xclang -load -Xclang ./plugin.so -Xclang -add-plugin -Xclang coplugin -c -o test/capture.o test/capture.cpp
+	clang++ -Werror -Xclang -verify -Xclang -load -Xclang ./plugin.so -Xclang -add-plugin -Xclang coplugin -c test/capture.cpp
+	clang++ -Werror -Xclang -verify -Xclang -load -Xclang ./plugin.so -Xclang -add-plugin -Xclang coplugin -c test/refcounting.cpp
 
 clean:
 	rm -f plugin.so plugin.o

--- a/clang/test/refcounting.cpp
+++ b/clang/test/refcounting.cpp
@@ -1,0 +1,19 @@
+#include <memory>
+
+class CheckFileInfo
+{
+};
+
+int main() {
+    {
+        // expected-error@+1 {{instance allocated on the stack, create it with std::shared_ptr [coplugin:refcounting]}}
+        CheckFileInfo checkFileInfo;
+    }
+
+    {
+        // good
+        auto checkFileInfo = std::make_shared<CheckFileInfo>();
+    }
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Finds:

  CXX      wsd/DocumentBroker.o
wsd/DocumentBroker.cpp:1035:27: error: instance allocated on the stack, create it with std::shared_ptr [coplugin:refcounting]
            CheckFileInfo checkFileInfo(poller, session->getPublicUri(), [](CheckFileInfo&) {});
                          ^~~~~~~~~~~~~
1 error generated.

With 67504c45efeb36a8d91b1ce85b27af8cf257e051 (CheckFileInfo created
without std::shared_ptr, 2025-02-13) reverted.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ic702d5ab3cd08c0de54df5edc61db8d5c50834fb
