### PR TITLE
browser: remove unused nodejs canvas pkg

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -15,7 +15,6 @@
     "autolinker": "3.14.1",
     "browserify": "16.5.1",
     "browserify-css": "0.15.0",
-    "canvas": "^2.6.1",
     "d3": "6.7.0",
     "dompurify": "3.2.4",
     "eslint": "7.0.0",


### PR DESCRIPTION
Change-Id: I548db86fd4e426312f3d0404f8557c9275633895


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Remove unused nodejs canvas pkg

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

