### PR TITLE
fix(MacOS): Allow Mac users more system keybinds

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -406,7 +406,6 @@ L.Map.Keyboard = L.Handler.extend({
 		}
 
 		if (window.KeyboardShortcuts.processEvent(app.UI.language.fromURL, ev)) {
-			ev.preventDefault();
 			return;
 		}
 		if (this._map.jsdialog
@@ -493,7 +492,6 @@ L.Map.Keyboard = L.Handler.extend({
 
 		if (window.KeyboardShortcuts.processEvent(app.UI.language.fromURL, ev)) {
 			ev.shortCutActivated = true;
-			ev.preventDefault();
 			return;
 		}
 		if (!keyEventFn && docLayer && docLayer.postKeyboardEvent) {
@@ -672,11 +670,6 @@ L.Map.Keyboard = L.Handler.extend({
 
 		// Control + INSERT
 		if (this._isCtrlKey(e) && e.keyCode === this.keyCodes.INSERT) {
-			return true;
-		}
-
-		// Control + Shift + I, open browser developper tools
-		if (this._isCtrlKey(e) && e.shiftKey && e.keyCode === this.keyCodes.I) {
 			return true;
 		}
 

--- a/browser/src/map/handler/Map.KeyboardShortcuts.ts
+++ b/browser/src/map/handler/Map.KeyboardShortcuts.ts
@@ -42,6 +42,7 @@ class ShortcutDescriptor {
     unoAction: string;
     dispatchAction: string;
     viewType: ViewType;
+    preventDefault: boolean;
 
     constructor({
         docType = null,
@@ -52,6 +53,7 @@ class ShortcutDescriptor {
         unoAction = null,
         dispatchAction = null,
         viewType = null,
+        preventDefault = true,
     }: {
         docType?: string,
         eventType: string,
@@ -61,6 +63,7 @@ class ShortcutDescriptor {
         unoAction?: string,
         dispatchAction?: string,
         viewType?: ViewType,
+        preventDefault?: boolean,
     }) {
         app.console.assert(keyCode !== null || key !== null, 'registering a keyboard shortcut without specifying either a key or a keyCode - this will result in an untriggerable shortcut');
 
@@ -72,6 +75,7 @@ class ShortcutDescriptor {
         this.unoAction = unoAction;
         this.dispatchAction = dispatchAction;
         this.viewType = viewType;
+        this.preventDefault = preventDefault;
     }
 }
 
@@ -137,6 +141,10 @@ class KeyboardShortcuts {
             } else if (shortcut.dispatchAction) {
                 action = shortcut.dispatchAction;
                 app.dispatcher.dispatch(action);
+            }
+
+            if (shortcut.preventDefault) {
+                event.preventDefault();
             }
 
             console.debug('handled keyboard shortcut: ' + action);
@@ -233,6 +241,9 @@ keyboardShortcuts.definitions.set('default', new Array<ShortcutDescriptor>(
 
 
     new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.ALT | Mod.CTRL, key: 'p', dispatchAction: 'userlist' }),
+
+    // Passthrough some system shortcuts
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL | Mod.SHIFT, key: 'I', preventDefault: false }), // Open browser developer tools
 ));
 
 // German shortcuts.

--- a/browser/src/map/handler/Map.KeyboardShortcuts.ts
+++ b/browser/src/map/handler/Map.KeyboardShortcuts.ts
@@ -74,7 +74,7 @@ class ShortcutDescriptor {
         preventDefault = true,
         platform = null,
     }: {
-        docType?: string,
+        docType?: 'text' | 'presentation' | 'drawing' | 'spreadsheet',
         eventType: string | readonly string[],
         modifier?: Mod,
         keyCode?: number | readonly number[],

--- a/browser/src/map/handler/Map.KeyboardShortcuts.ts
+++ b/browser/src/map/handler/Map.KeyboardShortcuts.ts
@@ -275,6 +275,12 @@ keyboardShortcuts.definitions.set('default', new Array<ShortcutDescriptor>(
     // Passthrough some system shortcuts
     new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL | Mod.SHIFT, key: 'I', preventDefault: false, platform: Platform.WINDOWS | Platform.LINUX }), // Open browser developer tools on Non-MacOS - shift means the I here is capital
     new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL | Mod.ALT, keyCode: 73 /* keyCode('I') === 73 */, preventDefault: false, platform: Platform.MAC }), // Open browser developer tools on MacOS - registered with keyCode as alt+i triggers a dead key on MacOS
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 'r', preventDefault: false, platform: Platform.MAC }), // Refresh browser tab
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 'm', preventDefault: false, platform: Platform.MAC }), // On MacOS, minimize window
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 'q', preventDefault: false, platform: Platform.MAC }), // On MacOS, quit browser
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 'w', preventDefault: false }), // Close current tab
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 'n', preventDefault: false }), // Open new browser window
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 't', preventDefault: false }), // Open new browser tab
 ));
 
 // German shortcuts.

--- a/browser/src/map/handler/Map.KeyboardShortcuts.ts
+++ b/browser/src/map/handler/Map.KeyboardShortcuts.ts
@@ -19,11 +19,19 @@ function isCtrlKey (e: KeyboardEvent) {
         return e.ctrlKey;
 }
 
+function isMacCtrlKey (e: KeyboardEvent) {
+    if ((window as any).ThisIsTheiOSApp || L.Browser.mac)
+        return e.ctrlKey;
+    else
+        return false;
+}
+
 enum Mod {
     NONE    = 0,
     CTRL    = 1,
     ALT     = 2,
     SHIFT   = 4,
+    MACCTRL = 8, // Ctrl (*not Cmd*) on a Mac
 }
 
 enum ViewType {
@@ -141,9 +149,11 @@ class KeyboardShortcuts {
         const alt = event.altKey;
         const keyCode = event.which;
         const key = event.key;
+        const macctrl = isMacCtrlKey(event);
         const modifier = (ctrl ? Mod.CTRL : Mod.NONE) |
             (shift ? Mod.SHIFT : Mod.NONE) |
-            (alt ? Mod.ALT : Mod.NONE);
+            (alt ? Mod.ALT : Mod.NONE) |
+            (macctrl ? Mod.MACCTRL : Mod.NONE);
         const platform = window.mode.isChromebook() ? Platform.CHROMEOSAPP :
                          window.ThisIsTheAndroidApp ? Platform.ANDROIDAPP : // Cannot come before window.mode.isChromebook() as all Chromebook app users are necessarily also Android app users
                          window.ThisIsTheiOSApp ? Platform.IOSAPP :

--- a/browser/src/map/handler/Map.KeyboardShortcuts.ts
+++ b/browser/src/map/handler/Map.KeyboardShortcuts.ts
@@ -42,7 +42,23 @@ class ShortcutDescriptor {
     dispatchAction: string;
     viewType: ViewType;
 
-    constructor(docType: string, eventType: string, modifier: Mod, key: string, unoAction: string, dispatchAction: string, viewType: ViewType = null) {
+    constructor({
+        docType = null,
+        eventType,
+        modifier = Mod.NONE,
+        key,
+        unoAction = null,
+        dispatchAction = null,
+        viewType = null,
+    }: {
+        docType?: string,
+        eventType: string,
+        modifier?: Mod,
+        key: string,
+        unoAction?: string,
+        dispatchAction?: string,
+        viewType?: ViewType,
+    }) {
         this.docType = docType;
         this.eventType = eventType;
         this.modifier = modifier;
@@ -164,54 +180,54 @@ keyboardShortcuts.definitions.set('default', new Array<ShortcutDescriptor>(
         Disable multi-sheet selection shortcuts in Calc.
         Disable F2 in Writer, formula bar is unsupported, and messes with further input.
     */
-    new ShortcutDescriptor(null, 'keydown', 0, 'F1', null, 'showhelp', null),
-    new ShortcutDescriptor(null, 'keydown', Mod.ALT, 'F1', null, 'focustonotebookbar', null),
-    new ShortcutDescriptor(null, 'keydown', Mod.CTRL, 'f', null,'home-search', null),
+    new ShortcutDescriptor({ eventType: 'keydown', key: 'F1', dispatchAction: 'showhelp' }),
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.ALT, key: 'F1', dispatchAction: 'focustonotebookbar' }),
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 'f', dispatchAction: 'home-search' }),
 
-    new ShortcutDescriptor('spreadsheet', 'keydown', Mod.CTRL | Mod.SHIFT, 'PageUp', undefined, undefined),
-    new ShortcutDescriptor('spreadsheet', 'keydown', Mod.CTRL | Mod.SHIFT, 'PageDown', undefined, undefined),
-    new ShortcutDescriptor('spreadsheet', 'keydown', 0, 'F5', null, null, null),
-
-
-    new ShortcutDescriptor('text', 'keydown', 0, 'F2', null, null, null),
-    new ShortcutDescriptor('text', 'keydown', 0, 'F3', '.uno:ExpandGlossary', null, null),
-    new ShortcutDescriptor('text', 'keydown', Mod.CTRL, 'F3', null, null, null),
-    new ShortcutDescriptor('text', 'keydown', 0, 'F5', null, null, null),
+    new ShortcutDescriptor({ docType: 'spreadsheet', eventType: 'keydown', modifier: Mod.CTRL | Mod.SHIFT, key: 'PageUp' }),
+    new ShortcutDescriptor({ docType: 'spreadsheet', eventType: 'keydown', modifier: Mod.CTRL | Mod.SHIFT, key: 'PageDown' }),
+    new ShortcutDescriptor({ docType: 'spreadsheet', eventType: 'keydown', key: 'F5' }),
 
 
-    new ShortcutDescriptor('presentation', 'keydown', 0, 'F5', null, 'presentation', null),
-    new ShortcutDescriptor('presentation', 'keydown', 0, 'PageUp', null, 'previouspart', ViewType.ReadOnly),
-    new ShortcutDescriptor('presentation', 'keydown', 0, 'PageDown', null, 'nextpart', ViewType.ReadOnly),
+    new ShortcutDescriptor({ docType: 'text', eventType: 'keydown', key: 'F2' }),
+    new ShortcutDescriptor({ docType: 'text', eventType: 'keydown', key: 'F3', unoAction: '.uno:ExpandGlossary' }),
+    new ShortcutDescriptor({ docType: 'text', eventType: 'keydown', modifier: Mod.CTRL, key: 'F3' }),
+    new ShortcutDescriptor({ docType: 'text', eventType: 'keydown', key: 'F5' }),
 
 
-    new ShortcutDescriptor('drawing', 'keydown', 0, 'F5', null, null, null),
-    new ShortcutDescriptor('drawing', 'keydown', 0, 'PageUp', null, 'previouspart', ViewType.ReadOnly),
-    new ShortcutDescriptor('drawing', 'keydown', 0, 'PageDown', null, 'nextpart', ViewType.ReadOnly),
-    new ShortcutDescriptor('drawing', 'keydown', 0, 'End', null, 'lastpart', ViewType.ReadOnly),
-    new ShortcutDescriptor('drawing', 'keydown', 0, 'Home', null, 'firstpart', ViewType.ReadOnly),
+    new ShortcutDescriptor({ docType: 'presentation', eventType: 'keydown', key: 'F5', dispatchAction: 'presentation' }),
+    new ShortcutDescriptor({ docType: 'presentation', eventType: 'keydown', key: 'PageUp', dispatchAction: 'previouspart', viewType: ViewType.ReadOnly }),
+    new ShortcutDescriptor({ docType: 'presentation', eventType: 'keydown', key: 'PageDown', dispatchAction: 'nextpart', viewType: ViewType.ReadOnly }),
 
 
-    new ShortcutDescriptor(null, 'keydown', Mod.ALT | Mod.CTRL, 'p', null, 'userlist', null),
+    new ShortcutDescriptor({ docType: 'drawing', eventType: 'keydown', key: 'F5' }),
+    new ShortcutDescriptor({ docType: 'drawing', eventType: 'keydown', key: 'PageUp', dispatchAction: 'previouspart', viewType: ViewType.ReadOnly }),
+    new ShortcutDescriptor({ docType: 'drawing', eventType: 'keydown', key: 'PageDown', dispatchAction: 'nextpart', viewType: ViewType.ReadOnly }),
+    new ShortcutDescriptor({ docType: 'drawing', eventType: 'keydown', key: 'End', dispatchAction: 'lastpart', viewType: ViewType.ReadOnly }),
+    new ShortcutDescriptor({ docType: 'drawing', eventType: 'keydown', key: 'Home', dispatchAction: 'firstpart', viewType: ViewType.ReadOnly }),
+
+
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.ALT | Mod.CTRL, key: 'p', dispatchAction: 'userlist' }),
 ));
 
 // German shortcuts.
 keyboardShortcuts.definitions.set('de', new Array<ShortcutDescriptor>(
-    new ShortcutDescriptor(null, 'keydown', 0, 'F12', null, 'saveas', null),
+    new ShortcutDescriptor({ eventType: 'keydown', key: 'F12', dispatchAction: 'saveas' }),
 
-    new ShortcutDescriptor('presentation', 'keydown', Mod.SHIFT, 'F9', '.uno:GridVisible', null),
-    new ShortcutDescriptor('presentation', 'keydown', Mod.SHIFT, 'F3', '.uno:ChangeCaseRotateCase', null),
-    new ShortcutDescriptor('presentation', 'keydown', Mod.SHIFT, 'F5', null, 'presentation', null), // Already available without this shortcut.
+    new ShortcutDescriptor({ docType: 'presentation', eventType: 'keydown', modifier: Mod.SHIFT, key: 'F9', unoAction: '.uno:GridVisible' }),
+    new ShortcutDescriptor({ docType: 'presentation', eventType: 'keydown', modifier: Mod.SHIFT, key: 'F3', unoAction: '.uno:ChangeCaseRotateCase' }),
+    new ShortcutDescriptor({ docType: 'presentation', eventType: 'keydown', modifier: Mod.SHIFT, key: 'F5', dispatchAction: 'presentation' }), // Already available without this shortcut.
 
-    new ShortcutDescriptor('text', 'keydown', Mod.SHIFT, 'F3', '.uno:ChangeCaseRotateCase', null),
-    new ShortcutDescriptor('text', 'keydown', 0, 'F5', '.uno:GoToPage', null, null),
-    new ShortcutDescriptor('text', 'keydown',  Mod.ALT | Mod.CTRL, 's', null, 'home-search', null),
+    new ShortcutDescriptor({ docType: 'text', eventType: 'keydown', modifier: Mod.SHIFT, key: 'F3', unoAction: '.uno:ChangeCaseRotateCase' }),
+    new ShortcutDescriptor({ docType: 'text', eventType: 'keydown', key: 'F5', unoAction: '.uno:GoToPage' }),
+    new ShortcutDescriptor({ docType: 'text', eventType: 'keydown',  modifier: Mod.ALT | Mod.CTRL, key: 's', dispatchAction: 'home-search' }),
 
-    new ShortcutDescriptor('spreadsheet', 'keydown', Mod.SHIFT, 'F3', '.uno:FunctionDialog', null),
-    new ShortcutDescriptor('spreadsheet', 'keydown', Mod.SHIFT, 'F2', null, 'insertcomment', null),
-    new ShortcutDescriptor('spreadsheet', 'keydown', 0, 'F4', null, 'togglerelative', null),
-    new ShortcutDescriptor('spreadsheet', 'keydown', 0, 'F9', '.uno:Calculate', null),
-    new ShortcutDescriptor('spreadsheet', 'keydown', 0, 'F5', null, 'focusonaddressinput', null),
-    new ShortcutDescriptor('spreadsheet', 'keydown', Mod.ALT, '0', '.uno:FormatCellDialog', null)
+    new ShortcutDescriptor({ docType: 'spreadsheet', eventType: 'keydown', modifier: Mod.SHIFT, key: 'F3', unoAction: '.uno:FunctionDialog' }),
+    new ShortcutDescriptor({ docType: 'spreadsheet', eventType: 'keydown', modifier: Mod.SHIFT, key: 'F2', dispatchAction: 'insertcomment' }),
+    new ShortcutDescriptor({ docType: 'spreadsheet', eventType: 'keydown', key: 'F4', dispatchAction: 'togglerelative' }),
+    new ShortcutDescriptor({ docType: 'spreadsheet', eventType: 'keydown', key: 'F9', unoAction: '.uno:Calculate' }),
+    new ShortcutDescriptor({ docType: 'spreadsheet', eventType: 'keydown', key: 'F5', dispatchAction: 'focusonaddressinput' }),
+    new ShortcutDescriptor({ docType: 'spreadsheet', eventType: 'keydown', modifier: Mod.ALT, key: '0', unoAction: '.uno:FormatCellDialog' })
 ));
 
 (window as any).KeyboardShortcuts = keyboardShortcuts;

--- a/browser/src/map/handler/Map.KeyboardShortcuts.ts
+++ b/browser/src/map/handler/Map.KeyboardShortcuts.ts
@@ -74,15 +74,67 @@ class ShortcutDescriptor {
         preventDefault = true,
         platform = null,
     }: {
+        /** The type of document to register this keybind in. If omitted, the keybind will be registered for all document types */
         docType?: 'text' | 'presentation' | 'drawing' | 'spreadsheet',
+        /** The event type or types to register this keybind for. Generally you probably want this to be 'keydown' */
         eventType: string | readonly string[],
+        /** A bitfield of modifiers you want to be active. For example, Mod.CTRL | Mod.SHIFT would mean that *both* control and shift would need to be held while pressing the keybind.
+
+        On Mac, command is seen as Mod.CTRL and there is a separate Mod.MACCTRL to read control
+
+        If ommitted, no modifier will be required
+
+        @default Mod.NONE */
         modifier?: Mod,
+        /** The keyCode of the shortcut trigger key, as seen in the table on https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
+
+        It is rare but possible for this to provide different results in different browsers. For example, Safari sometimes returns keyCode 0 (unknown) on some event types when the bind would trigger certain system shortcuts. You should test any shortcuts you make with 'keyCode' on different browsers and systems to make sure they all work as intended.
+
+        You must provide at least one of 'key' or 'keyCode'. If you provide both, either a matching key or a matching keyCode will trigger the binding.
+
+        @deprecated Unless you know you need this, you should probably use 'key' instead, as this relies on a deprecated web API. It will not be removed as dead keys cannot be properly handled in the key API */
         keyCode?: number | readonly number[],
+        /** The key of the shortcut trigger key, as seen on https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
+
+        You must provide at least one of 'key' or 'keyCode'. If you provide both, either a matching key or a matching keyCode will trigger the binding.
+
+        When adding shortcuts using 'key' you should always test in multiple browsers and systems or ask for review from someone who can. Sometimes, particularly on keybinds that trigger "dead keys" (accents for letters), there are inconsistencies in different browsers. It's also possible for multiple different key combinations to trigger the same typed glyph - leading to this munging different keybinds together */
         key?: string,
+        /** The uno command, including its .uno: prefix, to run when this keybind is pressed
+
+        If both the unoAction and dispatchAction are provided, only the unoAction will trigger. The dispatchAction will be ignored.
+
+        If ommitted, no uno command will be run when this keybind is pressed */
         unoAction?: string,
+        /** The action to dispatch when the keybind is pressed
+
+        If both the unoAction and dispatchAction are provided, only the unoAction will trigger. The dispatchAction will be ignored.
+
+        If ommitted, no action will be dispatched when this keybind is pressed */
         dispatchAction?: string,
+        /** The view type (Edit or ReadOnly) to restrict this keybind to
+
+        If ommitted, the keybind will be active in both Edit and ReadOnly view types */
         viewType?: ViewType,
+        /** Whether to prevent the default system binding. This is important if you're overriding a system binding, and not generally harmful otherwise
+
+        Note that all keypresses which include a control (or a command on mac) are already preventDefaulted elsewhere to be sent to core. If you want to stop this, you should manually register a binding without any action but with this option set to false
+
+        Note that some browsers may not allow you to preventDefault some events. For example, Safari will not allow you to preventDefault the command+r keybind to refresh the current tab
+
+        @default true
+        */
         preventDefault?: boolean,
+        /** A bitfield of platforms you want this keybind to be active on
+
+        A user on any provided platform will get the keybind, so providing Platform.WINDOWS | Platform.LINUX would bind the key for both Windows *and* Linux (but not iOS, Android or Chromebook).
+
+        Platforms are detected in a mutually-exclusive fashion - that is: although, for example, Chromebook app users are necessarily using the Android app, they will only ever be registered as their most specific possible platform.
+
+        There will never be a platformless user. If a platform can't be detected, the user will be assumed to be using Linux. This is probably an OK assumption, given Windows and MacOS already have specific detections earlier.
+
+        If ommitted, the keybind will be active on all platforms
+        */
         platform?: Platform,
     }) {
         app.console.assert(keyCode !== null || key !== null, 'registering a keyboard shortcut without specifying either a key or a keyCode - this will result in an untriggerable shortcut');


### PR DESCRIPTION
Online doesn't know what keybinds it has. Instead, it leaves knowing that up to core. This means we preventDefault() on keybinds relatively indiscriminately, having explicit carve-outs for keybinds we want to execute - such as Ctrl+Shift+I to open the browser devtools, and sending everything to core.

Sometimes, we may have keybinds which don't have a core equivalent - for example Cmd+Ctrl+Space. In this case the keybind is ignored in core and Everything Is Fine... mostly. The problem is when these bindings collide with system bindings. Cmd+Ctrl+Space happens to be the binding on MacOS to open the emoji picker... which previously never opened in Collabora Online. Another example is the MacOS minimize keybind, Cmd+M, which appeared to do nothing but was preventing a MacOS system shortcut in some browsers.

Similarly, sometimes there are keybinds which, while interpreted as some action in core, have a well-understood meaning for the system. An example is Cmd+R or Cmd+M (refresh tab, used in LibreOffice as "justify text right"). This is such an obviously-bad thing to bind over that Safari won't let you!.. but Chrome and Firefox both will, causing some nasty browser inconsistencies and breaking users' expectations of how the web works.

Don't do that.


Change-Id: I3b5c3390e5eb88e8e38e552fa424cedd946f65e9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

