### PR TITLE
browser/socket: print warning in case of error

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1645,8 +1645,8 @@ app.definitions.Socket = L.Class.extend({
 		this._map.fire('hyperlinkclicked', {url: link, coordinates: coords});
 	},
 
-	_onSocketError: function () {
-		window.app.console.debug('_onSocketError:');
+	_onSocketError: function (event) {
+		window.app.console.warn('_onSocketError:', event);
 		this._map.hideBusy();
 		// Let onclose (_onSocketClose) report errors.
 	},


### PR DESCRIPTION
Change-Id: I62b0dbaf046a8640fab14cc531a42266848f806c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Use the event to log the error information when a socket error happens:
https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/error_event

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

