### PR TITLE
following: don't stop if using scrollbar

### DIFF
--- a/browser/src/map/handler/Map.Mouse.js
+++ b/browser/src/map/handler/Map.Mouse.js
@@ -97,6 +97,10 @@ L.Map.Mouse = L.Handler.extend({
 				}
 			}
 
+			var scrollSection = app.sectionContainer.getSectionWithName(L.CSections.Scroll.name);
+			if (scrollSection.sectionProperties.mouseIsOnVerticalScrollBar || scrollSection.sectionProperties.mouseIsOnHorizontalScrollBar)
+				return;
+
 			// Core side is handling the mouseup by itself when the right button is down.
 			// If we fire mouseup for right button, there will be duplicate.
 			// Without this, selected text in a text box is un-selected via a right click. Therefore, copy / cut operations are disabled.


### PR DESCRIPTION
Scrollbar section is on top of document, if we click there - events are propagated. If we follow someone we don't want to stop just by scrolling. Let's not allow to pass events to the document if user clicks on a scrollbar.

```
(anonymous) (Map.Mouse.js:133)
_executeMouseEvents (Map.Mouse.js:196)
setTimeout
(anonymous) (Map.Mouse.js:136)
(anonymous) (global.js:954)
fire (Events.js:153)
_fireDOMEvent (Map.js:1602)
_handleDOMEvent (Map.js:1572)
(anonymous) (global.js:954)
handler (DomEvent.js:52)
```