### PR TITLE
Use DOMPurify 3.2.4

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -136,7 +136,7 @@ COOL_ADMIN_JS =\
 
 NODE_MODULES_SRC =\
 	autolinker@3.14.1 \
-	dompurify@3.1.7 \
+	dompurify@3.2.4 \
 	json-js@1.1.2 \
 	select2@4.0.13 \
 	l10n-for-node@0.0.1 \

--- a/browser/npm-shrinkwrap.json.in
+++ b/browser/npm-shrinkwrap.json.in
@@ -2368,9 +2368,9 @@
       }
     },
     "dompurify": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg=="
     },
     "domutils": {
       "version": "1.7.0",

--- a/browser/package.json
+++ b/browser/package.json
@@ -18,7 +18,7 @@
     "browserify-css": "0.15.0",
     "canvas": "^2.6.1",
     "d3": "6.7.0",
-    "dompurify": "3.1.7",
+    "dompurify": "3.2.4",
     "eslint": "7.0.0",
     "eslint-config-prettier": "^9.1.0",
     "fzstd": "0.1.0",

--- a/browser/tsconfig.json
+++ b/browser/tsconfig.json
@@ -6,13 +6,12 @@
       "lib": ["dom", "es2016"],
       "sourceMap": false,
       "incremental": true,
-
-      "moduleResolution": "classic",
+      "moduleResolution": "node",
       "noImplicitAny": true,
       "removeComments": false,
       "preserveConstEnums": false,
       "downlevelIteration": true,
-      "watch": false,
+      "watch": false
     },
     "exclude": [
       "node_modules",

--- a/cool-sbom-template.spdx.json
+++ b/cool-sbom-template.spdx.json
@@ -220,7 +220,7 @@
     {
       "SPDXID": "SPDXRef-dompurify",
       "name": "DOMPurify",
-      "versionInfo": "3.1.7",
+      "versionInfo": "3.2.4",
       "filesAnalyzed": false,
       "downloadLocation": "NONE",
       "licenseConcluded": "Apache-2.0"


### PR DESCRIPTION
DOMPurify before 3.2.4 has an incorrect template literal regular expression, sometimes leading to mutation
cross-site scripting (mXSS).


Change-Id: If69bb5b06a0519c56c13019f7d19d7f58856814e
