### PR TITLE
Seperate focus cell references and other references

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -1094,8 +1094,6 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			if (!textMsg.match('EMPTY'))
 				this._highlightColAndRow(textMsg);
 		}
-		else
-			this._resetReferencesMarks();
 	},
 
 	updateHighlight: function () {
@@ -1105,7 +1103,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				this._highlightColAndRow(updateMsg);
 			}
 			else
-				this._resetReferencesMarks();
+				this._resetReferencesMarks('focuscell');
 		}
 	},
 
@@ -1120,9 +1118,8 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		else
 			strTwips = textMsg.match(/\d+/g);
 
-		this._resetReferencesMarks();
+		this._resetReferencesMarks('focuscell');
 		var references = [];
-		this._referencesAll = [];
 		var rectangles = [];
 		var strColor = getComputedStyle(document.documentElement).getPropertyValue('--column-row-highlight');
 		var maxCol = 268435455;
@@ -1162,7 +1159,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				weight: 2 * app.dpiScale,
 				opacity: 0.25});
 
-			references.push({mark: reference, part: part});
+			references.push({mark: reference, part: part, type: 'focuscell'});
 			this._referencesAll.push(references[i]);
 		}
 		this._updateReferenceMarks();

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2823,9 +2823,14 @@ L.CanvasTileLayer = L.Layer.extend({
 		this._references.clear();
 	},
 
-	_resetReferencesMarks: function () {
-		this._referencesAll = [];
+	_resetReferencesMarks: function (type) {
 		this._clearReferences();
+
+        if (type === undefined)
+		    this._referencesAll = [];
+        else if (type === 'focuscell')
+            this._referencesAll = this._referencesAll.filter(function(e) { return e.type !== 'focuscell' });
+
 		this._updateReferenceMarks();
 	},
 


### PR DESCRIPTION
"focuscell" reference type is defined for the focus cell feature. resetReferenceMarks can reset the reference by type anymore. And It won't affect the other references.


Change-Id: Ia0ade35bb5c87549eebeea2d73b1d149e3adc9c5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

