### PR TITLE
feat(slideshow): Add touch gesture support

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -11,6 +11,8 @@ window.app = {
 	console: {}
 };
 
+// For typings (including the global object), please see browser/src/global.d.ts
+
 // This function may look unused, but it's needed in WASM and Android to send data through the fake websocket. Please
 // don't remove it without first grepping for 'Base64ToArrayBuffer' in the C++ code
 // eslint-disable-next-line

--- a/browser/package.json
+++ b/browser/package.json
@@ -4,6 +4,7 @@
   "description": "Collabora Online front-end",
   "devDependencies": {
     "@braintree/sanitize-url": "6.0.2",
+    "@types/hammerjs": "^2.0.46",
     "@types/jquery": "^3.5.29",
     "@types/jquery.contextmenu": "^1.7.38",
     "@types/jqueryui": "^1.12.21",

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -16,7 +16,6 @@ declare var app: any;
 declare var _: any;
 declare var Autolinker: any;
 declare var DOMPurify : any;
-declare var Hammer: any;
 
 namespace cool {
 

--- a/browser/src/canvas/sections/TilesSection.ts
+++ b/browser/src/canvas/sections/TilesSection.ts
@@ -12,7 +12,6 @@
 /* See CanvasSectionContainer.ts for explanations. */
 
 declare var L: any;
-declare var Hammer: any;
 declare var app: any;
 
 namespace cool {

--- a/browser/src/global.d.ts
+++ b/browser/src/global.d.ts
@@ -1,0 +1,18 @@
+interface COOLTouch {
+	isTouchEvent: (e: Event | HammerInput) => boolean;
+	touchOnly: <F extends (e: Event | HammerInput) => void>(
+		f: F,
+	) => (e: Event | HammerInput) => ReturnType<F> | undefined;
+	mouseOnly: <F extends (e: Event | HammerInput) => void>(
+		f: F,
+	) => (e: Event | HammerInput) => ReturnType<F> | undefined;
+	hasPrimaryTouchscreen: () => boolean;
+	hasAnyTouchscreen: () => boolean;
+	lastEventWasTouch: boolean | null;
+	lastEventTime: Date | null;
+	currentlyUsingTouchscreen: () => boolean;
+}
+
+interface Window {
+	touch: COOLTouch;
+}

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -130,6 +130,7 @@ class SlideShowPresenter {
 	private _onKeyDownHandler: (e: KeyboardEvent) => void;
 	private _onImpressModeChanged: any = null;
 	private _startingPresentation: boolean = false;
+	private _hammer: HammerManager;
 
 	constructor(map: any) {
 		this._cypressSVGPresentationTest =
@@ -346,6 +347,20 @@ class SlideShowPresenter {
 		canvas.addEventListener(
 			'mousemove',
 			this._slideShowNavigator.onMouseMove.bind(this._slideShowNavigator),
+		);
+
+		if (this._hammer) {
+			this._hammer.off('swipe');
+		}
+		this._hammer = new Hammer(canvas);
+		this._hammer.get('swipe').set({
+			direction: Hammer.DIRECTION_ALL,
+		});
+		this._hammer.on(
+			'swipe',
+			window.touch
+				.touchOnly(this._slideShowNavigator.onSwipe)
+				.bind(this._slideShowNavigator),
 		);
 
 		this._slideShowHandler.getContext().aCanvas = canvas;

--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -17,6 +17,7 @@ class SlideShowNavigator {
 	private slideShowHandler: SlideShowHandler;
 	private presenter: SlideShowPresenter;
 	private keyHandlerMap: Record<string, () => void>;
+	private swipeHandlerMap: Record<string, () => void>;
 	private _canvasClickHandler: MouseClickHandler;
 	private currentSlide: number;
 	private prevSlide: number;
@@ -45,6 +46,12 @@ class SlideShowNavigator {
 			Space: this.dispatchEffect.bind(this),
 			Backspace: this.rewindEffect.bind(this),
 			Escape: this.quit.bind(this),
+		};
+		this.swipeHandlerMap = {
+			[Hammer.DIRECTION_RIGHT]: this.rewindEffect.bind(this),
+			[Hammer.DIRECTION_LEFT]: this.dispatchEffect.bind(this),
+			[Hammer.DIRECTION_UP]: this.quit.bind(this),
+			[Hammer.DIRECTION_DOWN]: this.quit.bind(this),
 		};
 	}
 
@@ -410,6 +417,18 @@ class SlideShowNavigator {
 		aEvent.stopPropagation();
 		if (!this.isEnabled && aEvent.code !== 'Escape') return;
 		const handler = this.keyHandlerMap[aEvent.code];
+		if (handler) handler();
+	}
+
+	onSwipe(event: HammerInput) {
+		event.preventDefault();
+		if (
+			!this.isEnabled &&
+			event.direction !== Hammer.DIRECTION_DOWN &&
+			event.direction !== Hammer.DIRECTION_UP
+		)
+			return;
+		const handler = this.swipeHandlerMap[event.direction];
 		if (handler) handler();
 	}
 


### PR DESCRIPTION
Previously the only way to control a presentation from a touchscreen was
by tapping to go forward - one slide at a time until you got to the end
where you could tap to exit. This is "non-ideal" for web touchscreen
users, and a blocker on adding support for the new presentation code to
the mobile apps.

I've added some code using hammer.js to detect swipes and act on them,
mirroring some of the keyboard actions. I've done my best to replicate
existing expectations (swipe forwards to go forwards, swipe backwards to
go backwards, swipe up-or-down to exit) from the previous presentation
code.