### PR TITLE
wsd: browsersetting: fix SIGABRT when syncing browsersetting

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4083,14 +4083,15 @@ void DocumentBroker::syncBrowserSettings(const std::string& userId, const std::s
         try
         {
             it.second->updateBrowserSettingsJSON(json);
+            sessionForUpload = it.second;
         }
         catch (const std::exception& exc)
         {
             LOG_WRN("Failed to update browsersetting json for session["
-                    << sessionForUpload->getId() << "], skipping the browsersetting upload step");
+                    << it.second->getId() << "] with error[" << exc.what()
+                    << "], skipping the browsersetting upload step");
             return;
         }
-        sessionForUpload = it.second;
     }
 
     // upload browsersetting only once if we found matching session


### PR DESCRIPTION
```
wsd-05530-05210 2025-03-14 05:50:12.416584 +0000 [ docbroker_2fe ] INF Syncing browsersettings of the users| wsd/COOLWSD.cpp:341

wsd-05530-05210 2025-03-14 05:50:12.422754 +0000 [ docbroker_2fe ] SIG Fatal signal received: SIGABRT code: 18446744073709551610 for address: 0x730000159a
Backtrace 5530 - wsd 24.04.13.2snapshot 8266fe8509:

Files in quarantine:
/usr/bin/coolwsd
    SigUtil::dumpBacktrace()
        /home/collabora/jenkins/workspace/package_cool_24.04_rpm/rpmbuild/BUILD/coolwsd-24.04.13.2snapshot/common/SigUtil.cpp:462
/lib/x86_64-linux-gnu/libpthread.so.0
    __restore_rt
        ??:?
/lib/x86_64-linux-gnu/libc.so.6
    __GI_raise
        /build/glibc-5efeFw/glibc-2.27/signal/../sysdeps/unix/sysv/linux/raise.c:51 (discriminator 3)
/lib/x86_64-linux-gnu/libc.so.6
    __GI_abort
        /build/glibc-5efeFw/glibc-2.27/stdlib/abort.c:81
/lib/x86_64-linux-gnu/libpthread.so.0
    __restore_rt
        ??:?
/usr/bin/coolwsd
    SocketPoll::poll(long, bool)
        /home/collabora/jenkins/workspace/package_cool_24.04_rpm/rpmbuild/BUILD/coolwsd-24.04.13.2snapshot/net/Socket.cpp:584 (discriminator 2)
/usr/bin/coolwsd
    DocumentBroker::pollThread()
        /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/chrono.h:650 (discriminator 5)
/usr/bin/coolwsd
    DocumentBroker::DocumentBrokerPoll::pollingThread()
        /home/collabora/jenkins/workspace/package_cool_24.04_rpm/rpmbuild/BUILD/coolwsd-24.04.13.2snapshot/wsd/DocumentBroker.cpp:157
/usr/bin/coolwsd
    SocketPoll::pollingThreadEntry()
        /home/collabora/jenkins/workspace/package_cool_24.04_rpm/rpmbuild/BUILD/coolwsd-24.04.13.2snapshot/net/Socket.cpp:452 (discriminator 3)
/lib/x86_64-linux-gnu/libpthread.so.0
    start_thread
        /build/glibc-5efeFw/glibc-2.27/nptl/pthread_create.c:463
/lib/x86_64-linux-gnu/libc.so.6
    clone
        /build/glibc-5efeFw/glibc-2.27/misc/../sysdeps/unix/sysv/linux/x86_64/clone.S:97
```

Change-Id: Ie23cce488d098e3ce86536f6e91bb00b6194efbe

* Target version: master 

