### PR TITLE
Set input elements to autocomplete="off" to prevent browser autofill

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -245,7 +245,7 @@ L.Control.JSDialog = L.Control.extend({
 		instance.form = L.DomUtil.create('form', 'jsdialog-container ui-dialog ui-widget-content lokdialog_container', instance.container);
 		instance.form.setAttribute('role', 'dialog');
 		instance.form.setAttribute('aria-labelledby', instance.title);
-
+		instance.form.setAttribute('autocomplete', 'off');
 		// Prevent overlay from getting the click, except if we want click to dismiss
 		// Like in the case of the inactivity message.
 		// https://github.com/CollaboraOnline/online/issues/7403

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -342,6 +342,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		spinfield.type = 'number';
 		spinfield.dir = document.documentElement.dir;
 		spinfield.tabIndex = '0';
+		spinfield.setAttribute('autocomplete', 'off');
 		controls['spinfield'] = spinfield;
 
 

--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -187,6 +187,7 @@ JSDialog.combobox = function (parentContainer, data, builder) {
 	content.id = data.id + '-input';
 	content.value = data.text;
 	content.role = 'combobox';
+	content.setAttribute('autocomplete', 'off');
 
 	if (data.aria) {
 		content.setAttribute('aria-label',data.aria.label);

--- a/browser/src/control/jsdialog/Widget.Edit.ts
+++ b/browser/src/control/jsdialog/Widget.Edit.ts
@@ -73,6 +73,7 @@ class EditWidget {
 		edit.value = data.text;
 		edit.id = data.id + '-input';
 		edit.dir = 'auto';
+		edit.setAttribute('autocomplete', 'off');
 
 		result.input = edit;
 


### PR DESCRIPTION
Change-Id: I0c86a21b95babf866a49d3db9800cd3be45e929a

* Target version: master 

### Summary
This adds autocomplete="off" to input elements including radio buttons, checkboxes, spinfields and text inputs. This prevents unwanted browser autofill behavior and native browser popups that can interfere with the application's form handling.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

