### PR TITLE
docker: remove packages which were only needed for installation

### DIFF
--- a/docker/from-packages/Dockerfile
+++ b/docker/from-packages/Dockerfile
@@ -124,6 +124,8 @@ RUN --mount=type=secret,id=secret_key \
     chown cool:cool /etc/coolwsd/coolwsd.xml && \
 # Fix ownership of config directory that will be modified on start of the container by cool user
     chown cool:cool /etc/coolwsd && \
+# Remove packages which were only needed for installation (dependecies of curl, gnupg, fc-cache etc.)
+    dpkg --purge --ignore-depends=apt-transport-https,cpio,curl,dirmngr,fontconfig,fontconfig-config,fonts-dejavu-core,gnupg,gnupg-l10n,gnupg-utils,gnupg2,gpg,gpg-agent,gpg-wks-client,gpg-wks-server,gpgconf,gpgsm,krb5-locales,libassuan0,libbrotli1,libcap2-bin,libcurl4,libexpat1,libfontconfig1,libfreetype6,libgpm2,libksba8,libldap-2.5-0,libldap-common,libncursesw6,libnghttp2-14,libnpth0,libpng16-16,libpsl5,libreadline8,librtmp1,libsasl2-2,libsasl2-modules,libsasl2-modules-db,libsqlite3-0,libssh2-1,libssl3,openssl,pinentry-curses,publicsuffix,readline-common apt-transport-https cpio curl dirmngr fontconfig-config fonts-dejavu-core fontconfig gnupg gnupg-l10n gnupg-utils gnupg2 gpg gpg-agent gpg-wks-client gpg-wks-server gpgconf gpgsm krb5-locales libassuan0 libbrotli1 libcap2-bin libcurl4 libexpat1 libfontconfig1 libfreetype6 libgpm2 libksba8 libldap-2.5-0 libldap-common libncursesw6 libnghttp2-14 libnpth0 libpng16-16 libpsl5 libreadline8 librtmp1 libsasl2-2 libsasl2-modules libsasl2-modules-db libsqlite3-0 libssh2-1 libssl3 openssl pinentry-curses publicsuffix readline-common && \
 # Remove perl-base, it's not needed and triggered some license scanner because of Paul Hsieh derivative license
     dpkg --purge  --force-remove-essential --ignore-depends=perl-base perl-base && \
 # Cleanup


### PR DESCRIPTION
It is primarily to please vulnerability scanners. E.g. docker scout: 
- Before: 1 high, 1 medium, 35 low severity vulnerabilities 
- After: 24 low severity vulnerabilities


Change-Id: I1b0fa99bace739b38976e2fd4e7b30bfa9ce1f11

