### PR TITLE
Use correct command for style sidebar

### DIFF
--- a/browser/css/spreadsheet.css
+++ b/browser/css/spreadsheet.css
@@ -208,14 +208,6 @@
 	z-index: -1;
 }
 
-/* Sidebar: Style: Hide dialog button
-   - There is no paragraph style dialog in calc
-   - The style sidebar pane visible on core side is not implemented in online
-*/
-[data-docType='spreadsheet'] .unoEditStyle.sidebar {
-	display: none;
-}
-
 /* formulabar */
 #formulabar-row {
 	display: grid;

--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -127,8 +127,7 @@ L.Control.Menubar = L.Control.extend({
 					{name: _UNO('.uno:RejectAllTrackedChanges', 'text'), id: 'rejectalltrackedchanges', type: 'action'},
 					{uno: '.uno:PreviousTrackedChange'},
 					{uno: '.uno:NextTrackedChange'}
-				]},
-				{uno: '.uno:EditStyle'}
+				]}
 			]},
 			{name: _UNO('.uno:ViewMenu', 'text'), id: 'view', type: 'menu',
 			 menu: (window.mode.isTablet() ? [
@@ -148,6 +147,7 @@ L.Control.Menubar = L.Control.extend({
 					{name: _('Dark Mode'), id: 'toggledarktheme', type: 'action'},
 					{name: _('Invert Background'), id: 'invertbackground', type: 'action'},
 					{uno: '.uno:SidebarDeck.PropertyDeck', name: _UNO('.uno:Sidebar')},
+					{uno: '.uno:SidebarDeck.StyleListDeck', name: _('Style list')},
 					{uno: '.uno:Navigator', id: 'navigator'},
 					{type: 'separator'},
 					{name: _UNO('.uno:ShowAnnotations', 'text'), id: 'showannotations', type: 'action'},
@@ -767,6 +767,7 @@ L.Control.Menubar = L.Control.extend({
 				   {name: _('Invert Background'), id: 'invertbackground', type: 'action'},
 				   {uno: '.uno:SidebarDeck.PropertyDeck', name: _UNO('.uno:Sidebar')},
 				   {uno: '.uno:Navigator', id: 'navigator'},
+				   {uno: '.uno:SidebarDeck.StyleListDeck', name: _('Style list')},
 				   {type: 'separator'},
 				   {name: _UNO('.uno:ToggleSheetGrid', 'spreadsheet', true), uno: '.uno:ToggleSheetGrid', id: 'sheetgrid'},
 				   {name: _('Focus Cell'), type:'action', id: 'columnrowhighlight'},
@@ -899,6 +900,7 @@ L.Control.Menubar = L.Control.extend({
 					{uno: '.uno:SetOptimalColumnWidth'}]},
 				{uno: '.uno:FontDialog'},
 				{uno: '.uno:ParagraphDialog'},
+				{uno: '.uno:SidebarDeck.StyleListDeck'},
 				{uno: '.uno:PageFormatDialog'},
 				{type: 'separator'},
 				{uno: '.uno:TransformDialog'},

--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -145,7 +145,6 @@ var unoCommandsArray = {
 	'EditRegion':{text:{menu:_('~Sections...'),},},
 	'EditSparkline':{spreadsheet:{menu:_('Edit Sparkline...'),},},
 	'EditSparklineGroup':{spreadsheet:{menu:_('Edit Sparkline Group...'),},},
-	'EditStyle':{global:{menu:_('~Edit Style...'),},presentation:{menu:_('E~dit Style...'),},},
 	'EnterGroup':{global:{menu:_('~Enter Group'),},},
 	'EntireCell':{text:{context:_('Select Cell'),menu:_('C~ell'),},},
 	'EntireColumn':{presentation:{menu:_('Select Column'),},text:{menu:_('~Column'),},},


### PR DESCRIPTION
Remove old CSS rule to hide style sidebar shortcut. We have it now in calc. Unify menubar command with other places. EditStyle doesn't work second time when used.

Menubar changes:
    - put "Open the Styles Deck" in Calc -> Format (like in Writer)
    - add "Styles Deck" in Calc -> View
    - moved Edit -> View in Writer for "Styles Deck" (similar to Navigator and general properties Sidebar decks)