### PR TITLE
fix(wsd): Lower unknown resource log messages to warning

### DIFF
--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -936,7 +936,7 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
         }
         else
         {
-            LOG_ERR("Unknown resource: " << requestDetails.toString());
+            LOG_WRN("Unknown resource: " << requestDetails.toString());
 
             // Bad request.
             HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);


### PR DESCRIPTION
Signed-off-by: Julius Knorr <jus@bitgrid.net>
Change-Id: I81834521c6d73045fdf1470a1ea3f49907dff3f9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

As discussed via chat, this should reduce the log noise a bit as a 404 response for an unknown URL is probably not worth an error message. Lets just warn about it.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

