### PR TITLE
Impress: Return silently if a comment is being edited.

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -2366,17 +2366,6 @@ export class CommentSection extends app.definitions.canvasSectionObject {
 		this.disableLayoutAnimation = true;
 		var comment;
 		if (Comment.isAnyEdit()) {
-			this.map.uiManager.showConfirmModal(
-				'comments-update',
-				_('Comments Updated'),
-				_('Another user has updated comments. Would you like to proceed updating?'),
-				_('OK'),
-				() => {
-					CommentSection.pendingImport = false;
-					this.clearList();
-					this.importComments(commentList);
-				}
-			);
 			CommentSection.pendingImport = true;
 			return;
 		}


### PR DESCRIPTION
While importing comments, confirmation popup causes false alerts. Issue: Because when user's comment is autosaved, import comments is activated and model pops up.


Change-Id: I61d75d4ee5c9343f14edb86630c9b5e49b29a7ec

![1](https://github.com/user-attachments/assets/2e1fd0aa-5617-4b90-ac43-0601f93e8989)

