### PR TITLE
Log: Allow to set the logToFileUiPath

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -691,7 +691,14 @@ namespace Log
         AutoPtr<Channel> channelUILog;
         if (logToFileUICmd)
         {
-            channelUILog = static_cast<Poco::Channel*>(new Poco::FileChannel("coolwsd-ui-cmd.log"));
+            std::string logPath;
+            const auto it = configUICmd.find("path");
+            if (it != configUICmd.cend()) {
+                logPath = it->second;
+            } else {
+                logPath = "coolwsd-ui-cmd.log";
+            }
+            channelUILog = static_cast<Poco::Channel*>(new Poco::FileChannel(logPath));
             for (const auto& pair : configUICmd)
             {
                 channelUILog->setProperty(pair.first, pair.second);


### PR DESCRIPTION
Change-Id: Ib4b7cc71db1fc7ddb0a9726962d493780a43fbd8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Currently logging_ui_cmd.file.property.path setting values is not used 

It is used then used to save data from `LogUiCmd` class.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

