### PR TITLE
discovery: add Settings app to support settings iframe URL

### DIFF
--- a/common/Common.hpp
+++ b/common/Common.hpp
@@ -63,6 +63,7 @@ constexpr const char NEW_CHILD_URI[] = "/coolws/newchild";
 constexpr const char FORKIT_URI[] = "/coolws/forkit";
 
 constexpr const char CAPABILITIES_END_POINT[] = "/hosting/capabilities";
+constexpr const char SETTING_IFRAME_END_POINT[] = "admin/adminIntegratorSettings.html";
 
 /// The file suffix used to mark the file slated for uploading.
 constexpr const char TO_UPLOAD_SUFFIX[] = ".upload";

--- a/discovery.xml
+++ b/discovery.xml
@@ -461,6 +461,9 @@
 
         <!-- End of legacy MIME-type actions -->
 
+        <app name="Settings">
+            <action name="iframe" ext=""/>
+        </app>
         <app name="Capabilities">
             <action name="getinfo" ext=""/>
         </app>

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -2310,6 +2310,11 @@ std::string ClientRequestDispatcher::getDiscoveryXML()
             elem->setAttribute(urlsrc, uriValue);
         }
 
+        if (parent && parent->getAttribute("name") == "Settings")
+        {
+            elem->setAttribute(urlsrc, uriBaseValue + SETTING_IFRAME_END_POINT);
+        }
+
         // Set the View extensions cache as well.
         if (elem->getAttribute("name") == "edit")
         {


### PR DESCRIPTION
Change-Id: Ib4f903c6d7fef466bd967ccbba11abc97d6582b9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

[discovery: add Settings app to support settings iframe URL](https://github.com/CollaboraOnline/online/commit/4f2cf87c77f77199f2e50b770ccbf5727d0b730f)

![Screenshot from 2025-02-25 14-28-53](https://github.com/user-attachments/assets/9f36da87-33de-4155-a81e-f53d3bff397f)

