### PR TITLE
Unload While Loading

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3878,7 +3878,8 @@ void DocumentBroker::disconnectSessionInternal(const std::shared_ptr<ClientSessi
             LOG_DBG("Disconnecting session [" << id << "] from Kit");
             hardDisconnect = session->disconnectFromKit();
 
-            if (!Util::isMobileApp() && !isLoaded() && _sessions.empty())
+            if (!Util::isMobileApp() && !isLoaded() &&
+                _sessions.size() <= 1) // We remove the session below, so we still have it here.
             {
                 // We aren't even loaded and no other views--kill.
                 // If we send disconnect, we risk hanging because we flag Core for
@@ -3891,6 +3892,8 @@ void DocumentBroker::disconnectSessionInternal(const std::shared_ptr<ClientSessi
                                     << "] isn't loaded yet. Terminating the child roughly");
                 if (_childProcess)
                     _childProcess->terminate();
+
+                stop("Disconnected before loading");
             }
         }
 


### PR DESCRIPTION
**wsd: handle disconnection while loading**
When the client disconnects while we are
loading the document, we risk getting
in an invalid state.

When we get disconnected while loading,
we have logic to terminate the kit.
Unfortunately, we don't account for
the fact that the session isn't yet
removed from the container, and fail
to detect this case. Furtheremore,
we should stop the DocBroker poll,
which we didn't previously.

Also, we fix an invalid state transition:

**wsd: avoid transitioning to LIVE from WAIT_DISCONNECT**
wsd: avoid transitioning to LIVE from WAIT_DISCONNECT
In the event that we gave up on loading,
we should never change the state back to LIVE
once we are in WAIT_DISCONNECT.

This was caught with: WRN  ToClient-002: Unusual race - attempts to
transition from SessionState::WAIT_DISCONNECT to SessionState::LIVE|
wsd/ClientSession.cpp:151
