### PR TITLE
wsd: fix: browsersetting is uploaded multiple times

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -332,17 +332,19 @@ void COOLWSD::alertAllUsersInternal(const std::string& msg)
 }
 
 #if !MOBILEAPP
-void COOLWSD::syncUsersBrowserSettings(const std::string& userId, const std::string& json)
+void COOLWSD::syncUsersBrowserSettings(const std::string& userId, const pid_t childPid, const std::string& json)
 {
     if constexpr (Util::isMobileApp())
         return;
     std::lock_guard<std::mutex> docBrokersLock(DocBrokersMutex);
 
-    LOG_INF("Syncing browsersettings of the users");
+    LOG_INF("Syncing browsersettings for all the users");
 
     for (auto& brokerIt : DocBrokers)
     {
         std::shared_ptr<DocumentBroker> docBroker = brokerIt.second;
+        if (docBroker->getPid() == childPid)
+            continue;
         docBroker->addCallback([userId, json, docBroker]()
                                { docBroker->syncBrowserSettings(userId, json); });
     }

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -248,7 +248,7 @@ public:
     static void setMigrationMsgReceived(const std::string& docKey);
     static void setAllMigrationMsgReceived();
 #if !MOBILEAPP
-    static void syncUsersBrowserSettings(const std::string& userId, const std::string& json);
+    static void syncUsersBrowserSettings(const std::string& userId, const pid_t childPid, const std::string& json);
 #endif
 
 #if ENABLE_DEBUG

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1367,7 +1367,17 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         {
             std::string json;
             getTokenString(tokens[2], "json", json);
-            COOLWSD::syncUsersBrowserSettings(getUserId(), json);
+            updateBrowserSettingsJSON(json);
+            COOLWSD::syncUsersBrowserSettings(getUserId(), docBroker->getPid(), json);
+            try
+            {
+                uploadBrowserSettingsToWopiHost();
+            }
+            catch (const std::exception& exc)
+            {
+                LOG_WRN("Failed to upload browsersetting json for session ["
+                        << getId() << ']');
+            }
         }
     }
 #endif
@@ -1381,6 +1391,47 @@ bool ClientSession::_handleInput(const char *buffer, int length)
 }
 
 #if !MOBILEAPP
+void ClientSession::uploadBrowserSettingsToWopiHost()
+{
+    const Authorization& auth = getAuthorization();
+    Poco::URI uriObject = DocumentBroker::getPresetUploadBaseUrl(_uriPublic);
+
+    const std::string& filePath = "/settings/userconfig/browsersetting/browsersetting.json";
+    uriObject.addQueryParameter("fileId", filePath);
+    auth.authorizeURI(uriObject);
+
+    const std::string& uriAnonym = COOLWSD::anonymizeUrl(uriObject.toString());
+
+    auto httpRequest = StorageConnectionManager::createHttpRequest(uriObject, auth);
+    httpRequest.setVerb(http::Request::VERB_POST);
+    auto httpSession = StorageConnectionManager::getHttpSession(uriObject);
+
+    std::ostringstream jsonStream;
+    _browserSettingsJSON->stringify(jsonStream, 2);
+    httpRequest.setBody(jsonStream.str(), "application/json; charset=utf-8");
+
+    http::Session::FinishedCallback finishedCallback =
+        [this, uriAnonym](const std::shared_ptr<http::Session>& wopiSession)
+    {
+        wopiSession->asyncShutdown();
+
+        const std::shared_ptr<const http::Response> httpResponse = wopiSession->response();
+        const http::StatusLine statusLine = httpResponse->statusLine();
+        if (statusLine.statusCode() != http::StatusCode::OK)
+        {
+            LOG_ERR("Failed to upload updated browsersetting to wopiHost["
+                    << uriAnonym << "] with status[" << statusLine.reasonPhrase() << ']');
+            return;
+        }
+        LOG_TRC("Successfully uploaded browsersetting to wopiHost");
+    };
+
+    LOG_DBG("Uploading browsersetting json [" << jsonStream.str() << "] to wopiHost[" << uriAnonym
+                                              << ']');
+    httpSession->setFinishedHandler(std::move(finishedCallback));
+    httpSession->asyncRequest(httpRequest, *COOLWSD::getWebServerPoll());
+}
+
 void ClientSession::updateBrowserSettingsJSON(const std::string& json)
 {
     Poco::JSON::Parser parser;

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -290,6 +290,8 @@ public:
         return _browserSettingsJSON;
     }
 
+    void uploadBrowserSettingsToWopiHost();
+
     /// Override parsedDocOption values we get from browser setting json
     /// Because when client sends `load url` it doesn't have information about browser setting json
     void overrideDocOption();

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4069,12 +4069,10 @@ void DocumentBroker::alertAllUsers(const std::string& msg)
 void DocumentBroker::syncBrowserSettings(const std::string& userId, const std::string& json)
 {
     ASSERT_CORRECT_THREAD();
-    LOG_DBG("Updating browser setting with json[" << json
+    LOG_DBG("Updating browsersetting with json[" << json
                                                  << "] for all sessions with userId [" << userId
                                                  << ']');
 
-    // update browsersetting for all the matching session
-    std::shared_ptr<ClientSession> sessionForUpload;
     for (auto& it : _sessions)
     {
         if (it.second->getUserId() != userId)
@@ -4082,8 +4080,9 @@ void DocumentBroker::syncBrowserSettings(const std::string& userId, const std::s
 
         try
         {
+            LOG_TRC("Updating browsersetting with json[" << json << "] for session["
+                                                         << it.second->getId() << ']');
             it.second->updateBrowserSettingsJSON(json);
-            sessionForUpload = it.second;
         }
         catch (const std::exception& exc)
         {
@@ -4092,19 +4091,6 @@ void DocumentBroker::syncBrowserSettings(const std::string& userId, const std::s
                     << "], skipping the browsersetting upload step");
             return;
         }
-    }
-
-    // upload browsersetting only once if we found matching session
-    if (!sessionForUpload)
-        return;
-
-    try
-    {
-        uploadBrowserSettingsToWopiHost(sessionForUpload);
-    }
-    catch (const std::exception& exc)
-    {
-        LOG_WRN("Failed to upload browsersetting json for session [" << sessionForUpload->getId());
     }
 }
 
@@ -4175,47 +4161,6 @@ void DocumentBroker::uploadPresetsToWopiHost()
 
         LOG_DBG("Successfully uploaded presetFile[" << fileName << ']');
     }
-}
-
-void DocumentBroker::uploadBrowserSettingsToWopiHost(const std::shared_ptr<ClientSession>& session)
-{
-    const Authorization& auth = session->getAuthorization();
-    Poco::URI uriObject = DocumentBroker::getPresetUploadBaseUrl(_uriPublic);
-
-    const std::string& filePath = "/settings/userconfig/browsersetting/browsersetting.json";
-    uriObject.addQueryParameter("fileId", filePath);
-    auth.authorizeURI(uriObject);
-
-    const std::string& uriAnonym = COOLWSD::anonymizeUrl(uriObject.toString());
-
-    auto httpRequest = StorageConnectionManager::createHttpRequest(uriObject, auth);
-    httpRequest.setVerb(http::Request::VERB_POST);
-    auto httpSession = StorageConnectionManager::getHttpSession(uriObject);
-
-    auto browserSettingsJSON = session->getBrowserSettingJSON();
-    std::ostringstream jsonStream;
-    browserSettingsJSON->stringify(jsonStream, 2);
-    httpRequest.setBody(jsonStream.str(), "application/json; charset=utf-8");
-
-    http::Session::FinishedCallback finishedCallback =
-        [uriAnonym](const std::shared_ptr<http::Session>& wopiSession)
-    {
-        wopiSession->asyncShutdown();
-
-        const std::shared_ptr<const http::Response> httpResponse = wopiSession->response();
-        const http::StatusLine statusLine = httpResponse->statusLine();
-        if (statusLine.statusCode() != http::StatusCode::OK)
-        {
-            LOG_ERR("Failed to upload updated browsersetting to wopiHost["
-                    << uriAnonym << "] with status[" << statusLine.reasonPhrase() << ']');
-            return;
-        }
-        LOG_TRC("Successfully uploaded browsersetting to wopiHost");
-    };
-
-    LOG_DBG("Uploading browsersetting json [" << jsonStream.str() << "] to wopiHost[" << uriAnonym << ']');
-    httpSession->setFinishedHandler(std::move(finishedCallback));
-    httpSession->asyncRequest(httpRequest, *COOLWSD::getWebServerPoll());
 }
 #endif
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -380,8 +380,6 @@ public:
 #if !MOBILEAPP
     void syncBrowserSettings(const std::string& userId, const std::string& json);
 
-    void uploadBrowserSettingsToWopiHost(const std::shared_ptr<ClientSession>& session);
-
     void uploadPresetsToWopiHost();
 #endif
 


### PR DESCRIPTION
- Steps to reproduce:
1. Open 2 document for same user
2. Do a single change like for e.g toggle sidebar
3. Notice in logs browsersetting is uploaded twice

- It happens because syncBrowserSettings was getting called for each docbroker and in syncBrowserSetting we were uploading the browsersetting if we find a session with same userId.

- For above mentioned case we uploaded twice


Change-Id: I5bb1f3a6830bc3bc944e74e4f718c9962958db54

* Target version: master 
