### PR TITLE
private/ash/misc

### DIFF
--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -661,7 +661,7 @@ namespace FileUtil
         {
             std::string fullpath(path);
             if (!fullpath.ends_with("/"))
-                fullpath.append("/");
+                fullpath.push_back('/');
             fullpath.append(f->d_name);
 
             struct stat statbuf;

--- a/configure.ac
+++ b/configure.ac
@@ -1212,10 +1212,10 @@ AC_COMPILE_IFELSE([AC_LANG_SOURCE([
     #endif
 ])],
                     [AC_MSG_RESULT([yes])
-                    AC_DEFINE([HAVE_CLANG],true,[whether the C++ compiler is clang])],
+                    AC_DEFINE([HAVE_CLANG],1,[whether the C++ compiler is clang]) HAVE_CLANG=true],
                     [AC_MSG_RESULT([no])
-                    AC_DEFINE([HAVE_CLANG],false,[whether the C++ compiler is clang])])
-AM_CONDITIONAL([HAVE_CLANG], [test "$HAVE_CLANG" = "true"])
+                    AC_DEFINE([HAVE_CLANG],0,[whether the C++ compiler is clang])])
+AM_CONDITIONAL([HAVE_CLANG], [$HAVE_CLANG])
 AC_SUBST(HAVE_CLANG)
 
 CXXFLAGS="$CXXFLAGS $CXXFLAGS_CXXSTD"

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3826,7 +3826,7 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         });
 #else
         // Register download id -> URL mapping in the DocumentBroker
-        auto url = std::string("../../") + payload.substr(payload.find_last_of("/"));
+        auto url = std::string("../../") + payload.substr(payload.find_last_of('/'));
         auto downloadId = Util::rng::getFilename(64);
         std::string docBrokerMessage = "registerdownload: downloadid=" + downloadId + " url=" + url + " clientid=" + getId();
         _docManager->sendFrame(docBrokerMessage.c_str(), docBrokerMessage.length());

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2726,15 +2726,13 @@ std::string extractCertificate(const std::string & certificate)
     const std::string header("-----BEGIN CERTIFICATE-----");
     const std::string footer("-----END CERTIFICATE-----");
 
-    std::string result;
-
     size_t pos1 = certificate.find(header);
     if (pos1 == std::string::npos)
-        return result;
+        return std::string();
 
     size_t pos2 = certificate.find(footer, pos1 + 1);
     if (pos2 == std::string::npos)
-        return result;
+        return std::string();
 
     pos1 = pos1 + header.length();
     pos2 = pos2 - pos1;

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -37,6 +37,7 @@
 #include <androidapp.hpp>
 #endif
 
+#include <wasm/base64.hpp>
 #include <common/ConfigUtil.hpp>
 #include <common/FileUtil.hpp>
 #include <common/JsonUtil.hpp>
@@ -68,18 +69,6 @@ using Poco::URI;
 using namespace COOLProtocol;
 
 bool ChildSession::NoCapsForKit = false;
-
-namespace {
-
-std::vector<unsigned char> decodeBase64(const std::string & inputBase64)
-{
-    std::istringstream stream(inputBase64);
-    Poco::Base64Decoder base64Decoder(stream);
-    std::istreambuf_iterator<char> eos;
-    return std::vector<unsigned char>(std::istreambuf_iterator<char>(base64Decoder), eos);
-}
-
-}
 
 namespace {
 
@@ -1784,11 +1773,12 @@ bool ChildSession::insertFile(const StringVector& tokens)
         else
         {
             assert(type == "graphic" || type == "multimedia");
-            auto binaryData = decodeBase64(data);
+            std::string binaryData;
+            macaron::Base64::Decode(data, binaryData);
             const std::string tempFile = FileUtil::createRandomTmpDir() + '/' + name;
             std::ofstream fileStream;
             fileStream.open(tempFile);
-            fileStream.write(reinterpret_cast<char*>(binaryData.data()), binaryData.size());
+            fileStream.write(binaryData.data(), binaryData.size());
             fileStream.close();
             url = "file://" + tempFile;
         }
@@ -2763,10 +2753,11 @@ bool ChildSession::askSignatureStatus(const char* buffer, int length, const Stri
                 return false;
 
             std::string chainCertificate = rChainPtr;
-            std::vector<unsigned char> binaryChainCertificate = decodeBase64(extractCertificate(chainCertificate));
+            std::string binaryChainCertificate;
+            macaron::Base64::Decode(extractCertificate(chainCertificate), binaryChainCertificate);
 
             bResult = getLOKitDocument()->addCertificate(
-                binaryChainCertificate.data(),
+                reinterpret_cast<const unsigned char*>(binaryChainCertificate.data()),
                 binaryChainCertificate.size());
 
             if (!bResult)

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3343,7 +3343,7 @@ std::string ChildSession::getBlockedCommandType(std::string command)
         CommandControl::LockManager::getLockedCommandList().end())
         return "locked";
 
-    return "";
+    return std::string();
 }
 #endif
 

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2724,8 +2724,8 @@ namespace
 
 std::string extractCertificate(const std::string & certificate)
 {
-    const std::string header("-----BEGIN CERTIFICATE-----");
-    const std::string footer("-----END CERTIFICATE-----");
+    constexpr std::string_view header("-----BEGIN CERTIFICATE-----");
+    constexpr std::string_view footer("-----END CERTIFICATE-----");
 
     size_t pos1 = certificate.find(header);
     if (pos1 == std::string::npos)

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -18,12 +18,6 @@
 #include <common/Unit.hpp>
 #include <common/Util.hpp>
 
-#include <climits>
-#include <fstream>
-#include <memory>
-#include <sstream>
-#include <string_view>
-
 #define LOK_USE_UNSTABLE_API
 #include <LibreOfficeKit/LibreOfficeKitEnums.h>
 
@@ -53,12 +47,19 @@
 #include "KitHelper.hpp"
 #include <Png.hpp>
 #include <Clipboard.hpp>
-#include <string>
 #include <CommandControl.hpp>
 
 #ifdef IOS
 #include "DocumentViewController.h"
 #endif
+
+#include <climits>
+#include <fstream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
 
 using Poco::JSON::Object;
 using Poco::JSON::Parser;

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3944,7 +3944,7 @@ void LogUiCommands::logSaveLoad(std::string cmd, const std::string & path, std::
     uiLogLine._timeStart = timeStart;
     uiLogLine._timeEnd = std::chrono::steady_clock::now();
     uiLogLine._repeat = 1;
-    uiLogLine._cmd = cmd;
+    uiLogLine._cmd = std::move(cmd);
 
     std::size_t size = 0;
     const auto st = FileUtil::Stat(path);

--- a/net/FakeSocket.cpp
+++ b/net/FakeSocket.cpp
@@ -93,7 +93,7 @@ static std::string flush()
     else if (loggingCallback != nullptr)
         loggingCallback(loggingBuffer.str());
     loggingBuffer.str("");
-    return "";
+    return std::string();
 }
 
 #ifdef __ANDROID__

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1520,7 +1520,7 @@ private:
 
         if (_port != "80" && _port != "443")
         {
-            host.append(":");
+            host.push_back(':');
             host.append(_port);
         }
         _request.set("Host", std::move(host)); // Make sure the host is set.

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1787,7 +1787,7 @@ namespace {
         static std::string generateKey()
         {
             auto random = Util::rng::getBytes(16);
-            return macaron::Base64::Encode(std::string(random.begin(), random.end()));
+            return macaron::Base64::Encode(std::string_view(random.data(), random.size()));
         }
     };
 }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -17,7 +17,7 @@ endif
 AM_CXXFLAGS = $(CPPUNIT_CFLAGS) -DTDOC=\"$(abs_top_srcdir)/test/data\" -DTDIST=\"$(DIST_FOLDER)\" \
 	-I${top_srcdir}/common -I${top_srcdir}/net -I${top_srcdir}/wsd -I${top_srcdir}/kit \
 	-I${top_srcdir} -I${top_srcdir}/test \
-	-pthread -DCOOLWSD_DATADIR='"@COOLWSD_DATADIR@"' \
+	-DCOOLWSD_DATADIR='"@COOLWSD_DATADIR@"' \
 	-DCOOLWSD_CONFIGDIR='"@COOLWSD_CONFIGDIR@"' \
 	-DCOOLWSD_LOGLEVEL='"@COOLWSD_LOGLEVEL@"' \
 	-DDEBUG_ABSSRCDIR='"@abs_srcdir@"' \
@@ -113,6 +113,7 @@ AM_LDFLAGS = -module $(MAGIC_TO_FORCE_SHLIB_CREATION) $(ZLIB_LIBS) $(ZSTD_LIBS) 
 
 # Clang's linker doesn't like -pthread.
 if !HAVE_CLANG
+AM_CXXFLAGS += -pthread
 AM_LDFLAGS += -pthread
 endif
 

--- a/tools/Config.cpp
+++ b/tools/Config.cpp
@@ -120,7 +120,7 @@ bool Config::SupportKeyStringProvided = false;
 std::uint64_t Config::AnonymizationSalt = 0;
 bool Config::AnonymizationSaltProvided = false;
 
-int MigrateConfig(std::string, std::string,  bool);
+int MigrateConfig(const std::string&, const std::string&, bool);
 
 void Config::displayHelp()
 {

--- a/tools/ConfigMigrationAssistant.cpp
+++ b/tools/ConfigMigrationAssistant.cpp
@@ -22,7 +22,6 @@
 #include <Poco/AutoPtr.h>
 
 using Poco::Util::XMLConfiguration;
-using Poco::Util::AbstractConfiguration;
 
 static const std::string NET_POST_ALLOW_HOST = ".net.post_allow.host";
 static const std::string STORAGE_WOPI_HOST = ".storage.wopi.host";

--- a/tools/ConfigMigrationAssistant.cpp
+++ b/tools/ConfigMigrationAssistant.cpp
@@ -259,7 +259,8 @@ void PostProcess(XMLConfiguration &targetConfig)
     }
 }
 
-int MigrateConfig(std::string oldConfigFile, std::string newConfigFile, bool write) {
+int MigrateConfig(const std::string& oldConfigFile, const std::string& newConfigFile, bool write)
+{
     PreProcess();
     Poco::AutoPtr<XMLConfiguration> oldXMLConfig(new XMLConfiguration(oldConfigFile));
     Poco::AutoPtr<XMLConfiguration> newXMLConfig(new XMLConfiguration(newConfigFile));

--- a/tools/ConfigMigrationAssistant.cpp
+++ b/tools/ConfigMigrationAssistant.cpp
@@ -64,8 +64,9 @@ void MigrateLevel(const XMLConfiguration &sourceConfig, XMLConfiguration &target
     {
         const std::string sourceElement = sourceConfig.getString(sourceLevel);
         // Need to handle keys pointing to multiple elements separately, refer to multiElems
-        const std::string commonKeyPart =
-                sourceLevel.find("[") != std::string::npos ? sourceLevel.substr(0, sourceLevel.find("[")) : sourceLevel;
+        const std::string commonKeyPart = sourceLevel.find('[') != std::string::npos
+                                              ? sourceLevel.substr(0, sourceLevel.find('['))
+                                              : sourceLevel;
         if (multiElems.find(commonKeyPart) != multiElems.end())
         {
             if (commonKeyPart == ".logging.file.property")

--- a/tools/ConfigMigrationAssistant.cpp
+++ b/tools/ConfigMigrationAssistant.cpp
@@ -61,7 +61,7 @@ void MigrateLevel(const XMLConfiguration &sourceConfig, XMLConfiguration &target
     }
     if (subKeys.empty())
     {
-        const std::string sourceElement = sourceConfig.getString(sourceLevel);
+        std::string sourceElement = sourceConfig.getString(sourceLevel);
         // Need to handle keys pointing to multiple elements separately, refer to multiElems
         const std::string commonKeyPart = sourceLevel.find('[') != std::string::npos
                                               ? sourceLevel.substr(0, sourceLevel.find('['))

--- a/wasm/base64.hpp
+++ b/wasm/base64.hpp
@@ -37,7 +37,8 @@ namespace macaron {
 class Base64 {
  public:
 
-  static std::string Encode(const std::string& data) {
+  static std::string Encode(const std::string_view data)
+  {
     static constexpr char sEncodingTable[] = {
       'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
       'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
@@ -77,7 +78,8 @@ class Base64 {
     return ret;
   }
 
-  static std::string Decode(const std::string& input, std::string& out) {
+  static std::string Decode(const std::string_view input, std::string& out)
+  {
     static constexpr unsigned char kDecodingTable[] = {
       64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
       64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -240,7 +240,7 @@ std::string removeProtocolAndPort(const std::string& host)
         result = host;
 
     // port
-    pos = result.find(":");
+    pos = result.find(':');
     if (pos != std::string::npos)
     {
         if (pos == 0)

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -244,7 +244,7 @@ std::string removeProtocolAndPort(const std::string& host)
     if (pos != std::string::npos)
     {
         if (pos == 0)
-            return "";
+            return std::string();
 
         result = result.substr(0, pos);
     }
@@ -700,7 +700,7 @@ inline std::string getLaunchBase(bool asAdmin = false)
         auto passwd = ConfigUtil::getConfigValue<std::string>("admin_console.password", "");
 
         if (user.empty() || passwd.empty())
-            return "";
+            return std::string();
 
         oss << user << ':' << passwd << '@';
     }

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4180,7 +4180,7 @@ std::string DocumentBroker::getDownloadURL(const std::string& downloadId)
     if (found != _registeredDownloadLinks.end())
         return found->second;
 
-    return "";
+    return std::string();
 }
 
 void DocumentBroker::unregisterDownloadId(const std::string& downloadId)

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1660,7 +1660,7 @@ void DocumentBroker::asyncInstallPresets(const std::shared_ptr<ClientSession>& s
             for (const auto& fileName : fileNames)
             {
                 std::string filePath = searchDir;
-                filePath.append("/");
+                filePath.push_back('/');
                 filePath.append(fileName);
                 std::filesystem::file_time_type ts = std::filesystem::last_write_time(filePath, ec);
                 if (ec)
@@ -4087,7 +4087,7 @@ void DocumentBroker::uploadPresetsToWopiHost(const Authorization& auth)
     for (const auto& fileName : fileNames)
     {
         std::string fileJailPath = searchDir;
-        fileJailPath.append("/");
+        fileJailPath.push_back('/');
         fileJailPath.append(fileName);
         std::filesystem::file_time_type currentTimestamp =
             std::filesystem::last_write_time(fileJailPath, ec);

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4523,7 +4523,7 @@ void DocumentBroker::handleClipboardRequest(ClipboardRequest type,  const std::s
         LOG_ERR("Could not find matching session to handle clipboard request for " << viewId << " tag: " << tag);
 }
 
-void DocumentBroker::handleMediaRequest(std::string range,
+void DocumentBroker::handleMediaRequest(const std::string_view range,
                                         const std::shared_ptr<Socket>& socket,
                                         const std::string& tag)
 {
@@ -4569,7 +4569,7 @@ void DocumentBroker::handleMediaRequest(std::string range,
 #endif
 
             auto session = std::make_shared<http::server::Session>();
-            session->asyncUpload(path, "video/mp4", std::move(range));
+            session->asyncUpload(path, "video/mp4", range);
             streamSocket->setHandler(std::static_pointer_cast<ProtocolHandlerInterface>(session));
         }
     }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -433,7 +433,8 @@ public:
     static bool lookupSendClipboardTag(const std::shared_ptr<StreamSocket> &socket,
                                        const std::string &tag, bool sendError = false);
 
-    void handleMediaRequest(std::string range, const std::shared_ptr<Socket>& socket, const std::string& tag);
+    void handleMediaRequest(const std::string_view range, const std::shared_ptr<Socket>& socket,
+                            const std::string& tag);
 
     /// True if any flag to close, terminate, or to unload is set.
     bool isUnloading() const { return isUnloadingUnrecoverably() || _docState.isUnloadRequested(); }

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -791,7 +791,7 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
 
                 LOG_DBG("Saving uploaded file[" << fileName << "] to directory[" << dirPath << ']');
                 std::ofstream outfile;
-                dirPath.append("/");
+                dirPath.push_back('/');
                 dirPath.append(fileName);
                 outfile.open(dirPath, std::ofstream::binary);
                 outfile.write(buffer.data(), size);

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -400,8 +400,8 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
     {
         Poco::URI requestUri(request.getURI());
         const Poco::Path path = requestUri.getPath();
-        const std::string prefix = "/wopi/files";
-        const std::string suffix = "/contents";
+        constexpr std::string_view prefix = "/wopi/files";
+        constexpr std::string_view suffix = "/contents";
         std::string localPath;
         if (path.toString().ends_with(suffix))
         {

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -338,7 +338,7 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
                 DocChanged = 1010  // Document changed externally in storage
             };
 
-        std::string getLastModifiedTime()
+        std::string getLastModifiedTime() const
         {
             return Util::getIso8601FracformatTime(fileLastModifiedTime);
         }
@@ -360,19 +360,17 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
 
     public:
         // Lookup a file in our file-list
-        static std::shared_ptr<LocalFileInfo> getOrCreateFile(const std::string &lpath, const std::string &fname)
+        static const std::shared_ptr<LocalFileInfo>& getOrCreateFile(const std::string& lpath,
+                                                                     const std::string& fname)
         {
-            auto it = std::find_if(fileInfoVec.begin(), fileInfoVec.end(), [&lpath](const std::shared_ptr<LocalFileInfo>& obj)
-            {
-                return obj->localPath == lpath;
-            });
+            const auto it = std::find_if(fileInfoVec.begin(), fileInfoVec.end(),
+                                         [&lpath](const std::shared_ptr<LocalFileInfo>& obj)
+                                         { return obj->localPath == lpath; });
 
             if (it != fileInfoVec.end())
                 return *it;
 
-            auto fileInfo = std::make_shared<LocalFileInfo>(lpath, fname);
-            fileInfoVec.emplace_back(fileInfo);
-            return fileInfo;
+            return fileInfoVec.emplace_back(std::make_shared<LocalFileInfo>(lpath, fname));
         }
     };
     std::atomic<unsigned> lastLocalId;
@@ -420,7 +418,7 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
 
         if (request.getMethod() == "GET" && !path.toString().ends_with(suffix))
         {
-            std::shared_ptr<LocalFileInfo> localFile =
+            const std::shared_ptr<LocalFileInfo>& localFile =
                 LocalFileInfo::getOrCreateFile(localPath, path.getFileName());
 
             std::string userId = std::to_string(lastLocalId++);
@@ -505,8 +503,8 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
         }
         else if(request.getMethod() == "GET" && path.toString().ends_with(suffix))
         {
-            std::shared_ptr<LocalFileInfo> localFile =
-                LocalFileInfo::getOrCreateFile(localPath,path.getFileName());
+            const std::shared_ptr<LocalFileInfo>& localFile =
+                LocalFileInfo::getOrCreateFile(localPath, path.getFileName());
             std::ostringstream ss;
             std::ifstream inputFile(localFile->localPath);
             ss << inputFile.rdbuf();
@@ -520,8 +518,8 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
         }
         else if (request.getMethod() == "POST" && path.toString().ends_with(suffix))
         {
-            std::shared_ptr<LocalFileInfo> localFile =
-                LocalFileInfo::getOrCreateFile(localPath,path.getFileName());
+            const std::shared_ptr<LocalFileInfo>& localFile =
+                LocalFileInfo::getOrCreateFile(localPath, path.getFileName());
             std::string wopiTimestamp = request.get("X-COOL-WOPI-Timestamp", std::string());
             if (wopiTimestamp.empty())
                 wopiTimestamp = request.get("X-LOOL-WOPI-Timestamp", std::string());
@@ -733,7 +731,7 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
                 throw BadRequestException("Invalid URI: " + configPath);
             }
 
-            std::shared_ptr<LocalFileInfo> localFile =
+            const std::shared_ptr<LocalFileInfo>& localFile =
                 LocalFileInfo::getOrCreateFile(configPath, path.getFileName());
             std::ostringstream ss;
             std::ifstream inputFile(localFile->localPath);

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -362,7 +362,7 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
         // Lookup a file in our file-list
         static std::shared_ptr<LocalFileInfo> getOrCreateFile(const std::string &lpath, const std::string &fname)
         {
-            auto it = std::find_if(fileInfoVec.begin(), fileInfoVec.end(), [&lpath](const std::shared_ptr<LocalFileInfo> obj)
+            auto it = std::find_if(fileInfoVec.begin(), fileInfoVec.end(), [&lpath](const std::shared_ptr<LocalFileInfo>& obj)
             {
                 return obj->localPath == lpath;
             });

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -344,14 +344,15 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
         }
 
         LocalFileInfo() = delete;
-        LocalFileInfo(const std::string &lPath, const std::string &fName)
+        LocalFileInfo(std::string lPath, std::string fName)
+            : localPath(std::move(lPath))
+            , fileName(std::move(fName))
         {
-            fileName = fName;
-            localPath = lPath;
             const FileUtil::Stat stat(localPath);
             size = std::to_string(stat.size());
             fileLastModifiedTime = stat.modifiedTimepoint();
         }
+
     private:
         // Internal tracking of known files: to store various data
         // on files - rather than writing it back to the file-system.

--- a/wsd/FileServerUtil.cpp
+++ b/wsd/FileServerUtil.cpp
@@ -160,9 +160,9 @@ std::string PreProcessedFile::substitute(const std::unordered_map<std::string, s
                     // Leave original variable as-is.
                     if (seg.first == SegmentType::Variable)
                     {
-                        recon.append("%");
+                        recon.push_back('%');
                         recon.append(seg.second);
-                        recon.append("%");
+                        recon.push_back('%');
                     }
                     else if (seg.first == SegmentType::CommentedVariable)
                     {

--- a/wsd/RemoteConfig.cpp
+++ b/wsd/RemoteConfig.cpp
@@ -694,7 +694,7 @@ std::string RemoteAssetConfigPoll::removeTemplate(const std::string& uri,
     const std::string filename = path.substr(path.find_last_of('/') + 1);
     std::string assetFile;
     assetFile.append(tmpPath);
-    assetFile.append("/");
+    assetFile.push_back('/');
     assetFile.append(filename);
     FileUtil::removeFile(assetFile);
     return assetFile;


### PR DESCRIPTION
- **configure: skip -pthread with clang**
- **wsd: find with single-character strings is slower**
- **wsd: misc cleanup**
- **wsd: avoid implict string conversion from empty literal**
- **wsd: avoid returning named default-constructed objects**
- **wsd: reduce copies**
- **wsd: include ordering**
- **wsd: push_back single-characters to strings**
- **wsd: avoid copying arguments**
- **wsd: avoid copying arguments**
- **wsd: avoid copying arguments**
- **wsd: constexpr static strings**
- **killpoco: replace base-64 decoder with internal one**
- **wsd: Base64::Encode takes string_view to avoid temp strings**
- **wsd: remove const to enable move**
- **wsd: return cached LocalFileInfo shared_ptr**
- **wsd: reduce argument copying**
