### PR TITLE
socket: print errno when closing while reading

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1513,7 +1513,9 @@ public:
             else if (read == 0 || (read < 0 && (last_errno == EPIPE || last_errno == ECONNRESET)))
             {
                 // There is nothing more to read; either we got EOF, or we drained after ECONNRESET.
-                LOG_DBG("Closed after reading");
+                LOG_DBG("Closed after reading (" << Util::symbolicErrno(last_errno)
+                                                               << "): " << std::strerror(last_errno)
+                                                               << '')';
                 closed = true;
             }
         }


### PR DESCRIPTION
Change-Id: Ib51c887b308edf2c9fdade308283c59d0c771808


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

socket: print errno when closing while reading.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

