### PR TITLE
cool#11254 unit-tiletest: restore tests

### DIFF
--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -993,8 +993,6 @@ void TileCacheTests::testTileInvalidateWriter()
 
 void TileCacheTests::testTileInvalidateWriterPage()
 {
-    // Expects to get invalidates without requesting tiles.
-    return;
     const char* testname = "tileInvalidateWriterPage ";
 
     std::string documentPath, documentURL;
@@ -1002,6 +1000,13 @@ void TileCacheTests::testTileInvalidateWriterPage()
 
     std::shared_ptr<http::WebSocketSession> socket
         = loadDocAndGetSession(_socketPoll, _uri, documentURL, testname);
+
+    // Request a tile before expecting an invalidate.
+    sendTextFrame(socket, "tilecombine nviewid=0 part=0 width=256 height=256 "
+                           "tileposx=0 tileposy=0 tilewidth=3840 tileheight=3840",
+                  testname);
+    std::vector<char> tile = getResponseMessage(socket, "tile:", testname);
+    LOK_ASSERT_MESSAGE("Did not receive tile message as expected", !tile.empty());
 
     sendChar(socket, '\n', skCtrl, testname); // Send Ctrl+Enter (page break).
     assertResponseString(socket, "invalidatetiles:", testname);


### PR DESCRIPTION
- **cool#11254 unit-tiletest: restore testTileInvalidateWriter()**
- **cool#11254 unit-tiletest: restore testTileInvalidateWriterPage()**
- **cool#11254 unit-tiletest: restore testTileInvalidateCalc()**
- **cool#11254 unit-tiletest: restore testTileRequestByInvalidation()**
