### PR TITLE
ensure threads are re-started on a failed joinThreads.

### DIFF
--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -298,6 +298,37 @@ public:
 
     void updateActivityHeader() const;
 
+    /// Really important that if we drop, we re-start for the kit.
+    class ThreadDropper final {
+        Document *_doc;
+    public:
+        ThreadDropper() : _doc(nullptr) { }
+        ~ThreadDropper()
+        {
+            if (_doc) _doc->startThreads();
+        }
+        void clear()
+        {
+            _doc = nullptr;
+        }
+        bool dropThreads(Document *doc)
+        {
+            if (doc->joinThreads())
+            {
+                // only this path starts later.
+                _doc = doc;
+                return true;
+            }
+            return false;
+        }
+        void startThreads()
+        {
+            if (_doc)
+                _doc->startThreads();
+            _doc = nullptr;
+        }
+    };
+
     bool joinThreads();
     void startThreads();
 


### PR DESCRIPTION
If we got a:

[ kitbroker_002 ] WRN  Failed to ensure we have just one thread for bgsave, we have: 2 synchronously saving| kit/Kit.cpp:1451

Then we would bail out of forkToSave without re-starting the _deltaPool.

So guard against that from all return paths more simply.


Change-Id: I0751b68613832da3b3a2bb96235300d638119035


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

