### PR TITLE
feat(docker): pass arguments directly to the entry point

### DIFF
--- a/docker/from-packages/Dockerfile
+++ b/docker/from-packages/Dockerfile
@@ -139,5 +139,5 @@ USER 100
 
 # FIXME
 # Use the old starter script until we find out how to replace it.
-CMD ["/start-collabora-online.sh"]
+ENTRYPOINT ["/start-collabora-online.sh"]
 

--- a/docker/from-packages/scripts/start-collabora-online.sh
+++ b/docker/from-packages/scripts/start-collabora-online.sh
@@ -27,4 +27,4 @@ mv -f certs/ca/root.crt.pem /etc/coolwsd/ca-chain.cert.pem
 fi
 
 # Start coolwsd
-exec /usr/bin/coolwsd --version --use-env-vars --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/coolwsd --o:cache_files.path=/opt/cool/cache --o:logging.color=false --o:stop_on_config_change=true ${extra_params}
+exec /usr/bin/coolwsd --version --use-env-vars --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/coolwsd --o:cache_files.path=/opt/cool/cache --o:logging.color=false --o:stop_on_config_change=true ${extra_params} "$@"

--- a/docker/from-source-gh-action/Dockerfile
+++ b/docker/from-source-gh-action/Dockerfile
@@ -78,4 +78,4 @@ EXPOSE 9980
 # switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
 USER 100
 
-CMD ["/start-collabora-online.sh"]
+ENTRYPOINT ["/start-collabora-online.sh"]

--- a/docker/from-source-gh-action/start-collabora-online.sh
+++ b/docker/from-source-gh-action/start-collabora-online.sh
@@ -27,4 +27,4 @@ mv -f certs/ca/root.crt.pem /etc/coolwsd/ca-chain.cert.pem
 fi
 
 # Start coolwsd
-exec /usr/bin/coolwsd --version --use-env-vars --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/coolwsd --o:cache_files.path=/opt/cool/cache --o:logging.color=false --o:stop_on_config_change=true ${extra_params}
+exec /usr/bin/coolwsd --version --use-env-vars --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/coolwsd --o:cache_files.path=/opt/cool/cache --o:logging.color=false --o:stop_on_config_change=true ${extra_params} "$@"

--- a/docker/from-source/ArchLinux
+++ b/docker/from-source/ArchLinux
@@ -38,4 +38,4 @@ RUN usermod -u 972 cool
 # switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
 USER 972
 
-CMD ["/start-collabora-online.sh"]
+ENTRYPOINT ["/start-collabora-online.sh"]

--- a/docker/from-source/Debian
+++ b/docker/from-source/Debian
@@ -41,4 +41,4 @@ EXPOSE 9980
 # switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
 USER 100
 
-CMD ["/start-collabora-online.sh"]
+ENTRYPOINT ["/start-collabora-online.sh"]

--- a/docker/from-source/Fedora
+++ b/docker/from-source/Fedora
@@ -34,4 +34,4 @@ EXPOSE 9980
 # switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
 USER 999
 
-CMD ["/start-collabora-online.sh"]
+ENTRYPOINT ["/start-collabora-online.sh"]

--- a/docker/from-source/Ubuntu
+++ b/docker/from-source/Ubuntu
@@ -42,4 +42,4 @@ EXPOSE 9980
 # switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
 USER 100
 
-CMD ["/start-collabora-online.sh"]
+ENTRYPOINT ["/start-collabora-online.sh"]

--- a/docker/from-source/openSUSE
+++ b/docker/from-source/openSUSE
@@ -37,4 +37,4 @@ EXPOSE 9980
 # switch to cool user (use numeric user id to be compatible with Kubernetes Pod Security Policies)
 USER 498
 
-CMD ["/start-collabora-online.sh"]
+ENTRYPOINT ["/start-collabora-online.sh"]


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Consider using the Collabora Online container in a federated Nextcloud setup. To make federation work, an additional parameter to configure CSPs has to be passed to Collabora: `--o:net.content_security_policy="frame-ancestors *.example.com:*;"`.

However, this is not possible via the current `extra_params` environment variable as it will do word splitting on spaces. Instead of retaining spaces, it will split the frame ancestors configuration on each space.

**Actual:** `|--o:net.content_security_policy="frame-ancestors|*.example.com:*;"|` (2 arguments)
**Expected:** `|--o:net.content_security_policy=frame-ancestors *.example.com:*;|` (1 argument)

The `|` character was added to demonstrate word splitting problems. It represents the separation of arguments as parsed in the entry point script.

#### Usage example in a Kubernetes Pod:
```
spec:
  containers:
  - image: my-collabora-image:latest
    args:
    - --o:net.content_security_policy=frame-ancestors *.example.com:*;
```

#### Alternative

Configure CSPs in the XML configuration file. However, this requires an additional volume. The Collabora Online deployment should stay stateless (see Nextcloud All-In-One).

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

