### PR TITLE
setting: allow wordbook to edit and remove words from wordbook

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -117,6 +117,7 @@ endef
 
 COOL_ADMIN_TS = \
 	admin/src/ModalDialogCreator.ts \
+	admin/src/integrator/WordBook.ts \
 	admin/src/integrator/AdminIntegratorSettings.ts
 
 COOL_ADMIN_TS_JS = $(patsubst %.ts,$(TYPESCRIPT_JS_DIR)/%.js,$(COOL_ADMIN_TS))

--- a/browser/admin/css/adminIntegratorSettings.css
+++ b/browser/admin/css/adminIntegratorSettings.css
@@ -397,6 +397,8 @@ ul {
   list-style: none;
   padding: 0;
   margin: 0 0 16px;
+  max-height: 40vh;
+  overflow-y: auto;
 }
 
 #dicWordList li {

--- a/browser/admin/css/adminIntegratorSettings.css
+++ b/browser/admin/css/adminIntegratorSettings.css
@@ -334,3 +334,114 @@ ul {
   justify-content: center;
   margin-inline-start: var(--default-grid-baseline);
 }
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5); /* semi-transparent black */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  background-color: #fff;
+  padding: 20px;
+  width: 400px;
+  max-width: 90%;
+  border-radius: 4px;
+  box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+}
+
+.modal-content h2 {
+  font-size: 21px;
+  text-align: center;
+  margin: 0 0 16px;
+}
+
+.dic-input-container {
+  display: flex;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.dic-input-container input[type="text"] {
+  flex: 1;
+  padding: 8px;
+  font-size: 15px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.dic-input-container button {
+  margin-left: 8px;
+  padding: 8px 12px;
+  font-size: 15px;
+  cursor: pointer;
+  background-color: var(--color-primary, #00679e);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.dic-input-container button:hover {
+  background-color: var(--color-primary-hover, #3285b1);
+}
+
+#dicWordList {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 16px;
+}
+
+#dicWordList li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 0;
+}
+
+#dicWordList li button {
+  background-color: transparent;
+  border: none;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.dic-button-container {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+}
+
+.dic-button-container button {
+  padding: 8px 16px;
+  font-size: 15px;
+  cursor: pointer;
+  border: none;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.dic-button-container button:nth-child(1) {
+  background-color: #eee;
+  color: #333;
+}
+
+.dic-button-container button:nth-child(1):hover {
+  background-color: #ddd;
+}
+
+.dic-button-container button:nth-child(2) {
+  background-color: var(--color-primary, #00679e);
+  color: #fff;
+}
+
+.dic-button-container button:nth-child(2):hover {
+  background-color: var(--color-primary-hover, #3285b1);
+}

--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -42,740 +42,526 @@ interface SectionConfig {
 	enabledFor?: string;
 }
 
-const API_ENDPOINTS = {
-	uploadSettings: window.enableDebug
-		? '/wopi/settings/upload'
-		: '/browser/dist/upload-settings',
-	fetchSharedConfig: '/browser/dist/fetch-settings-config',
-	deleteSharedConfig: '/browser/dist/delete-settings-config',
-	fetchDictionary: 'browser/dist/fetch-dic',
-};
+class SettingIframe {
+	private wordbook;
 
-const PATH = {
-	autoTextUpload: () => settingConfigBasePath() + '/autotext/',
-	wordBookUpload: () => settingConfigBasePath() + '/wordbook/',
-	browserSettingsUpload: () => settingConfigBasePath() + '/browsersetting/',
-	XcuUpload: () => settingConfigBasePath() + '/xcu/',
-};
+	private API_ENDPOINTS = {
+		uploadSettings: window.enableDebug
+			? '/wopi/settings/upload'
+			: '/browser/dist/upload-settings',
+		fetchSharedConfig: '/browser/dist/fetch-settings-config',
+		deleteSharedConfig: '/browser/dist/delete-settings-config',
+		fetchDictionary: 'browser/dist/fetch-dic',
+	};
 
-// TODO: Move wordbook to separate class/module
+	private PATH = {
+		autoTextUpload: () => this.settingConfigBasePath() + '/autotext/',
+		wordBookUpload: () => this.settingConfigBasePath() + '/wordbook/',
+		browserSettingsUpload: () =>
+			this.settingConfigBasePath() + '/browsersetting/',
+		XcuUpload: () => this.settingConfigBasePath() + '/xcu/',
+	};
 
-interface DicFile {
-	headerType: string; // eg. "OOoUserDict1"
-	language: string; // the value after "lang:" (eg. "<none>")
-	dictType: string; // the value after "type:" (eg. "positive")
-	words: string[]; // list of dictionary words
-}
-
-function parseDicFile(content: string): DicFile {
-	const lines = content.split(/\r?\n/).filter((line) => line.trim() !== '');
-	const delimiterIndex = lines.findIndex((line) => line.trim() === '---');
-	if (delimiterIndex === -1) {
-		window.alert('Invalid dictionary format');
-		throw new Error('Invalid dictionary format: missing delimiter "---"');
-	}
-	if (delimiterIndex < 3) {
-		window.alert('Invalid dictionary format');
-		throw new Error(
-			'Invalid dictionary format: not enough header lines before delimiter',
-		);
+	init(): void {
+		this.initWindowVariables();
+		this.insertConfigSections();
+		void this.fetchAndPopulateSharedConfigs();
+		this.wordbook = (window as any).WordBook;
 	}
 
-	const headerType = lines[0].trim();
+	async uploadWordbookFile(filename: string, content: string): Promise<void> {
+		const file = new File([content], filename, { type: 'text/plain' });
+		await this.uploadFile(this.PATH.wordBookUpload(), file);
+	}
 
-	const languageMatch = lines[1].trim().match(/^lang:\s*(.*)$/i);
-	const language = languageMatch ? languageMatch[1].trim() : '';
+	private initWindowVariables(): void {
+		const element = document.getElementById('initial-variables');
+		if (!element) return;
 
-	const typeMatch = lines[2].trim().match(/^type:\s*(.*)$/i);
-	const dictType = typeMatch ? typeMatch[1].trim() : '';
-
-	const words = lines
-		.slice(delimiterIndex + 1)
-		.filter((line) => line.trim() !== '');
-
-	return { headerType, language, dictType, words };
-}
-
-function buildDicFile(dic: DicFile): string {
-	const header = [
-		dic.headerType.trim(),
-		`lang: ${dic.language}`,
-		`type: ${dic.dictType}`,
-	];
-	return [...header, '---', ...dic.words].join('\n');
-}
-
-function updateWordList(listEl: HTMLElement, dic: DicFile): void {
-	listEl.innerHTML = '';
-	dic.words.forEach((word, index) => {
-		// TODO IDEA: Extract list as components?
-
-		const li = document.createElement('li');
-		li.classList.add('list-item__wrapper');
-
-		const listItemDiv = document.createElement('div');
-		listItemDiv.classList.add('list-item');
-
-		const wordContainer = document.createElement('div');
-		wordContainer.classList.add('list-item__anchor');
-
-		const wordContentDiv = document.createElement('div');
-		wordContentDiv.classList.add('list-item-content');
-
-		const wordTextDiv = document.createElement('div');
-		wordTextDiv.classList.add('list-item-content__main');
-		const wordNameDiv = document.createElement('div');
-		wordNameDiv.classList.add('list-item-content__name');
-		wordNameDiv.textContent = word;
-
-		wordTextDiv.appendChild(wordNameDiv);
-		wordContentDiv.appendChild(wordTextDiv);
-		wordContainer.appendChild(wordContentDiv);
-
-		listItemDiv.appendChild(wordContainer);
-
-		const delButton = document.createElement('button');
-		delButton.type = 'button';
-		delButton.classList.add(
-			'button',
-			'button--size-normal',
-			'button--icon-only',
-			'button--vue-secondary',
-			'delete-icon',
-		);
-		delButton.innerHTML = `
-		<span class="button__wrapper">
-		  <span aria-hidden="true" class="button__icon">
-			<span aria-hidden="true" role="img" class="material-design-icon">
-			  <svg fill="currentColor" width="20" height="20" viewBox="0 0 24 24">
-				<path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19
-						  A2,2 0 0,0 8,21H16
-						  A2,2 0 0,0 18,19V7H6V19Z"></path>
-			  </svg>
-			</span>
-		  </span>
-		</span>
-	  `;
-		delButton.addEventListener('click', () => {
-			dic.words.splice(index, 1);
-			updateWordList(listEl, dic);
-		});
-		listItemDiv.appendChild(delButton);
-
-		li.appendChild(listItemDiv);
-		listEl.appendChild(li);
-	});
-}
-
-function openDicEditor(fileName: string, dic: DicFile): void {
-	const modal = document.createElement('div');
-	modal.className = 'modal';
-
-	const modalContent = document.createElement('div');
-	modalContent.className = 'modal-content';
-
-	const titleEl = document.createElement('h2');
-	titleEl.textContent = `${fileName} (Edit)`;
-	titleEl.style.textAlign = 'center';
-	modalContent.appendChild(titleEl);
-
-	const inputContainer = document.createElement('div');
-	inputContainer.className = 'dic-input-container';
-	inputContainer.style.margin = '16px 0';
-
-	const newWordInput = document.createElement('input');
-	newWordInput.type = 'text';
-	newWordInput.placeholder = 'Enter new word';
-	newWordInput.className = 'input-field__input';
-	inputContainer.appendChild(newWordInput);
-
-	const addButton = document.createElement('button');
-	addButton.textContent = 'Add';
-	addButton.className = 'button button--vue-secondary';
-	addButton.style.marginLeft = '8px';
-	addButton.addEventListener('click', () => {
-		const newWord = newWordInput.value.trim();
-		if (newWord) {
-			dic.words.push(newWord);
-			updateWordList(wordList, dic);
-			newWordInput.value = '';
+		window.accessToken = element.dataset.accessToken;
+		window.accessTokenTTL = element.dataset.accessTokenTtl;
+		window.enableDebug = element.dataset.enableDebug === 'true';
+		window.wopiSettingBaseUrl = element.dataset.wopiSettingBaseUrl;
+		window.iframeType = element.dataset.iframeType;
+		window.cssVars = element.dataset.cssVars;
+		if (window.cssVars) {
+			window.cssVars = atob(window.cssVars);
+			const styleEl = document.createElement('style');
+			styleEl.setAttribute('id', 'dynamic-css-vars');
+			styleEl.textContent = window.cssVars;
+			document.head.appendChild(styleEl);
 		}
-	});
-	inputContainer.appendChild(addButton);
 
-	modalContent.appendChild(inputContainer);
+		if (window.enableDebug) {
+			const debugInfoList = document.createElement('ul');
+			const debugInfoEle1 = document.createElement('li');
+			debugInfoEle1.textContent = 'AccessToken: ' + window.accessToken;
+			debugInfoList.append(debugInfoEle1);
 
-	const wordList = document.createElement('ul');
-	wordList.id = 'dicWordList';
-	updateWordList(wordList, dic);
-	modalContent.appendChild(wordList);
+			const debugInfoEle2 = document.createElement('li');
+			debugInfoEle2.textContent = 'WOPI Base URL: ' + window.wopiSettingBaseUrl;
+			debugInfoList.append(debugInfoEle2);
 
-	const buttonContainer = document.createElement('div');
-	buttonContainer.className = 'dic-button-container';
-	buttonContainer.style.textAlign = 'center';
-	buttonContainer.style.marginTop = '24px';
+			const debugInfoEle3 = document.createElement('li');
+			debugInfoEle3.textContent = 'IFrameType: ' + window.iframeType;
+			debugInfoList.append(debugInfoEle3);
 
-	const cancelButton = document.createElement('button');
-	cancelButton.textContent = 'Cancel';
-	cancelButton.className = 'button button--vue-tertiary';
-	cancelButton.style.marginRight = '12px';
-	cancelButton.addEventListener('click', () => {
-		document.body.removeChild(modal);
-	});
-	buttonContainer.appendChild(cancelButton);
+			const debugInfo = document.createElement('div');
+			const debugInfoHeading = document.createElement('h4');
+			debugInfoHeading.textContent = 'DebugInfo: ';
+			debugInfo.append(debugInfoHeading);
+			debugInfo.append(debugInfoList);
 
-	const submitButton = document.createElement('button');
-	submitButton.textContent = 'Submit';
-	submitButton.className = 'button button--vue-primary';
-	submitButton.addEventListener('click', async () => {
-		console.debug('dic', dic);
-		const updatedContent = buildDicFile(dic);
-		console.debug('Updated Dictionary Content:\n', updatedContent);
-		await updateDicFile(fileName, updatedContent);
-		document.body.removeChild(modal);
-	});
+			const fileControls = document.getElementById('fileControls');
+			fileControls?.append(debugInfo);
+		}
+	}
 
-	buttonContainer.appendChild(submitButton);
+	private insertConfigSections(): void {
+		const sharedConfigsContainer = document.getElementById('allConfigSection');
+		if (!sharedConfigsContainer) return;
 
-	modalContent.appendChild(buttonContainer);
-	modal.appendChild(modalContent);
-	document.body.appendChild(modal);
-}
-
-async function updateDicFile(filename: string, content: string) {
-	const file = new File([content], filename, { type: 'text/plain' });
-	await uploadFile(PATH.wordBookUpload(), file);
-}
-
-async function fetchDicFile(fileId: string): Promise<void> {
-	const formData = new FormData();
-	formData.append('fileUrl', fileId);
-	formData.append('accessToken', window.accessToken ?? '');
-	try {
-		const apiUrl = API_ENDPOINTS.fetchDictionary;
-
-		const response = await fetch(apiUrl, {
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${window.accessToken}`,
+		const configSections: SectionConfig[] = [
+			{
+				sectionTitle: 'Autotext',
+				listId: 'autotextList',
+				inputId: 'autotextFile',
+				buttonId: 'uploadAutotextButton',
+				fileAccept: '.bau',
+				buttonText: 'Upload Autotext',
+				uploadPath: this.PATH.autoTextUpload(),
 			},
-			body: formData,
-		});
-
-		if (!response.ok) {
-			throw new Error(`Upload failed: ${response.statusText}`);
-		}
-
-		let textValue = await response.text();
-		console.debug('textValue: ', textValue);
-
-		const dic = parseDicFile(textValue);
-		const fileName = getFilename(fileId, false);
-		openDicEditor(fileName, dic);
-	} catch (error: unknown) {
-		const message = error instanceof Error ? error.message : 'Unknown error';
-		console.error(`Error uploading file: ${message}`);
-	}
-}
-
-async function readFileAsText(file: File): Promise<string> {
-	return new Promise<string>((resolve, reject) => {
-		const reader = new FileReader();
-		reader.onload = () => resolve(reader.result as string);
-		reader.onerror = () => reject(reader.error);
-		reader.readAsText(file);
-	});
-}
-
-function parseWords(content: string): string[] {
-	const lines = content
-		.split(/\r?\n/)
-		.map((line) => line.trim())
-		.filter((line) => line !== '');
-	const delimiterIndex = lines.findIndex((line) => line === '---');
-	if (delimiterIndex !== -1) {
-		return lines.slice(delimiterIndex + 1);
-	}
-	return lines;
-}
-
-async function wordbookValidation(uploadPath: string, file: File) {
-	try {
-		const content = await readFileAsText(file);
-		let dicWords: string[];
-		try {
-			dicWords = parseWords(content);
-		} catch (error) {
-			window.alert('Invalid dictionary format. Please check the file.');
-			console.error('Error parsing dictionary file:', error);
-			return;
-		}
-		// TODO: Assuming default values - should be dynamic later?
-		const defaultHeaderType = 'OOoUserDict1';
-		const defaultLanguage = '<none>';
-		const defaultDictType = 'positive';
-		const newDic: DicFile = {
-			headerType: defaultHeaderType,
-			language: defaultLanguage,
-			dictType: defaultDictType,
-			words: dicWords,
-		};
-		const newContent = buildDicFile(newDic);
-		const newFile = new File([newContent], file.name, { type: 'text/plain' });
-		await uploadFile(uploadPath, newFile);
-	} catch (error) {
-		window.alert('Something went wrong while uploading dictionary file');
-	}
-}
-
-function settingConfigBasePath(): string {
-	return '/settings/' + getConfigType();
-}
-
-function getConfigType(): string {
-	return isAdmin() ? 'systemconfig' : 'userconfig';
-}
-
-function isAdmin(): boolean {
-	return window.iframeType === 'admin';
-}
-
-function init(): void {
-	initWindowVariables();
-	insertConfigSections();
-	void fetchAndPopulateSharedConfigs();
-}
-
-function createConfigSection(config: SectionConfig): HTMLDivElement {
-	const sectionEl = document.createElement('div');
-	sectionEl.classList.add('section');
-
-	const headingEl = document.createElement('h3');
-	headingEl.textContent = config.sectionTitle;
-
-	const ulEl = document.createElement('ul');
-	ulEl.id = config.listId;
-
-	const inputEl = document.createElement('input');
-	inputEl.type = 'file';
-	inputEl.classList.add('hidden');
-	inputEl.id = config.inputId;
-	inputEl.accept = config.fileAccept;
-
-	const buttonEl = document.createElement('button');
-	buttonEl.id = config.buttonId;
-	buttonEl.type = 'button';
-	buttonEl.classList.add(
-		'inline-button',
-		'button',
-		'button--size-normal',
-		'button--text-only',
-		'button--vue-secondary',
-	);
-	buttonEl.innerHTML = `
-	  <span class="button__wrapper">
-		<span class="button__text">${config.buttonText}</span>
-	  </span>
-	`;
-
-	sectionEl.appendChild(headingEl);
-	sectionEl.appendChild(ulEl);
-	sectionEl.appendChild(inputEl);
-	sectionEl.appendChild(buttonEl);
-
-	return sectionEl;
-}
-
-function insertConfigSections(): void {
-	const sharedConfigsContainer = document.getElementById('allConfigSection');
-	if (!sharedConfigsContainer) return;
-
-	const configSections: SectionConfig[] = [
-		{
-			sectionTitle: 'Autotext',
-			listId: 'autotextList',
-			inputId: 'autotextFile',
-			buttonId: 'uploadAutotextButton',
-			fileAccept: '.bau',
-			buttonText: 'Upload Autotext',
-			uploadPath: PATH.autoTextUpload(),
-		},
-		{
-			sectionTitle: 'Wordbook',
-			listId: 'wordbookList',
-			inputId: 'wordbookFile',
-			buttonId: 'uploadWordbookButton',
-			fileAccept: '.dic',
-			buttonText: 'Upload Wordbook',
-			uploadPath: PATH.wordBookUpload(),
-		},
-		{
-			sectionTitle: 'Browser Settings',
-			listId: 'BrowserSettingsList',
-			inputId: 'BrowserSettingsFile',
-			buttonId: 'uploadBrowserSettingsButton',
-			fileAccept: '.json',
-			buttonText: 'Upload Browser Setting',
-			uploadPath: PATH.browserSettingsUpload(),
-			enabledFor: 'userconfig',
-		},
-		{
-			sectionTitle: 'Xcu',
-			listId: 'XcuList',
-			inputId: 'XcuFile',
-			buttonId: 'uploadXcuButton',
-			fileAccept: '.xcu',
-			buttonText: 'Upload Xcu',
-			uploadPath: PATH.XcuUpload(),
-		},
-	];
-
-	configSections.forEach((cfg) => {
-		if (cfg.enabledFor && cfg.enabledFor !== getConfigType()) {
-			return;
-		}
-
-		const sectionEl = createConfigSection(cfg);
-		const fileInput = sectionEl.querySelector<HTMLInputElement>(
-			`#${cfg.inputId}`,
-		);
-		const button = sectionEl.querySelector<HTMLButtonElement>(
-			`#${cfg.buttonId}`,
-		);
-
-		if (fileInput && button) {
-			button.addEventListener('click', () => {
-				fileInput.click();
-			});
-
-			fileInput.addEventListener('change', () => {
-				if (fileInput.files?.length) {
-					if (cfg.uploadPath === PATH.wordBookUpload()) {
-						wordbookValidation(cfg.uploadPath, fileInput.files[0]);
-					} else {
-						uploadFile(cfg.uploadPath, fileInput.files[0]);
-					}
-					fileInput.value = '';
-				}
-			});
-		}
-
-		sharedConfigsContainer.appendChild(sectionEl);
-	});
-}
-
-function initWindowVariables(): void {
-	const element = document.getElementById('initial-variables');
-	if (!element) return;
-
-	window.accessToken = element.dataset.accessToken;
-	window.accessTokenTTL = element.dataset.accessTokenTtl;
-	window.enableDebug = element.dataset.enableDebug === 'true';
-	window.wopiSettingBaseUrl = element.dataset.wopiSettingBaseUrl;
-	window.iframeType = element.dataset.iframeType;
-	window.cssVars = element.dataset.cssVars;
-	if (window.cssVars) {
-		window.cssVars = atob(window.cssVars);
-		const styleEl = document.createElement('style');
-		styleEl.setAttribute('id', 'dynamic-css-vars');
-		styleEl.textContent = window.cssVars;
-		document.head.appendChild(styleEl);
-	}
-
-	if (window.enableDebug) {
-		const debugInfoList = document.createElement('ul');
-		const debugInfoEle1 = document.createElement('li');
-		debugInfoEle1.textContent = 'AccessToken: ' + window.accessToken;
-		debugInfoList.append(debugInfoEle1);
-
-		const debugInfoEle2 = document.createElement('li');
-		debugInfoEle2.textContent = 'WOPI Base URL: ' + window.wopiSettingBaseUrl;
-		debugInfoList.append(debugInfoEle2);
-
-		const debugInfoEle3 = document.createElement('li');
-		debugInfoEle3.textContent = 'IFrameType: ' + window.iframeType;
-		debugInfoList.append(debugInfoEle3);
-
-		const debugInfo = document.createElement('div');
-		const debugInfoHeading = document.createElement('h4');
-		debugInfoHeading.textContent = 'DebugInfo: ';
-		debugInfo.append(debugInfoHeading);
-		debugInfo.append(debugInfoList);
-
-		const fileControls = document.getElementById('fileControls');
-		fileControls?.append(debugInfo);
-	}
-}
-
-// TODO: Upload dic file separately? We shouldn't allow to upload headers
-async function uploadFile(filePath: string, file: File): Promise<void> {
-	const formData = new FormData();
-	formData.append('file', file);
-	formData.append('filePath', filePath);
-	if (window.wopiSettingBaseUrl) {
-		formData.append('wopiSettingBaseUrl', window.wopiSettingBaseUrl);
-	}
-
-	try {
-		const apiUrl = API_ENDPOINTS.uploadSettings;
-
-		const response = await fetch(apiUrl, {
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${window.accessToken}`,
+			{
+				sectionTitle: 'Wordbook',
+				listId: 'wordbookList',
+				inputId: 'wordbookFile',
+				buttonId: 'uploadWordbookButton',
+				fileAccept: '.dic',
+				buttonText: 'Upload Wordbook',
+				uploadPath: this.PATH.wordBookUpload(),
 			},
-			body: formData,
-		});
-
-		if (!response.ok) {
-			throw new Error(`Upload failed: ${response.statusText}`);
-		}
-
-		await fetchAndPopulateSharedConfigs();
-	} catch (error: unknown) {
-		const message = error instanceof Error ? error.message : 'Unknown error';
-		console.error(`Error uploading file: ${message}`);
-	}
-}
-
-async function fetchAndPopulateSharedConfigs(): Promise<void> {
-	if (!window.wopiSettingBaseUrl) {
-		console.error('Shared Config URL is missing in initial variables.');
-		return;
-	}
-	console.debug('iframeType page', window.iframeType);
-
-	if (!window.accessToken) {
-		console.error('Access token is missing in initial variables.');
-		return;
-	}
-
-	const formData = new FormData();
-	formData.append('sharedConfigUrl', window.wopiSettingBaseUrl);
-	formData.append('accessToken', window.accessToken);
-	formData.append('type', getConfigType());
-
-	try {
-		const response = await fetch(API_ENDPOINTS.fetchSharedConfig, {
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${window.accessToken}`,
+			{
+				sectionTitle: 'Browser Settings',
+				listId: 'BrowserSettingsList',
+				inputId: 'BrowserSettingsFile',
+				buttonId: 'uploadBrowserSettingsButton',
+				fileAccept: '.json',
+				buttonText: 'Upload Browser Setting',
+				uploadPath: this.PATH.browserSettingsUpload(),
+				enabledFor: 'userconfig',
 			},
-			body: formData,
-		});
+			{
+				sectionTitle: 'Xcu',
+				listId: 'XcuList',
+				inputId: 'XcuFile',
+				buttonId: 'uploadXcuButton',
+				fileAccept: '.xcu',
+				buttonText: 'Upload Xcu',
+				uploadPath: this.PATH.XcuUpload(),
+			},
+		];
 
-		if (!response.ok) {
-			throw new Error(`Could not fetch shared config: ${response.statusText}`);
-		}
+		configSections.forEach((cfg) => {
+			if (cfg.enabledFor && cfg.enabledFor !== this.getConfigType()) {
+				return;
+			}
 
-		const data: ConfigData = await response.json();
-		populateSharedConfigUI(data);
-		console.debug('Shared config data: ', data);
-	} catch (error: unknown) {
-		console.error('Error fetching shared config:', error);
-	}
-}
+			const sectionEl = this.createConfigSection(cfg);
+			const fileInput = sectionEl.querySelector<HTMLInputElement>(
+				`#${cfg.inputId}`,
+			);
+			const button = sectionEl.querySelector<HTMLButtonElement>(
+				`#${cfg.buttonId}`,
+			);
 
-function getFilename(uri: string, removeExtension = true): string {
-	let filename = uri.substring(uri.lastIndexOf('/') + 1);
-	if (removeExtension) {
-		filename = filename.replace(/\.[^.]+$/, '');
-	}
-	return filename;
-}
-
-function populateList(
-	listId: string,
-	items: ConfigItem[],
-	category: string,
-): void {
-	const listEl = document.getElementById(listId);
-	if (!listEl) return;
-
-	listEl.innerHTML = '';
-
-	items.forEach((item) => {
-		const fileName = getFilename(item.uri, false);
-
-		const li = document.createElement('li');
-		li.classList.add('list-item__wrapper');
-
-		const listItemDiv = document.createElement('div');
-		listItemDiv.classList.add('list-item');
-
-		const anchor = document.createElement('div');
-		anchor.classList.add('list-item__anchor');
-
-		const listItemContentDiv = document.createElement('div');
-		listItemContentDiv.classList.add('list-item-content');
-
-		const listItemContentMainDiv = document.createElement('div');
-		listItemContentMainDiv.classList.add('list-item-content__main');
-
-		const listItemContentNameDiv = document.createElement('div');
-		listItemContentNameDiv.classList.add('list-item-content__name');
-		listItemContentNameDiv.textContent = fileName;
-
-		listItemContentMainDiv.appendChild(listItemContentNameDiv);
-		listItemContentDiv.appendChild(listItemContentMainDiv);
-		anchor.appendChild(listItemContentDiv);
-
-		const extraActionsDiv = document.createElement('div');
-		extraActionsDiv.classList.add('list-item-content__extra-actions');
-
-		const downloadBtn = document.createElement('button');
-		downloadBtn.type = 'button';
-		downloadBtn.classList.add(
-			'button',
-			'button--size-normal',
-			'button--icon-only',
-			'button--vue-secondary',
-			'download-icon',
-		);
-
-		// todo : replace svg to css class?
-		downloadBtn.innerHTML = `
-			<span class="button__wrapper">
-				<span aria-hidden="true" class="button__icon">
-					<span aria-hidden="true" role="img" class="material-design-icon">
-						<svg fill="currentColor" width="20" height="20" viewBox="0 0 24 24" class="material-design-icon__svg">
-							<path d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"></path>
-						</svg>
-					</span>
-				</span>
-			</span>
-		`;
-		downloadBtn.addEventListener('click', () => {
-			window.open(item.uri, '_blank');
-		});
-
-		const deleteBtn = document.createElement('button');
-		deleteBtn.type = 'button';
-		deleteBtn.classList.add(
-			'button',
-			'button--size-normal',
-			'button--icon-only',
-			'button--vue-secondary',
-			'delete-icon',
-		);
-		deleteBtn.innerHTML = `
-			<span class="button__wrapper">
-				<span aria-hidden="true" class="button__icon">
-					<span aria-hidden="true" role="img" class="material-design-icon">
-						<svg fill="currentColor" width="20" height="20" viewBox="0 0 24 24" class="material-design-icon__svg">
-							<path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19
-								A2,2 0 0,0 8,21H16
-								A2,2 0 0,0 18,19V7H6V19Z"></path>
-						</svg>
-					</span>
-				</span>
-			</span>
-		`;
-		deleteBtn.addEventListener('click', async () => {
-			try {
-				if (!window.accessToken) {
-					throw new Error('Access token is missing.');
-				}
-				if (!window.wopiSettingBaseUrl) {
-					throw new Error('wopiSettingBaseUrl is missing.');
-				}
-
-				const fileId =
-					settingConfigBasePath() +
-					category +
-					'/' +
-					getFilename(item.uri, false);
-
-				const formData = new FormData();
-				formData.append('fileId', fileId);
-				formData.append('sharedConfigUrl', window.wopiSettingBaseUrl);
-				formData.append('accessToken', window.accessToken);
-
-				const response = await fetch(API_ENDPOINTS.deleteSharedConfig, {
-					method: 'POST',
-					headers: {
-						Authorization: `Bearer ${window.accessToken}`,
-					},
-					body: formData,
+			if (fileInput && button) {
+				button.addEventListener('click', () => {
+					fileInput.click();
 				});
 
-				if (!response.ok) {
-					throw new Error(`Delete failed: ${response.statusText}`);
-				}
-
-				await fetchAndPopulateSharedConfigs();
-			} catch (error: unknown) {
-				console.error('Error deleting file:', error);
+				fileInput.addEventListener('change', () => {
+					if (fileInput.files?.length) {
+						if (cfg.uploadPath === this.PATH.wordBookUpload()) {
+							this.wordbook.wordbookValidation(
+								cfg.uploadPath,
+								fileInput.files[0],
+							);
+						} else {
+							this.uploadFile(cfg.uploadPath, fileInput.files[0]);
+						}
+						fileInput.value = '';
+					}
+				});
 			}
+
+			sharedConfigsContainer.appendChild(sectionEl);
 		});
+	}
 
-		extraActionsDiv.append(downloadBtn, deleteBtn);
+	private async fetchAndPopulateSharedConfigs(): Promise<void> {
+		if (!window.wopiSettingBaseUrl) {
+			console.error('Shared Config URL is missing in initial variables.');
+			return;
+		}
+		console.debug('iframeType page', window.iframeType);
 
-		// Add an "Edit" button for dic file only
-		if (category === '/wordbook') {
-			const editBtn = document.createElement('button');
-			editBtn.type = 'button';
-			editBtn.classList.add(
+		if (!window.accessToken) {
+			console.error('Access token is missing in initial variables.');
+			return;
+		}
+
+		const formData = new FormData();
+		formData.append('sharedConfigUrl', window.wopiSettingBaseUrl);
+		formData.append('accessToken', window.accessToken);
+		formData.append('type', this.getConfigType());
+
+		try {
+			const response = await fetch(this.API_ENDPOINTS.fetchSharedConfig, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${window.accessToken}`,
+				},
+				body: formData,
+			});
+
+			if (!response.ok) {
+				throw new Error(
+					`Could not fetch shared config: ${response.statusText}`,
+				);
+			}
+
+			const data: ConfigData = await response.json();
+			this.populateSharedConfigUI(data);
+			console.debug('Shared config data: ', data);
+		} catch (error: unknown) {
+			console.error('Error fetching shared config:', error);
+		}
+	}
+
+	private createConfigSection(config: SectionConfig): HTMLDivElement {
+		const sectionEl = document.createElement('div');
+		sectionEl.classList.add('section');
+
+		const headingEl = document.createElement('h3');
+		headingEl.textContent = config.sectionTitle;
+
+		const ulEl = document.createElement('ul');
+		ulEl.id = config.listId;
+
+		const inputEl = document.createElement('input');
+		inputEl.type = 'file';
+		inputEl.classList.add('hidden');
+		inputEl.id = config.inputId;
+		inputEl.accept = config.fileAccept;
+
+		const buttonEl = document.createElement('button');
+		buttonEl.id = config.buttonId;
+		buttonEl.type = 'button';
+		buttonEl.classList.add(
+			'inline-button',
+			'button',
+			'button--size-normal',
+			'button--text-only',
+			'button--vue-secondary',
+		);
+		buttonEl.innerHTML = `
+		  <span class="button__wrapper">
+			<span class="button__text">${config.buttonText}</span>
+		  </span>
+		`;
+
+		sectionEl.appendChild(headingEl);
+		sectionEl.appendChild(ulEl);
+		sectionEl.appendChild(inputEl);
+		sectionEl.appendChild(buttonEl);
+
+		return sectionEl;
+	}
+
+	private async fetchDicFile(fileId: string): Promise<void> {
+		const formData = new FormData();
+		formData.append('fileUrl', fileId);
+		formData.append('accessToken', window.accessToken ?? '');
+		try {
+			const apiUrl = this.API_ENDPOINTS.fetchDictionary;
+
+			const response = await fetch(apiUrl, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${window.accessToken}`,
+				},
+				body: formData,
+			});
+
+			if (!response.ok) {
+				throw new Error(`Upload failed: ${response.statusText}`);
+			}
+
+			let textValue = await response.text();
+			console.debug('textValue: ', textValue);
+
+			const dic = this.wordbook.parseDicFile(textValue);
+			const fileName = this.getFilename(fileId, false);
+			this.wordbook.openDicEditor(fileName, dic);
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : 'Unknown error';
+			console.error(`Error uploading file: ${message}`);
+		}
+	}
+
+	private async uploadFile(filePath: string, file: File): Promise<void> {
+		const formData = new FormData();
+		formData.append('file', file);
+		formData.append('filePath', filePath);
+		if (window.wopiSettingBaseUrl) {
+			formData.append('wopiSettingBaseUrl', window.wopiSettingBaseUrl);
+		}
+
+		try {
+			const apiUrl = this.API_ENDPOINTS.uploadSettings;
+
+			const response = await fetch(apiUrl, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${window.accessToken}`,
+				},
+				body: formData,
+			});
+
+			if (!response.ok) {
+				throw new Error(`Upload failed: ${response.statusText}`);
+			}
+
+			await this.fetchAndPopulateSharedConfigs();
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : 'Unknown error';
+			console.error(`Error uploading file: ${message}`);
+		}
+	}
+
+	private populateList(
+		listId: string,
+		items: ConfigItem[],
+		category: string,
+	): void {
+		const listEl = document.getElementById(listId);
+		if (!listEl) return;
+
+		listEl.innerHTML = '';
+
+		items.forEach((item) => {
+			const fileName = this.getFilename(item.uri, false);
+
+			const li = document.createElement('li');
+			li.classList.add('list-item__wrapper');
+
+			const listItemDiv = document.createElement('div');
+			listItemDiv.classList.add('list-item');
+
+			const anchor = document.createElement('div');
+			anchor.classList.add('list-item__anchor');
+
+			const listItemContentDiv = document.createElement('div');
+			listItemContentDiv.classList.add('list-item-content');
+
+			const listItemContentMainDiv = document.createElement('div');
+			listItemContentMainDiv.classList.add('list-item-content__main');
+
+			const listItemContentNameDiv = document.createElement('div');
+			listItemContentNameDiv.classList.add('list-item-content__name');
+			listItemContentNameDiv.textContent = fileName;
+
+			listItemContentMainDiv.appendChild(listItemContentNameDiv);
+			listItemContentDiv.appendChild(listItemContentMainDiv);
+			anchor.appendChild(listItemContentDiv);
+
+			const extraActionsDiv = document.createElement('div');
+			extraActionsDiv.classList.add('list-item-content__extra-actions');
+
+			const downloadBtn = document.createElement('button');
+			downloadBtn.type = 'button';
+			downloadBtn.classList.add(
 				'button',
 				'button--size-normal',
 				'button--icon-only',
 				'button--vue-secondary',
-				'edit-icon',
+				'download-icon',
 			);
-			editBtn.innerHTML = `
+
+			// todo : replace svg to css class?
+			downloadBtn.innerHTML = `
 				<span class="button__wrapper">
 					<span aria-hidden="true" class="button__icon">
 						<span aria-hidden="true" role="img" class="material-design-icon">
-							<svg fill="currentColor" width="20" height="20" viewBox="0 0 24 24">
-								<path d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"></path>
+							<svg fill="currentColor" width="20" height="20" viewBox="0 0 24 24" class="material-design-icon__svg">
+								<path d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"></path>
 							</svg>
 						</span>
 					</span>
 				</span>
 			`;
-			editBtn.addEventListener('click', async () => {
-				await fetchDicFile(item.uri);
+			downloadBtn.addEventListener('click', () => {
+				window.open(item.uri, '_blank');
 			});
-			extraActionsDiv.appendChild(editBtn);
-		}
 
-		listItemDiv.append(anchor, extraActionsDiv);
-		li.appendChild(listItemDiv);
-		listEl.appendChild(li);
-	});
-}
+			const deleteBtn = document.createElement('button');
+			deleteBtn.type = 'button';
+			deleteBtn.classList.add(
+				'button',
+				'button--size-normal',
+				'button--icon-only',
+				'button--vue-secondary',
+				'delete-icon',
+			);
+			deleteBtn.innerHTML = `
+				<span class="button__wrapper">
+					<span aria-hidden="true" class="button__icon">
+						<span aria-hidden="true" role="img" class="material-design-icon">
+							<svg fill="currentColor" width="20" height="20" viewBox="0 0 24 24" class="material-design-icon__svg">
+								<path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19
+									A2,2 0 0,0 8,21H16
+									A2,2 0 0,0 18,19V7H6V19Z"></path>
+							</svg>
+						</span>
+					</span>
+				</span>
+			`;
+			deleteBtn.addEventListener('click', async () => {
+				try {
+					if (!window.accessToken) {
+						throw new Error('Access token is missing.');
+					}
+					if (!window.wopiSettingBaseUrl) {
+						throw new Error('wopiSettingBaseUrl is missing.');
+					}
 
-function populateSharedConfigUI(data: ConfigData): void {
-	const browserSettingButton = document.getElementById(
-		'uploadBrowserSettingsButton',
-	) as HTMLButtonElement | null;
+					const fileId =
+						this.settingConfigBasePath() +
+						category +
+						'/' +
+						this.getFilename(item.uri, false);
 
-	if (browserSettingButton) {
-		if (data.browsersetting && data.browsersetting.length > 0) {
-			browserSettingButton.style.display = 'none';
-		} else {
-			browserSettingButton.style.removeProperty('display');
-		}
+					const formData = new FormData();
+					formData.append('fileId', fileId);
+					formData.append('sharedConfigUrl', window.wopiSettingBaseUrl);
+					formData.append('accessToken', window.accessToken);
+
+					const response = await fetch(this.API_ENDPOINTS.deleteSharedConfig, {
+						method: 'POST',
+						headers: {
+							Authorization: `Bearer ${window.accessToken}`,
+						},
+						body: formData,
+					});
+
+					if (!response.ok) {
+						throw new Error(`Delete failed: ${response.statusText}`);
+					}
+
+					await this.fetchAndPopulateSharedConfigs();
+				} catch (error: unknown) {
+					console.error('Error deleting file:', error);
+				}
+			});
+
+			extraActionsDiv.append(downloadBtn, deleteBtn);
+
+			// Add an "Edit" button for dic file only
+			if (category === '/wordbook') {
+				const editBtn = document.createElement('button');
+				editBtn.type = 'button';
+				editBtn.classList.add(
+					'button',
+					'button--size-normal',
+					'button--icon-only',
+					'button--vue-secondary',
+					'edit-icon',
+				);
+				editBtn.innerHTML = `
+					<span class="button__wrapper">
+						<span aria-hidden="true" class="button__icon">
+							<span aria-hidden="true" role="img" class="material-design-icon">
+								<svg fill="currentColor" width="20" height="20" viewBox="0 0 24 24">
+									<path d="M3 17.25V21h3.75l11-11.03-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 0 0 0-1.41l-2.34-2.34a1 1 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"></path>
+								</svg>
+							</span>
+						</span>
+					</span>
+				`;
+				editBtn.addEventListener('click', async () => {
+					await this.fetchDicFile(item.uri);
+				});
+				extraActionsDiv.appendChild(editBtn);
+			}
+
+			listItemDiv.append(anchor, extraActionsDiv);
+			li.appendChild(listItemDiv);
+			listEl.appendChild(li);
+		});
 	}
 
-	const xcuSettingButton = document.getElementById(
-		'uploadXcuButton',
-	) as HTMLButtonElement | null;
+	private populateSharedConfigUI(data: ConfigData): void {
+		const browserSettingButton = document.getElementById(
+			'uploadBrowserSettingsButton',
+		) as HTMLButtonElement | null;
 
-	if (xcuSettingButton) {
-		if (data.xcu && data.xcu.length > 0) {
-			xcuSettingButton.style.display = 'none';
-		} else {
-			xcuSettingButton.style.removeProperty('display');
+		if (browserSettingButton) {
+			if (data.browsersetting && data.browsersetting.length > 0) {
+				browserSettingButton.style.display = 'none';
+			} else {
+				browserSettingButton.style.removeProperty('display');
+			}
 		}
+
+		const xcuSettingButton = document.getElementById(
+			'uploadXcuButton',
+		) as HTMLButtonElement | null;
+
+		if (xcuSettingButton) {
+			if (data.xcu && data.xcu.length > 0) {
+				xcuSettingButton.style.display = 'none';
+			} else {
+				xcuSettingButton.style.removeProperty('display');
+			}
+		}
+
+		// todo: dynamically generate this list too from configSections
+		if (data.autotext)
+			this.populateList('autotextList', data.autotext, '/autotext');
+		if (data.wordbook)
+			this.populateList('wordbookList', data.wordbook, '/wordbook');
+		if (data.browsersetting)
+			this.populateList(
+				'BrowserSettingsList',
+				data.browsersetting,
+				'/browsersetting',
+			);
+		if (data.xcu) this.populateList('XcuList', data.xcu, '/xcu');
 	}
 
-	// todo: dynamically generate this list too from configSections
-	if (data.autotext) populateList('autotextList', data.autotext, '/autotext');
-	if (data.wordbook) populateList('wordbookList', data.wordbook, '/wordbook');
-	if (data.browsersetting)
-		populateList('BrowserSettingsList', data.browsersetting, '/browsersetting');
-	if (data.xcu) populateList('XcuList', data.xcu, '/xcu');
+	private getConfigType(): string {
+		return this.isAdmin() ? 'systemconfig' : 'userconfig';
+	}
+
+	private isAdmin(): boolean {
+		return window.iframeType === 'admin';
+	}
+
+	private settingConfigBasePath(): string {
+		return '/settings/' + this.getConfigType();
+	}
+
+	private getFilename(uri: string, removeExtension = true): string {
+		let filename = uri.substring(uri.lastIndexOf('/') + 1);
+		if (removeExtension) {
+			filename = filename.replace(/\.[^.]+$/, '');
+		}
+		return filename;
+	}
 }
 
-document.addEventListener('DOMContentLoaded', init);
+(window as any).settingIframe = new SettingIframe();
+
+document.addEventListener('DOMContentLoaded', () => {
+	(window as any).settingIframe.init();
+});

--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -51,7 +51,7 @@ class SettingIframe {
 			: '/browser/dist/upload-settings',
 		fetchSharedConfig: '/browser/dist/fetch-settings-config',
 		deleteSharedConfig: '/browser/dist/delete-settings-config',
-		fetchDictionary: 'browser/dist/fetch-dic',
+		fetchWordbook: 'browser/dist/fetch-wordbook',
 	};
 
 	private PATH = {
@@ -278,12 +278,12 @@ class SettingIframe {
 		return sectionEl;
 	}
 
-	private async fetchDicFile(fileId: string): Promise<void> {
+	private async fetchWordbookFile(fileId: string): Promise<void> {
 		const formData = new FormData();
 		formData.append('fileUrl', fileId);
 		formData.append('accessToken', window.accessToken ?? '');
 		try {
-			const apiUrl = this.API_ENDPOINTS.fetchDictionary;
+			const apiUrl = this.API_ENDPOINTS.fetchWordbook;
 
 			const response = await fetch(apiUrl, {
 				method: 'POST',
@@ -300,9 +300,9 @@ class SettingIframe {
 			let textValue = await response.text();
 			console.debug('textValue: ', textValue);
 
-			const dic = this.wordbook.parseDicFile(textValue);
+			const wordbook = this.wordbook.parseWordbookFile(textValue);
 			const fileName = this.getFilename(fileId, false);
-			this.wordbook.openDicEditor(fileName, dic);
+			this.wordbook.openWordbookEditor(fileName, wordbook);
 		} catch (error: unknown) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
 			console.error(`Error uploading file: ${message}`);
@@ -466,7 +466,7 @@ class SettingIframe {
 
 			extraActionsDiv.append(downloadBtn, deleteBtn);
 
-			// Add an "Edit" button for dic file only
+			// Add an "Edit" button for wordbook file only
 			if (category === '/wordbook') {
 				const editBtn = document.createElement('button');
 				editBtn.type = 'button';
@@ -489,7 +489,7 @@ class SettingIframe {
 					</span>
 				`;
 				editBtn.addEventListener('click', async () => {
-					await this.fetchDicFile(item.uri);
+					await this.fetchWordbookFile(item.uri);
 				});
 				extraActionsDiv.appendChild(editBtn);
 			}

--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -67,14 +67,15 @@ interface DicFile {
 	words: string[]; // list of dictionary words
 }
 
-// TODO: error handling for non parsed file - how we should handle it?
 function parseDicFile(content: string): DicFile {
 	const lines = content.split(/\r?\n/).filter((line) => line.trim() !== '');
 	const delimiterIndex = lines.findIndex((line) => line.trim() === '---');
 	if (delimiterIndex === -1) {
+		window.alert('Invalid dictionary format');
 		throw new Error('Invalid dictionary format: missing delimiter "---"');
 	}
 	if (delimiterIndex < 3) {
+		window.alert('Invalid dictionary format');
 		throw new Error(
 			'Invalid dictionary format: not enough header lines before delimiter',
 		);

--- a/browser/admin/src/integrator/WordBook.ts
+++ b/browser/admin/src/integrator/WordBook.ts
@@ -1,0 +1,251 @@
+/* eslint-disable */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+interface DicFile {
+	headerType: string; // eg. "OOoUserDict1"
+	language: string; // the value after "lang:" (eg. "<none>")
+	dictType: string; // the value after "type:" (eg. "positive")
+	words: string[]; // list of dictionary words
+}
+
+class WordBook {
+	openDicEditor(fileName: string, dic: DicFile): void {
+		const modal = document.createElement('div');
+		modal.className = 'modal';
+
+		const modalContent = document.createElement('div');
+		modalContent.className = 'modal-content';
+
+		const titleEl = document.createElement('h2');
+		titleEl.textContent = `${fileName} (Edit)`;
+		titleEl.style.textAlign = 'center';
+		modalContent.appendChild(titleEl);
+
+		const inputContainer = document.createElement('div');
+		inputContainer.className = 'dic-input-container';
+		inputContainer.style.margin = '16px 0';
+
+		const newWordInput = document.createElement('input');
+		newWordInput.type = 'text';
+		newWordInput.placeholder = 'Enter new word';
+		newWordInput.className = 'input-field__input';
+		inputContainer.appendChild(newWordInput);
+
+		const addButton = document.createElement('button');
+		addButton.textContent = 'Add';
+		addButton.className = 'button button--vue-secondary';
+		addButton.style.marginLeft = '8px';
+		addButton.addEventListener('click', () => {
+			const newWord = newWordInput.value.trim();
+			if (newWord) {
+				dic.words.push(newWord);
+				this.updateWordList(wordList, dic);
+				newWordInput.value = '';
+			}
+		});
+		inputContainer.appendChild(addButton);
+
+		modalContent.appendChild(inputContainer);
+
+		const wordList = document.createElement('ul');
+		wordList.id = 'dicWordList';
+		this.updateWordList(wordList, dic);
+		modalContent.appendChild(wordList);
+
+		const buttonContainer = document.createElement('div');
+		buttonContainer.className = 'dic-button-container';
+		buttonContainer.style.textAlign = 'center';
+		buttonContainer.style.marginTop = '24px';
+
+		const cancelButton = document.createElement('button');
+		cancelButton.textContent = 'Cancel';
+		cancelButton.className = 'button button--vue-tertiary';
+		cancelButton.style.marginRight = '12px';
+		cancelButton.addEventListener('click', () => {
+			document.body.removeChild(modal);
+		});
+		buttonContainer.appendChild(cancelButton);
+
+		const submitButton = document.createElement('button');
+		submitButton.textContent = 'Submit';
+		submitButton.className = 'button button--vue-primary';
+		submitButton.addEventListener('click', async () => {
+			console.debug('dic', dic);
+			const updatedContent = this.buildDicFile(dic);
+			console.debug('Updated Dictionary Content:\n', updatedContent);
+			await (window as any).settingIframe.uploadWordbookFile(
+				fileName,
+				updatedContent,
+			);
+			document.body.removeChild(modal);
+		});
+
+		buttonContainer.appendChild(submitButton);
+
+		modalContent.appendChild(buttonContainer);
+		modal.appendChild(modalContent);
+		document.body.appendChild(modal);
+	}
+
+	parseDicFile(content: string): DicFile {
+		const lines = content.split(/\r?\n/).filter((line) => line.trim() !== '');
+		const delimiterIndex = lines.findIndex((line) => line.trim() === '---');
+		if (delimiterIndex === -1) {
+			window.alert('Invalid dictionary format');
+			throw new Error('Invalid dictionary format: missing delimiter "---"');
+		}
+		if (delimiterIndex < 3) {
+			window.alert('Invalid dictionary format');
+			throw new Error(
+				'Invalid dictionary format: not enough header lines before delimiter',
+			);
+		}
+
+		const headerType = lines[0].trim();
+
+		const languageMatch = lines[1].trim().match(/^lang:\s*(.*)$/i);
+		const language = languageMatch ? languageMatch[1].trim() : '';
+
+		const typeMatch = lines[2].trim().match(/^type:\s*(.*)$/i);
+		const dictType = typeMatch ? typeMatch[1].trim() : '';
+
+		const words = lines
+			.slice(delimiterIndex + 1)
+			.filter((line) => line.trim() !== '');
+
+		return { headerType, language, dictType, words };
+	}
+
+	async wordbookValidation(uploadPath: string, file: File) {
+		try {
+			const content = await this.readFileAsText(file);
+			let dicWords: string[];
+			try {
+				dicWords = this.parseWords(content);
+			} catch (error) {
+				window.alert('Invalid dictionary format. Please check the file.');
+				console.error('Error parsing dictionary file:', error);
+				return;
+			}
+			// TODO: Assuming default values - should be dynamic later?
+			const defaultHeaderType = 'OOoUserDict1';
+			const defaultLanguage = '<none>';
+			const defaultDictType = 'positive';
+			const newDic: DicFile = {
+				headerType: defaultHeaderType,
+				language: defaultLanguage,
+				dictType: defaultDictType,
+				words: dicWords,
+			};
+			const newContent = this.buildDicFile(newDic);
+			await (window as any).settingIframe.uploadWordbookFile(
+				file.name,
+				newContent,
+			);
+		} catch (error) {
+			window.alert('Something went wrong while uploading dictionary file');
+		}
+	}
+
+	private buildDicFile(dic: DicFile): string {
+		const header = [
+			dic.headerType.trim(),
+			`lang: ${dic.language}`,
+			`type: ${dic.dictType}`,
+		];
+		return [...header, '---', ...dic.words].join('\n');
+	}
+
+	private updateWordList(listEl: HTMLElement, dic: DicFile): void {
+		listEl.innerHTML = '';
+		dic.words.forEach((word, index) => {
+			// TODO IDEA: Extract list as components?
+
+			const li = document.createElement('li');
+			li.classList.add('list-item__wrapper');
+
+			const listItemDiv = document.createElement('div');
+			listItemDiv.classList.add('list-item');
+
+			const wordContainer = document.createElement('div');
+			wordContainer.classList.add('list-item__anchor');
+
+			const wordContentDiv = document.createElement('div');
+			wordContentDiv.classList.add('list-item-content');
+
+			const wordTextDiv = document.createElement('div');
+			wordTextDiv.classList.add('list-item-content__main');
+			const wordNameDiv = document.createElement('div');
+			wordNameDiv.classList.add('list-item-content__name');
+			wordNameDiv.textContent = word;
+
+			wordTextDiv.appendChild(wordNameDiv);
+			wordContentDiv.appendChild(wordTextDiv);
+			wordContainer.appendChild(wordContentDiv);
+
+			listItemDiv.appendChild(wordContainer);
+
+			const delButton = document.createElement('button');
+			delButton.type = 'button';
+			delButton.classList.add(
+				'button',
+				'button--size-normal',
+				'button--icon-only',
+				'button--vue-secondary',
+				'delete-icon',
+			);
+			delButton.innerHTML = `
+            <span class="button__wrapper">
+              <span aria-hidden="true" class="button__icon">
+                <span aria-hidden="true" role="img" class="material-design-icon">
+                  <svg fill="currentColor" width="20" height="20" viewBox="0 0 24 24">
+                    <path d="M19,4H15.5L14.5,3H9.5L8.5,4H5V6H19M6,19
+                              A2,2 0 0,0 8,21H16
+                              A2,2 0 0,0 18,19V7H6V19Z"></path>
+                  </svg>
+                </span>
+              </span>
+            </span>
+          `;
+			delButton.addEventListener('click', () => {
+				dic.words.splice(index, 1);
+				this.updateWordList(listEl, dic);
+			});
+			listItemDiv.appendChild(delButton);
+
+			li.appendChild(listItemDiv);
+			listEl.appendChild(li);
+		});
+	}
+
+	private async readFileAsText(file: File): Promise<string> {
+		return new Promise<string>((resolve, reject) => {
+			const reader = new FileReader();
+			reader.onload = () => resolve(reader.result as string);
+			reader.onerror = () => reject(reader.error);
+			reader.readAsText(file);
+		});
+	}
+
+	private parseWords(content: string): string[] {
+		const lines = content
+			.split(/\r?\n/)
+			.map((line) => line.trim())
+			.filter((line) => line !== '');
+		const delimiterIndex = lines.findIndex((line) => line === '---');
+		if (delimiterIndex !== -1) {
+			return lines.slice(delimiterIndex + 1);
+		}
+		return lines;
+	}
+}
+
+(window as any).WordBook = new WordBook();

--- a/browser/admin/src/integrator/WordBook.ts
+++ b/browser/admin/src/integrator/WordBook.ts
@@ -9,7 +9,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-interface DicFile {
+interface WordbookFile {
 	headerType: string; // eg. "OOoUserDict1"
 	language: string; // the value after "lang:" (eg. "<none>")
 	dictType: string; // the value after "type:" (eg. "positive")
@@ -17,7 +17,7 @@ interface DicFile {
 }
 
 class WordBook {
-	openDicEditor(fileName: string, dic: DicFile): void {
+	openWordbookEditor(fileName: string, wordbook: WordbookFile): void {
 		const modal = document.createElement('div');
 		modal.className = 'modal';
 
@@ -46,8 +46,8 @@ class WordBook {
 		addButton.addEventListener('click', () => {
 			const newWord = newWordInput.value.trim();
 			if (newWord) {
-				dic.words.push(newWord);
-				this.updateWordList(wordList, dic);
+				wordbook.words.push(newWord);
+				this.updateWordList(wordList, wordbook);
 				newWordInput.value = '';
 			}
 		});
@@ -57,7 +57,7 @@ class WordBook {
 
 		const wordList = document.createElement('ul');
 		wordList.id = 'dicWordList';
-		this.updateWordList(wordList, dic);
+		this.updateWordList(wordList, wordbook);
 		modalContent.appendChild(wordList);
 
 		const buttonContainer = document.createElement('div');
@@ -78,8 +78,8 @@ class WordBook {
 		submitButton.textContent = 'Submit';
 		submitButton.className = 'button button--vue-primary';
 		submitButton.addEventListener('click', async () => {
-			console.debug('dic', dic);
-			const updatedContent = this.buildDicFile(dic);
+			console.debug('wordbook', wordbook);
+			const updatedContent = this.buildWordbookFile(wordbook);
 			console.debug('Updated Dictionary Content:\n', updatedContent);
 			await (window as any).settingIframe.uploadWordbookFile(
 				fileName,
@@ -95,7 +95,7 @@ class WordBook {
 		document.body.appendChild(modal);
 	}
 
-	parseDicFile(content: string): DicFile {
+	parseWordbookFile(content: string): WordbookFile {
 		const lines = content.split(/\r?\n/).filter((line) => line.trim() !== '');
 		const delimiterIndex = lines.findIndex((line) => line.trim() === '---');
 		if (delimiterIndex === -1) {
@@ -139,13 +139,13 @@ class WordBook {
 			const defaultHeaderType = 'OOoUserDict1';
 			const defaultLanguage = '<none>';
 			const defaultDictType = 'positive';
-			const newDic: DicFile = {
+			const newDic: WordbookFile = {
 				headerType: defaultHeaderType,
 				language: defaultLanguage,
 				dictType: defaultDictType,
 				words: dicWords,
 			};
-			const newContent = this.buildDicFile(newDic);
+			const newContent = this.buildWordbookFile(newDic);
 			await (window as any).settingIframe.uploadWordbookFile(
 				file.name,
 				newContent,
@@ -155,18 +155,18 @@ class WordBook {
 		}
 	}
 
-	private buildDicFile(dic: DicFile): string {
+	private buildWordbookFile(wordbook: WordbookFile): string {
 		const header = [
-			dic.headerType.trim(),
-			`lang: ${dic.language}`,
-			`type: ${dic.dictType}`,
+			wordbook.headerType.trim(),
+			`lang: ${wordbook.language}`,
+			`type: ${wordbook.dictType}`,
 		];
-		return [...header, '---', ...dic.words].join('\n');
+		return [...header, '---', ...wordbook.words].join('\n');
 	}
 
-	private updateWordList(listEl: HTMLElement, dic: DicFile): void {
+	private updateWordList(listEl: HTMLElement, wordbook: WordbookFile): void {
 		listEl.innerHTML = '';
-		dic.words.forEach((word, index) => {
+		wordbook.words.forEach((word, index) => {
 			// TODO IDEA: Extract list as components?
 
 			const li = document.createElement('li');
@@ -216,8 +216,8 @@ class WordBook {
             </span>
           `;
 			delButton.addEventListener('click', () => {
-				dic.words.splice(index, 1);
-				this.updateWordList(listEl, dic);
+				wordbook.words.splice(index, 1);
+				this.updateWordList(listEl, wordbook);
 			});
 			listItemDiv.appendChild(delButton);
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -943,7 +943,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
             return;
         }
 
-        if (endPoint == "fetch-dic")
+        if (endPoint == "fetch-wordbook")
         {
             fetchDictionaries(request, message, socket);
             return;

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -141,6 +141,10 @@ private:
                                         Poco::MemoryInputStream& message,
                                         const std::shared_ptr<StreamSocket>& socket);
 
+    static void fetchDictionaries(const Poco::Net::HTTPRequest& request,
+                                   Poco::MemoryInputStream& message,
+                                   const std::shared_ptr<StreamSocket>& socket);
+
     static void deleteWopiSettingConfigs(const Poco::Net::HTTPRequest& request,
                                          Poco::MemoryInputStream& message,
                                          const std::shared_ptr<StreamSocket>& socket);


### PR DESCRIPTION
Change-Id: I68b70ee8c140e8e71f312b6120ae880fab46a5d1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Description

This PR enables the edit button for WordBook, which opens a popup dialog allowing you to add or delete words from the dictionary.

It also updates the .dic file upload flow:
	-  Previously, .dic files were uploaded directly without processing, which caused issues.
	-  Now, if a user uploads a file without headers, a default header is appended; if headers are present, they are removed and replaced with our own.



### TODO

- [x] Blocker: error handling for non parsed file - how we should handle it? 
- [x] Blocker: Upload dic file separately? We shouldn't allow to upload headers
- [x] Blocker: Test for all case
- [x] Non-Blocker - Move wordbook to separate class/module
- [ ] Follow-Up - when we load a large file - we should add some kind of loader. 
- [ ] Follow-Up - optimization: cache the file? Maybe an async call to fetch too?
