### PR TITLE
fix coolmap crash

### DIFF
--- a/tools/map.cpp
+++ b/tools/map.cpp
@@ -499,14 +499,13 @@ static void dumpPages(unsigned proc_id, unsigned parent_id, const char *type, co
 
 static std::vector<char> compressBitmap(const std::vector<char> &bitmap)
 {
-    size_t i;
     std::vector<char> output;
-    for (i = 0; i < bitmap.size(); ++i)
+    for (size_t i = 0, count = bitmap.size(); i < count; ++i)
     {
         char cur;
         int cnt = 0;
         size_t j = i;
-        for (cur = bitmap[j]; bitmap[j] == cur; ++j)
+        for (cur = bitmap[j]; j < count && bitmap[j] == cur; ++j)
             ++cnt;
         output.push_back(cur);
         if (cnt > 3)


### PR DESCRIPTION
stl_vector.h:1149: Assertion '__n < this->size()' failed.


Change-Id: Ie9a081fd6c797be181b0075c70b54b5bed8f4a1b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

