### PR TITLE
handle large wordbook file with Web Worker

### DIFF
--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -300,7 +300,7 @@ class SettingIframe {
 			let textValue = await response.text();
 			console.debug('textValue: ', textValue);
 
-			const wordbook = this.wordbook.parseWordbookFile(textValue);
+			const wordbook = await this.wordbook.parseWordbookFileAsync(textValue);
 			const fileName = this.getFilename(fileId, false);
 			this.wordbook.openWordbookEditor(fileName, wordbook);
 		} catch (error: unknown) {

--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -279,6 +279,7 @@ class SettingIframe {
 	}
 
 	private async fetchWordbookFile(fileId: string): Promise<void> {
+		this.wordbook.startLoader();
 		const formData = new FormData();
 		formData.append('fileUrl', fileId);
 		formData.append('accessToken', window.accessToken ?? '');
@@ -302,10 +303,12 @@ class SettingIframe {
 
 			const wordbook = await this.wordbook.parseWordbookFileAsync(textValue);
 			const fileName = this.getFilename(fileId, false);
+			this.wordbook.stopLoader();
 			this.wordbook.openWordbookEditor(fileName, wordbook);
 		} catch (error: unknown) {
 			const message = error instanceof Error ? error.message : 'Unknown error';
 			console.error(`Error uploading file: ${message}`);
+			this.wordbook.stopLoader();
 		}
 	}
 

--- a/browser/admin/src/integrator/WordBook.ts
+++ b/browser/admin/src/integrator/WordBook.ts
@@ -135,6 +135,7 @@ class WordBook {
 				this.currWordbookFile.words.push(newWord);
 				if (this.virtualWordList) {
 					this.virtualWordList.refresh(this.currWordbookFile.words);
+					this.virtualWordList.scrollToBottom();
 				}
 				newWordInput.value = '';
 			}
@@ -370,8 +371,12 @@ class VirtualWordList {
 		if (newWords) {
 			this.words = newWords;
 		}
-		this.contentWrapper.style.height = `${this.words.length * this.itemHeight}px`;
+		this.contentWrapper.style.height = `${(this.words.length + 1) * this.itemHeight}px`;
 		this.onScroll();
+	}
+
+	public scrollToBottom(): void {
+		this.container.scrollTop = (this.words.length + 1) * this.itemHeight;
 	}
 }
 

--- a/browser/admin/src/integrator/WordBook.ts
+++ b/browser/admin/src/integrator/WordBook.ts
@@ -158,35 +158,6 @@ class WordBook {
 		});
 	}
 
-	parseWordbookFile(content: string): WordbookFile {
-		const lines = content.split(/\r?\n/).filter((line) => line.trim() !== '');
-		const delimiterIndex = lines.findIndex((line) => line.trim() === '---');
-		if (delimiterIndex === -1) {
-			window.alert('Invalid dictionary format');
-			throw new Error('Invalid dictionary format: missing delimiter "---"');
-		}
-		if (delimiterIndex < 3) {
-			window.alert('Invalid dictionary format');
-			throw new Error(
-				'Invalid dictionary format: not enough header lines before delimiter',
-			);
-		}
-
-		const headerType = lines[0].trim();
-
-		const languageMatch = lines[1].trim().match(/^lang:\s*(.*)$/i);
-		const language = languageMatch ? languageMatch[1].trim() : '';
-
-		const typeMatch = lines[2].trim().match(/^type:\s*(.*)$/i);
-		const dictType = typeMatch ? typeMatch[1].trim() : '';
-
-		const words = lines
-			.slice(delimiterIndex + 1)
-			.filter((line) => line.trim() !== '');
-
-		return { headerType, language, dictType, words };
-	}
-
 	async wordbookValidation(uploadPath: string, file: File) {
 		try {
 			const content = await this.readFileAsText(file);

--- a/browser/admin/src/integrator/WordBook.ts
+++ b/browser/admin/src/integrator/WordBook.ts
@@ -17,6 +17,25 @@ interface WordbookFile {
 }
 
 class WordBook {
+	private loadingModal: HTMLDivElement | null = null;
+
+	startLoader() {
+		this.loadingModal = document.createElement('div');
+		this.loadingModal.className = 'modal';
+		const loadingContent = document.createElement('div');
+		loadingContent.className = 'modal-content';
+		loadingContent.textContent = 'Loading Wordbook...';
+		this.loadingModal.appendChild(loadingContent);
+		document.body.appendChild(this.loadingModal);
+	}
+
+	stopLoader() {
+		if (this.loadingModal) {
+			document.body.removeChild(this.loadingModal);
+			this.loadingModal = null;
+		}
+	}
+
 	openWordbookEditor(fileName: string, wordbook: WordbookFile): void {
 		const modal = document.createElement('div');
 		modal.className = 'modal';

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -2370,6 +2370,8 @@ void FileServerRequestHandler::preprocessIntegratorAdminFile(const HTTPRequest& 
     csp.appendDirective("img-src", "'self'");
     csp.appendDirective("img-src", "data:"); // Equivalent to unsafe-inline!
 
+    csp.appendDirective("worker-src", "'self' blob:");
+
     const auto& config = Application::instance().config();
     csp.merge(config.getString("net.content_security_policy", ""));
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -950,7 +950,7 @@ void FileServerRequestHandler::handleRequest(const HTTPRequest& request,
 
         if (endPoint == "fetch-wordbook")
         {
-            fetchDictionaries(request, message, socket);
+            fetchWordbook(request, message, socket);
             return;
         }
 
@@ -2114,7 +2114,7 @@ void FileServerRequestHandler::fetchWopiSettingConfigs(const Poco::Net::HTTPRequ
     httpSession->asyncRequest(httpRequest, *COOLWSD::getWebServerPoll());
 }
 
-void FileServerRequestHandler::fetchDictionaries(const Poco::Net::HTTPRequest& request,
+void FileServerRequestHandler::fetchWordbook(const Poco::Net::HTTPRequest& request,
                                                  Poco::MemoryInputStream& message,
                                                  const std::shared_ptr<StreamSocket>& socket)
 {

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -141,7 +141,7 @@ private:
                                         Poco::MemoryInputStream& message,
                                         const std::shared_ptr<StreamSocket>& socket);
 
-    static void fetchDictionaries(const Poco::Net::HTTPRequest& request,
+    static void fetchWordbook(const Poco::Net::HTTPRequest& request,
                                    Poco::MemoryInputStream& message,
                                    const std::shared_ptr<StreamSocket>& socket);
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Previously, loading large dictionary files sometimes crashed the browser due to synchronous parsing. This change converts the parsing process to run asynchronously using a Web Worker, ensuring that the main UI remains responsive while large files are downloaded and processed in the background.

Additional changes:
- Renamed some references from "dictionaries" to "wordbook" for consistency.
- Added a loader UI during the file download process.
- [fix: implement custom smooth scrolling for large wordbooks](https://github.com/CollaboraOnline/online/pull/11199/commits/d8409a58d488556bdc842fae501408131a240f26)
- [enhancement: Scroll to end when we add new word to wordlist](https://github.com/CollaboraOnline/online/pull/11199/commits/1a5b4d4a15442e5ad5df604e5145f94e7cb3a085)