### PR TITLE
cypress: reduce the max num of open file descriptors to catch problems

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -572,11 +572,15 @@ else
   OUTPUT_TO_FILE=false
 endif
 
+QUIET_SAMPLES = $(QUIET_SAMPLES_$(V))
+QUIET_SAMPLES_ = $(QUIET_SAMPLES_$(AM_DEFAULT_VERBOSITY))
+QUIET_SAMPLES_0 = @echo "  SAMPLES " $@;
+
 setup-wsd: all @JAILS_PATH@ @CACHE_PATH@ presets-dir
 	@echo "Launching coolwsd"
 	@fc-cache "@LO_PATH@"/share/fonts/truetype
 	@mkdir -p $(abs_top_builddir)/test/samples
-	@$(abs_top_srcdir)/scripts/build-samples.py $(abs_top_srcdir)/test/samples $(abs_top_srcdir)/test/samples
+	$(QUIET_SAMPLES) $(abs_top_srcdir)/scripts/build-samples.py $(abs_top_srcdir)/test/samples $(abs_top_srcdir)/test/samples
 	@echo
 
 COMMON_PARAMS = \

--- a/cypress_test/Makefile.am
+++ b/cypress_test/Makefile.am
@@ -181,6 +181,8 @@ define start_coolwsd
 	$(if $(coolwsd),true,$(call start_coolwsd_instance))
 endef
 
+# Use 'ulimit' to intentionally reduce the maximum number of open file descriptors: if 1024 is not
+# enough, then probably we leak them.
 define start_coolwsd_instance
 	$(eval FREE_PORT:=$(shell $(GET_PORT_BINARY) --host=127.0.0.1 $(ALLOWED_PORTS)))
 	export $FREE_PORT
@@ -194,7 +196,7 @@ define start_coolwsd_instance
 	$(V)fc-cache "@LO_PATH@"/share/fonts/truetype
 	$(V)echo
 	$(V)mkdir -p $(dir $(COOLWSD_OUTPUT))
-	../coolwsd --o:sys_template_path="@SYSTEMPLATE_PATH@" \
+	ulimit -n 1024; ../coolwsd --o:sys_template_path="@SYSTEMPLATE_PATH@" \
 			--o:child_root_path="@JAILS_PATH@" \
 			--o:cache_files.path="@CACHE_PATH@" \
 			--o:storage.filesystem[@allow]=true \


### PR DESCRIPTION
- **automake silent rules: handle build-samples.py**
- **cypress: reduce the max num of open file descriptors to catch problems**
