### PR TITLE
Better OOM Handling

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -5313,11 +5313,19 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n    Next StorageAttributes:";
     _nextStorageAttrs.dumpState(os, "\n      ");
 
+    os << "\n  Storage:";
+    _storage->dumpState(os, "\n    ");
+
+    os << '\n';
     _lockCtx->dumpState(os);
 
     if (_tileCache)
+    {
+        os << '\n';
         _tileCache->dumpState(os);
+    }
 
+    os << '\n';
     _poll->dumpState(os);
 
 #if !MOBILEAPP

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2321,6 +2321,19 @@ bool DocumentBroker::isStorageOutdated() const
             << " and the last uploaded file was modified at " << lastModifiedTime << ", which are "
             << (currentModifiedTime == lastModifiedTime ? "identical" : "different"));
 
+#ifdef ENABLE_DEBUG
+    if (_storageManager.getLastUploadedFileModifiedTime() != _saveManager.getLastModifiedTime())
+    {
+        const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+        LOG_ERR("StorageManager's lastModifiedTime ["
+                << Util::getTimeForLog(now, _storageManager.getLastUploadedFileModifiedTime())
+                << "] doesn't match that of SaveManager's ["
+                << Util::getTimeForLog(now, _saveManager.getLastModifiedTime())
+                << "]. File lastModifiedTime: [" << Util::getTimeForLog(now, currentModifiedTime)
+                << ']');
+    }
+#endif
+
     // Compare to the last uploaded file's modified-time.
     return currentModifiedTime != lastModifiedTime;
 }

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -904,11 +904,16 @@ std::size_t WopiStorage::uploadLocalFileToStorageAsync(
 
         LOG_DBG(wopiLog << " async upload request: " << httpRequest.header().toString());
 
-        _uploadHttpSession->setConnectFailHandler([asyncUploadCallback](const std::shared_ptr<http::Session>& /* httpSession */) {
-            LOG_ERR("Cannot connect for uploading to wopi storage.");
-            asyncUploadCallback(AsyncUpload(AsyncUpload::State::Error,
-                            UploadResult(UploadResult::Result::FAILED, "Connection failed.")));
-        });
+        _uploadHttpSession->setConnectFailHandler(
+            [asyncUploadCallback,
+             uriObject](const std::shared_ptr<http::Session>& /* httpSession */)
+            {
+                LOG_ERR("Cannot connect to [" << uriObject.toString()
+                                              << "] for uploading to wopi storage");
+                asyncUploadCallback(
+                    AsyncUpload(AsyncUpload::State::Error,
+                                UploadResult(UploadResult::Result::FAILED, "Connection failed.")));
+            });
 
         // Notify client via callback that the request is in progress...
         asyncUploadCallback(


### PR DESCRIPTION
Mostly logging and state-dumping improvements, with only one functional change where we now upload when previously we had skipped it. The commit log (and comments) explain the case in question, which is rather rare but gets us stuck.

- **wsd: better admin OOM closing**
- **wsd: dump Storage state**
- **wsd: log the URI that we failed to connect to**
- **wsd: detect inconsistent lastModifiedTime in the managers**
- **wsd: allow uploading when otherwise there might be no need**
