### PR TITLE
wsd/wopiAccessCheck: handle self-signed certificate

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1361,6 +1361,18 @@ public:
 #endif
     }
 
+    long getSslVerifyResult()
+    {
+#if ENABLE_SSL
+        std::shared_ptr<StreamSocket> socket = _socket.lock();
+        if (socket)
+            return socket->getSslVerifyResult();
+        return _handshakeSslVerifyFailure;
+#else
+        return 0; // X509_V_OK
+#endif
+    }
+
     std::string getSslCert(std::string& subjectHash)
     {
 #if ENABLE_SSL


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Add new CheckStatus SelfSignedCertificate and ExpiredCertificate along the way.

Fixes #11162

Context: https://github.com/CollaboraOnline/online/pull/9202

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

