### PR TITLE
net/SslSocket: don't log Zero_Return and EAGAIN in dbg level

### DIFF
--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -381,10 +381,19 @@ private:
         const unsigned long bioError = ERR_peek_error();
         const std::string bioErrStr = getBioError(bioError);
 
-        LOG_DBG("SSL error (" << context << "): " << sslErrorToName(sslError) << " (" << sslError
+        // Having an empty answer is valid, no need to log
+        // EAGAIN, SSL_ERROR_WANT_READ/SSL_ERROR_WANT_WRITE are normal business
+        if (bioError != SSL_ERROR_ZERO_RETURN && bioError != SSL_ERROR_WANT_READ && bioError != SSL_ERROR_WANT_WRITE) {
+            LOG_DBG("SSL error (" << context << "): " << sslErrorToName(sslError) << " (" << sslError
                               << "), rc: " << rc << ", errno: " << last_errno << " ("
                               << Util::symbolicErrno(last_errno) << ": "
                               << std::strerror(last_errno) << ")" << ": " << bioErrStr);
+        } else {
+            LOG_TRC("SSL error (" << context << "): " << sslErrorToName(sslError) << " (" << sslError
+                              << "), rc: " << rc << ", errno: " << last_errno << " ("
+                              << Util::symbolicErrno(last_errno) << ": "
+                              << std::strerror(last_errno) << ")" << ": " << bioErrStr);
+        }
 
         // Handle non-fatal cases first.
         switch (sslError)


### PR DESCRIPTION
### Summary

Since those are very common and aren't errors, print output about them only in trace.

Logs are filled with logs such as:

Feb 18 01:13:45 collabora coolwsd[509]: wsd-00509-00509 2025-02-18 01:13:45.083739 +0100 [ coolwsd ] DBG  #37: SSL error (handshake): WANT_READ (2), rc: -1, errno: 11 (EAGAIN: Resource temporarily unavailable): BIO error: 0: error:00000000:lib(0)::reason(0):| net/SslSocket.hpp:384

Feb 18 01:13:45 collabora coolwsd[509]: wsd-00509-00509 2025-02-18 01:13:45.099295 +0100 [ coolwsd ] DBG  #37: SSL error (read): WANT_READ (2), rc: -1, errno: 11 (EAGAIN: Resource temporarily unavailable): BIO error: 0: error:00000000:lib(0)::reason(0):| net/SslSocket.hpp:384

Feb 18 15:22:12 collabora coolwsd[509]: wsd-00509-00520 2025-02-18 15:22:12.216662 +0100 [ websrv_poll ] DBG  #37: SSL error (read): ZERO_RETURN (6), rc: 0, errno: 0 (0: Success): BIO error: 0: error:00000000:lib(0)::reason(0):| net/SslSocket.hpp:384

But they have very little value, an empty response ZERO_RETURN or EAGAIN/WANT_READ/WANT_WRITE are just normal workflow.
It is up to the calling code to log if an empty response is an issue or not.

Change-Id: I33036a817a4e94146f2a27c2f6be031477874543

* Target version: master 

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

