### PR TITLE
feat(iOS): Support loading video

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -448,6 +448,8 @@ class MobileAppInitializer extends InitializerBase {
 		window.coolLogging = "true";
 		window.outOfFocusTimeoutSecs = 1000000;
 		window.idleTimeoutSecs = 1000000;
+
+		window.canvasSlideshowEnabled = true;
 	}
 }
 

--- a/browser/src/map/handler/Map.SlideShow.js
+++ b/browser/src/map/handler/Map.SlideShow.js
@@ -46,7 +46,7 @@ L.Map.SlideShow = L.Handler.extend({
 			return;
 		}
 
-		if (window.ThisIsTheiOSApp || window.ThisIsTheAndroidApp) {
+		if (window.ThisIsTheAndroidApp) {
 			window.postMobileMessage('SLIDESHOW');
 			return;
 		}

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -582,10 +582,7 @@ class SlideShowPresenter {
 			return false;
 		}
 
-		if (
-			(window as any).ThisIsTheiOSApp ||
-			(window as any).ThisIsTheAndroidApp
-		) {
+		if ((window as any).ThisIsTheAndroidApp) {
 			window.postMobileMessage('SLIDESHOW');
 			return false;
 		}

--- a/common/MobileApp.hpp
+++ b/common/MobileApp.hpp
@@ -59,6 +59,7 @@ public:
 
 #ifdef IOS
     CODocument *coDocument;
+    std::weak_ptr<DocumentBroker> docBroker;
 #endif
 };
 

--- a/ios/Mobile.xcodeproj/project.pbxproj
+++ b/ios/Mobile.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		BEDCC8992456FFAD00FB02BD /* SceneDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = BEDCC8982456FFAC00FB02BD /* SceneDelegate.mm */; };
 		BEFB1EE121C29CC70081D757 /* L10n.mm in Sources */ = {isa = PBXBuildFile; fileRef = BEFB1EE021C29CC70081D757 /* L10n.mm */; };
 		D49B580F2D1077F700E0E607 /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D49B580E2D1077F700E0E607 /* UniformTypeIdentifiers.framework */; };
+		D4A0F3D72D64E86C00472DEE /* CoolURLSchemeHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = D4A0F3D62D64E86C00472DEE /* CoolURLSchemeHandler.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -1473,6 +1474,8 @@
 		BEFB1EDF21C29CC70081D757 /* L10n.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = L10n.h; sourceTree = "<group>"; };
 		BEFB1EE021C29CC70081D757 /* L10n.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = L10n.mm; sourceTree = "<group>"; };
 		D49B580E2D1077F700E0E607 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
+		D4A0F3D62D64E86C00472DEE /* CoolURLSchemeHandler.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoolURLSchemeHandler.mm; sourceTree = "<group>"; };
+		D4A0F3D82D663A0000472DEE /* CoolURLSchemeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoolURLSchemeHandler.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2629,6 +2632,8 @@
 		BE8D77292136762500AC58EA /* Mobile */ = {
 			isa = PBXGroup;
 			children = (
+				D4A0F3D82D663A0000472DEE /* CoolURLSchemeHandler.h */,
+				D4A0F3D62D64E86C00472DEE /* CoolURLSchemeHandler.mm */,
 				BE58E13021874A2E00249358 /* Mobile.entitlements */,
 				BE5EB5D92140363100E0826C /* ios.mm */,
 				BE00F8922139494E001CE2D4 /* Resources */,
@@ -3679,6 +3684,7 @@
 				BE5EB5C1213FE29900E0826C /* Log.cpp in Sources */,
 				A5C2FA5A2AC1BB3900265946 /* Simd.cpp in Sources */,
 				BEDCC84E2452F82800FB02BD /* MobileApp.cpp in Sources */,
+				D4A0F3D72D64E86C00472DEE /* CoolURLSchemeHandler.mm in Sources */,
 				BE5EB5DA2140363100E0826C /* ios.mm in Sources */,
 				BE5EB5D421400DC100E0826C /* DocumentBroker.cpp in Sources */,
 				BEA28377214FFD8C00848631 /* Unit.cpp in Sources */,

--- a/ios/Mobile/CODocument.mm
+++ b/ios/Mobile/CODocument.mm
@@ -108,7 +108,8 @@ static std::atomic<unsigned> appDocIdCounter(1);
                           isMessageOfType(buffer, "delta:", length) ||
                           isMessageOfType(buffer, "renderfont:", length) ||
                           isMessageOfType(buffer, "rendersearchlist:", length) ||
-                          isMessageOfType(buffer, "windowpaint:", length));
+                          isMessageOfType(buffer, "windowpaint:", length) ||
+                          isMessageOfType(buffer, "slidelayer:", length));
 
     const char *pretext = binaryMessage ? "window.TheFakeWebSocket.onmessage({'data': window.atob('"
                                         : "window.TheFakeWebSocket.onmessage({'data': window.b64d('";

--- a/ios/Mobile/CoolURLSchemeHandler.h
+++ b/ios/Mobile/CoolURLSchemeHandler.h
@@ -27,4 +27,5 @@
 
 - (id)initWithDocument:(CODocument *)document;
 - (std::shared_ptr<DocumentBroker>)getDocumentBroker;
+- (std::optional<std::tuple<NSUInteger, NSUInteger, NSUInteger>>)getPositionsAndSizeForRange:(NSString *)range withTotalSize:(NSInteger)size;
 @end

--- a/ios/Mobile/CoolURLSchemeHandler.h
+++ b/ios/Mobile/CoolURLSchemeHandler.h
@@ -1,0 +1,30 @@
+// -*- Mode: objc; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*-
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#import "ios.h"
+#import <Foundation/NSObject.h>
+
+#import <WebKit/WKURLSchemeTask.h>
+#import <WebKit/WKURLSchemeHandler.h>
+
+#import "CODocument.h"
+
+#import <wsd/DocumentBroker.hpp>
+
+@interface CoolURLSchemeHandler : NSObject<WKURLSchemeHandler>
+{
+    NSMutableSet<id<WKURLSchemeTask>> *ongoingTasks;
+    CODocument *document;
+}
+
+- (id)initWithDocument:(CODocument *)document;
+- (std::shared_ptr<DocumentBroker>)getDocumentBroker;
+@end

--- a/ios/Mobile/CoolURLSchemeHandler.mm
+++ b/ios/Mobile/CoolURLSchemeHandler.mm
@@ -1,0 +1,117 @@
+// -*- Mode: objc; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*-
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#import "config.h"
+
+#import "CoolURLSchemeHandler.h"
+
+#import "MobileApp.hpp"
+
+#import <Foundation/NSSet.h>
+#import <Foundation/NSURL.h>
+#import <Foundation/NSURLResponse.h>
+
+#import <Foundation/NSString.h>
+
+#import <Poco/URI.h>
+
+#import <wsd/DocumentBroker.hpp>
+
+@implementation CoolURLSchemeHandler
+- (id)initWithDocument:(CODocument *)document {
+    self->document = document;
+    self->ongoingTasks = [[NSMutableSet alloc] init];
+    return self;
+}
+
+- (std::shared_ptr<DocumentBroker>)getDocumentBroker {
+    std::weak_ptr<DocumentBroker> docBroker = DocumentData::get(document->appDocId).docBroker;
+    
+    return docBroker.lock();
+}
+
+- (void)webView:(WKWebView *)webView startURLSchemeTask:(id<WKURLSchemeTask>)urlSchemeTask {
+    [ongoingTasks addObject:urlSchemeTask];
+    
+    // Get tag from request
+    Poco::URI requestUri([[[urlSchemeTask.request.URL absoluteString] stringByRemovingPercentEncoding] UTF8String]);
+    Poco::URI::QueryParameters params = requestUri.getQueryParameters();
+    std::string tag;
+    
+    for (const auto& it : params) {
+        if (it.first == "Tag") {
+            tag = it.second;
+        }
+    }
+    
+    // Get path from tag & open a stream
+    std::string mediaPath = [self getDocumentBroker]->getEmbeddedMediaPath(tag);
+    
+    NSMutableDictionary<NSString*, NSString*> * responseHeaders = [[NSMutableDictionary alloc] init];
+        
+    if (mediaPath.empty() || !std::filesystem::exists(mediaPath)) {
+        [responseHeaders setObject:@"0" forKey:@"Content-Length"];
+
+        NSHTTPURLResponse * response = [[NSHTTPURLResponse alloc]
+                                        initWithURL:urlSchemeTask.request.URL
+                                        statusCode:404
+                                        HTTPVersion:nil
+                                        headerFields:responseHeaders
+        ];
+        [urlSchemeTask didReceiveResponse:response];
+
+        [ongoingTasks removeObject:urlSchemeTask];
+        [urlSchemeTask didFinish];
+
+        return;
+    }
+
+    NSInteger size = std::filesystem::file_size(mediaPath);
+
+    [responseHeaders setObject:[NSString stringWithFormat:@"%ld", size] forKey:@"Content-Length"];
+    
+    // Send preliminary file details
+    NSHTTPURLResponse * response = [[NSHTTPURLResponse alloc]
+                                    initWithURL:urlSchemeTask.request.URL
+                                    statusCode:200
+                                    HTTPVersion:nil
+                                    headerFields:responseHeaders
+    ];
+    [urlSchemeTask didReceiveResponse:response];
+
+    // Send actual file data
+    std::ifstream media(mediaPath, std::ios_base::in | std::ios_base::binary);
+    char* chunk = new char[size];
+
+    media.read(chunk, size);
+        
+    if (![ongoingTasks containsObject:urlSchemeTask]) {
+        // The task was cancelled: exit immediately, without calling any further methods as per Apple docs
+        media.close();
+        return;
+    }
+    
+    NSData * data = [NSData dataWithBytes:chunk length:size];
+    [urlSchemeTask didReceiveData:data];
+    
+    delete[] chunk;
+    media.close();
+    
+    // Tell the other side that we finished, and remove the ongoing-ness of the task
+    [ongoingTasks removeObject:urlSchemeTask];
+    [urlSchemeTask didFinish];
+}
+
+- (void)webView:(WKWebView *)webView stopURLSchemeTask:(id<WKURLSchemeTask>)urlSchemeTask {
+    // Yeet the task from the ongoingTasks
+    [ongoingTasks removeObject:urlSchemeTask];
+}
+@end

--- a/ios/Mobile/CoolURLSchemeHandler.mm
+++ b/ios/Mobile/CoolURLSchemeHandler.mm
@@ -38,6 +38,74 @@
     return docBroker.lock();
 }
 
+
+- (std::optional<std::tuple<NSUInteger, NSUInteger, NSUInteger>>)getPositionsAndSizeForRange:(NSString *)range withTotalSize:(NSInteger)size {
+    if ([range containsString:@","]) {
+        return std::nullopt; // We do not provide multiple-range support
+    }
+    
+    if (![range hasPrefix:@"bytes="]) {
+        return std::nullopt; // Malformed range request - at time of writing bytes is the only valid type
+    }
+    
+    NSString * unprefixedRange = [range substringFromIndex:[@"bytes=" length]];
+    NSArray * rangeComponents = [unprefixedRange componentsSeparatedByString:@"-"];
+    
+    if ([rangeComponents count] != 2) {
+        return std::nullopt; // Malformed range request - does not contain exactly 1 dash
+    }
+    
+    // Yes, this lets through some malformed range requests if one side has a string and the other an integer - e.g. 'bytes=three-70' ... but I'm not sure I really mind
+    // The other issues were all about things that would make it impossible to parse... treating non-numbers as the empty-string seems benign and easier to let it slip through
+    // We can't use NSIntegers as they aren't nullable - we would get 0 instead... this rounds decimals, again fairly benign in my opinion
+    NSNumberFormatter * formatter = [[NSNumberFormatter alloc] init];
+    formatter.numberStyle = NSNumberFormatterStyle::NSNumberFormatterNoStyle;
+
+    NSNumber * left = [formatter numberFromString:[rangeComponents firstObject]];
+    NSNumber * right = [formatter numberFromString:[rangeComponents lastObject]];
+    
+    if (left == nil && right == nil) {
+        return std::nullopt; // Malformed range request - at most one side can be empty
+    }
+    
+    if (left == nil) {
+        // Number is "-foo", specifying bytes before the end
+        NSUInteger start = size - [right unsignedIntegerValue];
+        NSUInteger end = size - 1;
+        
+        if (start < 0) {
+            return std::nullopt; // Invalid range - too long
+        }
+        
+        return std::make_optional(std::make_tuple(start, end, [right integerValue]));
+    }
+    
+    if (right == nil) {
+        // Number is "foo-", specifying a start position and asking for bytes until the end
+        NSUInteger start = [left unsignedIntegerValue];
+        NSUInteger end = size - 1;
+        
+        if (start > end) {
+            return std::nullopt; // Invalid range - negative size
+        }
+        
+        return std::make_optional(std::make_tuple(start, end, end - start + 1));
+    }
+    
+    NSUInteger start = [left unsignedIntegerValue];
+    NSUInteger end = [right unsignedIntegerValue];
+    
+    if (start > end) {
+        return std::nullopt; // Invalid range - negative size
+    }
+    
+    if (end >= size) {
+        return std::nullopt; // Invalid range - out of bounds
+    }
+    
+    return std::make_optional(std::make_tuple(start, end, end - start + 1));
+}
+
 - (void)webView:(WKWebView *)webView startURLSchemeTask:(id<WKURLSchemeTask>)urlSchemeTask {
     [ongoingTasks addObject:urlSchemeTask];
     
@@ -75,22 +143,66 @@
     }
 
     NSInteger size = std::filesystem::file_size(mediaPath);
+    
+    NSDictionary<NSString*, NSString*> * requestHeaders = urlSchemeTask.request.allHTTPHeaderFields;
+    
+    NSInteger responseStatus = 200;
+    NSInteger start = 0;
+    NSInteger end = size - 1; // 'end' is considered to be *inclusive* here to match the range header
+    
+    bool errorResponse = false;
 
-    [responseHeaders setObject:[NSString stringWithFormat:@"%ld", size] forKey:@"Content-Length"];
+    NSString * rangeHeader = [requestHeaders objectForKey:@"Range"];
+    std::optional<std::tuple<NSUInteger, NSUInteger, NSUInteger>> rangePositionsAndSize = [self getPositionsAndSizeForRange:rangeHeader withTotalSize:size];
+
+    if (rangeHeader != nil && rangePositionsAndSize == std::nullopt) {
+        responseStatus = 416;
+        [responseHeaders
+         setObject:[NSString
+                    stringWithFormat:@"bytes */%ld",
+                    static_cast<long>(size)]
+         forKey:@"Content-Range"];
+        errorResponse = true;
+    } else {
+        responseStatus = 206;
+        NSInteger totalSize = size;
+        std::tie(start, end, size) = rangePositionsAndSize.value();
+        [responseHeaders
+         setObject:[NSString
+                    stringWithFormat:@"bytes %ld-%ld/%ld",
+                    start,
+                    end,
+                    totalSize]
+         forKey:@"Content-Range"];
+    }
+        
+    
+    if (!errorResponse) {
+        [responseHeaders setObject:[NSString stringWithFormat:@"%ld", size] forKey:@"Content-Length"];
+    }
+    
+    [responseHeaders setObject:@"bytes" forKey:@"Accept-Ranges"];
     
     // Send preliminary file details
     NSHTTPURLResponse * response = [[NSHTTPURLResponse alloc]
                                     initWithURL:urlSchemeTask.request.URL
-                                    statusCode:200
+                                    statusCode:responseStatus
                                     HTTPVersion:nil
                                     headerFields:responseHeaders
     ];
     [urlSchemeTask didReceiveResponse:response];
-
-    // Send actual file data
+    
+    if (errorResponse) {
+        [ongoingTasks removeObject:urlSchemeTask];
+        [urlSchemeTask didFinish];
+        return;
+    }
+    
+    // Send file data, chunked into small amounts (1MiB (1048576 bytes) - the actual number here is pretty arbitrary)
     std::ifstream media(mediaPath, std::ios_base::in | std::ios_base::binary);
     char* chunk = new char[size];
-
+    
+    media.seekg(start);
     media.read(chunk, size);
         
     if (![ongoingTasks containsObject:urlSchemeTask]) {

--- a/ios/Mobile/DocumentViewController.h
+++ b/ios/Mobile/DocumentViewController.h
@@ -18,9 +18,6 @@
 
 @property (strong) CODocument *document;
 @property (strong) WKWebView *webView;
-@property (strong) WKWebView *slideshowWebView;
-@property std::string slideshowFile;
-@property (strong) NSURL *slideshowURL;
 
 - (void)bye;
 

--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -29,6 +29,7 @@
 #import "SigUtil.hpp"
 #import "Util.hpp"
 #import "Clipboard.hpp"
+#import "CoolURLSchemeHandler.h"
 
 #import "DocumentViewController.h"
 
@@ -94,7 +95,10 @@ static IMP standardImpOfInputAccessoryView = nil;
     [userContentController addScriptMessageHandlerWithReply:self contentWorld:[WKContentWorld pageWorld] name:@"clipboard"];
 
     configuration.userContentController = userContentController;
-
+    
+    CoolURLSchemeHandler * schemeHandler = [[CoolURLSchemeHandler alloc] initWithDocument:self.document];
+    [configuration setURLSchemeHandler:schemeHandler forURLScheme:@"cool"];
+    
     self.webView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration];
     self.webView.translatesAutoresizingMaskIntoConstraints = NO;
     self.webView.allowsLinkPreview = NO;

--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -603,68 +603,6 @@ static IMP standardImpOfInputAccessoryView = nil;
 
             [self bye];
             return;
-        } else if ([message.body isEqualToString:@"SLIDESHOW"]) {
-
-            // Create the SVG for the slideshow.
-
-            self.slideshowFile = FileUtil::createRandomTmpDir() + "/slideshow.svg";
-            self.slideshowURL = [NSURL fileURLWithPath:[NSString stringWithUTF8String:self.slideshowFile.c_str()] isDirectory:NO];
-
-            DocumentData::get(self.document->appDocId).loKitDocument->saveAs([[self.slideshowURL absoluteString] UTF8String], "svg", nullptr);
-
-            // Add a new full-screen WebView displaying the slideshow.
-
-            WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
-            WKUserContentController *userContentController = [[WKUserContentController alloc] init];
-
-            [userContentController addScriptMessageHandler:self name:@"lok"];
-
-            configuration.userContentController = userContentController;
-
-            self.slideshowWebView = [[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration];
-
-            [self.slideshowWebView becomeFirstResponder];
-
-            self.slideshowWebView.contentMode = UIViewContentModeScaleAspectFit;
-            self.slideshowWebView.translatesAutoresizingMaskIntoConstraints = NO;
-            self.slideshowWebView.navigationDelegate = self;
-            self.slideshowWebView.UIDelegate = self;
-
-            self.webView.hidden = true;
-
-            [self.view addSubview:self.slideshowWebView];
-            [self.view bringSubviewToFront:self.slideshowWebView];
-            
-            if (@available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
-#if ENABLE_DEBUG == 1
-                self.slideshowWebView.inspectable = YES;
-#else
-                self.slideshowWebView.inspectable = NO;
-#endif
-            }
-
-            WKWebView *slideshowWebViewP = self.slideshowWebView;
-            NSDictionary *views = NSDictionaryOfVariableBindings(slideshowWebViewP);
-            [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-0-[slideshowWebViewP(>=0)]-0-|"
-                                                                              options:0
-                                                                              metrics:nil
-                                                                                views:views]];
-            [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-0-[slideshowWebViewP(>=0)]-0-|"
-                                                                              options:0
-                                                                              metrics:nil
-                                                                                views:views]];
-            [self.slideshowWebView loadRequest:[NSURLRequest requestWithURL:self.slideshowURL]];
-
-            return;
-        } else if ([message.body isEqualToString:@"EXITSLIDESHOW"]) {
-
-            std::remove(self.slideshowFile.c_str());
-
-            [self.slideshowWebView removeFromSuperview];
-            self.slideshowWebView = nil;
-            self.webView.hidden = false;
-
-            return;
         } else if ([message.body isEqualToString:@"PRINT"]) {
 
             // Create the PDF to print.

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -101,6 +101,7 @@
 
 #ifdef IOS
 #include "ios.h"
+#include "DocumentBroker.hpp"
 #endif
 
 using Poco::Exception;
@@ -116,6 +117,11 @@ using namespace COOLProtocol;
 using JsonUtil::makePropertyValue;
 
 extern "C" { void dump_kit_state(void); /* easy for gdb */ }
+
+#ifdef IOS
+extern std::map<std::string, std::shared_ptr<DocumentBroker>> DocBrokers;
+extern std::mutex DocBrokersMutex;
+#endif
 
 #if !MOBILEAPP
 
@@ -1985,6 +1991,12 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
         LOG_DBG("Returned lokit::documentLoad(" << anonymizeUrl(pURL) << ") in " << elapsed);
 #ifdef IOS
         DocumentData::get(_mobileAppDocId).loKitDocument = _loKitDocument.get();
+        {
+            std::unique_lock<std::mutex> docBrokersLock(DocBrokersMutex);
+            auto docBrokerIt = DocBrokers.find(_docKey);
+            assert(docBrokerIt != DocBrokers.end());
+            DocumentData::get(_mobileAppDocId).docBroker = docBrokerIt->second;
+        }
 #endif
         if (!_loKitDocument || !_loKitDocument->get())
         {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -5353,6 +5353,62 @@ void DocumentBroker::removeEmbeddedMedia(const std::string& json)
     }
 }
 
+// This is used on mobile to allow our custom URL handling to get the media path
+// 
+// on iOS this works through CoolURLSchemeHandler.mm, which handles cool:/cool/media?Tag=... requests in much the same way as
+// https://.../cool/media?Tag=... would be handled by COOLWSD on a server. As part of that, we need to get the media path from
+// the tag using this function
+std::string DocumentBroker::getEmbeddedMediaPath(const std::string& id)
+{
+    
+    const auto it = _embeddedMedia.find(id);
+
+    if (it == _embeddedMedia.end())
+    {
+        LOG_ERR("Invalid media request in Doc [" << _docId << "] with tag [" << id << ']');
+        return std::string();
+    }
+
+    LOG_DBG("Media: " << it->second);
+    Poco::JSON::Object::Ptr object;
+
+    if (!JsonUtil::parseJSON(it->second, object))
+    {
+        LOG_ERR("Invalid media object in Doc [" << _docId << "] with tag [" << id << "] (could not parse JSON)");
+        return std::string();
+    }
+
+    if (JsonUtil::getJSONValue<std::string>(object, "id") != id)
+    {
+        LOG_ERR("Invalid media object in Doc [" << _docId << "] with tag [" << id << "] (ID does not match search)");
+        return std::string();
+    }
+
+    const std::string url = JsonUtil::getJSONValue<std::string>(object, "url");
+
+    if (!Util::toLower(url).starts_with("file://"))
+    {
+        LOG_ERR("Invalid media object in Doc [" << _docId << "] with tag [" << id << "] (URL does not start with file://)");
+        return std::string();
+    }
+
+    const std::string localPath = url.substr(sizeof("file:///") - 1);
+
+#if !MOBILEAPP
+    // We always extract media files in /tmp. Normally, we are in jail (chroot),
+    // and this would need to be accessed from WSD through the JailRoot path.
+    // But, when we have NoCapsForKit there is no jail, so the media file ends
+    // up in the host (AppImage) /tmp
+    const std::string path = COOLWSD::NoCapsForKit ? "/" + localPath :
+        FileUtil::buildLocalPathToJail(
+            COOLWSD::EnableMountNamespaces, COOLWSD::ChildRoot + _jailId, localPath);
+#else
+    const std::string path = getJailRoot() + "/" + localPath;
+#endif
+
+    return path;
+}
+
 void DocumentBroker::onUrpMessage(const char* data, size_t len)
 {
     const auto session = getWriteableSession();

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -525,6 +525,8 @@ public:
     /// Remove embedded media objects.
     void removeEmbeddedMedia(const std::string& json);
 
+    std::string getEmbeddedMediaPath(const std::string& id);
+
     void onUrpMessage(const char* data, size_t len);
 
     void setMigrationMsgReceived() { _migrateMsgReceived = true; }

--- a/wsd/ServerURL.hpp
+++ b/wsd/ServerURL.hpp
@@ -93,7 +93,11 @@ public:
 
     std::string getSubURLForEndpoint(const std::string &path) const
     {
+#ifdef IOS
+        return std::string("cool:") + _pathPlus + path;
+#else
         return std::string("http") + (_ssl ? "s" : "") + "://" + _schemeAuthority + _pathPlus + path;
+#endif
     }
 };
 


### PR DESCRIPTION
Previously, as videos are normally loaded via a /media/ endpoint on the
server, mobile apps did not support loading it. That's because mobile
apps lack a server.

To get around either making a server (opening up HTTP just to serve user
media) or embedding the content directly into the page (as data:, losing
control of when the content was loaded and losing the ability to update
to partial loading - essential for long videos), I've opted to use a
custom protocol handler. Effectively, requests to "cool:/cool/media" are
treated as iOS media requests. Sadly this technique won't immediately
work on Android as it doesn't seem to support custom protocol handlers
so I'll possibly have to make up something else over there (it'll
probably be best to use a similar technique though).

I've also implemented support for the Range header, which will allow us
to only load part of the video (à la https://github.com/CollaboraOnline/online/pull/7367)

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>