### PR TITLE
cool#11064 any input: enable COOL_ANYINPUT_CONSIDER_PRIORITY by default

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3082,8 +3082,7 @@ bool anyInputCallback(void* data, int mostUrgentPriority)
 
     if (document)
     {
-        static bool considerPriority = std::getenv("COOL_ANYINPUT_CONSIDER_PRIORITY");
-        if (considerPriority && document->isLoaded())
+        if (document->isLoaded())
         {
             // Check if core has high-priority tasks in which case we don't interrupt.
             std::shared_ptr<lok::Document> kitDocument = document->getLOKitDocument();


### PR DESCRIPTION
This wasn't possible previously, because the core side was missing
commit 4f15a47c7faf55997e776af738106d3da229c7d2 (cool#11064 Set priority
of some idles to TaskPriority::DEFAULT_IDLE, 2025-02-18), but now
co-25.04 has it.

The benefit is that now we don't interrupt high priority core jobs now,
and only start painting tiles after the high priority tasks are done,
but still before idle tasks.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I5556fdbc43841a2fbf3e2ea084199c17e04439d6
