### PR TITLE
output from writerand is unused

### DIFF
--- a/docker/from-packages/scripts/start-collabora-online.sh
+++ b/docker/from-packages/scripts/start-collabora-online.sh
@@ -8,7 +8,6 @@ if test "${DONT_GEN_SSL_CERT-set}" = set; then
 mkdir -p /tmp/ssl/
 cd /tmp/ssl/
 mkdir -p certs/ca
-openssl rand -writerand /opt/cool/.rnd
 openssl genrsa -out certs/ca/root.key.pem 2048
 openssl req -x509 -new -nodes -key certs/ca/root.key.pem -days 9131 -out certs/ca/root.crt.pem -subj "/C=DE/ST=BW/L=Stuttgart/O=Dummy Authority/CN=Dummy Authority"
 mkdir -p certs/servers

--- a/docker/from-source-gh-action/start-collabora-online.sh
+++ b/docker/from-source-gh-action/start-collabora-online.sh
@@ -8,7 +8,6 @@ if test "${DONT_GEN_SSL_CERT-set}" = set; then
 mkdir -p /tmp/ssl/
 cd /tmp/ssl/
 mkdir -p certs/ca
-openssl rand -writerand /opt/cool/.rnd
 openssl genrsa -out certs/ca/root.key.pem 2048
 openssl req -x509 -new -nodes -key certs/ca/root.key.pem -days 9131 -out certs/ca/root.crt.pem -subj "/C=DE/ST=BW/L=Stuttgart/O=Dummy Authority/CN=Dummy Authority"
 mkdir -p certs/servers


### PR DESCRIPTION
so doesn't need to be written.

See man 1 openssl for "Random State Options", -rand option reads the output from -writerand and that's unused here and apparently unnecessary since OpenSSL 1.1.1


Change-Id: Ia3709f993b71644be8f0b816a88212efc7b76092


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

