### PR TITLE
automake silent rules: handle create-sbom.py

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -576,6 +576,10 @@ QUIET_SAMPLES = $(QUIET_SAMPLES_$(V))
 QUIET_SAMPLES_ = $(QUIET_SAMPLES_$(AM_DEFAULT_VERBOSITY))
 QUIET_SAMPLES_0 = @echo "  SAMPLES " $@;
 
+QUIET_SBOM = $(QUIET_SBOM_$(V))
+QUIET_SBOM_ = $(QUIET_SBOM_$(AM_DEFAULT_VERBOSITY))
+QUIET_SBOM_0 = @echo "  SBOM    " $@;
+
 setup-wsd: all @JAILS_PATH@ @CACHE_PATH@ presets-dir
 	@echo "Launching coolwsd"
 	@fc-cache "@LO_PATH@"/share/fonts/truetype
@@ -833,4 +837,4 @@ czech: check
 	@echo "This should do something much cooler"
 
 collabora-online-sbom.spdx.json: coolforkit-ns
-	python3 $(abs_top_srcdir)/scripts/create-sbom.py $(abs_top_builddir)
+	$(QUIET_SBOM) python3 $(abs_top_srcdir)/scripts/create-sbom.py $(abs_top_builddir)


### PR DESCRIPTION
Similar to commit cffb277cc22a0b25fdac783f0cd876eeb8a85a0d (automake
silent rules: handle build-samples.py, 2025-03-06), so 'make V=1' shows
the full output and it's more compact in the --enable-silent-rules case.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I1cc0a92d218cdcde36a70f6c06367a26a1e09d8f
