### PR TITLE
status bar: remove right and left arrows

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -462,6 +462,13 @@ body {
 	color: var(--color-main-text);
 }
 
+@media screen and (max-width: 500px) {
+	#search-input {
+		width: 100px;
+	}
+}
+
+
 .cool-character {
 	table-layout: fixed;
 	font: 17px/1.5 'Helvetica Neue', Arial, Helvetica, sans-serif;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -291,7 +291,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 #toolbar-down .ui-badge,
 #toolbar-down .unolabel {
 	font-family: var(--cool-font);
-	font-size: var(--default-font-size);
+	font-size: var(--default-font-size) !important;
 	color: var(--color-status-badge) !important;
 }
 
@@ -2024,6 +2024,11 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	background-color: transparent !important;
 	border-color: transparent;
 }
+
+#toolbar-down  .jsdialog .ui-edit-container{
+	place-content: center;
+}
+
 /* Formula Wizard */
 #FormulaDialog .ui-tabs-root {
 	background-color: var(--color-background-tabs-group);
@@ -2295,6 +2300,11 @@ kbd,
 #showcomments-container[default-state='true'],
 #insertmode-container[default-state='true'],
 #permissionmode-container[default-state='true'],
+#documentstatus-container[default-state='true'],
 #statusselectionmode-container[default-state='true'] {
+	display: none !important;
+}
+
+.status-hidden {
 	display: none !important;
 }

--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -181,11 +181,11 @@ class StatusBar extends JSDialog.Toolbar {
 		this.updateHtmlItem('ShowComments', state ? statemsg : ' ');
 	}
 
-	_generateHtmlItem(id) {
+	_generateHtmlItem(id, dataPriority) {
 		var isReadOnlyMode = app.map ? app.map.isReadOnlyMode() : true;
 		var canUserWrite = !app.isReadOnly();
 
-		return {
+		const item = {
 			type: 'container',
 			id: id + '-container',
 			children: [
@@ -194,7 +194,13 @@ class StatusBar extends JSDialog.Toolbar {
 			],
 			vertical: false,
 			visible: false
-		};
+		}
+
+		if (dataPriority) {
+			item.dataPriority = dataPriority;
+		}
+
+		return item;
 	}
 
 	_generateStateMenuEntry(id, text, selection) {
@@ -216,7 +222,7 @@ class StatusBar extends JSDialog.Toolbar {
 			.filter((item) => { return item.selected; })
 			.map((item) => { return item.text; });
 		var text = selected.length ? selected.join('; ') : _('None');
-		return {type: 'menubutton', id: 'StateTableCellMenu', text: text, image: false, menu: submenu, visible: visible};
+		return {type: 'menubutton', id: 'StateTableCellMenu', text: text, image: false, menu: submenu, visible: visible, dataPriority: 5};
 	}
 
 	_generateZoomItems() {
@@ -248,30 +254,30 @@ class StatusBar extends JSDialog.Toolbar {
 			{type: 'customtoolitem',  id: 'searchprev', command: 'searchprev', text: _UNO('.uno:UpSearch'), enabled: false, pressAndHold: true},
 			{type: 'customtoolitem',  id: 'searchnext', command: 'searchnext', text: _UNO('.uno:DownSearch'), enabled: false, pressAndHold: true},
 			{type: 'customtoolitem',  id: 'cancelsearch', command: 'cancelsearch', text: _('Cancel the search'), visible: false},
-			{type: 'separator', id: 'searchbreak', orientation: 'vertical' },
+			{type: 'separator', id: 'searchbreak', orientation: 'vertical'},
 			this._generateHtmlItem('statusdocpos'), 					// spreadsheet
-			this._generateHtmlItem('rowcolselcount'), 					// spreadsheet
+			this._generateHtmlItem('rowcolselcount', 1), 					// spreadsheet
 			this._generateHtmlItem('statepagenumber'), 					// text
-			this._generateHtmlItem('statewordcount'), 					// text
-			this._generateHtmlItem('insertmode'),						// spreadsheet, text
-			this._generateHtmlItem('showcomments'),					    // text
-			this._generateHtmlItem('statusselectionmode'),				// text
+			this._generateHtmlItem('statewordcount', 1), 					// text
+			this._generateHtmlItem('insertmode', 5),						// spreadsheet, text
+			this._generateHtmlItem('showcomments', 4),					    // text
+			this._generateHtmlItem('statusselectionmode', 6),				// text
 			this._generateHtmlItem('slidestatus'),						// presentation
 			this._generateHtmlItem('pagestatus'),						// drawing
-			{type: 'menubutton', id: 'languagestatus:LanguageStatusMenu'},	// spreadsheet, text, presentation
-			{type: 'separator', id: 'languagestatusbreak', orientation: 'vertical', visible: false}, // spreadsheet
-			this._generateHtmlItem('statetablecell'),					// spreadsheet
+			{type: 'menubutton', id: 'languagestatus:LanguageStatusMenu', dataPriority: 3},	// spreadsheet, text, presentation
+			{type: 'separator', id: 'languagestatusbreak', orientation: 'vertical', visible: false, dataPriority: 3}, // spreadsheet
+			this._generateHtmlItem('statetablecell', 4),					// spreadsheet
 			this._generateStateTableCellMenuItem(2, false),			// spreadsheet
-			{type: 'separator', id: 'statetablebreak', orientation: 'vertical', visible: false}, // spreadsheet
+			{type: 'separator', id: 'statetablebreak', orientation: 'vertical', visible: false, dataPriority: 7}, // spreadsheet
 			this._generateHtmlItem('permissionmode'),					// spreadsheet, text, presentation
 			{type: 'toolitem', id: 'signstatus', command: '.uno:Signature', w2icon: '', text: _UNO('.uno:Signature'), visible: false},
 			{type: 'spacer',  id: 'permissionspacer'},
-			this._generateHtmlItem('documentstatus'),					// spreadsheet, text, presentation, drawing
-			{type: 'customtoolitem',  id: 'prev', command: 'prev', text: _UNO('.uno:PageUp', 'text'), pressAndHold: true},
-			{type: 'customtoolitem',  id: 'next', command: 'next', text: _UNO('.uno:PageDown', 'text'), pressAndHold: true},
-			{type: 'separator', id: 'prevnextbreak', orientation: 'vertical'},
+			this._generateHtmlItem('documentstatus', 2),					// spreadsheet, text, presentation, drawing
+			{type: 'customtoolitem',  id: 'prev', command: 'prev', text: _UNO('.uno:PageUp', 'text'), pressAndHold: true, dataPriority: 9},
+			{type: 'customtoolitem',  id: 'next', command: 'next', text: _UNO('.uno:PageDown', 'text'), pressAndHold: true, dataPriority: 9},
+			{type: 'separator', id: 'prevnextbreak', orientation: 'vertical', dataPriority: 9},
 		].concat(window.mode.isTablet() ? [] : [
-			{type: 'customtoolitem',  id: 'zoomreset', command: 'zoomreset', text: _('Reset zoom'), icon: 'zoomreset.svg'},
+			{type: 'customtoolitem',  id: 'zoomreset', command: 'zoomreset', text: _('Reset zoom'), icon: 'zoomreset.svg', dataPriority: 8},
 			{type: 'customtoolitem',  id: 'zoomout', command: 'zoomout', text: _UNO('.uno:ZoomMinus'), icon: 'minus.svg'},
 			{type: 'menubutton', id: 'zoom', text: '100', selected: 'zoom100', menu: this._generateZoomItems(), image: false},
 			{type: 'customtoolitem',  id: 'zoomin', command: 'zoomin', text: _UNO('.uno:ZoomPlus'), icon: 'plus.svg'}
@@ -284,9 +290,8 @@ class StatusBar extends JSDialog.Toolbar {
 
 		this.parentContainer.replaceChildren();
 		this.builder.build(this.parentContainer, this.getToolItems());
-
 		this.onLanguagesUpdated();
-		JSDialog.MakeScrollable(this.parentContainer, this.parentContainer.querySelector('div'));
+		JSDialog.MakeStatusPriority(this.parentContainer.querySelector('div'), this.getToolItems());
 		JSDialog.RefreshScrollables();
 	}
 
@@ -566,6 +571,16 @@ class StatusBar extends JSDialog.Toolbar {
 		JSDialog.MenuDefinitions.set('LanguageStatusMenu', menuEntries);
 	}
 
+    updateDefaultStateAttribute() {
+        const docstatcontainer = document.getElementById('documentstatus-container');
+        const documentStatus = document.getElementById('DocumentStatus');
+        if (documentStatus && (!documentStatus.textContent || documentStatus.textContent.trim() === '')) {
+            docstatcontainer.setAttribute('default-state', 'true');
+        } else if (docstatcontainer.hasAttribute('default-state')) {
+            docstatcontainer.removeAttribute('default-state');
+        }
+    }
+
 	onInitModificationIndicator(lastmodtime) {
 		if (!this.isSaveIndicatorActive())
 			return;
@@ -578,6 +593,7 @@ class StatusBar extends JSDialog.Toolbar {
 			return;
 		}
 		docstatcontainer.classList.remove('hidden');
+        this.updateDefaultStateAttribute()
 
 		this.map.fire('modificationindicatorinitialized');
 	}
@@ -590,6 +606,9 @@ class StatusBar extends JSDialog.Toolbar {
 		if (this._lastModstatus !== e.status) {
 			this.updateHtmlItem('DocumentStatus', e.status);
 			this._lastModStatus = e.status;
+
+            // Update default-state attribute after updating status
+            this.updateDefaultStateAttribute()
 		}
 		if (e.lastSaved !== null && e.lastSaved !== undefined) {
 			const lastSaved = document.getElementById('last-saved');

--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -181,23 +181,7 @@ function shouldHaveZoomLevel(zoomLevel) {
 function makeZoomItemsVisible() {
 	cy.log('>> makeZoomItemsVisible - start');
 
-	const scrollRight = () => {
-		cy.cGet('#toolbar-down .ui-scroll-right:visible').then($scrollRightButton => {
-			if ($scrollRightButton.is(':visible')) {
-				// Wrap .ui-scroll-right so we can continue executing commands
-				cy.wrap($scrollRightButton).click();
-				// Wait the same ms as in Util.ScrollableBar.ts timeout
-				cy.wait(350);
-				// Scroll again if $scrollRightButton is visible
-				cy.cGet('#toolbar-down .ui-scroll-right').then($scrollRightButtonInner => {
-					if ($scrollRightButtonInner.is(':visible'))
-						scrollRight();
-				});
-			}
-		});
-	};
-
-	scrollRight();
+	// Ensure the #zoomin element is visible
 	cy.cGet('#toolbar-down #zoomin').should('be.visible');
 
 	cy.log('<< makeZoomItemsVisible - end');

--- a/cypress_test/integration_tests/desktop/calc/bottom_bar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/bottom_bar_spec.js
@@ -6,14 +6,17 @@ var calcHelper = require('../../common/calc_helper');
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Calc bottom bar tests.', function() {
 
 	beforeEach(function() {
+		// Ensure the viewport is large enough to show the whole status bar
+		// In Calc #StateTableCellMenu has a high data-priority
+		// and will be hidden if the bottom bar doesn't have enough space
+		cy.viewport(1280, 720);
 		helper.setupAndLoadDocument('calc/BottomBar.ods');
 	});
 
 	it('Bottom tool bar.', function() {
 		cy.cGet('#map').focus();
 		calcHelper.clickOnFirstCell();
-		cy.cGet('#StateTableCellMenu').click();
-		// If it clicks, it passes.
+		cy.cGet('#StateTableCellMenu:visible').click();
 		cy.cGet('body').contains('.ui-combobox-entry', 'CountA').click();
 	});
 });

--- a/cypress_test/integration_tests/desktop/calc/statusbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/statusbar_spec.js
@@ -44,6 +44,10 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Statubar tests.', function
 	});
 
 	it('Selected data summary.', function() {
+		// Ensure the viewport is large enough to show the whole status bar
+		// In Calc #StateTableCellMenu has a high data-priority
+		// and will be hidden if the status bar doesn't have enough space
+		cy.viewport(1280, 720);
 		cy.cGet('#StateTableCell').should('have.text', 'Average: ; Sum: 0');
 		helper.typeIntoInputField(helper.addressInputSelector, 'A1:A2');
 		cy.cGet('#StateTableCell').should('have.text', 'Average: 15.5; Sum: 31');


### PR DESCRIPTION
Change-Id: Ied57f580bc7c1ea5d488e935f5f906f0935bd3cf

* Target version: master 

### Previews
[Screencast from 25-03-25 04:40:39.webm](https://github.com/user-attachments/assets/199992d7-fbc2-4032-97a5-abb1f9bc7544)


### Summary
- Removes the left and right arrows from the status bar to address inconsistencies after removing default states.
- The arrows also block the Zoom "+" which is frustrating to users as they would need to double click the arrow to remove it and click zoom +

