### PR TITLE
Impress: Fix drag & drop slide pages for reordering.

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -398,7 +398,7 @@ L.Control.PartsPreview = L.Control.extend({
 	// We will use this function because IE doesn't support "Array.from" feature.
 	_findClickedPart: function (element) {
 		for (var i = 0; i < this._partsPreviewCont.children.length; i++) {
-			if (this._partsPreviewCont.children[i] === element) {
+			if (this._partsPreviewCont.children[i] === element || this._partsPreviewCont.children[i] === element.parentNode) {
 				return i;
 			}
 		}


### PR DESCRIPTION
Sometimes the child of the expected element fires the event. Check also parentNode when searching for clicked part.

Issue:
* Cannot re-position a slide by dragging without first selecting it.


Change-Id: I884fc2908ef6523b0f2ad58e00b3793fcda1de2e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

