### PR TITLE
status bar: hide on/off indicators if they have default values

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2291,3 +2291,10 @@ kbd,
 #FormulaDialog #ed_formula.ui-textarea {
 	max-width: 392px;
 }
+
+#showcomments-container:has(#ShowComments[default-state='true']),
+#insertmode-container:has(#InsertMode[default-state='true']),
+#permissionmode-container:has(.status-edit-mode[default-state='true']),
+#statusselectionmode-container:has(#StatusSelectionMode[default-state='true']) {
+	display: none !important;
+}

--- a/browser/src/control/jsdialog/Widget.HTMLContent.ts
+++ b/browser/src/control/jsdialog/Widget.HTMLContent.ts
@@ -50,18 +50,28 @@ function getPermissionModeElements(
 	} else {
 		permissionModeDiv.classList.add('status-edit-mode');
 		permissionModeDiv.title = _('Permission Mode');
+		permissionModeDiv.setAttribute('default-state', 'true');
 		permissionModeDiv.textContent = _('Edit mode');
 	}
 
 	return permissionModeDiv;
 }
 
-function getStatusbarItemElements(id: string, title: string, text: string) {
+function getStatusbarItemElements(
+	id: string,
+	title: string,
+	text: string,
+	isDefault: boolean = false,
+) {
 	const div = document.createElement('div');
 	div.id = id;
 	div.className = 'jsdialog ui-badge';
 	div.title = title;
 	div.textContent = text;
+
+	if (isDefault) {
+		div.setAttribute('default-state', 'true');
+	}
 
 	return div;
 }
@@ -83,7 +93,12 @@ function getStatusDocPosElements(text: string) {
 }
 
 function getInsertModeElements(text: string) {
-	return getStatusbarItemElements('InsertMode', _('Entering text mode'), text);
+	return getStatusbarItemElements(
+		'InsertMode',
+		_('Entering text mode'),
+		text,
+		text === 'Insert',
+	);
 }
 
 function getSelectionModeElements(text: string) {
@@ -91,6 +106,7 @@ function getSelectionModeElements(text: string) {
 		'StatusSelectionMode',
 		_('Selection Mode'),
 		text,
+		text === 'Standard selection',
 	);
 }
 
@@ -138,7 +154,12 @@ function getDocumentStatusElements(text: string) {
 }
 
 function getShowCommentsStatusElements(text: string) {
-	return getStatusbarItemElements('ShowComments', _('Show Comments'), text);
+	return getStatusbarItemElements(
+		'ShowComments',
+		_('Show Comments'),
+		text,
+		text === 'Comments: On',
+	);
 }
 
 var getElementsFromId = function (


### PR DESCRIPTION
Change-Id: Iec53e53cc820fe14c3a5657b80e59b5d01b26a5a

* Resolves: #11170 
* Target version: master 

### Summary
Add data-default attribute to status elements to hide indicators when they are in default state:
 - InsertMode when the value is 'Insert'
 - showcomments when the value is 'Comments: On'
 - permissionmode when the value is 'Edit mode'
 - StatusSelectionMode when the value is 'Standard selection'

### Previews
![Screenshot from 2025-02-17 22-29-36](https://github.com/user-attachments/assets/0ea962d8-189c-49a9-bc63-fcce9ad6b5ba)


