### PR TITLE
Fix missing include for poco 1.14.1

### DIFF
--- a/common/JsonUtil.hpp
+++ b/common/JsonUtil.hpp
@@ -22,6 +22,7 @@
 #include <Poco/Dynamic/Var.h>
 #include <Poco/JSON/Object.h>
 #include <Poco/JSON/Parser.h>
+#include <Poco/JSON/JSONException.h>
 
 namespace JsonUtil
 {
@@ -277,4 +278,3 @@ Poco::JSON::Object::Ptr makePropertyValue(const std::string& type, const T& val)
 } // end namespace JsonUtil
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */
-


### PR DESCRIPTION
* Resolves: #11175
* Target version: master 

### Summary

This fixes compilation with poco 1.14.1 (and probably 1.14 - but I haven't explicitly tested that


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required