### PR TITLE
Reduce String Copying

### DIFF
--- a/common/JsonUtil.hpp
+++ b/common/JsonUtil.hpp
@@ -176,7 +176,7 @@ static char getEscapementChar(char ch)
     }
 }
 
-static void writeEscapedSequence(uint32_t ch, std::vector<char>& buf)
+inline void writeEscapedSequence(uint32_t ch, std::string& buf)
 {
     switch (ch)
     {
@@ -207,10 +207,10 @@ static void writeEscapedSequence(uint32_t ch, std::vector<char>& buf)
     }
 }
 
-inline std::string escapeJSONValue(std::string val)
+inline std::string escapeJSONValue(const std::string_view val)
 {
-    std::vector<char> buf;
-    buf.reserve(val.size() + 10); // some small initial extra space for escaping
+    std::string buf;
+    buf.reserve(val.size() + 64); // some small initial extra space for escaping
     for (size_t i = 0; i < val.size(); ++i)
     {
         const char ch = val[i];
@@ -240,7 +240,8 @@ inline std::string escapeJSONValue(std::string val)
                 break;
         }
     }
-    return std::string(buf.data(), buf.size());
+
+    return buf;
 }
 
 /// Extract all json entries into a map.

--- a/common/StateEnum.hpp
+++ b/common/StateEnum.hpp
@@ -59,11 +59,6 @@
                "Enum value is out of range.");                                                     \
         return NAME##_names[static_cast<int>(e)];                                                  \
     }                                                                                              \
-    /* Returns the state name only, without the namespace, as a std::string. */                    \
-    [[maybe_unused]] static inline std::string toStringShort(NAME e)                                                \
-    {                                                                                              \
-        return nameShort(e);                                                                       \
-    }                                                                                              \
     /* Returns the state name with the namespace. */                                               \
     [[maybe_unused]] static inline const char* name(NAME e)                                        \
     {                                                                                              \

--- a/common/StateEnum.hpp
+++ b/common/StateEnum.hpp
@@ -10,6 +10,7 @@
 #include <iosfwd>
 #include <type_traits>
 #include <string>
+#include <string_view>
 
 /// Enum macro specifically for state-machines.
 /// Has several limitations, some intentional. For example,
@@ -52,30 +53,30 @@
 #define STATE_ENUM(NAME, ...)                                                                      \
     enum class NAME : char;                                                                        \
     /* Returns the state name only, without the namespace. */                                      \
-    static inline const char* nameShort(NAME e)                                                    \
+    [[maybe_unused]] static inline constexpr std::string_view nameShort(NAME e) noexcept           \
     {                                                                                              \
-        static const char* const NAME##_names[] = { FOR_EACH(STRINGIFY1, NAME, __VA_ARGS__) };     \
+        constexpr std::string_view NAME##_names[] = { FOR_EACH(STRINGIFY1, NAME, __VA_ARGS__) };   \
         assert(static_cast<unsigned>(e) < N_ELEMENTS(NAME##_names) &&                              \
                "Enum value is out of range.");                                                     \
         return NAME##_names[static_cast<int>(e)];                                                  \
     }                                                                                              \
     /* Returns the state name with the namespace. */                                               \
-    [[maybe_unused]] static inline const char* name(NAME e)                                        \
+    [[maybe_unused]] static inline constexpr std::string_view name(NAME e) noexcept                \
     {                                                                                              \
-        static const char* const NAME##_names[] = { FOR_EACH(STRINGIFY2, NAME, __VA_ARGS__) };     \
+        constexpr std::string_view NAME##_names[] = { FOR_EACH(STRINGIFY2, NAME, __VA_ARGS__) };   \
         assert(static_cast<unsigned>(e) < N_ELEMENTS(NAME##_names) &&                              \
                "Enum value is out of range.");                                                     \
         return NAME##_names[static_cast<int>(e)];                                                  \
     }                                                                                              \
-    [[maybe_unused]] static const size_t NAME##Max = COUNT_ARGS(__VA_ARGS__);                      \
+    [[maybe_unused]] static constexpr size_t NAME##Max = COUNT_ARGS(__VA_ARGS__);                  \
     enum class NAME : char                                                                         \
     {                                                                                              \
         __VA_ARGS__                                                                                \
     }
 
 /// Support seamless serialization of STATE_ENUM to ostream.
-template <typename T, typename std::enable_if<
-                          std::is_same<decltype(name(T())), const char*>::value>::type* = nullptr>
+template <typename T, typename std::enable_if<std::is_same<
+                          decltype(name(T())), std::string_view>::value>::type* = nullptr>
 inline std::ostream& operator<<(std::ostream& os, const T state)
 {
     os << name(state);

--- a/common/StateEnum.hpp
+++ b/common/StateEnum.hpp
@@ -65,19 +65,14 @@
         return nameShort(e);                                                                       \
     }                                                                                              \
     /* Returns the state name with the namespace. */                                               \
-    static inline const char* name(NAME e)                                                         \
+    [[maybe_unused]] static inline const char* name(NAME e)                                        \
     {                                                                                              \
         static const char* const NAME##_names[] = { FOR_EACH(STRINGIFY2, NAME, __VA_ARGS__) };     \
         assert(static_cast<unsigned>(e) < N_ELEMENTS(NAME##_names) &&                              \
                "Enum value is out of range.");                                                     \
         return NAME##_names[static_cast<int>(e)];                                                  \
     }                                                                                              \
-    /* Returns the state name, with the namespace, as a std::string. */                            \
-    [[maybe_unused]] static inline std::string toString(NAME e)                                                     \
-    {                                                                                              \
-        return name(e);                                                                            \
-    }                                                                                              \
-    [[maybe_unused]] static const size_t NAME##Max = COUNT_ARGS(__VA_ARGS__);                                       \
+    [[maybe_unused]] static const size_t NAME##Max = COUNT_ARGS(__VA_ARGS__);                      \
     enum class NAME : char                                                                         \
     {                                                                                              \
         __VA_ARGS__                                                                                \

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -583,8 +583,7 @@ void UnitBase::exitTest(TestResult result, const std::string& reason)
 std::string UnitKit::getResultMessage() const
 {
     assert(isFinished());
-    return std::string("unitresult: ") +
-        toStringShort(_result) + " " + _reason;
+    return std::string("unitresult: ") + std::string(nameShort(_result)) + " " + _reason;
 }
 
 void UnitWSD::processUnitResult(const StringVector &tokens)

--- a/net/DelaySocket.cpp
+++ b/net/DelaySocket.cpp
@@ -123,7 +123,7 @@ public:
             shutdown();
             break;
         }
-        DELAY_LOG('#' << getFD() << " changed to state " << toStringShort(newState) << '\n');
+        DELAY_LOG('#' << getFD() << " changed to state " << nameShort(newState) << '\n');
         _state = newState;
     }
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1902,18 +1902,18 @@ public:
     }
 
     /// Start a partial asynchronous upload from a file based on the contents of a "Range" header
-    bool asyncUpload(std::string fromFile, std::string mimeType, std::string rangeHeader)
+    bool asyncUpload(std::string fromFile, std::string mimeType, const std::string_view rangeHeader)
     {
-        size_t equalsPos = rangeHeader.find("=");
+        const size_t equalsPos = rangeHeader.find('=');
         if (equalsPos == std::string::npos) return asyncUpload(std::move(fromFile), std::move(mimeType));
 
-        std::string unit = rangeHeader.substr(0, equalsPos);
+        const std::string_view unit = rangeHeader.substr(0, equalsPos);
         if (unit != "bytes") return asyncUpload(std::move(fromFile), std::move(mimeType));
 
-        std::string range = rangeHeader.substr(equalsPos + 1);
+        const std::string_view range = rangeHeader.substr(equalsPos + 1);
 
-        size_t dashPos = range.find("-");
-        std::string startString = range.substr(0, dashPos);
+        size_t dashPos = range.find('-');
+        const std::string_view startString = range.substr(0, dashPos);
         std::string endString = "-1";
 
         if (dashPos != std::string::npos) {
@@ -1924,7 +1924,8 @@ public:
         int end = -1;
         bool startIsSuffix = false;
 
-        if (startString == "") {
+        if (startString.empty())
+        {
             // Could be a suffix
             try {
                 start = std::stoi(endString);
@@ -1938,7 +1939,7 @@ public:
         }
 
         try {
-            start = std::stoi(startString);
+            start = std::stoi(std::string(startString));
             end = std::stoi(endString) + 1;
         }
         catch (std::invalid_argument&) {}

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1445,7 +1445,7 @@ LocalServerSocket::~LocalServerSocket()
 std::ostream& StreamSocket::stream(std::ostream& os) const
 {
     os << "StreamSocket[#" << getFD()
-       << ", " << toStringShort(_wsState)
+       << ", " << nameShort(_wsState)
        << ", " << Socket::toString(type())
        << " @ ";
     if (Type::IPv6 == type())

--- a/test/KitPidHelpers.cpp
+++ b/test/KitPidHelpers.cpp
@@ -103,7 +103,7 @@ void helpers::waitForKitPidsReady(
         oss << "Current kit processes:"
             << " Doc Kits: " << getPidList(docKitPids)
             << " Spare Kits: " << getPidList(spareKitPids);
-        LOK_ASSERT_FAIL("Timed out waiting for kit processes to close: " + oss.str());
+        LOK_ASSERT_FAIL("Timed out waiting for kit processes to close: " << oss.str());
     }
 }
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -139,6 +139,7 @@ test_base_sources = \
 	RequestDetailsTests.cpp \
 	StringVectorTests.cpp \
 	FileServeWhiteBoxTests.cpp \
+	NetUtilWhiteBoxTests.cpp \
 	WhiteBoxTests.cpp \
 	HttpWhiteBoxTests.cpp \
 	DeltaTests.cpp \

--- a/test/NetUtilWhiteBoxTests.cpp
+++ b/test/NetUtilWhiteBoxTests.cpp
@@ -1,0 +1,278 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <net/Buffer.hpp>
+#include <net/NetUtil.hpp>
+
+#include <test/lokassert.hpp>
+
+#include <cppunit/TestAssert.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+/// Net-utility WhiteBox unit-tests.
+class NetUtilWhiteBoxTests : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE(NetUtilWhiteBoxTests);
+    CPPUNIT_TEST(testBufferClass);
+    CPPUNIT_TEST(testParseUri);
+    CPPUNIT_TEST(testParseUriUrl);
+    CPPUNIT_TEST(testParseUrl);
+    CPPUNIT_TEST_SUITE_END();
+
+    void testBufferClass();
+    void testParseUri();
+    void testParseUriUrl();
+    void testParseUrl();
+};
+
+void NetUtilWhiteBoxTests::testBufferClass()
+{
+    constexpr auto testname = __func__;
+
+    Buffer buf;
+    LOK_ASSERT_EQUAL(0UL, buf.size());
+    LOK_ASSERT_EQUAL(true, buf.empty());
+    LOK_ASSERT(buf.getBlock() == nullptr);
+    buf.eraseFirst(buf.size());
+    LOK_ASSERT_EQUAL(0UL, buf.size());
+    LOK_ASSERT_EQUAL(true, buf.empty());
+
+    // Small data.
+    const char data[] = "abcdefghijklmnop";
+    buf.append(data, sizeof(data));
+
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(sizeof(data)), buf.size());
+    LOK_ASSERT_EQUAL(false, buf.empty());
+    LOK_ASSERT(buf.getBlock() != nullptr);
+    LOK_ASSERT_EQUAL(0, memcmp(buf.getBlock(), data, buf.size()));
+
+    // Erase one char at a time.
+    for (std::size_t i = buf.size(); i > 0; --i)
+    {
+        buf.eraseFirst(1);
+        LOK_ASSERT_EQUAL(i - 1, buf.size());
+        LOK_ASSERT_EQUAL(i == 1, buf.empty()); // Not empty until the last element.
+        LOK_ASSERT_EQUAL(buf.getBlock() != nullptr, !buf.empty());
+        if (!buf.empty())
+            LOK_ASSERT_EQUAL(0, memcmp(buf.getBlock(), data + (sizeof(data) - i) + 1, buf.size()));
+    }
+
+    // Large data.
+    constexpr std::size_t BlockSize = 512 * 1024; // We add twice this.
+    constexpr std::size_t BlockCount = 10;
+    for (std::size_t i = 0; i < BlockCount; ++i)
+    {
+        const auto prevSize = buf.size();
+
+        const std::vector<char> dataLarge(2 * BlockSize, 'a' + i); // Block of a single char.
+        buf.append(dataLarge.data(), dataLarge.size());
+        LOK_ASSERT_EQUAL(prevSize + (2 * BlockSize), buf.size());
+
+        // Remove half.
+        buf.eraseFirst(BlockSize);
+        LOK_ASSERT_EQUAL(prevSize + BlockSize, buf.size());
+        LOK_ASSERT_EQUAL(0, memcmp(buf.getBlock() + prevSize, dataLarge.data(), BlockSize));
+    }
+
+    LOK_ASSERT_EQUAL(BlockSize * BlockCount, buf.size());
+    LOK_ASSERT_EQUAL(false, buf.empty());
+
+    // Remove each block of data and test.
+    for (std::size_t i = BlockCount / 2; i < BlockCount; ++i) // We removed half above.
+    {
+        LOK_ASSERT_EQUAL(false, buf.empty());
+        LOK_ASSERT_EQUAL(BlockSize * 2 * (BlockCount - i), buf.size());
+
+        const std::vector<char> dataLarge(BlockSize * 2, 'a' + i); // Block of a single char.
+        LOK_ASSERT_EQUAL(0, memcmp(buf.getBlock(), dataLarge.data(), BlockSize));
+
+        buf.eraseFirst(BlockSize * 2);
+    }
+
+    LOK_ASSERT_EQUAL(0UL, buf.size());
+    LOK_ASSERT_EQUAL(true, buf.empty());
+
+    // Very large data.
+    const std::vector<char> dataLarge(20 * BlockSize, 'x'); // Block of a single char.
+    buf.append(dataLarge.data(), dataLarge.size());
+    LOK_ASSERT_EQUAL(dataLarge.size(), buf.size());
+
+    buf.append(data, sizeof(data)); // Add small data.
+    LOK_ASSERT_EQUAL(dataLarge.size() + sizeof(data), buf.size());
+
+    buf.eraseFirst(dataLarge.size()); // Remove large data.
+    LOK_ASSERT_EQUAL(sizeof(data), buf.size());
+    LOK_ASSERT_EQUAL(false, buf.empty());
+    LOK_ASSERT_EQUAL(0, memcmp(buf.getBlock(), data, buf.size()));
+
+    buf.eraseFirst(buf.size()); // Remove all.
+    LOK_ASSERT_EQUAL(0UL, buf.size());
+    LOK_ASSERT_EQUAL(true, buf.empty());
+}
+
+void NetUtilWhiteBoxTests::testParseUri()
+{
+    constexpr auto testname = __func__;
+
+    std::string scheme = "***";
+    std::string host = "***";
+    std::string port = "***";
+
+    LOK_ASSERT(!net::parseUri(std::string(), scheme, host, port));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT(host.empty());
+    LOK_ASSERT(port.empty());
+
+    LOK_ASSERT(net::parseUri("localhost", scheme, host, port));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("localhost"), host);
+    LOK_ASSERT(port.empty());
+
+    LOK_ASSERT(net::parseUri("127.0.0.1", scheme, host, port));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
+    LOK_ASSERT(port.empty());
+
+    LOK_ASSERT(net::parseUri("domain.com", scheme, host, port));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT(port.empty());
+
+    LOK_ASSERT(net::parseUri("127.0.0.1:9999", scheme, host, port));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
+    LOK_ASSERT_EQUAL(std::string("9999"), port);
+
+    LOK_ASSERT(net::parseUri("domain.com:88", scheme, host, port));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT_EQUAL(std::string("88"), port);
+
+    LOK_ASSERT(net::parseUri("http://domain.com", scheme, host, port));
+    LOK_ASSERT_EQUAL(std::string("http://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT(port.empty());
+
+    LOK_ASSERT(net::parseUri("https://domain.com:88", scheme, host, port));
+    LOK_ASSERT_EQUAL(std::string("https://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT_EQUAL(std::string("88"), port);
+
+    LOK_ASSERT(net::parseUri("http://domain.com/path/to/file", scheme, host, port));
+    LOK_ASSERT_EQUAL(std::string("http://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT(port.empty());
+
+    LOK_ASSERT(net::parseUri("https://domain.com:88/path/to/file", scheme, host, port));
+    LOK_ASSERT_EQUAL(std::string("https://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT_EQUAL(std::string("88"), port);
+
+    LOK_ASSERT(net::parseUri("wss://127.0.0.1:9999/", scheme, host, port));
+    LOK_ASSERT_EQUAL(std::string("wss://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
+    LOK_ASSERT_EQUAL(std::string("9999"), port);
+}
+
+void NetUtilWhiteBoxTests::testParseUriUrl()
+{
+    constexpr auto testname = __func__;
+
+    std::string scheme = "***";
+    std::string host = "***";
+    std::string port = "***";
+    std::string pathAndQuery = "***";
+
+    LOK_ASSERT(!net::parseUri(std::string(), scheme, host, port, pathAndQuery));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT(host.empty());
+    LOK_ASSERT(port.empty());
+    LOK_ASSERT(pathAndQuery.empty());
+
+    LOK_ASSERT(net::parseUri("localhost", scheme, host, port, pathAndQuery));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("localhost"), host);
+    LOK_ASSERT(port.empty());
+    LOK_ASSERT(pathAndQuery.empty());
+
+    LOK_ASSERT(net::parseUri("127.0.0.1", scheme, host, port, pathAndQuery));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
+    LOK_ASSERT(port.empty());
+    LOK_ASSERT(pathAndQuery.empty());
+
+    LOK_ASSERT(net::parseUri("domain.com", scheme, host, port, pathAndQuery));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT(port.empty());
+    LOK_ASSERT(pathAndQuery.empty());
+
+    LOK_ASSERT(net::parseUri("127.0.0.1:9999", scheme, host, port, pathAndQuery));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
+    LOK_ASSERT_EQUAL(std::string("9999"), port);
+    LOK_ASSERT(pathAndQuery.empty());
+
+    LOK_ASSERT(net::parseUri("domain.com:88", scheme, host, port, pathAndQuery));
+    LOK_ASSERT(scheme.empty());
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT_EQUAL(std::string("88"), port);
+    LOK_ASSERT(pathAndQuery.empty());
+
+    LOK_ASSERT(net::parseUri("http://domain.com", scheme, host, port, pathAndQuery));
+    LOK_ASSERT_EQUAL(std::string("http://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT(port.empty());
+    LOK_ASSERT(pathAndQuery.empty());
+
+    LOK_ASSERT(net::parseUri("https://domain.com:88", scheme, host, port, pathAndQuery));
+    LOK_ASSERT_EQUAL(std::string("https://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT_EQUAL(std::string("88"), port);
+
+    LOK_ASSERT(net::parseUri("http://domain.com/path/to/file", scheme, host, port, pathAndQuery));
+    LOK_ASSERT_EQUAL(std::string("http://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT(port.empty());
+    LOK_ASSERT_EQUAL(std::string("/path/to/file"), pathAndQuery);
+
+    LOK_ASSERT(
+        net::parseUri("https://domain.com:88/path/to/file", scheme, host, port, pathAndQuery));
+    LOK_ASSERT_EQUAL(std::string("https://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
+    LOK_ASSERT_EQUAL(std::string("88"), port);
+    LOK_ASSERT_EQUAL(std::string("/path/to/file"), pathAndQuery);
+
+    LOK_ASSERT(net::parseUri("wss://127.0.0.1:9999/", scheme, host, port, pathAndQuery));
+    LOK_ASSERT_EQUAL(std::string("wss://"), scheme);
+    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
+    LOK_ASSERT_EQUAL(std::string("9999"), port);
+    LOK_ASSERT_EQUAL(std::string("/"), pathAndQuery);
+}
+
+void NetUtilWhiteBoxTests::testParseUrl()
+{
+    constexpr auto testname = __func__;
+
+    LOK_ASSERT_EQUAL(std::string(), net::parseUrl(""));
+
+    LOK_ASSERT_EQUAL(std::string(), net::parseUrl("https://sub.domain.com:80"));
+    LOK_ASSERT_EQUAL(std::string("/"), net::parseUrl("https://sub.domain.com:80/"));
+
+    LOK_ASSERT_EQUAL(std::string("/some/path"),
+                     net::parseUrl("https://sub.domain.com:80/some/path"));
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION(NetUtilWhiteBoxTests);
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitOAuth.cpp
+++ b/test/UnitOAuth.cpp
@@ -81,7 +81,7 @@ public:
             }
             else
             {
-                LOK_ASSERT_FAIL("Unexpected phase: " + toString(_phase));
+                LOK_ASSERT_FAIL("Unexpected phase: " << name(_phase));
             }
         }
         catch (const std::exception& ex)
@@ -158,7 +158,7 @@ public:
                 passTest("Finished all cases successfully");
                 break;
             default:
-                LOK_ASSERT_FAIL("Unexpected phase: " + toString(_phase));
+                LOK_ASSERT_FAIL("Unexpected phase: " << name(_phase));
         }
 
         return true;

--- a/test/UnitQuarantine.cpp
+++ b/test/UnitQuarantine.cpp
@@ -178,7 +178,7 @@ public:
                 WSD_CMD("closedocument");
                 break;
             case Scenario::VerifyOverwrite:
-                LOK_ASSERT_FAIL("Unexpected modification in " + toString(_scenario));
+                LOK_ASSERT_FAIL("Unexpected modification in " << name(_scenario));
                 break;
         }
 

--- a/test/UnitSaveTorture.cpp
+++ b/test/UnitSaveTorture.cpp
@@ -436,7 +436,7 @@ class UnitKitSaveTorture : public UnitKit
             TST_LOG("stamp exists " << name);
             if (std::chrono::steady_clock::now() - start > std::chrono::seconds(10))
             {
-                LOK_ASSERT_FAIL("Timed out while waiting for stamp file " + name + " to go");
+                LOK_ASSERT_FAIL("Timed out while waiting for stamp file " << name << " to go");
                 return;
             }
             std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/test/UnitTyping.cpp
+++ b/test/UnitTyping.cpp
@@ -123,7 +123,7 @@ public:
             result.length() != responseLen + 1 + sizeof(correct) ||
             memcmp(result.c_str() + responseLen + 1, (const char *)correct, sizeof(correct)))
         {
-            LOK_ASSERT_FAIL("Error: wrong textselectioncontent:\n" + Util::dumpHex(result));
+            LOK_ASSERT_FAIL("Error: wrong textselectioncontent:\n" << Util::dumpHex(result));
             return TestResult::Failed;
         }
 

--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -183,7 +183,7 @@ public:
                 WSD_CMD("closedocument");
                 break;
             case Scenario::VerifyOverwrite:
-                LOK_ASSERT_FAIL("Unexpected modification in " + toString(_scenario));
+                LOK_ASSERT_FAIL("Unexpected modification in " << name(_scenario));
                 break;
         }
 

--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -355,7 +355,8 @@ private:
 
 public:
     UnitWOPIReadOnly(Scenario scenario, bool disconnect)
-        : WopiTestServer("UnitWOPIReadOnly_" + toStringShort(scenario) + (disconnect ? "_X" : ""))
+        : WopiTestServer("UnitWOPIReadOnly_" + std::string(nameShort(scenario)) +
+                         (disconnect ? "_X" : ""))
         , _phase(Phase::Load)
         , _scenario(scenario)
         , _disconnect(disconnect)

--- a/test/UnitWOPILock.cpp
+++ b/test/UnitWOPILock.cpp
@@ -88,7 +88,7 @@ public:
         }
         else
         {
-            LOK_ASSERT_FAIL("Unexpected lock-state change while in " + toString(_phase));
+            LOK_ASSERT_FAIL("Unexpected lock-state change while in " << name(_phase));
         }
 
         return nullptr; // Success.
@@ -216,7 +216,7 @@ public:
         }
         else
         {
-            LOK_ASSERT_FAIL("Unexpected lock-state change while in " + toString(_phase));
+            LOK_ASSERT_FAIL("Unexpected lock-state change while in " << name(_phase));
         }
 
         return nullptr; // Success.
@@ -418,7 +418,7 @@ public:
         }
         else
         {
-            LOK_ASSERT_FAIL("Unexpected lock-state change while in " + toString(_phase));
+            LOK_ASSERT_FAIL("Unexpected lock-state change while in " << name(_phase));
         }
 
         return nullptr; // Success.
@@ -538,7 +538,7 @@ public:
         }
         else
         {
-            LOK_ASSERT_FAIL("Unexpected lock-state change while in " + toString(_phase));
+            LOK_ASSERT_FAIL("Unexpected lock-state change while in " << name(_phase));
         }
 
         return nullptr; // Success.
@@ -691,7 +691,7 @@ public:
         }
         else
         {
-            LOK_ASSERT_FAIL("Unexpected lock-state change while in " + toString(_phase));
+            LOK_ASSERT_FAIL("Unexpected lock-state change while in " << name(_phase));
         }
 
         return nullptr; // Success.

--- a/test/WOPIUploadConflictCommon.hpp
+++ b/test/WOPIUploadConflictCommon.hpp
@@ -242,7 +242,7 @@ public:
                 WSD_CMD("closedocument");
                 break;
             case Scenario::VerifyOverwrite:
-                LOK_ASSERT_FAIL("Unexpected modification in " + toString(_scenario));
+                LOK_ASSERT_FAIL("Unexpected modification in " << name(_scenario));
                 break;
         }
 
@@ -272,7 +272,7 @@ public:
                 WSD_CMD("savetostorage force=1");
                 break;
             case Scenario::VerifyOverwrite:
-                LOK_ASSERT_FAIL("Unexpected error in " + toString(_scenario));
+                LOK_ASSERT_FAIL("Unexpected error in " << name(_scenario));
                 break;
         }
 

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -1233,7 +1233,7 @@ void WhiteBoxTests::testJsonUtilEscapeJSONValue()
 {
     constexpr auto testname = __func__;
 
-    const std::string in = "domain\\username";
+    constexpr std::string_view in = "domain\\username";
     const std::string expected = "domain\\\\username";
     LOK_ASSERT_EQUAL(JsonUtil::escapeJSONValue(in), expected);
 }

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -20,6 +20,7 @@
 #include <Util.hpp>
 #include <common/Anonymizer.hpp>
 #include <common/Message.hpp>
+#include <common/StateEnum.hpp>
 #include <common/ThreadPool.hpp>
 
 #include <test/lokassert.hpp>
@@ -30,6 +31,7 @@
 #include <chrono>
 #include <cstddef>
 #include <fstream>
+#include <sstream>
 
 /// WhiteBox unit-tests.
 class WhiteBoxTests : public CPPUNIT_NS::TestFixture
@@ -55,6 +57,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testStringCompare);
     CPPUNIT_TEST(testSafeAtoi);
     CPPUNIT_TEST(testJsonUtilEscapeJSONValue);
+    CPPUNIT_TEST(testStateEnum);
     CPPUNIT_TEST(testFindInVector);
     CPPUNIT_TEST(testThreadPool);
     CPPUNIT_TEST_SUITE_END();
@@ -79,6 +82,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testStringCompare();
     void testSafeAtoi();
     void testJsonUtilEscapeJSONValue();
+    void testStateEnum();
     void testFindInVector();
     void testThreadPool();
 
@@ -985,6 +989,53 @@ void WhiteBoxTests::testJsonUtilEscapeJSONValue()
     constexpr std::string_view in = "domain\\username";
     const std::string expected = "domain\\\\username";
     LOK_ASSERT_EQUAL(JsonUtil::escapeJSONValue(in), expected);
+}
+
+STATE_ENUM(TestState, First, Second, Last);
+void WhiteBoxTests::testStateEnum()
+{
+    constexpr auto testname = __func__;
+
+    LOK_ASSERT_EQUAL_STR("TestState::First", name(TestState::First));
+    LOK_ASSERT_EQUAL_STR("TestState::Second", name(TestState::Second));
+    LOK_ASSERT_EQUAL_STR("TestState::Last", name(TestState::Last));
+
+    LOK_ASSERT_EQUAL_STR("First", nameShort(TestState::First));
+    LOK_ASSERT_EQUAL_STR("Second", nameShort(TestState::Second));
+    LOK_ASSERT_EQUAL_STR("Last", nameShort(TestState::Last));
+
+    TestState e = TestState::First;
+
+    e = TestState::First;
+    LOK_ASSERT_EQUAL_STR("TestState::First", name(e));
+    e = TestState::Second;
+    LOK_ASSERT_EQUAL_STR("TestState::Second", name(e));
+    e = TestState::Last;
+    LOK_ASSERT_EQUAL_STR("TestState::Last", name(e));
+
+    e = TestState::First;
+    LOK_ASSERT_EQUAL_STR("First", nameShort(e));
+    e = TestState::Second;
+    LOK_ASSERT_EQUAL_STR("Second", nameShort(e));
+    e = TestState::Last;
+    LOK_ASSERT_EQUAL_STR("Last", nameShort(e));
+
+    std::ostringstream oss;
+
+    e = TestState::First;
+    oss << e;
+    LOK_ASSERT_EQUAL_STR("TestState::First", oss.str());
+    oss.str("");
+
+    e = TestState::Second;
+    oss << e;
+    LOK_ASSERT_EQUAL_STR("TestState::Second", oss.str());
+    oss.str("");
+
+    e = TestState::Last;
+    oss << e;
+    LOK_ASSERT_EQUAL_STR("TestState::Last", oss.str());
+    oss.str("");
 }
 
 void WhiteBoxTests::testFindInVector()

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -11,29 +11,25 @@
 
 #include <config.h>
 
-#include <test/lokassert.hpp>
-#include <cppunit/TestAssert.h>
-#include <cstddef>
-
-#include <common/Anonymizer.hpp>
-#include <Auth.hpp>
-#include <ChildSession.hpp>
 #include <Common.hpp>
 #include <FileUtil.hpp>
-#include <Kit.hpp>
+#include <JsonUtil.hpp>
 #include <Protocol.hpp>
+#include <TileCache.hpp>
 #include <TileDesc.hpp>
 #include <Util.hpp>
-#include <JsonUtil.hpp>
-
+#include <common/Anonymizer.hpp>
 #include <common/Message.hpp>
 #include <common/ThreadPool.hpp>
-#include <wsd/FileServer.hpp>
+
+#include <test/lokassert.hpp>
+
+#include <cppunit/TestAssert.h>
+#include <cppunit/extensions/HelperMacros.h>
 
 #include <chrono>
+#include <cstddef>
 #include <fstream>
-
-#include <cppunit/extensions/HelperMacros.h>
 
 /// WhiteBox unit-tests.
 class WhiteBoxTests : public CPPUNIT_NS::TestFixture

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -29,8 +29,6 @@
 #include <common/Message.hpp>
 #include <common/ThreadPool.hpp>
 #include <wsd/FileServer.hpp>
-#include <net/Buffer.hpp>
-#include <net/NetUtil.hpp>
 
 #include <chrono>
 #include <fstream>
@@ -57,12 +55,8 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testAnonymization);
     CPPUNIT_TEST(testIso8601Time);
     CPPUNIT_TEST(testClockAsString);
-    CPPUNIT_TEST(testBufferClass);
     CPPUNIT_TEST(testStat);
     CPPUNIT_TEST(testStringCompare);
-    CPPUNIT_TEST(testParseUri);
-    CPPUNIT_TEST(testParseUriUrl);
-    CPPUNIT_TEST(testParseUrl);
     CPPUNIT_TEST(testSafeAtoi);
     CPPUNIT_TEST(testJsonUtilEscapeJSONValue);
     CPPUNIT_TEST(testFindInVector);
@@ -85,12 +79,8 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testAnonymization();
     void testIso8601Time();
     void testClockAsString();
-    void testBufferClass();
     void testStat();
     void testStringCompare();
-    void testParseUri();
-    void testParseUriUrl();
-    void testParseUrl();
     void testSafeAtoi();
     void testJsonUtilEscapeJSONValue();
     void testFindInVector();
@@ -878,91 +868,6 @@ void WhiteBoxTests::testClockAsString()
 #endif
 }
 
-void WhiteBoxTests::testBufferClass()
-{
-    constexpr auto testname = __func__;
-
-    Buffer buf;
-    LOK_ASSERT_EQUAL(0UL, buf.size());
-    LOK_ASSERT_EQUAL(true, buf.empty());
-    LOK_ASSERT(buf.getBlock() == nullptr);
-    buf.eraseFirst(buf.size());
-    LOK_ASSERT_EQUAL(0UL, buf.size());
-    LOK_ASSERT_EQUAL(true, buf.empty());
-
-    // Small data.
-    const char data[] = "abcdefghijklmnop";
-    buf.append(data, sizeof(data));
-
-    LOK_ASSERT_EQUAL(static_cast<std::size_t>(sizeof(data)), buf.size());
-    LOK_ASSERT_EQUAL(false, buf.empty());
-    LOK_ASSERT(buf.getBlock() != nullptr);
-    LOK_ASSERT_EQUAL(0, memcmp(buf.getBlock(), data, buf.size()));
-
-    // Erase one char at a time.
-    for (std::size_t i = buf.size(); i > 0; --i)
-    {
-        buf.eraseFirst(1);
-        LOK_ASSERT_EQUAL(i - 1, buf.size());
-        LOK_ASSERT_EQUAL(i == 1, buf.empty()); // Not empty until the last element.
-        LOK_ASSERT_EQUAL(buf.getBlock() != nullptr, !buf.empty());
-        if (!buf.empty())
-            LOK_ASSERT_EQUAL(0, memcmp(buf.getBlock(), data + (sizeof(data) - i) + 1, buf.size()));
-    }
-
-    // Large data.
-    constexpr std::size_t BlockSize = 512 * 1024; // We add twice this.
-    constexpr std::size_t BlockCount = 10;
-    for (std::size_t i = 0; i < BlockCount; ++i)
-    {
-        const auto prevSize = buf.size();
-
-        const std::vector<char> dataLarge(2 * BlockSize, 'a' + i); // Block of a single char.
-        buf.append(dataLarge.data(), dataLarge.size());
-        LOK_ASSERT_EQUAL(prevSize + (2 * BlockSize), buf.size());
-
-        // Remove half.
-        buf.eraseFirst(BlockSize);
-        LOK_ASSERT_EQUAL(prevSize + BlockSize, buf.size());
-        LOK_ASSERT_EQUAL(0, memcmp(buf.getBlock() + prevSize, dataLarge.data(), BlockSize));
-    }
-
-    LOK_ASSERT_EQUAL(BlockSize * BlockCount, buf.size());
-    LOK_ASSERT_EQUAL(false, buf.empty());
-
-    // Remove each block of data and test.
-    for (std::size_t i = BlockCount / 2; i < BlockCount; ++i) // We removed half above.
-    {
-        LOK_ASSERT_EQUAL(false, buf.empty());
-        LOK_ASSERT_EQUAL(BlockSize * 2 * (BlockCount - i), buf.size());
-
-        const std::vector<char> dataLarge(BlockSize * 2, 'a' + i); // Block of a single char.
-        LOK_ASSERT_EQUAL(0, memcmp(buf.getBlock(), dataLarge.data(), BlockSize));
-
-        buf.eraseFirst(BlockSize * 2);
-    }
-
-    LOK_ASSERT_EQUAL(0UL, buf.size());
-    LOK_ASSERT_EQUAL(true, buf.empty());
-
-    // Very large data.
-    const std::vector<char> dataLarge(20 * BlockSize, 'x'); // Block of a single char.
-    buf.append(dataLarge.data(), dataLarge.size());
-    LOK_ASSERT_EQUAL(dataLarge.size(), buf.size());
-
-    buf.append(data, sizeof(data)); // Add small data.
-    LOK_ASSERT_EQUAL(dataLarge.size() + sizeof(data), buf.size());
-
-    buf.eraseFirst(dataLarge.size()); // Remove large data.
-    LOK_ASSERT_EQUAL(sizeof(data), buf.size());
-    LOK_ASSERT_EQUAL(false, buf.empty());
-    LOK_ASSERT_EQUAL(0, memcmp(buf.getBlock(), data, buf.size()));
-
-    buf.eraseFirst(buf.size()); // Remove all.
-    LOK_ASSERT_EQUAL(0UL, buf.size());
-    LOK_ASSERT_EQUAL(true, buf.empty());
-}
-
 void WhiteBoxTests::testStat()
 {
     constexpr auto testname = __func__;
@@ -1026,158 +931,6 @@ void WhiteBoxTests::testStringCompare()
     LOK_ASSERT(!Util::iequal("abc", "abcd"));
 
     LOK_ASSERT(!Util::iequal("abc", 3, "abcd", 4));
-}
-
-void WhiteBoxTests::testParseUri()
-{
-    constexpr auto testname = __func__;
-
-    std::string scheme = "***";
-    std::string host = "***";
-    std::string port = "***";
-
-    LOK_ASSERT(!net::parseUri(std::string(), scheme, host, port));
-    LOK_ASSERT(scheme.empty());
-    LOK_ASSERT(host.empty());
-    LOK_ASSERT(port.empty());
-
-    LOK_ASSERT(net::parseUri("localhost", scheme, host, port));
-    LOK_ASSERT(scheme.empty());
-    LOK_ASSERT_EQUAL(std::string("localhost"), host);
-    LOK_ASSERT(port.empty());
-
-    LOK_ASSERT(net::parseUri("127.0.0.1", scheme, host, port));
-    LOK_ASSERT(scheme.empty());
-    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
-    LOK_ASSERT(port.empty());
-
-    LOK_ASSERT(net::parseUri("domain.com", scheme, host, port));
-    LOK_ASSERT(scheme.empty());
-    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
-    LOK_ASSERT(port.empty());
-
-    LOK_ASSERT(net::parseUri("127.0.0.1:9999", scheme, host, port));
-    LOK_ASSERT(scheme.empty());
-    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
-    LOK_ASSERT_EQUAL(std::string("9999"), port);
-
-    LOK_ASSERT(net::parseUri("domain.com:88", scheme, host, port));
-    LOK_ASSERT(scheme.empty());
-    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
-    LOK_ASSERT_EQUAL(std::string("88"), port);
-
-    LOK_ASSERT(net::parseUri("http://domain.com", scheme, host, port));
-    LOK_ASSERT_EQUAL(std::string("http://"), scheme);
-    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
-    LOK_ASSERT(port.empty());
-
-    LOK_ASSERT(net::parseUri("https://domain.com:88", scheme, host, port));
-    LOK_ASSERT_EQUAL(std::string("https://"), scheme);
-    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
-    LOK_ASSERT_EQUAL(std::string("88"), port);
-
-    LOK_ASSERT(net::parseUri("http://domain.com/path/to/file", scheme, host, port));
-    LOK_ASSERT_EQUAL(std::string("http://"), scheme);
-    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
-    LOK_ASSERT(port.empty());
-
-    LOK_ASSERT(net::parseUri("https://domain.com:88/path/to/file", scheme, host, port));
-    LOK_ASSERT_EQUAL(std::string("https://"), scheme);
-    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
-    LOK_ASSERT_EQUAL(std::string("88"), port);
-
-    LOK_ASSERT(net::parseUri("wss://127.0.0.1:9999/", scheme, host, port));
-    LOK_ASSERT_EQUAL(std::string("wss://"), scheme);
-    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
-    LOK_ASSERT_EQUAL(std::string("9999"), port);
-}
-
-void WhiteBoxTests::testParseUriUrl()
-{
-    constexpr auto testname = __func__;
-
-    std::string scheme = "***";
-    std::string host = "***";
-    std::string port = "***";
-    std::string pathAndQuery = "***";
-
-    LOK_ASSERT(!net::parseUri(std::string(), scheme, host, port, pathAndQuery));
-    LOK_ASSERT(scheme.empty());
-    LOK_ASSERT(host.empty());
-    LOK_ASSERT(port.empty());
-    LOK_ASSERT(pathAndQuery.empty());
-
-    LOK_ASSERT(net::parseUri("localhost", scheme, host, port, pathAndQuery));
-    LOK_ASSERT(scheme.empty());
-    LOK_ASSERT_EQUAL(std::string("localhost"), host);
-    LOK_ASSERT(port.empty());
-    LOK_ASSERT(pathAndQuery.empty());
-
-    LOK_ASSERT(net::parseUri("127.0.0.1", scheme, host, port, pathAndQuery));
-    LOK_ASSERT(scheme.empty());
-    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
-    LOK_ASSERT(port.empty());
-    LOK_ASSERT(pathAndQuery.empty());
-
-    LOK_ASSERT(net::parseUri("domain.com", scheme, host, port, pathAndQuery));
-    LOK_ASSERT(scheme.empty());
-    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
-    LOK_ASSERT(port.empty());
-    LOK_ASSERT(pathAndQuery.empty());
-
-    LOK_ASSERT(net::parseUri("127.0.0.1:9999", scheme, host, port, pathAndQuery));
-    LOK_ASSERT(scheme.empty());
-    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
-    LOK_ASSERT_EQUAL(std::string("9999"), port);
-    LOK_ASSERT(pathAndQuery.empty());
-
-    LOK_ASSERT(net::parseUri("domain.com:88", scheme, host, port, pathAndQuery));
-    LOK_ASSERT(scheme.empty());
-    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
-    LOK_ASSERT_EQUAL(std::string("88"), port);
-    LOK_ASSERT(pathAndQuery.empty());
-
-    LOK_ASSERT(net::parseUri("http://domain.com", scheme, host, port, pathAndQuery));
-    LOK_ASSERT_EQUAL(std::string("http://"), scheme);
-    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
-    LOK_ASSERT(port.empty());
-    LOK_ASSERT(pathAndQuery.empty());
-
-    LOK_ASSERT(net::parseUri("https://domain.com:88", scheme, host, port, pathAndQuery));
-    LOK_ASSERT_EQUAL(std::string("https://"), scheme);
-    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
-    LOK_ASSERT_EQUAL(std::string("88"), port);
-
-    LOK_ASSERT(net::parseUri("http://domain.com/path/to/file", scheme, host, port, pathAndQuery));
-    LOK_ASSERT_EQUAL(std::string("http://"), scheme);
-    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
-    LOK_ASSERT(port.empty());
-    LOK_ASSERT_EQUAL(std::string("/path/to/file"), pathAndQuery);
-
-    LOK_ASSERT(net::parseUri("https://domain.com:88/path/to/file", scheme, host, port, pathAndQuery));
-    LOK_ASSERT_EQUAL(std::string("https://"), scheme);
-    LOK_ASSERT_EQUAL(std::string("domain.com"), host);
-    LOK_ASSERT_EQUAL(std::string("88"), port);
-    LOK_ASSERT_EQUAL(std::string("/path/to/file"), pathAndQuery);
-
-    LOK_ASSERT(net::parseUri("wss://127.0.0.1:9999/", scheme, host, port, pathAndQuery));
-    LOK_ASSERT_EQUAL(std::string("wss://"), scheme);
-    LOK_ASSERT_EQUAL(std::string("127.0.0.1"), host);
-    LOK_ASSERT_EQUAL(std::string("9999"), port);
-    LOK_ASSERT_EQUAL(std::string("/"), pathAndQuery);
-}
-
-void WhiteBoxTests::testParseUrl()
-{
-    constexpr auto testname = __func__;
-
-    LOK_ASSERT_EQUAL(std::string(), net::parseUrl(""));
-
-    LOK_ASSERT_EQUAL(std::string(), net::parseUrl("https://sub.domain.com:80"));
-    LOK_ASSERT_EQUAL(std::string("/"), net::parseUrl("https://sub.domain.com:80/"));
-
-    LOK_ASSERT_EQUAL(std::string("/some/path"),
-                     net::parseUrl("https://sub.domain.com:80/some/path"));
 }
 
 void WhiteBoxTests::testSafeAtoi()

--- a/test/integration-http-server.cpp
+++ b/test/integration-http-server.cpp
@@ -495,7 +495,8 @@ void HTTPServerTest::testConvertToWithForwardedIP_Deny()
     }
     catch(const Poco::Exception& exc)
     {
-        LOK_ASSERT_FAIL(exc.displayText() + ": " + (exc.nested() ? exc.nested()->displayText() : ""));
+        LOK_ASSERT_FAIL(exc.displayText()
+                        << ": " << (exc.nested() ? exc.nested()->displayText() : ""));
     }
 }
 
@@ -553,7 +554,8 @@ void HTTPServerTest::testConvertToWithForwardedIP_Allow()
     }
     catch(const Poco::Exception& exc)
     {
-        LOK_ASSERT_FAIL(exc.displayText() + ": " + (exc.nested() ? exc.nested()->displayText() : ""));
+        LOK_ASSERT_FAIL(exc.displayText()
+                        << ": " << (exc.nested() ? exc.nested()->displayText() : ""));
     }
 }
 
@@ -605,7 +607,8 @@ void HTTPServerTest::testConvertToWithForwardedIP_DenyMulti()
     }
     catch(const Poco::Exception& exc)
     {
-        LOK_ASSERT_FAIL(exc.displayText() + ": " + (exc.nested() ? exc.nested()->displayText() : ""));
+        LOK_ASSERT_FAIL(exc.displayText()
+                        << ": " << (exc.nested() ? exc.nested()->displayText() : ""));
     }
 }
 

--- a/test/lokassert.hpp
+++ b/test/lokassert.hpp
@@ -208,5 +208,7 @@ inline constexpr bool failed() { return false; }
     {                                                                                              \
         TST_LOG("ERROR: Forced failure: " << message);                                             \
         LOK_ASSERT_IMPL(!"Forced failure: " #message); /* NOLINT(misc-static-assert) */            \
-        CPPUNIT_FAIL((message));                                                                   \
+        std::stringstream dummyStringstream;                                                       \
+        dummyStringstream << message;                                                              \
+        CPPUNIT_FAIL(dummyStringstream.str().c_str());                                             \
     } while (false)

--- a/tools/Replay.hpp
+++ b/tools/Replay.hpp
@@ -268,7 +268,7 @@ struct Stats {
 
     void endPhase(Log::Phase phase)
     {
-        std::string phaseAsString = Log::toStringShort(phase);
+        const std::string phaseAsString{ nameShort(phase) };
 
         const auto now = std::chrono::steady_clock::now();
         const size_t runMs = std::chrono::duration_cast<std::chrono::milliseconds>(now - _start).count();

--- a/tools/Replay.hpp
+++ b/tools/Replay.hpp
@@ -19,19 +19,19 @@
 
 #include "Socket.hpp"
 #include "WebSocketHandler.hpp"
+#include <TraceFile.hpp>
+#include <Util.hpp>
+#include <common/Log.hpp>
 #include <net/Ssl.hpp>
+#include <wsd/TileDesc.hpp>
 #if ENABLE_SSL
 #  include <SslSocket.hpp>
 #endif
 
-#include <TraceFile.hpp>
-#include <wsd/TileDesc.hpp>
-
 #include <iostream>
 #include <fstream>
 #include <ctime>
-#include <Util.hpp>
-#include <common/Log.hpp>
+#include <utility>
 
 struct PerfMetricInfo
 {
@@ -97,7 +97,8 @@ struct Histogram {
         }
     }
 
-    std::vector<PerfMetricInfo> getLatencyStats(std::string typeOfLatency, const std::string& testPhase)
+    std::vector<PerfMetricInfo> getLatencyStats(const std::string& typeOfLatency,
+                                                const std::string& testPhase)
     {
         size_t totalTiles = _items;
         size_t subTenCount = _buckets[0];
@@ -187,8 +188,8 @@ struct Stats {
         return totalDirtyPss;
     }
 
-    void accumulate(std::unordered_map<std::string, MessageStat> &map,
-                    const std::string token, size_t size)
+    void accumulate(std::unordered_map<std::string, MessageStat>& map, const std::string& token,
+                    size_t size)
     {
         auto it = map.find(token);
         MessageStat st = { 0, 0 };
@@ -306,32 +307,29 @@ struct Stats {
         }
     }
 
-    PerfMetricInfo getStressStats(size_t runMs, const std::string& testPhase)
+    PerfMetricInfo getStressStats(size_t runMs, std::string testPhase)
     {
-        PerfMetricInfo stressStats = {testPhase, "Stress run (ms)", runMs};
-        return  stressStats;
+        return PerfMetricInfo(std::move(testPhase), "Stress run (ms)", runMs);
     }
 
-    PerfMetricInfo getCPUUSageStats(size_t cpuUsage, const std::string testPhase)
+    PerfMetricInfo getCPUUSageStats(size_t cpuUsage, std::string testPhase)
     {
-        PerfMetricInfo cpuStats = {testPhase, "CPU Usage (us)", cpuUsage};
-        return cpuStats;
+        return PerfMetricInfo(std::move(testPhase), "CPU Usage (us)", cpuUsage);
     }
 
     std::vector<PerfMetricInfo> getNetworkStats(size_t recievedKb, size_t sentKb, const std::string& testPhase)
     {
         std::vector<PerfMetricInfo> networkStatsList;
 
-        networkStatsList.push_back(PerfMetricInfo{testPhase, "Bytes recieved (kB)", recievedKb});
-        networkStatsList.push_back(PerfMetricInfo{testPhase, "Bytes sent (kB)", sentKb});
+        networkStatsList.emplace_back(testPhase, "Bytes recieved (kB)", recievedKb);
+        networkStatsList.emplace_back(testPhase, "Bytes sent (kB)", sentKb);
 
         return networkStatsList;
     }
 
-    PerfMetricInfo getPeakMemoryUsageStats(size_t peakMemory, const std::string& testPhase)
+    PerfMetricInfo getPeakMemoryUsageStats(size_t peakMemory, std::string testPhase)
     {
-        PerfMetricInfo peakMemoryStats = {testPhase, "Peak memory usage (kB)", peakMemory};
-        return peakMemoryStats;
+        return PerfMetricInfo(std::move(testPhase), "Peak memory usage (kB)", peakMemory);
     }
 
     void dumpPerfStatsToCSV(std::vector<PerfMetricInfo> perfData)


### PR DESCRIPTION
- **wsd: remove toString from StateEnum**
- **wsd: remove toStringShort**
- **wsd: avoid intermediate vector when escaping JSON**
- **wsd: StateEnum const char`*` -> string_view**
- **wsd: reduce copying and simplify Replay.hpp**
- **wsd: minimize string copying in asyncUpload**
- **wsd: test: move NetUtil tests to NetUtilWhiteBoxTests.cpp**
- **wsd: test: include cleanup in WhiteBoxTests.cpp**
- **wsd: test: add StateEnum tests**
