### PR TITLE
ui-treeview: reduce margins to fit headings in treeview sidebar

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -693,19 +693,19 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 }
 
 .ui-treeview div[aria-level='2'] + .ui-treeview-expanded-content {
-	margin-left: 5ch;
+	margin-left: 3.5ch;
 }
 
 .ui-treeview div[aria-level='3'] + .ui-treeview-expanded-content {
-	margin-left: 7.5ch;
+	margin-left: 4.5ch;
 }
 
 .ui-treeview div[aria-level='4'] + .ui-treeview-expanded-content {
-	margin-left: 10ch;
+	margin-left: 5.5ch;
 }
 
 .ui-treeview div[aria-level='5'] + .ui-treeview-expanded-content {
-	margin-left: 12.5ch;
+	margin-left: 6.5ch;
 }
 
 .ui-treeview div.ui-treeview-expander {

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -343,6 +343,11 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 	font-size: 14px;
 	white-space: break-spaces;
 }
+
+#StyleListPanelPanelExpander .ui-treeview-cell-text {
+	white-space: break-spaces;
+}
+
 #NavigatorDeck .ui-treeview-cell {
 	/* Move this whole block away and fix in the main control */
 	display: flex;


### PR DESCRIPTION
Change-Id: I0ce4621c9db23ec429fcd8304f3133850f89495b

* Target version: master 

### Adjusted margins to fit the headings to fit in ui-treeview sidebar when Highlight styles is activated
Style list -> Hierarchical -> Default paragraph->  Body text -> List

### Before
![image](https://github.com/user-attachments/assets/c721f9df-db55-4d74-b606-a952434f28df)

### Now
![Screenshot from 2025-02-24 18-09-54](https://github.com/user-attachments/assets/e33c3354-5781-4498-9dc8-002472195cf1)

### Added text ellipsis on longer text and tooltips for style list
[Screencast from 27-02-25 15:03:18.webm](https://github.com/user-attachments/assets/19d9d889-90c8-47c5-ada5-ce5c7c922162)


-

