### PR TITLE
cool#11226 sw per-view redline on: add tri-state UI in the notebookbar

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2263,8 +2263,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'review-track-changes',
-				'type': 'bigtoolitem',
+				'id': 'review-track-changes:RecordTrackedChangesMenu',
+				'type': 'menubutton',
 				'text': _UNO('.uno:TrackChanges', 'text'),
 				'command': '.uno:TrackChanges',
 				'accessibility': { focusBack: true, combination: 'TC', de: null }

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -286,6 +286,24 @@ menuDefinitions.set('PasteMenu', [
 	},
 ] as Array<MenuDefinition>);
 
+menuDefinitions.set('RecordTrackedChangesMenu', [
+	{
+		id: 'review-track-changes-off',
+		text: _('Off'),
+		uno: '.uno:TrackChanges?TrackChanges:bool=false',
+	},
+	{
+		id: 'review-track-changes-all-views',
+		text: _('All users'),
+		uno: '.uno:TrackChangesInAllViews',
+	},
+	{
+		id: 'review-track-changes-this-view',
+		text: _('This user'),
+		uno: '.uno:TrackChangesInThisView',
+	},
+] as Array<MenuDefinition>);
+
 menuDefinitions.set('ConditionalFormatMenu', [
 	{
 		text: _('Highlight cells with...'),


### PR DESCRIPTION
Have 2 views, both are typing. View 1 turns on recording of tracked
changes, now surprisingly this is also turned on in view 2.

If we record track changes were part of the model previously, now this
is optionally part of the view.

Fix the problem by adding explicit UI to have recording 'off', or 'on'
for a single view / all views.

Requires core.git co-24.04 commit
a67519e2053fae13945df64c959e975bb1298833 (cool#11226 sw per-view redline
on: support this-view <-> all-views transition, 2025-03-10).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I1d5f1079e3b705b6844516a6938f54b446c0c261
