### PR TITLE
chore(iOS): Allow debugging slideshow webview

### DIFF
--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -630,7 +630,14 @@ static IMP standardImpOfInputAccessoryView = nil;
 
             [self.view addSubview:self.slideshowWebView];
             [self.view bringSubviewToFront:self.slideshowWebView];
-
+            
+            if (@available(macOS 13.3, iOS 16.4, tvOS 16.4, *)) {
+#if ENABLE_DEBUG == 1
+                self.slideshowWebView.inspectable = YES;
+#else
+                self.slideshowWebView.inspectable = NO;
+#endif
+            }
 
             WKWebView *slideshowWebViewP = self.slideshowWebView;
             NSDictionary *views = NSDictionaryOfVariableBindings(slideshowWebViewP);


### PR DESCRIPTION
Our main webview is debuggable in debug mode but we run slideshows in a separate webview - one which wasn't marked as debuggable.

That omission prevented it from showing up in Safari's remote debugger


Change-Id: I91ae6318e0a2f735c4cd0b7faf9a9d2b1d00c68a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

