### PR TITLE
wsd: preset: close socket for fetch-wordbook(backport)

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -956,7 +956,7 @@ bool FileServerRequestHandler::handleRequest(const HTTPRequest& request,
         if (endPoint == "fetch-wordbook")
         {
             fetchWordbook(request, message, socket);
-            return false;
+            return true;
         }
 
         // Is this a file we read at startup - if not; it's not for serving.


### PR DESCRIPTION
- fetch-wordbook is not async

Change-Id: Iac7ca9062b0e8ca6d0ff9b5da050bfea3015fcc4

* Target version: distro/collabora/co-24.04
