### PR TITLE
init _watchdogThread after _watchdogMutex was constructed

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -227,9 +227,9 @@ public:
 
 private:
     std::atomic_bool _saveCompleted; ///< Defend against spurious wakes.
-    std::thread _watchdogThread;
     std::condition_variable _watchdogCV;
     std::mutex _watchdogMutex;
+    std::thread _watchdogThread;
 };
 
 static std::unique_ptr<BackgroundSaveWatchdog> BgSaveWatchdog;


### PR DESCRIPTION
  terminate called after throwing an instance of 'std::system_error'
   what():  Invalid argument

```
 #7  0x00007eed108ae277 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
 #8  0x00007eed108ae4d8 in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6
 #9  0x000000000056014b in ?? ()
 #10 0x00000000005f899f in BackgroundSaveWatchdog::BackgroundSaveWatchdog(unsigned int, int)::{lambda()#1}::operator()() const ()
```

it strikes me that there is a possibility that _watchdogMutex might be used here before it gets initialized.


Change-Id: I04ed96a280dc02a2ecd534cc093e2584fd577aca


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

