### PR TITLE
wsd: revert remoteassetpoll, remote_asset_config is no longer needed

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -428,7 +428,6 @@ void setupChildRoot(bool bindMount, const std::string& childRoot, const std::str
     cleanupJails(childRoot);
 
     createJailPath(childRoot + CHILDROOT_TMP_INCOMING_PATH + "/fonts");
-    createJailPath(childRoot + CHILDROOT_TMP_INCOMING_PATH + "/templates/presnt");
     createJailPath(childRoot + CHILDROOT_TMP_SHARED_PRESETS_PATH);
 
     disableBindMounting(); // Clear to avoid surprises.

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -349,10 +349,6 @@
         <url desc="URL of optional JSON file that lists fonts to be included in Online" type="string" default=""></url>
     </remote_font_config>
 
-    <remote_asset_config>
-        <url desc="URL of optional JSON file that lists fonts and impress template to be included in Online" type="string" default=""></url>
-    </remote_asset_config>
-
     <fonts_missing>
         <handling desc="How to handle fonts missing in a document: 'report', 'log', 'both', or 'ignore'" type="string" default="log">log</handling>
     </fonts_missing>

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -83,7 +83,6 @@ public:
     static std::string FileServerRoot;
     static std::string ServiceRoot; ///< There are installations that need prefixing every page with some path.
     static std::string TmpFontDir;
-    static std::string TmpPresntTemplateDir;
     static std::string LOKitVersion;
     static bool EnableTraceEventLogging;
     static bool EnableAccessibility;


### PR DESCRIPTION
- It was added to install templates on the fly. After 608d3cae9377af85a47877f0124eac9888988811 this feature is no longer needed. Templates can be added by defining it in "SharedSetting" and "UserSetting" CheckFileInfo property for admin and user respectively.

- This patch reverts all the related commit added in the PR: https://github.com/CollaboraOnline/online/pull/10463

- List of reverted commits:
- Revert "wsd: remoteassetpoll: rename json property "stamp" to "version""
  4d922bb06c0cacde728bedbfb74eb33a81a95828.
- Revert "wsd: remoteassetpoll: rename jsonkey "presnt" to "presentation""
  1492f92d43b909e6c44c7661ba7c6b9193a8397e.
- Revert "wsd: remote: adjust templates json object" 2e79ac30bcb89f990fb68377867a07059c85a290.
- Revert "wsd: fix: don't start remoteassetconfig_poll if configkey is empty" 26b7530d2d5214c87a51b5c714a768a188f5beed.
- Revert "wsd: remove unused `RemoteFontConfigPoll`" 9885bc0c2993d1318c7c00cffa70c20f5e3dcc23.
- Revert "wsd: remoteconfig: use `RemoteAssetConfigPoll` for remote_font_config as well" d813277f5e3e30643b478726361d31383a8a32cc.
- Revert "wsd: remoteconfig: support `fontconfiguration` using `RemoteAssetConfigPoll`" d463610706b4a81c2eb14296b4015320c1840c7a.
- Revert "remoteassetpoll: remove templates when json entries is removed" 202e4a4cd0d17bece89a7a716ddc4f200cfd87e0.
- Revert "wsd: added "RemoteAssetConfigPoll"" 6478e37d87c9dbd24fad101eacef73a992c724a5.
- Revert "lokit: mount childroot/tmp/incoming/templates over instdir/share/common/template/presnt" c8e23844a72ed70432e64e9bfcd260a70fc4998b.


Change-Id: I60d0a5103ef8a5eced8a94e8d67569326cb81a5a

* Target version: master 

### TODO

- [x] Make sure it doesn't break anything else. 
  While testing I found out the remote font config doesn't work with subforkits :). Its unrelated to my patch. I will create a new ticket for it. Might as we transfer fonts to use Preset feature instead of remote font config

