### PR TITLE
protect asyncInstall lifecycle

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1501,8 +1501,12 @@ DocumentBroker::updateSessionWithWopiInfo(const std::shared_ptr<ClientSession>& 
 void PresetsInstallTask::asyncInstall(const std::string& uri, const std::string& stamp, const std::string& fileName,
                                       const std::shared_ptr<ClientSession>& session)
 {
-    auto presetInstallFinished = [this](const std::string& id, bool presetResult)
+    auto presetInstallFinished = [selfWeak = weak_from_this(), this](const std::string& id, bool presetResult)
     {
+        std::shared_ptr<PresetsInstallTask> selfLifecycle = selfWeak.lock();
+        if (!selfLifecycle)
+            return;
+
         installPresetFinished(id, presetResult);
     };
 


### PR DESCRIPTION
RequestVettingStation can complete and take down its PresetsInstallTask if the required subforkit is already available


Change-Id: I7b2ec831158022e904bb28223053150543a2a241


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

