### PR TITLE
tiles: avoid duplicated version bump

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4410,7 +4410,8 @@ void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined, bool 
                 tile.forceKeyframe();
             }
 
-            requestTileRendering(tile, forceKeyFrame, now, tilesNeedsRendering, session);
+            bool bumpVersion = false; // already done above
+            requestTileRendering(tile, forceKeyFrame, bumpVersion, now, tilesNeedsRendering, session);
         }
     }
     if (hasOldWireId)
@@ -4572,7 +4573,7 @@ void DocumentBroker::handleMediaRequest(std::string range,
     }
 }
 
-bool DocumentBroker::requestTileRendering(TileDesc& tile, bool forceKeyframe,
+bool DocumentBroker::requestTileRendering(TileDesc& tile, bool forceKeyframe, bool bumpVersion,
                                           const std::chrono::steady_clock::time_point &now,
                                           std::vector<TileDesc>& tilesNeedsRendering,
                                           const std::shared_ptr<ClientSession>& session)
@@ -4581,7 +4582,9 @@ bool DocumentBroker::requestTileRendering(TileDesc& tile, bool forceKeyframe,
     if (!tileCache().hasTileBeingRendered(tile, &now) || // There is no in progress rendering of the given tile
         tileCache().getTileBeingRenderedVersion(tile) < tile.getVersion()) // We need a newer version
     {
-        tile.setVersion(++_tileVersion);
+        if (bumpVersion)
+            tile.setVersion(++_tileVersion);
+
         if (forceKeyframe)
         {
             LOG_TRC("Forcing keyframe for tile was oldwid " << tile.getOldWireId());
@@ -4639,7 +4642,9 @@ void DocumentBroker::sendRequestedTiles(const std::shared_ptr<ClientSession>& se
             else
             {
                 // Not cached, needs rendering.
-                allSamePartAndSize &= requestTileRendering(tile, !cachedTile, now, tilesNeedsRendering, session);
+                bool bumpVersion = true;
+                bool forceKeyFrame = !cachedTile;
+                allSamePartAndSize &= requestTileRendering(tile, forceKeyFrame, bumpVersion, now, tilesNeedsRendering, session);
             }
             requestedTiles.pop_front();
         }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4380,9 +4380,10 @@ void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined, bool 
     const auto now = std::chrono::steady_clock::now();
     std::vector<TileDesc> tilesNeedsRendering;
     bool hasOldWireId = false;
+    ++_tileVersion; // bump only once
     for (auto& tile : tileCombined.getTiles())
     {
-        tile.setVersion(++_tileVersion);
+        tile.setVersion(_tileVersion);
 
         // client can force keyframe with an oldWid == 0 on tile
         if (canForceKeyframe && tile.isForcedKeyFrame())
@@ -4410,8 +4411,7 @@ void DocumentBroker::handleTileCombinedRequest(TileCombined& tileCombined, bool 
                 tile.forceKeyframe();
             }
 
-            bool bumpVersion = false; // already done above
-            requestTileRendering(tile, forceKeyFrame, bumpVersion, now, tilesNeedsRendering, session);
+            requestTileRendering(tile, forceKeyFrame, _tileVersion, now, tilesNeedsRendering, session);
         }
     }
     if (hasOldWireId)
@@ -4573,7 +4573,7 @@ void DocumentBroker::handleMediaRequest(std::string range,
     }
 }
 
-bool DocumentBroker::requestTileRendering(TileDesc& tile, bool forceKeyframe, bool bumpVersion,
+bool DocumentBroker::requestTileRendering(TileDesc& tile, bool forceKeyframe, int version,
                                           const std::chrono::steady_clock::time_point &now,
                                           std::vector<TileDesc>& tilesNeedsRendering,
                                           const std::shared_ptr<ClientSession>& session)
@@ -4582,8 +4582,7 @@ bool DocumentBroker::requestTileRendering(TileDesc& tile, bool forceKeyframe, bo
     if (!tileCache().hasTileBeingRendered(tile, &now) || // There is no in progress rendering of the given tile
         tileCache().getTileBeingRenderedVersion(tile) < tile.getVersion()) // We need a newer version
     {
-        if (bumpVersion)
-            tile.setVersion(++_tileVersion);
+        tile.setVersion(version);
 
         if (forceKeyframe)
         {
@@ -4613,6 +4612,7 @@ void DocumentBroker::sendRequestedTiles(const std::shared_ptr<ClientSession>& se
     // All tiles were processed on client side that we sent last time, so we can send
     // a new batch of tiles which was invalidated / requested in the meantime
     std::deque<TileDesc>& requestedTiles = session->getRequestedTiles();
+    bool bumpedVersion = false;
     if (!requestedTiles.empty() && hasTileCache())
     {
         std::vector<TileDesc> tilesNeedsRendering;
@@ -4642,9 +4642,13 @@ void DocumentBroker::sendRequestedTiles(const std::shared_ptr<ClientSession>& se
             else
             {
                 // Not cached, needs rendering.
-                bool bumpVersion = true;
+                if (!bumpedVersion)
+                {
+                    ++_tileVersion; // only once
+                    bumpedVersion = true;
+                }
                 bool forceKeyFrame = !cachedTile;
-                allSamePartAndSize &= requestTileRendering(tile, forceKeyFrame, bumpVersion, now, tilesNeedsRendering, session);
+                allSamePartAndSize &= requestTileRendering(tile, forceKeyFrame, _tileVersion, now, tilesNeedsRendering, session);
             }
             requestedTiles.pop_front();
         }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -590,7 +590,7 @@ public:
 private:
     /// Checks if we really need to request tile rendering or it's in progress
     /// returns true if all tiles are of the same part and size so can be grouped
-    inline bool requestTileRendering(TileDesc& tile, bool forceKeyFrame,
+    inline bool requestTileRendering(TileDesc& tile, bool forceKeyFrame, bool bumpVersion,
                                      const std::chrono::steady_clock::time_point &now,
                                      std::vector<TileDesc>& tilesNeedsRendering,
                                      const std::shared_ptr<ClientSession>& session);

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -590,7 +590,7 @@ public:
 private:
     /// Checks if we really need to request tile rendering or it's in progress
     /// returns true if all tiles are of the same part and size so can be grouped
-    inline bool requestTileRendering(TileDesc& tile, bool forceKeyFrame, bool bumpVersion,
+    inline bool requestTileRendering(TileDesc& tile, bool forceKeyFrame, int version,
                                      const std::chrono::steady_clock::time_point &now,
                                      std::vector<TileDesc>& tilesNeedsRendering,
                                      const std::shared_ptr<ClientSession>& session);


### PR DESCRIPTION
Related to issue #10980
Followup for 6ae718e
tiles: client cannot force keyframe

Version can protect us from rendering the same tile twice. The increase was introduced in commit 5260eae05f89056d4ffc1bdfad1927c3c5f9706d Avoid rendering / sending the same tile twice
