### PR TITLE
include size in tiles in 'extremely large tile combine' warning

### DIFF
--- a/common/RenderTiles.hpp
+++ b/common/RenderTiles.hpp
@@ -112,7 +112,8 @@ namespace RenderTiles
         const size_t pixmapHeight = tilesByY * pixelHeight;
 
         if (pixmapWidth > 4096 || pixmapHeight > 4096)
-            LOG_WRN("Unusual extremely large tile combine of size " << pixmapWidth << 'x' << pixmapHeight);
+            LOG_WRN("Unusual extremely large tile combine of size " << pixmapWidth << 'x' << pixmapHeight
+                    << " (" << tilesByX << 'x' << tilesByY << " tiles");
 
         RenderTiles::Buffer pixmap(pixmapWidth, pixmapHeight);
 


### PR DESCRIPTION
Change-Id: I8ca3a6cf15a844e6c7fe1613362b8f977781b83c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

