### PR TITLE
jsdialogs: slurp also widget updates

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -234,6 +234,7 @@ COOL_LIBS_JS_DST = $(patsubst %.js,$(DIST_FOLDER)/%.js,$(COOL_LIBS_JS))
 # in a rather precise order.
 COOL_JS_LST =\
 	src/app/DocUtil.ts \
+	src/app/LocaleService.ts \
 	src/docstate.js \
 	src/docstatefunctions.js \
 	src/docdispatcher.ts \

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -235,6 +235,7 @@ COOL_LIBS_JS_DST = $(patsubst %.js,$(DIST_FOLDER)/%.js,$(COOL_LIBS_JS))
 COOL_JS_LST =\
 	src/app/DocUtil.ts \
 	src/app/LocaleService.ts \
+	src/app/LayoutingService.ts \
 	src/docstate.js \
 	src/docstatefunctions.js \
 	src/docdispatcher.ts \

--- a/browser/src/app/LayoutingService.ts
+++ b/browser/src/app/LayoutingService.ts
@@ -1,0 +1,58 @@
+/* -*- js-indent-level: 8; fill-column: 100 -*- */
+
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * This file contains service which will coordinate intensive DOM modifications
+ * which may impact browser rendering performance.
+ */
+
+type LayoutingTask = () => void;
+
+class LayoutingService {
+	private _layoutTasks: Array<LayoutingTask> = [];
+	private _layoutTaskFlush: ReturnType<typeof setTimeout> | null = null;
+
+	private _flushLayoutingQueue() {
+		if (this._layoutTasks.length) {
+			window.requestAnimationFrame(() => {
+				const start = performance.now();
+				let task = this._layoutTasks.shift();
+				let duration = 0;
+				while (task) {
+					task.call(this);
+					duration = performance.now() - start;
+					if (duration > 10) {
+						this.scheduleLayouting();
+						break;
+					}
+					task = this._layoutTasks.shift();
+				}
+			});
+		}
+
+		this._layoutTaskFlush = null;
+	}
+
+	public appendLayoutingTask(task: LayoutingTask) {
+		this._layoutTasks.push(task);
+	}
+
+	public scheduleLayouting() {
+		if (this._layoutTaskFlush) return;
+
+		// get something around 60 fps
+		this._layoutTaskFlush = setTimeout(
+			this._flushLayoutingQueue.bind(this),
+			10,
+		);
+	}
+}

--- a/browser/src/app/LocaleService.ts
+++ b/browser/src/app/LocaleService.ts
@@ -24,8 +24,8 @@ class LocaleService {
 		this._initialized = true;
 
 		if (typeof Intl !== 'undefined') {
-			let formatter, lang;
 			try {
+				let formatter;
 				if (app.UI.language.fromURL && app.UI.language.fromURL !== '')
 					formatter = new Intl.NumberFormat(app.UI.language.fromURL);
 				else formatter = new Intl.NumberFormat(L.Browser.lang);
@@ -41,7 +41,7 @@ class LocaleService {
 					}
 				});
 			} catch (e) {
-				window.app.console.log('Exception parsing lang ' + lang + ' ' + e);
+				window.app.console.log('Exception parsing lang ' + e);
 			}
 		}
 	}

--- a/browser/src/app/LocaleService.ts
+++ b/browser/src/app/LocaleService.ts
@@ -1,0 +1,56 @@
+/* -*- js-indent-level: 8; fill-column: 100 -*- */
+
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * This file holds locale dependent options.
+ */
+
+class LocaleService {
+	private _globalDecimal: string = '.';
+	private _globalMinusSign: string = '-';
+	private _initialized: boolean = false;
+
+	public initializeNumberFormatting() {
+		if (this._initialized) return;
+		this._initialized = true;
+
+		if (typeof Intl !== 'undefined') {
+			let formatter, lang;
+			try {
+				if (app.UI.language.fromURL && app.UI.language.fromURL !== '')
+					formatter = new Intl.NumberFormat(app.UI.language.fromURL);
+				else formatter = new Intl.NumberFormat(L.Browser.lang);
+
+				formatter.formatToParts(-11.1).map((item) => {
+					switch (item.type) {
+						case 'decimal':
+							this._globalDecimal = item.value;
+							break;
+						case 'minusSign':
+							this._globalMinusSign = item.value;
+							break;
+					}
+				});
+			} catch (e) {
+				window.app.console.log('Exception parsing lang ' + lang + ' ' + e);
+			}
+		}
+	}
+
+	public getDecimalSeparator() {
+		return this._globalDecimal;
+	}
+
+	public getMinusSign() {
+		return this._globalMinusSign;
+	}
+}

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -753,7 +753,6 @@ L.Control.JSDialog = L.Control.extend({
 
 			this.createContainer(instance, documentFragment);
 			this.createDialog(instance);
-			this.addHandlers(instance);
 
 			// FIXME: remove this auto-bound instance so it will be clear what is passed
 			instance.updatePos = this.setPosition.bind(this, instance);
@@ -765,6 +764,9 @@ L.Control.JSDialog = L.Control.extend({
 					existingNode.replaceWith(instance.container);
 				else
 					dialogDomParent.append(instance.container);
+
+				// do in task to apply correct focus when already shown
+				this.addHandlers(instance);
 
 				// Special case for nonModal dialogues. Core side doesn't send their initial coordinates. We need to center them.
 				if (instance.nonModal && !(instance.startX && instance.startY)) {

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -760,7 +760,11 @@ L.Control.JSDialog = L.Control.extend({
 
 			app.layoutingService.appendLayoutingTask(() => {
 				// dialog built - add to DOM now
-				dialogDomParent.append(instance.container);
+				const existingNode = dialogDomParent.querySelector('[id="' + instance.container.id + '"]');
+				if (existingNode)
+					existingNode.replaceWith(instance.container);
+				else
+					dialogDomParent.append(instance.container);
 
 				// Special case for nonModal dialogues. Core side doesn't send their initial coordinates. We need to center them.
 				if (instance.nonModal && !(instance.startX && instance.startY)) {

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -237,9 +237,9 @@ L.Control.JSDialog = L.Control.extend({
 		return isMenu || isOnlyChild;
 	},
 
-	createContainer: function(instance, parentContainer) {
+	createContainer: function(instance, documentFragment) {
 		// it has to be form to handle default button
-		instance.container = L.DomUtil.create('div', 'jsdialog-window', parentContainer);
+		instance.container = L.DomUtil.create('div', 'jsdialog-window', documentFragment);
 		instance.container.id = instance.id;
 
 		instance.form = L.DomUtil.create('form', 'jsdialog-container ui-dialog ui-widget-content lokdialog_container', instance.container);
@@ -748,32 +748,42 @@ L.Control.JSDialog = L.Control.extend({
 			if (this.map)
 				this.map._progressBar.end();
 
-			this.createContainer(instance, instance.overlay ? instance.overlay: instance.containerParent);
+			const dialogDomParent = instance.overlay ? instance.overlay: instance.containerParent;
+			const documentFragment = new DocumentFragment(); // do not modify dom yet
+
+			this.createContainer(instance, documentFragment);
 			this.createDialog(instance);
 			this.addHandlers(instance);
 
 			// FIXME: remove this auto-bound instance so it will be clear what is passed
 			instance.updatePos = this.setPosition.bind(this, instance);
 
-			// Special case for nonModal dialogues. Core side doesn't send their initial coordinates. We need to center them.
-			if (instance.nonModal && !(instance.startX && instance.startY)) {
-				this.centerDialogPosition(instance);
-			} else {
-				instance.updatePos();
-			}
+			app.layoutingService.appendLayoutingTask(() => {
+				// dialog built - add to DOM now
+				dialogDomParent.append(instance.container);
 
-			// AutoPopup  will calculate popup position for Autofilter Popup
-			if (instance.isAutofilter && !instance.isAutoFillPreviewTooltip)
-				this.calculateAutoFilterPosition(instance);
-			else if (instance.isAutoFillPreviewTooltip || instance.isAutoCompletePopup){
-				this.updateAutoPopPosition(instance.container, instance.posx, instance.posy);
-			}
+				// Special case for nonModal dialogues. Core side doesn't send their initial coordinates. We need to center them.
+				if (instance.nonModal && !(instance.startX && instance.startY)) {
+					this.centerDialogPosition(instance);
+				} else {
+					instance.updatePos();
+				}
+
+				// AutoPopup  will calculate popup position for Autofilter Popup
+				if (instance.isAutofilter && !instance.isAutoFillPreviewTooltip)
+					this.calculateAutoFilterPosition(instance);
+				else if (instance.isAutoFillPreviewTooltip || instance.isAutoCompletePopup){
+					this.updateAutoPopPosition(instance.container, instance.posx, instance.posy);
+				}
+			});
 
 			this.dialogs[instance.id] = instance;
 
 			if (instance.isSnackbar && instance.snackbarTimeout > 0) {
 				instance.timeoutId = setTimeout(function () { app.map.uiManager.closeSnackbar(); }, instance.snackbarTimeout);
 			}
+
+			app.layoutingService.scheduleLayouting();
 		}
 	},
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2786,6 +2786,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			&& data.type !== 'time'
 			&& data.type !== 'separator'
 			&& data.type !== 'spacer'
+			&& data.type !== 'edit'
 			)
 			control.setAttribute('tabIndex', '0');
 	},

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -174,29 +174,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		this._currentDepth = 0;
 
-		if (typeof Intl !== 'undefined') {
-		    var formatter, lang;
-		    try {
-			if (app.UI.language.fromURL && app.UI.language.fromURL !== '')
-			    formatter = new Intl.NumberFormat(app.UI.language.fromURL);
-			else
-			    formatter = new Intl.NumberFormat(L.Browser.lang);
-
-			var that = this;
-			formatter.formatToParts(-11.1).map(function (item) {
-			     switch (item.type) {
-			     case 'decimal':
-				 that._decimal = item.value;
-				 break;
-			     case 'minusSign':
-				 that._minusSign = item.value;
-				 break;
-			    }
-			});
-		    } catch(e) {
-			    window.app.console.log('Exception parsing lang ' + lang + ' ' + e);
-		    }
-		}
+		app.localeService.initializeNumberFormatting();
+		this._decimal = app.localeService.getDecimalSeparator();
+		this._minusSign = app.localeService.getMinusSign();
 	},
 
 	reportValidity: function() {

--- a/browser/src/docstate.js
+++ b/browser/src/docstate.js
@@ -43,6 +43,7 @@ window.app = {
 	Log: null, // Attach Logger instance.
 	DebugManager: null, // Attach DebugManager class.
 	dispatcher: null, // A Dispatcher class instance is assigned to this.
+	layoutingService: null, // instance of a service processing squashed DOM updates
 	twipsToPixels: 0, // Twips to pixels multiplier.
 	pixelsToTwips: 0, // Pixels to twips multiplier.
 	accessibilityState: false, // If accessibility was enabled by user

--- a/browser/src/main.js
+++ b/browser/src/main.js
@@ -11,7 +11,7 @@
  */
 
 /* global errorMessages accessToken accessTokenTTL accessHeader createOnlineModule */
-/* global app $ L host idleTimeoutSecs outOfFocusTimeoutSecs _ LocaleService */
+/* global app $ L host idleTimeoutSecs outOfFocusTimeoutSecs _ LocaleService LayoutingService */
 /*eslint indent: [error, "tab", { "outerIIFEBody": 0 }]*/
 
 (function (global) {
@@ -35,6 +35,7 @@ else
 
 app.localeService = new LocaleService();
 app.setPermission(global.coolParams.get('permission') || 'edit');
+app.layoutingService = new LayoutingService();
 
 var timestamp = global.coolParams.get('timestamp');
 var target = global.coolParams.get('target') || '';

--- a/browser/src/main.js
+++ b/browser/src/main.js
@@ -11,7 +11,7 @@
  */
 
 /* global errorMessages accessToken accessTokenTTL accessHeader createOnlineModule */
-/* global app $ L host idleTimeoutSecs outOfFocusTimeoutSecs _ */
+/* global app $ L host idleTimeoutSecs outOfFocusTimeoutSecs _ LocaleService */
 /*eslint indent: [error, "tab", { "outerIIFEBody": 0 }]*/
 
 (function (global) {
@@ -33,6 +33,7 @@ if (window.ThisIsTheEmscriptenApp)
 else
 	var filePath = global.coolParams.get('file_path');
 
+app.localeService = new LocaleService();
 app.setPermission(global.coolParams.get('permission') || 'edit');
 
 var timestamp = global.coolParams.get('timestamp');

--- a/cypress_test/integration_tests/common/writer_helper.js
+++ b/cypress_test/integration_tests/common/writer_helper.js
@@ -25,12 +25,24 @@ function selectAllTextOfDoc() {
 function openFileProperties() {
 	cy.log('>> openFileProperties - start');
 
+	cy.cGet('.jsdialog-window').should('not.exist');
+
 	cy.cGet('#File-tab-label').then(function(element) {
 		if (!element.hasClass('selected'))
 			element.click();
 
 		cy.cGet('#File-container .unoSetDocumentProperties').click();
 	});
+
+	// file properties dialog appears 2 times due to embedded tab pages
+	// do not use it just after first one appears
+	cy.cGet('.jsdialog-window')
+		.should('exist')
+		.then(dialog => {
+			dialog.remove();
+		});
+
+	cy.cGet('.jsdialog-window').should('exist');
 
 	cy.log('<< openFileProperties - end');
 }

--- a/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
@@ -78,7 +78,12 @@ describe(['tagdesktop'], 'JSDialog unit test', function() {
 			var dialog = win.L.control.jsDialog();
 			dialog.onJSDialog({data: jsonDialog, callback: function() {}});
 			expect(Object.keys(dialog.dialogs)).to.have.length(1);
+		});
 
+		cy.cGet('#tabcontrol').should('be.visible');
+
+		cy.getFrameWindow().then(function(win) {
+			var dialog = win.L.control.jsDialog();
 			var current = win.document.activeElement;
 			expect(current.id).to.equal('tabcontrol-1');
 

--- a/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
@@ -7,27 +7,24 @@ const desktopHelper = require('../../common/desktop_helper');
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', function() {
 
 	beforeEach(function() {
+		cy.viewport(1400, 1000);
 		helper.setupAndLoadDocument('writer/file_properties.odt');
 		desktopHelper.switchUIToNotebookbar();
 	});
 
 	it('Add File Description.', function() {
 		writerHelper.openFileProperties();
-		// Too early click on the 'Description' button would have no effect.
-		cy.wait(500);
-		cy.cGet('#tabcontrol-2').click();
-		helper.waitUntilIdle('#title-input.ui-edit');
-		cy.cGet('#title-input.ui-edit').type('New Title');
-		// sometimes it doesn't finish typing
-		helper.waitUntilIdle('#title-input.ui-edit');
 
+		cy.cGet('#tabcontrol-2').click();
+
+		cy.cGet('#title-input.ui-edit').should('be.visible');;
+		cy.cGet('#title-input.ui-edit').type('New Title');
 		cy.cGet('#comments.ui-textarea').type('New');
 
-		helper.waitUntilIdle('#comments.ui-textarea');
 		cy.cGet('#ok.ui-pushbutton').click();
+
 		writerHelper.openFileProperties();
 
-		cy.wait(500);
 		cy.cGet('#tabcontrol-2').click();
 		cy.cGet('#title-input.ui-edit').should('have.value', 'New Title');
 		cy.cGet('#comments.ui-textarea').should('have.value', 'New');
@@ -35,39 +32,33 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 		cy.cGet('#cancel.ui-pushbutton').click();
 	});
 
-	it.skip('Add Custom Property.', function() {
+	it('Add Custom Property.', function() {
 		writerHelper.openFileProperties();
-		cy.cGet('#customprops-tab-label').click();
-		cy.wait(200);
+		cy.cGet('#tabcontrol-3').click();
 
 		// Add property
-		cy.cGet('.ui-pushbutton', 'Add Property').click();
-		helper.waitUntilIdle('#namebox');
-		cy.cGet('#namebox select').select('Mailstop');
+		cy.cGet('#add.ui-pushbutton').click();
+		cy.cGet('#namebox-input').type('Mailstop');
 
-		helper.waitUntilIdle('#value-input');
 		cy.cGet('#valueedit-input').type('123 Address');
 		cy.cGet('#ok.ui-pushbutton').click();
 
 		// Check property saved
 		writerHelper.openFileProperties();
-		cy.cGet('#customprops-tab-label').click();
-		cy.cGet('#valueedit-input.ui-edit').should('have.value', '123 Address');
+		cy.cGet('#tabcontrol-3').click();
+		cy.cGet('#valueedit-input').should('have.value', '123 Address');
 
 		cy.cGet('#cancel.ui-pushbutton').click();
 	});
 
-	it.skip('Add Custom Duration Property.', function() {
+	it('Add Custom Duration Property.', function() {
 		writerHelper.openFileProperties();
-		cy.cGet('#customprops-tab-label').click();
-		cy.wait(200);
+		cy.cGet('#tabcontrol-3').click();
 
 		// Add property
-		cy.cGet('.ui-pushbutton', 'Add Property').click();
-		helper.waitUntilIdle('#namebox');
-		cy.cGet('#namebox select').select('Received from');
-		helper.waitUntilIdle('#typebox');
-		cy.cGet('#typebox select').select('Duration');
+		cy.cGet('#add.ui-pushbutton').click();
+		cy.cGet('#namebox-input').type('Received from');
+		cy.cGet('#typebox-input').select('Duration');
 		cy.cGet('#durationbutton').click();
 		cy.cGet('#negative-input').check();
 		cy.cGet('#years-input').type('1');
@@ -80,29 +71,25 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 
 		// Check property saved
 		writerHelper.openFileProperties();
-		cy.cGet('#customprops-tab-label').click();
-		cy.cGet('#duration-input.ui-edit').should('have.value', '- Y: 1 M: 0 D: 2 H: 0 M: 0 S: 3');
+		cy.cGet('#tabcontrol-3').click();
+		cy.cGet('#duration-input').should('have.value', '- Y: 1 M: 0 D: 2 H: 0 M: 0 S: 3');
 		cy.cGet('#cancel.ui-pushbutton').click();
 	});
 
-	it.skip('Add Custom Yes/No Property.', function() {
+	it('Add Custom Yes/No Property.', function() {
 		writerHelper.openFileProperties();
-		cy.cGet('#customprops-tab-label').click();
-		cy.wait(200);
+		cy.cGet('#tabcontrol-3').click();
 
 		// Add property
-		cy.cGet('.ui-pushbutton', 'Add Property').click();
-		helper.waitUntilIdle('#namebox');
-		cy.cGet('#namebox select').select('Telephone number');
-		helper.waitUntilIdle('#typebox');
-		cy.cGet('#typebox-input select').select('Yes or no');
-		helper.waitUntilIdle('#yes-input');
+		cy.cGet('#add.ui-pushbutton').click();
+		cy.cGet('#namebox-input').type('Telephone number');
+		cy.cGet('#typebox-input').select('Yes or no');
 		cy.cGet('#yes-input').check();
 		cy.cGet('#ok.ui-pushbutton').click();
 
 		// Check property saved
 		writerHelper.openFileProperties();
-		cy.cGet('#customprops-tab-label').click();
+		cy.cGet('#tabcontrol-3').click();
 		cy.cGet('#yes-input').should('be.checked');
 		cy.cGet('#cancel.ui-pushbutton').click();
 	});


### PR DESCRIPTION
When we open big dialogs like eg. Format -> Character we first get the full dialog and then series of updates. We touch DOM a lot by replacing some nodes and layouting the content.

Let's create a queue which will collect them and flush at once.

Use DocumentFragment when we build widget to not insert directly into real Document.

Setup number formatting only once, not on every builder creation.

BEFORE (open Character dialog):
![beforequeue](https://github.com/user-attachments/assets/caacefeb-2eea-49e1-a2eb-ce42aab37eed)

Related to issue  #11124

All the layouting happens now in the seaparate task. JS for building dialog is shorter.
