### PR TITLE
avoid excessively wide tile combines

### DIFF
--- a/test/KitQueueTests.cpp
+++ b/test/KitQueueTests.cpp
@@ -27,11 +27,13 @@ class KitQueueTests : public CPPUNIT_NS::TestFixture
 {
     CPPUNIT_TEST_SUITE(KitQueueTests);
 
+#if 0
     CPPUNIT_TEST(testKitQueuePriority);
-    CPPUNIT_TEST(testTileCombinedRendering);
-    CPPUNIT_TEST(testTileRecombining);
     CPPUNIT_TEST(testViewOrder);
     CPPUNIT_TEST(testPreviewsDeprioritization);
+#endif
+    CPPUNIT_TEST(testTileCombinedRendering);
+    CPPUNIT_TEST(testTileRecombining);
     CPPUNIT_TEST(testSenderQueue);
     CPPUNIT_TEST(testSenderQueueProgress);
     CPPUNIT_TEST(testSenderQueueTileDeduplication);
@@ -43,11 +45,13 @@ class KitQueueTests : public CPPUNIT_NS::TestFixture
 
     CPPUNIT_TEST_SUITE_END();
 
+#if 0
     void testKitQueuePriority();
-    void testTileCombinedRendering();
-    void testTileRecombining();
     void testViewOrder();
     void testPreviewsDeprioritization();
+#endif
+    void testTileCombinedRendering();
+    void testTileRecombining();
     void testSenderQueue();
     void testSenderQueueProgress();
     void testSenderQueueTileDeduplication();
@@ -60,7 +64,9 @@ class KitQueueTests : public CPPUNIT_NS::TestFixture
     // Compat helper for tests
     std::string popHelper(KitQueue &queue)
     {
-        TileCombined c = queue.popTileQueue();
+        TilePrioritizer::Priority dummy;
+
+        TileCombined c = queue.popTileQueue(dummy);
 
         std::string result;
         if (c.getTiles().size() != 1)
@@ -72,6 +78,7 @@ class KitQueueTests : public CPPUNIT_NS::TestFixture
     }
 };
 
+#if 0
 void KitQueueTests::testKitQueuePriority()
 {
     constexpr auto testname = __func__;
@@ -83,7 +90,8 @@ void KitQueueTests::testKitQueuePriority()
     const std::string resLow = "tile nviewid=0 part=0 width=256 height=256 tileposx=0 tileposy=253440 tilewidth=3840 tileheight=3840 ver=-1";
     const KitQueue::Payload payloadLow(resLow.data(), resLow.data() + resLow.size());
 
-    KitQueue queue;
+    TilePrioritizer dummy;
+    KitQueue queue(dummy);
 
     // Request the tiles.
     queue.put(reqLow);
@@ -119,6 +127,7 @@ void KitQueueTests::testKitQueuePriority()
     LOK_ASSERT_EQUAL_STR(payloadLow, popHelper(queue));
     LOK_ASSERT_EQUAL_STR(payloadHigh, popHelper(queue));
 }
+#endif
 
 void KitQueueTests::testTileCombinedRendering()
 {
@@ -135,7 +144,8 @@ void KitQueueTests::testTileCombinedRendering()
     const std::string resFull = "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,0 tileposy=0,0,3840 tilewidth=3840 tileheight=3840 ver=-1,-1,-1";
     const KitQueue::Payload payloadFull(resFull.data(), resFull.data() + resFull.size());
 
-    KitQueue queue;
+    TilePrioritizer dummy;
+    KitQueue queue(dummy);
 
     // Horizontal.
     queue.put(req1);
@@ -169,7 +179,7 @@ void KitQueueTests::testTileRecombining()
 
     // but when we later extract that, it is just one "tilecombine" message
     LOK_ASSERT_EQUAL_STR(
-        "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=7680,0,3840 tileposy=0,0,0 "
+        "tilecombine nviewid=0 part=0 width=256 height=256 tileposx=0,3840,7680 tileposy=0,0,0 "
         "tilewidth=3840 tileheight=3840 ver=-1,-1,-1",
         popHelper(queue));
 
@@ -177,6 +187,7 @@ void KitQueueTests::testTileRecombining()
     LOK_ASSERT_EQUAL(0, static_cast<int>(queue.getTileQueueSize()));
 }
 
+#if 0
 void KitQueueTests::testViewOrder()
 {
     constexpr auto testname = __func__;
@@ -225,7 +236,8 @@ void KitQueueTests::testPreviewsDeprioritization()
 {
     constexpr auto testname = __func__;
 
-    KitQueue queue;
+    TilePrioritizer dummy;
+    KitQueue queue(dummy);
 
     // simple case - put previews to the queue and get everything back again
     const std::vector<std::string> previews =
@@ -287,6 +299,7 @@ void KitQueueTests::testPreviewsDeprioritization()
     // stays empty after all is done
     LOK_ASSERT_EQUAL(0, static_cast<int>(queue.getTileQueueSize()));
 }
+#endif
 
 namespace {
     std::string msgStr(const std::shared_ptr<Message> &item)
@@ -510,7 +523,8 @@ void KitQueueTests::testCallbackInvalidation()
 {
     constexpr auto testname = __func__;
 
-    KitQueue queue;
+    TilePrioritizer dummy;
+    KitQueue queue(dummy);
     KitQueue::Callback item;
 
     // join tiles
@@ -544,7 +558,8 @@ void KitQueueTests::testCallbackIndicatorValue()
 {
     constexpr auto testname = __func__;
 
-    KitQueue queue;
+    TilePrioritizer dummy;
+    KitQueue queue(dummy);
     KitQueue::Callback item;
 
     // join tiles
@@ -562,7 +577,8 @@ void KitQueueTests::testCallbackPageSize()
 {
     constexpr auto testname = __func__;
 
-    KitQueue queue;
+    TilePrioritizer dummy;
+    KitQueue queue(dummy);
     KitQueue::Callback item;
 
     // join tiles
@@ -580,7 +596,8 @@ void KitQueueTests::testCallbackModifiedStatusIsSkipped()
 {
     constexpr auto testname = __func__;
 
-    KitQueue queue;
+    TilePrioritizer dummy;
+    KitQueue queue(dummy);
     KitQueue::Callback item;
 
     std::stringstream ss;

--- a/test/KitQueueTests.cpp
+++ b/test/KitQueueTests.cpp
@@ -219,10 +219,19 @@ void KitQueueTests::testTileRecombining()
                   "tileposx=0,23040,49920,51840 tileposy=268800,268800,270720,270720 "
                   "tilewidth=1920 tileheight=1920 ver=-1,-1,-1,-1");
 
+        // rearrange this to avoid excessively large tile combines
+        // 0:140, 12:140
         LOK_ASSERT_EQUAL_STR(
             "tilecombine nviewid=1000 part=0 width=256 height=256 "
-            "tileposx=23040,0,49920,51840 tileposy=268800,268800,270720,270720 "
-            "tilewidth=1920 tileheight=1920 ver=-1,-1,-1,-1",
+            "tileposx=0,23040 tileposy=268800,268800 tilewidth=1920 "
+            "tileheight=1920 ver=-1,-1",
+            popHelper(queue));
+
+        // 26:141, 27:141
+        LOK_ASSERT_EQUAL_STR(
+            "tilecombine nviewid=1000 part=0 width=256 height=256 "
+            "tileposx=49920,51840 tileposy=270720,270720 "
+            "tilewidth=1920 tileheight=1920 ver=-1,-1",
             popHelper(queue));
 
         // and nothing remains in the queue

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -138,6 +138,7 @@ wsd_sources = \
 	../wsd/TileCache.cpp
 
 test_base_sources = \
+	KitQueueTests.cpp \
 	RequestDetailsTests.cpp \
 	StringVectorTests.cpp \
 	FileServeWhiteBoxTests.cpp \
@@ -149,8 +150,6 @@ test_base_sources = \
 	WopiProofTests.cpp \
 	UriTests.cpp \
 	$(wsd_sources)
-
-# test_base_sources += KitQueueTests.cpp
 
 common_sources = \
 	../common/Authorization.cpp \

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -181,6 +181,16 @@ public:
         return a ^ b;
     }
 
+    TileDesc makeTileForGridPos(int gridX, int gridY) const
+    {
+        TileDesc tile(*this);
+
+        tile._tilePosX = gridX * tile._tileWidth;
+        tile._tilePosY = gridY * tile._tileHeight;
+
+        return tile;
+    }
+
     /// Returns the tile's AABBox, i.e. tile-position + tile-extend
     Util::Rectangle toAABBox() const
     {
@@ -259,30 +269,6 @@ public:
             return false;
         }
         return true;
-    }
-
-    bool onSameRow(const TileDesc& other) const
-    {
-        if (!sameTileCombineParams(other))
-            return false;
-
-        return other.getTilePosY() + other.getTileHeight() >= getTilePosY() &&
-               other.getTilePosY() <= getTilePosY() + getTileHeight();
-    }
-
-    bool canCombine(const TileDesc& other) const
-    {
-        if (isPreview() || other.isPreview())
-            return false;
-
-        if (!onSameRow(other))
-            return false;
-
-        const int gridX = getTilePosX() / getTileWidth();
-        const int gridXOther = other.getTilePosX() / other.getTileWidth();
-        const int delta = gridX - gridXOther;
-        // a 4k screen - is sixteen 256 pixel wide tiles wide.
-        return (delta >= -16 && delta <= 16);
     }
 
     /// Serialize this instance into a string.

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -150,9 +150,7 @@ public:
         return !(*this == other);
     }
 
-    // Sort tiles, so they are arranged as ttb rows with ltr cells within rows,
-    // with previews at the end.
-    bool operator<(const TileDesc& other) const
+    bool compareAsAtTilePos(const TileDesc& other, int tilePosX, int tilePosY) const
     {
         return std::tie(_canonicalViewId, _id,
                         _mode, _part,
@@ -163,7 +161,14 @@ public:
                         other._mode, other._part,
                         other._height, other._width,
                         other._tileHeight, other._tileWidth,
-                        other._tilePosY, other._tilePosX);
+                        tilePosY, tilePosX);
+    }
+
+    // Sort tiles, so they are arranged as ttb rows with ltr cells within rows,
+    // with previews at the end.
+    bool operator<(const TileDesc& other) const
+    {
+        return compareAsAtTilePos(other, other._tilePosX, other._tilePosY);
     }
 
     // used to cache a hash of the key elements compared in ==
@@ -179,16 +184,6 @@ public:
         a ^= _width << 19;
 
         return a ^ b;
-    }
-
-    TileDesc makeTileForGridPos(int gridX, int gridY) const
-    {
-        TileDesc tile(*this);
-
-        tile._tilePosX = gridX * tile._tileWidth;
-        tile._tilePosY = gridY * tile._tileHeight;
-
-        return tile;
     }
 
     /// Returns the tile's AABBox, i.e. tile-position + tile-extend


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Try and create more sensible tile combines. Combine as many horizontal tiles as sensible with priority tile, working from both sides of it, favoring nearer tiles until reasonable span width is exhausted. Combine adjacent rows with this span. Distribute any "unused" available span width on comparing adjacent rows to pick up relatively cheap additions to the combine.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

