### PR TITLE
browsersetting: fix: client defaults to use darkTheme with inverted background

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1423,11 +1423,13 @@ void ClientSession::overrideDocOption()
     JsonUtil::findJSONValue(_browserSettingsJSON, "accessibilityState", accessibilityState);
     Poco::JSON::Object::Ptr darkBackgroundObj =
         _browserSettingsJSON->getObject("darkBackgroundForTheme");
-    if (!darkBackgroundObj.isNull())
-    {
+
+    // follow darkTheme preference if darkBackgroundForTheme is not set
+    if (darkBackgroundObj.isNull())
+        setDarkBackground(darkTheme);
+    else
         JsonUtil::findJSONValue(darkBackgroundObj, darkTheme == "true" ? "dark" : "light",
                                 darkBackgroundForTheme);
-    }
 
     if (!darkTheme.empty())
     {


### PR DESCRIPTION
- Steps to reproduce:
1. Open document and toggle darkmode
2. Reload the document

- Actual: Notice inverted document background with darkmode
- Expected: Both background and UI should be in darkmode


Change-Id: I22dc8cc45adc0baf98a95947242f927826c0437c