### PR TITLE
Reduce some cost of cursor update

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -290,8 +290,10 @@ L.Control.UIManager = L.Control.extend({
 		this.documentNameInput = L.control.documentNameInput();
 		this.map.addControl(this.documentNameInput);
 		this.map.addControl(L.control.alertDialog());
-		this.mobileWizard = L.control.mobileWizard();
-		this.map.addControl(this.mobileWizard);
+		if (window.mode.isMobile()) {
+			this.mobileWizard = L.control.mobileWizard();
+			this.map.addControl(this.mobileWizard);
+		}
 		this.map.addControl(L.control.languageDialog());
 		this.map.dialog = L.control.lokDialog();
 		this.map.addControl(this.map.dialog);

--- a/browser/src/control/jsdialog/Util.FocusCycle.js
+++ b/browser/src/control/jsdialog/Util.FocusCycle.js
@@ -19,6 +19,9 @@ function isAnyInputFocused() {
 	if (!app.map)
 		return false;
 
+	if (app.map.hasFocus())
+		return false;
+
 	var hasTunneledDialogOpened = app.map.dialog ? app.map.dialog.hasOpenedDialog() : false;
 	var hasJSDialogOpened = app.map.jsdialog ? app.map.jsdialog.hasDialogOpened() : false;
 	var hasJSDialogFocused = L.DomUtil.hasClass(document.activeElement, 'jsdialog');


### PR DESCRIPTION
- no need for mobile wizard on desktop
- shortcut for input detection

Related to issue #11124

![after-any-input](https://github.com/user-attachments/assets/9f7a2f7a-9760-4676-a5c5-77ce223384d1)
