### PR TITLE
status bar: update insert mode label for clarity

### DIFF
--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -464,11 +464,12 @@ class StatusBar extends JSDialog.Toolbar {
 			this.updateHtmlItem('RowColSelCount', state ? state : _('Select multiple cells'), !state);
 		}
 		else if (commandName === '.uno:InsertMode') {
-			this.updateHtmlItem('InsertMode', state ? L.Styles.insertMode[state].toLocaleString() : _('Insert mode: inactive'), !state);
+			this.updateHtmlItem('InsertMode', state ? L.Styles.insertMode[state].toLocaleString() : ' ', !state);
 
 			$('#InsertMode').removeClass();
 			$('#InsertMode').addClass('jsdialog ui-badge insert-mode-' + state);
-			$('#insertmode-container').attr('default-state', state || null);
+			var isDefaultState = state === 'true' || state === '';
+			$('#insertmode-container').attr('default-state', isDefaultState || null);
 
 			if ((state === 'false' || !state) && app.definitions.urlPopUpSection.isOpen()) {
 				this.map.hyperlinkUnderCursor = null;

--- a/cypress_test/integration_tests/desktop/calc/statusbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/statusbar_spec.js
@@ -36,11 +36,11 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Statubar tests.', function
 	});
 
 	it('Text editing mode.', function() {
-		cy.cGet('#InsertMode').should('have.text', 'Insert mode: inactive');
+		cy.cGet('#InsertMode').should('not.be.visible');
 		calcHelper.dblClickOnFirstCell();
 		cy.cGet('#InsertMode').should('have.text', 'Insert');
 		calcHelper.typeIntoFormulabar('{enter}');
-		cy.cGet('#InsertMode').should('have.text', 'Insert mode: inactive');
+		cy.cGet('#InsertMode').should('not.be.visible');
 	});
 
 	it('Selected data summary.', function() {

--- a/cypress_test/integration_tests/multiuser/calc/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/invalidations_spec.js
@@ -17,11 +17,11 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 	it('Join document', function() {
 		cy.cSetActiveFrame('#iframe1');
 
-		cy.cGet('#InsertMode', { timeout: Cypress.config('defaultCommandTimeout') * 2.0 }).should('have.text', 'Insert mode: inactive');
+		cy.cGet('#InsertMode', { timeout: Cypress.config('defaultCommandTimeout') * 2.0 }).should('not.be.visible');
 		helper.typeIntoDocument('X');
 		cy.cGet('#InsertMode', { timeout: Cypress.config('defaultCommandTimeout') * 2.0 }).should('have.text', 'Insert');
 		helper.typeIntoDocument('{enter}');
-		cy.cGet('#InsertMode', { timeout: Cypress.config('defaultCommandTimeout') * 2.0 }).should('have.text', 'Insert mode: inactive');
+		cy.cGet('#InsertMode', { timeout: Cypress.config('defaultCommandTimeout') * 2.0 }).should('not.be.visible');
 		cy.cGet(helper.addressInputSelector).should('have.prop', 'value', 'A2');
 		helper.typeIntoDocument('{uparrow}');
 		// wait until round trip of cell address


### PR DESCRIPTION
Change-Id: Iecc367a54024dac6719465b4dc7760c285298dd6

* Resolves: #11244 
* Target version: master 

### Summary
Change from "Insert mode: Inactive" to "Tracking changes: on" so users don’t think they can’t type when they actually can.

### Screenshot
![Screenshot from 2025-03-06 15-36-52](https://github.com/user-attachments/assets/49672c1c-8062-419f-b67e-052feafcb58b)

