### PR TITLE
Use timeout instead of interval for tile prefetching.

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -665,7 +665,7 @@ class TileManager {
 
 	private static clearTilesPreFetcher() {
 		if (this._tilesPreFetcher !== undefined) {
-			clearInterval(this._tilesPreFetcher);
+			clearTimeout(this._tilesPreFetcher);
 			this._tilesPreFetcher = undefined;
 		}
 	}
@@ -1469,7 +1469,7 @@ class TileManager {
 		this._preFetchMode = this._docLayer._selectedMode;
 		this._preFetchIdle = setTimeout(
 			L.bind(function () {
-				this._tilesPreFetcher = setInterval(
+				this._tilesPreFetcher = setTimeout(
 					L.bind(this.preFetchTiles, this),
 					interval,
 				);

--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -1074,16 +1074,17 @@ function typeIntoInputField(selector, text, clearBefore = true)
 {
 	cy.log('>> typeIntoInputField - start');
 
-	cy.cGet(selector).as('input');
-	cy.get('@input').focus();
-	cy.get('@input').should('have.focus');
 	if (clearBefore) {
-		cy.get('@input').invoke('val', '');
-		cy.get('@input').should('have.value', '');
+		cy.wait(300);
+		cy.cGet(selector).type('{selectall}{backspace}{selectall}{backspace}');
+		cy.wait(300);
 	}
 
-	cy.get('@input').type(text + '{enter}');
-	cy.get('@input').should('have.value', text);
+	cy.cGet(selector).type(text, {force: true});
+	cy.wait(300);
+	cy.cGet(selector).type('{enter}', {force: true});
+	cy.wait(300);
+	cy.cGet(selector).should('have.value', text);
 
 	cy.log('<< typeIntoInputField - end');
 }


### PR DESCRIPTION
Issue: interval calls itself multiple times.


Change-Id: I5ef46145debb02c2dd0d716b0adb0dc715449885


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

