### PR TITLE
Attempt to fix "dblClickOnFirstCell" instability of Cypress tests.

### DIFF
--- a/cypress_test/integration_tests/common/calc_helper.js
+++ b/cypress_test/integration_tests/common/calc_helper.js
@@ -69,7 +69,18 @@ function dblClickOnFirstCell() {
 	cy.log('>> dblClickOnFirstCell - start');
 
 	helper.typeIntoInputField(helper.addressInputSelector, 'A1');
-	clickOnFirstCell(false, true);
+
+	cy.wait(300);
+
+	cy.cGet('#test-div-OwnCellCursor')
+	.then(function(items) {
+		expect(items).to.have.lengthOf(1);
+		const item = items[0];
+		const boundingRectangle = item.getBoundingClientRect();
+		const xPos = (boundingRectangle.left + boundingRectangle.right) / 2;
+		const yPos = (boundingRectangle.top + boundingRectangle.bottom) / 2;
+		cy.cGet('body').dblclick(xPos, yPos);
+	});
 
 	cy.log('<< dblClickOnFirstCell - end');
 }


### PR DESCRIPTION
Change-Id: I384e7faa43a8d2778a57e0fbe0c3da03a0b3c115


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

