### PR TITLE
UILog fix save/load and add statistics

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3893,6 +3893,13 @@ void LogUiCommands::logLine(LogUiCommandsLine &line, bool isUndoChange)
 {
     // log command
     double timeDiffStart = std::chrono::duration<double>(line._timeStart - _session->_docManager->getLogUiCmd().getKitStartTimeSec()).count();
+
+    // Load / Save event made by application will reach here.
+    // In that case save without real userID
+    int userID = _session->_viewId;
+    if (_session->_clientVisibleArea.getWidth() == 0)
+        userID = -1;
+
     std::stringstream strToLog;
     strToLog << "kit=" << _session->_docManager->getDocId();
     strToLog << " time=" << std::fixed << std::setprecision(3) << timeDiffStart;
@@ -3901,7 +3908,7 @@ void LogUiCommands::logLine(LogUiCommandsLine &line, bool isUndoChange)
         double timeDiffEnd = std::chrono::duration<double>(line._timeEnd - line._timeStart).count();
         strToLog << " dur=" << std::fixed << std::setprecision(3) << timeDiffEnd;
     }
-    strToLog << " user=" << _session->_viewId;
+    strToLog << " user=" << userID;
     if (!isUndoChange)
     {
         strToLog << " rep=" << line._repeat;
@@ -3925,7 +3932,7 @@ void LogUiCommands::logLine(LogUiCommandsLine &line, bool isUndoChange)
         }
     }
 
-    _session->_docManager->getLogUiCmd().logUiCmdLine(_session->_viewId, strToLog.str());
+    _session->_docManager->getLogUiCmd().logUiCmdLine(userID, strToLog.str());
 
     if (!isUndoChange && line._undoChange != 0)
     {

--- a/kit/LogUI.cpp
+++ b/kit/LogUI.cpp
@@ -17,7 +17,8 @@ void LogUiCmd::logUiCmdLine(int userId, const std::string& line)
 {
     _fileStreamUICommands.write(line.c_str(), line.length());
     _fileStreamUICommands.write("\n", 1);
-    _usersLogged.insert(userId);
+    if (userId>=0)
+        _usersLogged.insert(userId);
 }
 
 void LogUiCmd::saveLogFile()


### PR DESCRIPTION
fixed a save/load problem ..
If application opened the document, it logged the open with its userID, so it seemed it has a real viewer user.

Now it will set userID to -1, if it is opened by an app, And if userID == 1, it will not count it.

Fixed the script part too... if userID<0 then it does not use it.

Made 5 statistics:
load / save:
- size-count (grouped by writer/calc/impress/draw)

load / save foreground / save background:
- size-time(median) (grouped by basic filetypes)


Change-Id: Ibac04981160bf86d43fabc6802facf61316c4984


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

