### PR TITLE
WIP - cool#11255 - don't free tile canvases, but queue them for re-use.

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -130,6 +130,7 @@ class Tile {
 	coords: TileCoordData;
 	current: boolean = true; // is this currently visible
 	canvas: any = null; // canvas ready to render
+	ctx: CanvasRenderingContext2D | null = null; // canvas context to render onto
 	imgDataCache: any = null; // flat byte array of canvas data
 	rawDeltas: any = null; // deltas ready to decompress
 	deltaCount: number = 0; // how many deltas on top of the keyframe
@@ -170,6 +171,79 @@ class Tile {
 	}
 }
 
+class CanvasItem {
+	canvas: HTMLCanvasElement | null = null;
+	ctx: CanvasRenderingContext2D | null = null;
+}
+
+// Allocating and freeing canvas' is surprisingly expensive and
+// can block rendering for long periods, so re-use canvas' instead.
+class CanvasCache {
+	private _tileSize: number;
+
+
+	private _canvasList : CanvasItem[] = [];
+
+	constructor(tileSize: number)
+	{
+		this._tileSize = tileSize;
+	}
+
+	acquireCanvas(tile: Tile) : CanvasRenderingContext2D | null
+	{
+		let item: CanvasItem;
+
+		if (this._canvasList.length === 0)
+		{
+			item = new CanvasItem();
+
+			// This allocation is usually cheap and reliable,
+			// getting the canvas context, not so much.
+			item.canvas = document.createElement('canvas');
+			item.canvas.width = this._tileSize;
+			item.canvas.height = this._tileSize;
+
+			// So we need to grab the context too ...
+			item.ctx = item.canvas.getContext('2d');
+			// handle null item.ctx higher up
+		}
+		else
+			item = this._canvasList.pop();
+
+		tile.canvas = item.canvas;
+		tile.ctx = item.ctx;
+
+		return item.ctx;
+	}
+
+	releaseCanvas(tile: Tile)
+	{
+		var item: CanvasItem = new CanvasItem();
+		item.canvas = tile.canvas;
+		item.ctx = tile.ctx;
+		tile.canvas = null;
+		tile.ctx = null;
+		this._canvasList.push(item);
+
+		tile.imgDataCache = null;
+	}
+
+	// Fix for cool#5876 allow immediate reuse of canvas context memory
+	// WKWebView has a hard limit on the number of bytes of canvas
+	// context memory that can be allocated. Reducing the canvas
+	// size to zero is a way to reduce the number of bytes counted
+	// against this limit.
+	private hardFreeCanvas(tile: Tile)
+	{
+		if (tile && tile.canvas) {
+			tile.canvas.width = 0;
+			tile.canvas.height = 0;
+			delete tile.canvas;
+		}
+		tile.imgDataCache = null;
+	}
+}
+
 class TileManager {
 	private static _docLayer: any;
 	private static _zoom: number;
@@ -197,10 +271,11 @@ class TileManager {
 	private static debugDeltas: boolean = false;
 	private static debugDeltasDetail: boolean = false;
 	private static tiles: any = {}; // stores all tiles, keyed by coordinates, and cached, compressed deltas
+	private static canvasCache: CanvasCache = new CanvasCache(256);
+	public  static tileSize: number = 256;
 
 	//private static _debugTime: any = {}; Reserved for future.
 
-	public static tileSize: number = 256;
 
 	public static initialize() {
 		if (window.Worker && !(window as any).ThisIsAMobileApp) {
@@ -217,7 +292,6 @@ class TileManager {
 		if (!(++this.gcCounter % 53)) this.garbageCollect();
 	}
 
-	// FIXME: could trim quite hard here, and do this at idle ...
 	// Set a high and low watermark of how many canvases we want
 	// and expire old ones
 	private static garbageCollect() {
@@ -310,20 +384,18 @@ class TileManager {
 
 	// work hard to ensure we get a canvas context to render with
 	private static ensureContext(tile: Tile) {
-		var ctx;
-
 		this.maybeGarbageCollect();
 
 		// important this is after the garbagecollect
 		if (!tile.canvas) this.ensureCanvas(tile, null, false);
 
-		if ((ctx = tile.canvas.getContext('2d'))) return ctx;
+		if (tile.ctx) return tile.ctx;
 
 		// Not a good result - we ran out of canvas memory
 		this.garbageCollect();
 
 		if (!tile.canvas) this.ensureCanvas(tile, null, false);
-		if ((ctx = tile.canvas.getContext('2d'))) return ctx;
+		if (tile.ctx) return tile.ctx;
 
 		// Free non-current canvas' and start again.
 		if (this.debugDeltas)
@@ -333,20 +405,20 @@ class TileManager {
 			if (t && !t.current) this.reclaimTileCanvasMemory(t);
 		}
 		if (!tile.canvas) this.ensureCanvas(tile, null, false);
-		if ((ctx = tile.canvas.getContext('2d'))) return ctx;
+		if (tile.ctx) return tile.ctx;
 
 		if (this.debugDeltas)
 			window.app.console.log(
-				'Throw everything overbarod to free all tiles canvas memory',
+				'Throw everything overboard to free all tiles canvas memory',
 			);
 		for (var key in this.tiles) {
 			var t = this.tiles[key];
 			this.reclaimTileCanvasMemory(t);
 		}
 		if (!tile.canvas) this.ensureCanvas(tile, null, false);
-		ctx = tile.canvas.getContext('2d');
-		if (!ctx) window.app.console.log('Error: out of canvas memory.');
-		return ctx;
+		if (!tile.ctx) window.app.console.log('Error: out of canvas memory.');
+
+		return tile.ctx;
 	}
 
 	private static decompressPendingDeltas(message: string) {
@@ -1055,18 +1127,8 @@ class TileManager {
 		}
 	}
 
-	// Fix for cool#5876 allow immediate reuse of canvas context memory
-	// WKWebView has a hard limit on the number of bytes of canvas
-	// context memory that can be allocated. Reducing the canvas
-	// size to zero is a way to reduce the number of bytes counted
-	// against this limit.
 	private static reclaimTileCanvasMemory(tile: Tile) {
-		if (tile && tile.canvas) {
-			tile.canvas.width = 0;
-			tile.canvas.height = 0;
-			delete tile.canvas;
-		}
-		tile.imgDataCache = null;
+		this.canvasCache.releaseCanvas(tile);
 	}
 
 	private static initPreFetchPartTiles() {
@@ -2215,14 +2277,7 @@ class TileManager {
 	public static ensureCanvas(tile: Tile, now: any, forPrefetch: any) {
 		if (!tile) return;
 		if (!tile.canvas) {
-			// This allocation is usually cheap and reliable,
-			// getting the canvas context, not so much.
-			var canvas = document.createElement('canvas');
-			canvas.width = this.tileSize;
-			canvas.height = this.tileSize;
-
-			tile.canvas = canvas;
-
+			this.canvasCache.acquireCanvas(tile);
 			this.rehydrateTile(tile);
 		}
 		if (!forPrefetch) {


### PR DESCRIPTION
A rather unfinished first-cut at this, we need to free up our tiles as/when we go idle to save GPU/CPU memory, and altogether optimise this further.


Change-Id: I12f55207feed684b7fee0188fb7ce914a9f5929f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

