### PR TITLE
wopi: Hide Rename button if WOPI doesn't support or allow

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -2306,6 +2306,9 @@ L.Control.Menubar = L.Control.extend({
 		if (menuItem.id === 'insertgraphicremote' && !this._map['wopi'].EnableInsertRemoteImage)
 			return false;
 
+		if (menuItem.id === 'renamedocument' && !(this._map['wopi']._supportsRename() && this._map['wopi'].UserCanRename))
+			return false;
+
 		if (menuItem.id === 'insertgraphic' && this._map['wopi'].DisableInsertLocalImage)
 			return false;
 

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -260,19 +260,21 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				]
 			});
 		}
-		content.push(
-			{
-				'type': 'container',
-				'children': [
-					{
-						'id': 'renamedocument',
-						'class': 'unoRenameDocument',
-						'type': 'bigcustomtoolitem',
-						'text': _('Rename'),
-					}
-				]
-			}
-		);
+		if (this._map['wopi']._supportsRename() && this._map['wopi'].UserCanRename) {
+			content.push(
+				{
+					'type': 'container',
+					'children': [
+						{
+							'id': 'renamedocument',
+							'class': 'unoRenameDocument',
+							'type': 'bigcustomtoolitem',
+							'text': _('Rename'),
+						}
+					]
+				}
+			);
+		}
 
 		return this.getTabPage('File', content);
 	},

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -313,20 +313,22 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				}
 			);
 		}
-		content.push(
-			{
-				'type': 'container',
-				'children': [
-					{
-						'id': 'renamedocument',
-						'class': 'unoRenameDocument',
-						'type': 'bigcustomtoolitem',
-						'text': _('Rename'),
-					}
-				]
-			}
-		);
+		if (this._map['wopi']._supportsRename() && this._map['wopi'].UserCanRename) {
+			content.push(
+				{
+					'type': 'container',
+					'children': [
+						{
+							'id': 'renamedocument',
+							'class': 'unoRenameDocument',
+							'type': 'bigcustomtoolitem',
+							'text': _('Rename'),
+						}
+					]
+				}
+			);
 
+		}
 		return this.getTabPage('File', content);
 	},
 

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -347,19 +347,21 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				]
 			});
 		}
-		content.push(
-			{
-				'type': 'container',
-				'children': [
-					{
-						'id': 'renamedocument',
-						'class': 'unoRenameDocument',
-						'type': 'bigcustomtoolitem',
-						'text': _('Rename'),
-					}
-				]
-			}
-		);
+		if (this._map['wopi']._supportsRename() && this._map['wopi'].UserCanRename) {
+			content.push(
+				{
+					'type': 'container',
+					'children': [
+						{
+							'id': 'renamedocument',
+							'class': 'unoRenameDocument',
+							'type': 'bigcustomtoolitem',
+							'text': _('Rename'),
+						}
+					]
+				}
+			);
+		}
 
 		return this.getTabPage('File', content);
 	},

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -325,18 +325,20 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			});
 		}
 
-		content.push({
-			'type': 'container',
-			'children': [
-				{
-					'id': 'renamedocument',
-					'class': 'unoRenameDocument',
-					'type': 'bigcustomtoolitem',
-					'text': _('Rename'),
-					'accessibility': { focusBack: true,	combination: 'RN' }
-				}
-			]
-		});
+		if (this._map['wopi']._supportsRename() && this._map['wopi'].UserCanRename) {
+			content.push({
+				'type': 'container',
+				'children': [
+					{
+						'id': 'renamedocument',
+						'class': 'unoRenameDocument',
+						'type': 'bigcustomtoolitem',
+						'text': _('Rename'),
+						'accessibility': { focusBack: true,	combination: 'RN' }
+					}
+				]
+			});
+		}
 
 		if (window.wasmEnabled) {
 			content.push({

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -105,6 +105,12 @@ L.Map.WOPI = L.Handler.extend({
 		this._map.off('updateviewslist');
 	},
 
+	// Return whether there is the capability to rename, not the permission.
+	// Since we fall back on Save As for rename isn't supported.
+	_supportsRename: function() {
+		return !!this.SupportsRename || !this.UserCanNotWriteRelative;
+	},
+
 	_setWopiProps: function(wopiInfo) {
 		var overridenFileInfo = window.checkFileInfoOverride;
 		// Store postmessageorigin property, if it exists


### PR DESCRIPTION
If either _supportsRename() or UserCanRename are false (default value) the rename document button is hidden. So is the menu item.
    
_supportRename() checks for both SupportsRename and not UserCanNotWriteRelative
    


Change-Id: I1543b6e02358ee6307a6c184440bd2a850a4b848


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Hide the rename document button / menu if rename isn't supported or allowed.

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

