### PR TITLE
net/HttpRequest: Reuse getSslVerifyResult in getSslVerifyMessage

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1352,10 +1352,7 @@ public:
     std::string getSslVerifyMessage()
     {
 #if ENABLE_SSL
-        std::shared_ptr<StreamSocket> socket = _socket.lock();
-        if (socket)
-            return SslStreamSocket::getSslVerifyString(socket->getSslVerifyResult());
-        return SslStreamSocket::getSslVerifyString(_handshakeSslVerifyFailure);
+        return SslStreamSocket::getSslVerifyString(getSslVerifyResult());
 #else
         return std::string();
 #endif


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Just factorize some code to avoid copy-paste.

getSslVeryResult was just introduced in https://github.com/CollaboraOnline/online/pull/11190/files#diff-f68b0eeef9794ad95ccedf3fc99472df8c8c97637411eb111b358c404b31bf1dR1364

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

