### PR TITLE
wsd: do not enqueue client messages if disconnected

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2826,7 +2826,7 @@ bool ClientSession::forwardToClient(const std::shared_ptr<Message>& payload)
 
 void ClientSession::enqueueSendMessage(const std::shared_ptr<Message>& data)
 {
-    if (isCloseFrame())
+    if (isCloseFrame() || isDisconnected())
     {
         LOG_TRC("Connection closed, dropping message " << data->id());
         return;


### PR DESCRIPTION
When enqueueing messages to send to a
client, it's not enough to check for
isCloseFrame(). It is possible
that the socket is shutdown, but the
close frame is not set.

isCloseFrame() is set onDisconnect(),
so it should implicitly be equivalent
to isDisconnected(). However, to be
extra safe and avoid edge cases where
the socket is disconnected but
isCloseFrame() returns false, we
don't add more messages in the queue.
