### PR TITLE
Compact mode: Fix toolbar-row height

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -176,7 +176,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	z-index: 11;
 }
 
-#toolbar-row {
+.hasnotebookbar > #toolbar-row {
 	height: 74px;
 }
 

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -245,10 +245,6 @@
 	top: 3px;
 }
 
-.main-nav:not(.hasnotebookbar) ~ #toolbar-wrapper .toolbar-row {
-	height: 42px;
-}
-
 /* center the toolbar */
 #tb_presentation-toolbar_item_left {
 	width: 50%;

--- a/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/autofilter_spec.js
@@ -20,11 +20,11 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'AutoFilter Complex', funct
 		helper.typeIntoInputField(helper.addressInputSelector, 'A1');
 		cy.wait(1000);
 
-		helper.typeIntoInputField(helper.addressInputSelector, 'U125');
+		helper.typeIntoInputField(helper.addressInputSelector, 'U126');
 		cy.cGet('#map').focus();
 		cy.wait(1000);
 
-		desktopHelper.assertScrollbarPosition('vertical', 240, 260);
+		desktopHelper.assertScrollbarPosition('vertical', 250, 270);
 		desktopHelper.assertScrollbarPosition('horizontal', 210, 230);
 	});
 

--- a/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
@@ -29,7 +29,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		helper.typeIntoDocument('{ctrl}{home}');
 		//scroll to bottom
 		desktopHelper.assertVisiblePage(1, 1, 4);
-		desktopHelper.pressKey(2, 'pagedown');
+		desktopHelper.pressKey(1, 'pagedown');
 		desktopHelper.assertVisiblePage(2, 2, 4);
 		desktopHelper.pressKey(1, 'pagedown');
 		desktopHelper.assertVisiblePage(3, 3, 4);


### PR DESCRIPTION
In compact mode, the toolbar-row (the second bar up top) was being set
with a hard coded pixel (42px) which was resulting in extra space and
the misaligned icon row.

The initial diff comes from:
  e88d9340a0067c9fb267fe3a3653e42c0298ee71
  Fix toolbar up section after w2ui rework

Maybe there is something I missed, but I think we can now safely
remove that compact mode related CSS declaration while making sure
the one that is intended to affect notebookbar only does that.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ic50c8a89578bb1dc7c2acf5f631fdea81a1d235d
