### PR TITLE
browsersetting: send multiple preference to server at once

### DIFF
--- a/browser/src/control/Control.Sidebar.ts
+++ b/browser/src/control/Control.Sidebar.ts
@@ -141,14 +141,22 @@ class Sidebar {
 				.height + 'px';
 	}
 
-	unsetSelectedSidebar() {
-		this.map.uiManager.setDocTypePref('PropertyDeck', false);
-		this.map.uiManager.setDocTypePref('SdSlideTransitionDeck', false);
-		this.map.uiManager.setDocTypePref('SdCustomAnimationDeck', false);
-		this.map.uiManager.setDocTypePref('SdMasterPagesDeck', false);
-		this.map.uiManager.setDocTypePref('NavigatorDeck', false);
-		this.map.uiManager.setDocTypePref('StyleListDeck', false);
-		this.map.uiManager.setDocTypePref('A11yCheckDeck', false);
+	updateSidebarPrefs(currentDeck: string) {
+		const decks = [
+			'PropertyDeck',
+			'SdSlideTransitionDeck',
+			'SdCustomAnimationDeck',
+			'SdMasterPagesDeck',
+			'NavigatorDeck',
+			'StyleListDeck',
+			'A11yCheckDeck',
+		];
+
+		const deckPref: { [key: string]: string } = {};
+		decks.forEach((deck: string) => {
+			deckPref[deck] = currentDeck === deck ? 'true' : 'false';
+		});
+		this.map.uiManager.setDocTypeMultiplePrefs(deckPref);
 	}
 
 	commandForDeck(deckId: string): string {
@@ -216,9 +224,8 @@ class Sidebar {
 					sidebarData.children[0] &&
 					sidebarData.children[0].id
 				) {
-					this.unsetSelectedSidebar();
 					var currentDeck = sidebarData.children[0].id;
-					this.map.uiManager.setDocTypePref(currentDeck, true);
+					this.updateSidebarPrefs(currentDeck);
 					if (this.targetDeckCommand) {
 						var stateHandler = this.map['stateChangeHandler'];
 						var isCurrent = stateHandler

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -1756,6 +1756,16 @@ L.Control.UIManager = L.Control.extend({
 		return window.prefs.set(`${docType}.${name}`, value);
 	},
 
+	setDocTypeMultiplePrefs: function (prefs) {
+		const docType = this.map.getDocType();
+
+		const deckPrefs = {};
+		for (const [key, value] of Object.entries(prefs)) {
+			deckPrefs[`${docType}.${key}`] = value
+		}
+		window.prefs.setMultiple(deckPrefs);
+	},
+
 	getBooleanDocTypePref: function(name, defaultValue = false) {
 		const docType = this.map.getDocType();
 		return window.prefs.getBoolean(`${docType}.${name}`, defaultValue);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -332,8 +332,7 @@ void COOLWSD::alertAllUsersInternal(const std::string& msg)
 }
 
 #if !MOBILEAPP
-void COOLWSD::syncUsersBrowserSettings(const std::string& userId, const std::string& key,
-                                       const std::string& value)
+void COOLWSD::syncUsersBrowserSettings(const std::string& userId, const std::string& json)
 {
     if constexpr (Util::isMobileApp())
         return;
@@ -344,8 +343,8 @@ void COOLWSD::syncUsersBrowserSettings(const std::string& userId, const std::str
     for (auto& brokerIt : DocBrokers)
     {
         std::shared_ptr<DocumentBroker> docBroker = brokerIt.second;
-        docBroker->addCallback([userId, key, value, docBroker]()
-                               { docBroker->syncBrowserSettings(userId, key, value); });
+        docBroker->addCallback([userId, json, docBroker]()
+                               { docBroker->syncBrowserSettings(userId, json); });
     }
 }
 #endif

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -248,8 +248,7 @@ public:
     static void setMigrationMsgReceived(const std::string& docKey);
     static void setAllMigrationMsgReceived();
 #if !MOBILEAPP
-    static void syncUsersBrowserSettings(const std::string& userId, const std::string& key,
-                                             const std::string& value);
+    static void syncUsersBrowserSettings(const std::string& userId, const std::string& json);
 #endif
 
 #if ENABLE_DEBUG

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -298,7 +298,7 @@ public:
     void overrideDocOption();
 
 #if !MOBILEAPP
-    void updateBrowserSettingsJSON(const std::string& key, const std::string& value);
+    void updateBrowserSettingsJSON(const std::string& json);
 #endif
 
 private:

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4031,11 +4031,10 @@ void DocumentBroker::alertAllUsers(const std::string& msg)
 }
 
 #if !MOBILEAPP
-void DocumentBroker::syncBrowserSettings(const std::string& userId, const std::string& key,
-                                         const std::string& value)
+void DocumentBroker::syncBrowserSettings(const std::string& userId, const std::string& json)
 {
     ASSERT_CORRECT_THREAD();
-    LOG_DBG("Updating browser setting with key[" << key << "] and value[" << value
+    LOG_DBG("Updating browser setting with json[" << json
                                                  << "] for all sessions with userId [" << userId
                                                  << ']');
 
@@ -4046,7 +4045,16 @@ void DocumentBroker::syncBrowserSettings(const std::string& userId, const std::s
         if (it.second->getUserId() != userId)
             continue;
 
-        it.second->updateBrowserSettingsJSON(key, value);
+        try
+        {
+            it.second->updateBrowserSettingsJSON(json);
+        }
+        catch (const std::exception& exc)
+        {
+            LOG_WRN("Failed to update browsersetting json for session["
+                    << sessionForUpload->getId() << "], skipping the browsersetting upload step");
+            return;
+        }
         sessionForUpload = it.second;
     }
 
@@ -4169,7 +4177,7 @@ void DocumentBroker::uploadBrowserSettingsToWopiHost(const std::shared_ptr<Clien
         LOG_TRC("Successfully uploaded browsersetting to wopiHost");
     };
 
-    LOG_DBG("Uploading updated browsersetting to wopiHost[" << uriAnonym << ']');
+    LOG_DBG("Uploading browsersetting json [" << jsonStream.str() << "] to wopiHost[" << uriAnonym << ']');
     httpSession->setFinishedHandler(std::move(finishedCallback));
     httpSession->asyncRequest(httpRequest, *COOLWSD::getWebServerPoll());
 }

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -383,8 +383,7 @@ public:
     void alertAllUsers(const std::string& msg);
 
 #if !MOBILEAPP
-    void syncBrowserSettings(const std::string& userId, const std::string& key,
-                             const std::string& value);
+    void syncBrowserSettings(const std::string& userId, const std::string& json);
 
     void uploadBrowserSettingsToWopiHost(const std::shared_ptr<ClientSession>& session);
 


### PR DESCRIPTION
- There are multiple sidebar setting/preference are set by client when user opens the sidebar.
- This patches avoid to send preference individually to each time.
- Ths will also the reduce the amount of upload request to wopihost.


Change-Id: I62d3000493f9d175b9190dffe7fefff79b8f976e

* Target version: master

