### PR TITLE
Align style list settings checkbox for visual consistency

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -433,3 +433,7 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 #TemplatePanel > div:nth-child(5) {
 	height: inherit;
 }
+
+#TemplatePanel #highlightstyles input {
+	margin-left: 0px;
+}


### PR DESCRIPTION
Change-Id: I9997609f0f94cfc09f7be39369af8aa5cef2e543

* Target version: master 

### Summary
Aligned the 'Highlight styles' checkbox to match the correct positioning, ensuring visual consistency and improved UI alignment.

### Before
![Screenshot from 2025-02-14 13-08-28](https://github.com/user-attachments/assets/6d0ccf90-fb4a-4649-88f1-bd7e46fa3931)

### After
![Screenshot from 2025-02-14 13-08-11](https://github.com/user-attachments/assets/0ee0391d-7335-4254-ac97-61c7eae6ea35)




