### PR TITLE
refactor: enforce hasSettingIframeSupport capability

### DIFF
--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -297,7 +297,6 @@ static const std::unordered_map<std::string, std::string> DefAppConfig = {
     { "watermark.text", "" },
     { "welcome.enable", "false" },
     { "zotero.enable", "true" },
-    { "setting_iframe.enable", "true" },
 };
 
 void initialize(const Poco::Util::AbstractConfiguration* config)

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -2435,7 +2435,7 @@ static std::string getCapabilitiesJson(bool convertToAvailable)
     capabilities->set("hasProxyPrefix", COOLWSD::IsProxyPrefixEnabled);
 
     // Set if this instance supports Setting Iframe
-    capabilities->set("hasSettingIframeSupport", ConfigUtil::getBool("setting_iframe.enable", true));
+    capabilities->set("hasSettingIframeSupport", true);
 
     // Set if this instance supports Zotero
     capabilities->set("hasZoteroSupport", ConfigUtil::getBool("zotero.enable", true));


### PR DESCRIPTION
Directly enable hasSettingIframeSupport by removing the configuration override for setting_iframe.enable


Change-Id: I5d827119f66b3a43656a4f18f2bc1b54f557d1b2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Mentioned here : https://github.com/CollaboraOnline/online/pull/11088#pullrequestreview-2598600195