### PR TITLE
lokit: fix fail to mount shared preset template directory

### DIFF
--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -218,6 +218,7 @@ void RequestVettingStation::launchInstallPresets()
     std::string configIdPresets = Poco::Path(presetsPath, Uri::encode(configId)).toString();
     Poco::File(Poco::Path(configIdPresets, "autotext")).createDirectories();
     Poco::File(Poco::Path(configIdPresets, "wordbook")).createDirectories();
+    Poco::File(Poco::Path(configIdPresets, "template")).createDirectories();
     // ensure the server config is downloaded and populate a subforkit when config is available
     _asyncInstallTask = DocumentBroker::asyncInstallPresets(*_poll, configId, sharedSettings.getUri(), configIdPresets,
                                                             nullptr, finishedCallback);


### PR DESCRIPTION
- happens when templates are not passed as a part of sharedconfig.json

Change-Id: I5ca53e35a6db3cef84d18ad8004ceeed4cc839ac

* Resolves: # <!-- related github issue -->
* Target version: master 
