### PR TITLE
kit: fix build

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3034,7 +3034,7 @@ int pollCallback(void* data, int timeoutUs)
 }
 
 // Do we have any pending input events from coolwsd ?
-bool anyInputCallback(void* data)
+bool anyInputCallback(void* data, int /*priority*/)
 {
     auto kitSocketPoll = reinterpret_cast<KitSocketPoll*>(data);
     const std::shared_ptr<Document>& document = kitSocketPoll->getDocument();


### PR DESCRIPTION
After core.git commit 4e01ac688d856db6c84199e495b6786d3480c9a3
(cool#11064 vcl lok: fold the scheduler info into the anyinput callback,
2025-02-18).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I0d961b5b392c242f38219c1920c29610e3e419d7
