### PR TITLE
Fix incorrect date display in cell comments

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -475,7 +475,8 @@ export class Comment extends CanvasSectionObject {
 			this.sectionProperties.authorAvatartdImg.style.borderColor = color;
 		}
 
-		var d = new Date(this.sectionProperties.data.dateTime.replace(/,.*/, 'Z'));
+		// dateTime already in UTC so we will not append Z that wil create issues while converting date
+		var d = new Date(this.sectionProperties.data.dateTime.replace(/,.*/, ''));
 		var dateOptions: any = { weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' };
 		this.sectionProperties.contentDate.innerText = isNaN(d.getTime()) ? this.sectionProperties.data.dateTime: d.toLocaleDateString((<any>String).locale, dateOptions);
 


### PR DESCRIPTION
- Fixed an issue where day and month were swapped in cell comments (e.g., "12.02.2025" interpreted as "02.12.2025").
- Implemented proper date parsing to correctly interpret DD.MM.YYYY HH:MM format.
- Ensured comments display the expected localized date format across different languages.( Specially in german)


Change-Id: Id6d44792bf005992ea22e62b27934e16fa6e3732


* Resolves: #11149
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

