### PR TITLE
browsersettting: don't send browsersetting message if parsing fails

### DIFF
--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -558,7 +558,8 @@ public:
 
     static void sendBrowserSetting(const std::shared_ptr<ClientSession>& session);
 
-    static void parseBrowserSettings(const std::shared_ptr<ClientSession>& session,
+    // Return true if parsing of browsersetting is successfull
+    static bool parseBrowserSettings(const std::shared_ptr<ClientSession>& session,
                                      const std::string& responseBody);
 
     /// Start an asynchronous Installation of the user presets, e.g. autotexts etc, as


### PR DESCRIPTION
- this will disable browsersetting on client side if parsing fails and user will rely on browser's local storage.

Change-Id: Ica24c0facc880db83f81957d403b5648376f1163

* Resolves: # <!-- related github issue -->
* Target version: master 

