### PR TITLE
Allow to handle custom uno commands without imgurl

### DIFF
--- a/browser/src/app/LOUtil.ts
+++ b/browser/src/app/LOUtil.ts
@@ -22,6 +22,10 @@ interface RectangleLike {
 	right: number;
 }
 
+interface IconNameMap {
+	[key: string]: string;
+}
+
 // LOUtil contains various LO related utility functions used
 // throughout the code.
 
@@ -238,6 +242,199 @@ class LOUtil {
 			? dummyEmptyImg
 			: defaultImageURL;
 		return defaultImageURL;
+	}
+
+	public static getIconNameOfCommand(name: string, noCommad: boolean) {
+		if (!name) return '';
+
+		var alreadyClean = noCommad;
+		var cleanName = name;
+
+		if (!alreadyClean || alreadyClean !== true) {
+			var prefixLength = '.uno:'.length;
+			if (name.substr(0, prefixLength) == '.uno:')
+				cleanName = name.substr(prefixLength);
+			cleanName = encodeURIComponent(cleanName).replace(/%/g, '');
+			cleanName = cleanName.toLowerCase();
+		}
+		var iconURLAliases: IconNameMap = {
+			// lc_closemobile.svg is generated when loading in NB mode then
+			// switch to compact mode: 1st hidden element in the top toolbar
+			closemobile: 'closedocmobile',
+			'file-saveas': 'saveas',
+			'home-search': 'recsearch',
+			'addmb-menu': 'ok',
+			closetablet: 'view',
+			defineprintarea: 'menuprintranges',
+			deleteprintarea: 'delete',
+			sheetrighttoleft: 'pararighttoleft',
+			alignleft: 'leftpara',
+			alignright: 'rightpara',
+			alignhorizontalcenter: 'centerpara',
+			alignblock: 'justifypara',
+			formatsparklinemenu: 'insertsparkline',
+			insertdatecontentcontrol: 'datefield',
+			editheaderandfooter: 'headerandfooter',
+			exportas: 'saveas',
+			insertheaderfooter: 'headerandfooter',
+			previoustrackedchange: 'prevrecord',
+			fieldtransparency: 'linetransparency',
+			lb_glow_transparency: 'linetransparency',
+			settransparency: 'linetransparency',
+			field_transparency: 'linetransparency',
+			selectionlanugagedefault: 'updateall',
+			connectortoolbox: 'connectorlines',
+			conditionalformatdialog: 'conditionalformatmenu',
+			groupoutlinemenu: 'group',
+			paperwidth: 'pagewidth',
+			charspacing: 'spacing',
+			fontworkcharacterspacingfloater: 'spacing',
+			tablesort: 'datasort',
+			spellcheckignoreall: 'spelling',
+			deleterowbreak: 'delbreakmenu',
+			alignmentpropertypanel: 'alignvcenter',
+			cellvertcenter: 'alignvcenter',
+			charbackcolor: 'backcolor',
+			charmapcontrol: 'insertsymbol',
+			insertrowsafter: 'insertrowsmenu',
+			insertobjectchart: 'drawchart',
+			textpropertypanel: 'sidebartextpanel',
+			spacepara15: 'linespacing',
+			orientationdegrees: 'rotation',
+			clearoutline: 'delete',
+			docsign: 'editdoc',
+			editmenu: 'editdoc',
+			drawtext: 'text',
+			inserttextbox: 'text',
+			accepttrackedchanges: 'acceptchanges',
+			accepttrackedchange: 'acceptchanges',
+			chartlinepanel: 'linestyle',
+			linepropertypanel: 'linestyle',
+			xlinestyle: 'linestyle',
+			listspropertypanel: 'outlinebullet',
+			shadowpropertypanel: 'shadowed',
+			incrementlevel: 'outlineleft',
+			menurowheight: 'rowheight',
+			setoptimalrowheight: 'rowheight',
+			cellverttop: 'aligntop',
+			scalignmentpropertypanel: 'aligntop',
+			hyperlinkdialog: 'inserthyperlink',
+			remotelink: 'inserthyperlink',
+			remoteaicontent: 'sdrespageobjs',
+			openhyperlinkoncursor: 'inserthyperlink',
+			pageformatdialog: 'pagedialog',
+			backgroundcolor: 'fillcolor',
+			cellappearancepropertypanel: 'fillcolor',
+			formatarea: 'fillcolor',
+			glowcolor: 'fillcolor',
+			sccellappearancepropertypanel: 'fillcolor',
+			insertcolumnsafter: 'insertcolumnsmenu',
+			insertnonbreakingspace: 'formattingmark',
+			insertcurrentdate: 'datefield',
+			insertdatefieldfix: 'datefield',
+			insertdatefield: 'datefield',
+			insertdatefieldvar: 'datefield',
+			setparagraphlanguagemenu: 'spelldialog',
+			spellingandgrammardialog: 'spelldialog',
+			spellonline: 'spelldialog',
+			styleapply3fstyle3astring3ddefault26familyname3astring3dcellstyles:
+				'fontcolor',
+			fontworkgalleryfloater: 'fontworkpropertypanel',
+			insertfieldctrl: 'insertfield',
+			pagenumberwizard: 'insertpagenumberfield',
+			entirerow: 'fromrow',
+			insertcheckboxcontentcontrol: 'checkbox',
+			cellvertbottom: 'alignbottom',
+			insertcurrenttime: 'inserttimefield',
+			inserttimefieldfix: 'inserttimefield',
+			inserttimefieldvar: 'inserttimefield',
+			cancelformula: 'cancel',
+			resetattributes: 'setdefault',
+			tabledialog: 'tablemenu',
+			insertindexesentry: 'insertmultiindex',
+			paperheight: 'pageheight',
+			masterslidespanel: 'masterslide',
+			slidemasterpage: 'masterslide',
+			tabledeletemenu: 'deletetable',
+			tracechangemode: 'trackchanges',
+			deleteallannotation: 'deleteallnotes',
+			sdtabledesignpanel: 'tabledesign',
+			tableeditpanel: 'tabledesign',
+			tableautofitmenu: 'columnwidth',
+			menucolumnwidth: 'columnwidth',
+			hyphenation: 'hyphenate',
+			objectbackone: 'behindobject',
+			deleteannotation: 'deletenote',
+			areapropertypanel: 'chartareapanel',
+			'downloadas-png': 'insertgraphic',
+			decrementlevel: 'outlineright',
+			acceptformula: 'ok',
+			insertannotation: 'shownote',
+			insertcomment: 'shownote',
+			objecttitledescription: 'shownote',
+			namegroup: 'shownote',
+			incrementindent: 'leftindent',
+			outlineup: 'moveup',
+			charttypepanel: 'diagramtype',
+			arrangeframemenu: 'arrangemenu',
+			bringtofront: 'arrangemenu',
+			scnumberformatpropertypanel: 'numberformatincdecimals',
+			graphicpropertypanel: 'graphicdialog',
+			rotateflipmenu: 'rotateleft',
+			outlinedown: 'movedown',
+			nexttrackedchange: 'nextrecord',
+			toggleorientation: 'orientation',
+			configuredialog: 'sidebar',
+			modifypage: 'sidebar',
+			parapropertypanel: 'paragraphdialog',
+			tablecellbackgroundcolor: 'fillcolor',
+			zoteroArtwork: 'zoteroThesis',
+			zoteroAudioRecording: 'zoteroThesis',
+			zoteroBill: 'zoteroThesis',
+			zoteroBlogPost: 'zoteroThesis',
+			zoteroBookSection: 'zoteroBook',
+			zoteroCase: 'zoteroThesis',
+			zoteroConferencePaper: 'zoteroThesis',
+			zoteroDictionaryEntry: 'zoteroThesis',
+			zoteroDocument: 'zoteroThesis',
+			zoteroEmail: 'zoteroThesis',
+			zoteroEncyclopediaArticle: 'zoteroThesis',
+			zoteroFilm: 'zoteroThesis',
+			zoteroForumPost: 'zoteroThesis',
+			zoteroHearing: 'zoteroThesis',
+			zoteroInstantMessage: 'zoteroThesis',
+			zoteroInterview: 'zoteroThesis',
+			zoteroLetter: 'zoteroThesis',
+			zoteroMagazineArticle: 'zoteroThesis',
+			zoteroWebpage: 'zoteroThesis',
+			zoteroaddeditcitation: 'insertauthoritiesentry',
+			zoteroaddnote: 'addcitationnote',
+			zoterorefresh: 'updateall',
+			zoterounlink: 'unlinkcitation',
+			zoteroaddeditbibliography: 'addeditbibliography',
+			zoteroeditbibliography: 'addeditbibliography',
+			zoterosetdocprefs: 'formproperties',
+			'sidebardeck.propertydeck': 'sidebar',
+			// Fix issue #6145 by adding aliases for the PDF and EPUB icons
+			// The fix for issues #6103 and #6104 changes the name of these
+			// icons so map the new names to the old names.
+			'downloadas-pdf': 'exportpdf',
+			'downloadas-direct-pdf': 'exportdirectpdf',
+			'downloadas-epub': 'exportepub',
+			languagestatusmenu: 'languagemenu',
+			cancelsearch: 'cancel',
+			printoptions: 'print',
+			togglesheetgrid: 'show',
+			'hamburger-tablet': 'fold',
+			exportdirectpdf: 'exportpdf',
+			textcolumnspropertypanel: 'entirecolumn',
+			'sidebardeck.stylelistdeck': 'editstyle',
+		};
+		if (iconURLAliases[cleanName]) {
+			cleanName = iconURLAliases[cleanName];
+		}
+
+		return 'lc_' + cleanName + '.svg';
 	}
 
 	public static checkIfImageExists(

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -817,7 +817,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (commandName && commandName.length && app.LOUtil.existsIconForCommand(commandName, builder.map.getDocType())) {
 			var iconName = builder._generateMenuIconName(commandName);
 			var iconSpan = L.DomUtil.create('span', 'menu-entry-icon ' + iconName, sectionTitle);
-			iconName = builder._createIconURL(iconName, true);
+			iconName = app.LOUtil.getIconNameOfCommand(iconName, true);
 			icon = L.DomUtil.create('img', '', iconSpan);
 			app.LOUtil.setImage(icon, iconName, builder.map);
 			icon.alt = '';
@@ -1959,216 +1959,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		}
 	},
 
-	_createIconURL: function(name, noCommad) {
-		if (!name)
-			return '';
-
-
-		var alreadyClean = noCommad;
-		var cleanName = name;
-
-
-		if (!alreadyClean || alreadyClean !== true) {
-			var prefixLength = '.uno:'.length;
-			if (name.substr(0, prefixLength) == '.uno:')
-				cleanName = name.substr(prefixLength);
-			cleanName = encodeURIComponent(cleanName).replace(/\%/g, '');
-			cleanName = cleanName.toLowerCase();
-		}
-
-		var iconURLAliases = {
-			// lc_closemobile.svg is generated when loading in NB mode then
-			// switch to compact mode: 1st hidden element in the top toolbar
-			'closemobile': 'closedocmobile',
-			'file-saveas': 'saveas',
-			'home-search': 'recsearch',
-			'addmb-menu': 'ok',
-			'closetablet': 'view',
-			'defineprintarea': 'menuprintranges',
-			'deleteprintarea': 'delete',
-			'sheetrighttoleft' : 'pararighttoleft',
-			'alignleft': 'leftpara',
-			'alignright': 'rightpara',
-			'alignhorizontalcenter': 'centerpara',
-			'alignblock': 'justifypara',
-			'formatsparklinemenu': 'insertsparkline',
-			'insertdatecontentcontrol': 'datefield',
-			'editheaderandfooter': 'headerandfooter',
-			'exportas': 'saveas',
-			'insertheaderfooter': 'headerandfooter',
-			'previoustrackedchange': 'prevrecord',
-			'fieldtransparency': 'linetransparency',
-			'lb_glow_transparency': 'linetransparency',
-			'settransparency': 'linetransparency',
-			'field_transparency': 'linetransparency',
-			'selectionlanugagedefault': 'updateall',
-			'connectortoolbox': 'connectorlines',
-			'conditionalformatdialog': 'conditionalformatmenu',
-			'groupoutlinemenu': 'group',
-			'paperwidth': 'pagewidth',
-			'charspacing': 'spacing',
-			'fontworkcharacterspacingfloater': 'spacing',
-			'tablesort': 'datasort',
-			'spellcheckignoreall': 'spelling',
-			'deleterowbreak': 'delbreakmenu',
-			'alignmentpropertypanel': 'alignvcenter',
-			'cellvertcenter': 'alignvcenter',
-			'charbackcolor': 'backcolor',
-			'charmapcontrol': 'insertsymbol',
-			'insertrowsafter': 'insertrowsmenu',
-			'insertobjectchart': 'drawchart',
-			'textpropertypanel': 'sidebartextpanel',
-			'spacepara15': 'linespacing',
-			'orientationdegrees': 'rotation',
-			'clearoutline': 'delete',
-			'docsign': 'editdoc',
-			'editmenu': 'editdoc',
-			'drawtext': 'text',
-			'inserttextbox': 'text',
-			'accepttrackedchanges': 'acceptchanges',
-			'accepttrackedchange': 'acceptchanges',
-			'chartlinepanel': 'linestyle',
-			'linepropertypanel': 'linestyle',
-			'xlinestyle': 'linestyle',
-			'listspropertypanel': 'outlinebullet',
-			'shadowpropertypanel': 'shadowed',
-			'incrementlevel': 'outlineleft',
-			'menurowheight': 'rowheight',
-			'setoptimalrowheight': 'rowheight',
-			'cellverttop': 'aligntop',
-			'scalignmentpropertypanel': 'aligntop',
-			'hyperlinkdialog': 'inserthyperlink',
-			'remotelink': 'inserthyperlink',
-			'remoteaicontent': 'sdrespageobjs',
-			'openhyperlinkoncursor': 'inserthyperlink',
-			'pageformatdialog': 'pagedialog',
-			'backgroundcolor': 'fillcolor',
-			'cellappearancepropertypanel': 'fillcolor',
-			'formatarea': 'fillcolor',
-			'glowcolor': 'fillcolor',
-			'sccellappearancepropertypanel': 'fillcolor',
-			'insertcolumnsafter': 'insertcolumnsmenu',
-			'insertnonbreakingspace': 'formattingmark',
-			'insertcurrentdate': 'datefield',
-			'insertdatefieldfix': 'datefield',
-			'insertdatefield': 'datefield',
-			'insertdatefieldvar': 'datefield',
-			'setparagraphlanguagemenu': 'spelldialog',
-			'spellingandgrammardialog': 'spelldialog',
-			'spellonline': 'spelldialog',
-			'styleapply3fstyle3astring3ddefault26familyname3astring3dcellstyles': 'fontcolor',
-			'fontworkgalleryfloater': 'fontworkpropertypanel',
-			'insertfieldctrl': 'insertfield',
-			'pagenumberwizard': 'insertpagenumberfield',
-			'entirerow': 'fromrow',
-			'insertcheckboxcontentcontrol': 'checkbox',
-			'cellvertbottom': 'alignbottom',
-			'insertcurrenttime': 'inserttimefield',
-			'inserttimefieldfix': 'inserttimefield',
-			'inserttimefieldvar': 'inserttimefield',
-			'cancelformula': 'cancel',
-			'resetattributes': 'setdefault',
-			'tabledialog': 'tablemenu',
-			'insertindexesentry': 'insertmultiindex',
-			'paperheight': 'pageheight',
-			'masterslidespanel': 'masterslide',
-			'slidemasterpage': 'masterslide',
-			'tabledeletemenu': 'deletetable',
-			'tracechangemode': 'trackchanges',
-			'deleteallannotation': 'deleteallnotes',
-			'sdtabledesignpanel': 'tabledesign',
-			'tableeditpanel': 'tabledesign',
-			'tableautofitmenu': 'columnwidth',
-			'menucolumnwidth': 'columnwidth',
-			'hyphenation': 'hyphenate',
-			'objectbackone': 'behindobject',
-			'deleteannotation': 'deletenote',
-			'areapropertypanel': 'chartareapanel',
-			'downloadas-png': 'insertgraphic',
-			'decrementlevel': 'outlineright',
-			'acceptformula': 'ok',
-			'insertannotation': 'shownote',
-			'insertcomment': 'shownote',
-			'objecttitledescription': 'shownote',
-			'namegroup': 'shownote',
-			'incrementindent': 'leftindent',
-			'outlineup': 'moveup',
-			'charttypepanel': 'diagramtype',
-			'arrangeframemenu': 'arrangemenu',
-			'bringtofront': 'arrangemenu',
-			'scnumberformatpropertypanel': 'numberformatincdecimals',
-			'graphicpropertypanel': 'graphicdialog',
-			'rotateflipmenu': 'rotateleft',
-			'outlinedown': 'movedown',
-			'nexttrackedchange': 'nextrecord',
-			'toggleorientation': 'orientation',
-			'configuredialog': 'sidebar',
-			'modifypage': 'sidebar',
-			'parapropertypanel': 'paragraphdialog',
-			'tablecellbackgroundcolor': 'fillcolor',
-			'zoteroArtwork':  'zoteroThesis',
-			'zoteroAudioRecording':  'zoteroThesis',
-			'zoteroBill':  'zoteroThesis',
-			'zoteroBlogPost':  'zoteroThesis',
-			'zoteroBookSection':  'zoteroBook',
-			'zoteroCase':  'zoteroThesis',
-			'zoteroConferencePaper':  'zoteroThesis',
-			'zoteroDictionaryEntry':  'zoteroThesis',
-			'zoteroDocument':  'zoteroThesis',
-			'zoteroEmail':  'zoteroThesis',
-			'zoteroEncyclopediaArticle':  'zoteroThesis',
-			'zoteroFilm':  'zoteroThesis',
-			'zoteroForumPost':  'zoteroThesis',
-			'zoteroHearing':  'zoteroThesis',
-			'zoteroInstantMessage':  'zoteroThesis',
-			'zoteroInterview':  'zoteroThesis',
-			'zoteroLetter':  'zoteroThesis',
-			'zoteroMagazineArticle':  'zoteroThesis',
-			'zoteroManuscript':  'zoteroThesis',
-			'zoteroMap':  'zoteroThesis',
-			'zoteroNewspaperArticle':  'zoteroThesis',
-			'zoteroNote':  'zoteroThesis',
-			'zoteroPatent':  'zoteroThesis',
-			'zoteroPodcast':  'zoteroThesis',
-			'zoteroPreprint':  'zoteroThesis',
-			'zoteroPresentation':  'zoteroThesis',
-			'zoteroRadioBroadcast':  'zoteroThesis',
-			'zoteroReport':  'zoteroThesis',
-			'zoteroComputerProgram':  'zoteroThesis',
-			'zoteroStatute':  'zoteroThesis',
-			'zoteroTvBroadcast':  'zoteroThesis',
-			'zoteroVideoRecording':  'zoteroThesis',
-			'zoteroWebpage':  'zoteroThesis',
-			'zoteroaddeditcitation': 'insertauthoritiesentry',
-			'zoteroaddnote': 'addcitationnote',
-			'zoterorefresh': 'updateall',
-			'zoterounlink': 'unlinkcitation',
-			'zoteroaddeditbibliography': 'addeditbibliography',
-			'zoteroeditbibliography': 'addeditbibliography',
-			'zoterosetdocprefs': 'formproperties',
-			'sidebardeck.propertydeck' : 'sidebar',
-			// Fix issue #6145 by adding aliases for the PDF and EPUB icons
-			// The fix for issues #6103 and #6104 changes the name of these
-			// icons so map the new names to the old names.
-			'downloadas-pdf': 'exportpdf',
-			'downloadas-direct-pdf': 'exportdirectpdf',
-			'downloadas-epub': 'exportepub',
-			'languagestatusmenu': 'languagemenu',
-			'cancelsearch': 'cancel',
-			'printoptions': 'print',
-			'togglesheetgrid': 'show',
-			'hamburger-tablet': 'fold',
-			'exportdirectpdf': 'exportpdf',
-			'textcolumnspropertypanel':'entirecolumn',
-			'sidebardeck.stylelistdeck': 'editstyle',
-		};
-		if (iconURLAliases[cleanName]) {
-			cleanName = iconURLAliases[cleanName];
-		}
-
-		return 'lc_' + cleanName + '.svg';
-	},
-
 	// make a class identifier from parent's id by walking up the tree
 	_getParentId : function(it) {
 		while (it.parent && !it.id)
@@ -2295,7 +2085,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				}
 				else {
 					buttonImage = L.DomUtil.create('img', '', button);
-					app.LOUtil.setImage(buttonImage, builder._createIconURL(data.command), builder.map);
+					app.LOUtil.setImage(buttonImage, app.LOUtil.getIconNameOfCommand(data.command), builder.map);
 				}
 			} else {
 				buttonImage = false;
@@ -2674,7 +2464,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (commandName && commandName.length && app.LOUtil.existsIconForCommand(commandName, builder.map.getDocType())) {
 			var iconName = builder._generateMenuIconName(commandName);
 			var iconSpan = L.DomUtil.create('span', 'menu-entry-icon ' + iconName, menuEntry);
-			iconName = builder._createIconURL(iconName, true);
+			iconName = app.LOUtil.getIconNameOfCommand(iconName, true);
 			icon = L.DomUtil.create('img', '', iconSpan);
 			app.LOUtil.setImage(icon, iconName, builder.map);
 			icon.alt = '';

--- a/browser/src/control/Control.MobileWizardBuilder.js
+++ b/browser/src/control/Control.MobileWizardBuilder.js
@@ -79,7 +79,7 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 		var commandName = data.id  && data.id.startsWith('.uno:') ? data.id.substring('.uno:'.length) : data.id;
 		if (commandName && commandName.length && app.LOUtil.existsIconForCommand(commandName, builder.map.getDocType())) {
 			var image = L.DomUtil.create('img', 'spinfieldimage', div);
-			var icon = (data.id === 'Transparency') ? builder._createIconURL('settransparency') : builder._createIconURL(data.id);
+			var icon = (data.id === 'Transparency') ? app.LOUtil.getIconNameOfCommand('settransparency') : app.LOUtil.getIconNameOfCommand(data.id);
 			app.LOUtil.setImage(image, icon, builder.map);
 			icon.alt = '';
 		}
@@ -237,7 +237,7 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 
 		var iconPath = null;
 		if (data.command)
-			iconPath = builder._createIconURL(data.command);
+			iconPath = app.LOUtil.getIconNameOfCommand(data.command);
 
 		builder._explorableEntry(parentContainer, data, contentNode, builder, valueNode, iconPath);
 
@@ -546,7 +546,7 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 
 		updateFunction(null);
 
-		var iconPath = builder._createIconURL(data.command);
+		var iconPath = app.LOUtil.getIconNameOfCommand(data.command);
 		var noColorControl = (data.command !== '.uno:FontColor' && data.command !== '.uno:Color');
 		var autoColorControl = (data.command === '.uno:FontColor' || data.command === '.uno:Color');
 
@@ -637,7 +637,7 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 		var iconPath = null;
 		var entryId = data.id;
 		if (entryId && entryId.length) {
-			iconPath = builder._createIconURL(entryId);
+			iconPath = app.LOUtil.getIconNameOfCommand(entryId);
 		}
 
 		builder._explorableEntry(parentContainer, data, content, builder, null, iconPath);
@@ -666,7 +666,7 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 
 		var nodeId = data.command.indexOf('.uno:') === 0 ? data.command.substr('.uno:'.length) : data.command;
 		var contentNode = {id: nodeId, type: 'mobile-popup-container', children: [], onshow: onShow};
-		var iconPath = builder._createIconURL(data.command);
+		var iconPath = app.LOUtil.getIconNameOfCommand(data.command);
 
 		builder._explorableEntry(parentContainer, data, contentNode, builder, null, iconPath);
 

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -713,8 +713,13 @@ L.Control.UIManager = L.Control.extend({
 	setCssRulesForCustomButtons: function() {
 		for (var button of this.customButtons) {
 			const item = document.querySelector(".w2ui-icon." + encodeURIComponent(button.id));
+			var imgUrl = button.imgurl;
 			if (item) {
-				item.style.background = 'url("' + encodeURI(button.imgurl) + '")';
+				if(button.imgurl === undefined || button.imgurl === "") {
+					var iconName = app.LOUtil.getIconNameOfCommand(button.unoCommand);
+					imgUrl = app.LOUtil.getImageURL(iconName);
+				}
+				item.style.background = 'url("' + encodeURI(imgUrl) + '")';
 				item.style.backgroundRepeat = 'no-repeat';
 				item.style.backgroundPosition = 'center';
 			}

--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -40,7 +40,7 @@ JSDialog.comboboxEntry = function (parentContainer, data, builder) {
 
 	if (data.icon) {
 		var icon = L.DomUtil.create('img', 'ui-combobox-icon', entry);
-		builder._isStringCloseToURL(data.icon) ? icon.src = data.icon : app.LOUtil.setImage(icon,  builder._createIconURL(data.icon), builder.map);
+		builder._isStringCloseToURL(data.icon) ? icon.src = data.icon : app.LOUtil.setImage(icon,  app.LOUtil.getIconNameOfCommand(data.icon), builder.map);
 	}
 
 	if (data.hint) {

--- a/browser/src/control/jsdialog/Widget.SidebarContainers.ts
+++ b/browser/src/control/jsdialog/Widget.SidebarContainers.ts
@@ -76,7 +76,7 @@ JSDialog.panel = function (
 							)
 						: '',
 				},
-				icon: builder._createIconURL('morebutton'),
+				icon: app.LOUtil.getIconNameOfCommand('morebutton'),
 			},
 			builder,
 		);

--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -471,7 +471,7 @@ class TreeViewControl {
 
 		const iconId = this.getCellIconId(entry.columns[index]);
 		L.DomUtil.addClass(icon, iconId + 'img');
-		const iconName = builder._createIconURL(iconId, true);
+		const iconName = app.LOUtil.getIconNameOfCommand(iconId, true);
 		app.LOUtil.setImage(icon, iconName, builder.map);
 		icon.tabIndex = -1;
 		icon.alt = ''; //In this case, it is advisable to use an empty alt tag for the icons, as the information of the function is available in text form

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -442,7 +442,7 @@ L.Map.WOPI = L.Handler.extend({
 			return;
 		}
 		else if (msg.MessageId === 'Insert_Button' &&
-			msg.Values && msg.Values.id && msg.Values.imgurl) {
+			msg.Values && msg.Values.id) {
 			this._map.uiManager.insertButton(msg.Values);
 			return;
 		} else if (msg.MessageId === 'Send_UNO_Command' && msg.Values && msg.Values.Command) {


### PR DESCRIPTION
Before imgurl was essential while inserting custom buttons. Now we find the button icon via uno command name even if the imgurl doesn't send by user.


Change-Id: Ide8f6df68018fcac98ce95f1a5c4a9317cff3473


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

