### PR TITLE
Added document's last modified information in impress

### DIFF
--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -28,7 +28,8 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 							'type': 'toolitem',
 							'text': _('Save'),
 							'command': '.uno:Save',
-							'accessKey': '1'
+							'accessKey': '1',
+							'isCustomTooltip': true
 						}
 					]
 				} : {}

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -29,7 +29,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 							'type': 'toolitem',
 							'text': _('Save'),
 							'command': '.uno:Save',
-							'accessKey': '1'
+							'accessKey': '1',
+							'isCustomTooltip': true
 						}
 					]
 				} : {}


### PR DESCRIPTION
- we have custom tooltip that gave information about document's last saved state
- this is missing from impress and draw.
- this patch will enable the custom tooltip for impress and draw

Before:
![image](https://github.com/user-attachments/assets/d8590dad-1ebe-420f-be01-be56512fcb1e)

After:
![image](https://github.com/user-attachments/assets/2a6906fd-1f61-494e-83c0-842458dc4fab)

Change-Id: Ifc00921f127e517dbe9a497243e8f40b2e37ace9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

