### PR TITLE
Better Valgrind Support

### DIFF
--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -72,7 +72,7 @@ static std::atomic<bool> ForwardSigUsr2Flag(false); ///< Flags to forward SIG_US
 
 static std::atomic<size_t> ActivityStringIndex = 0;
 static std::string ActivityHeader;
-static std::array<std::atomic<char *>, 16> ActivityStrings;
+static std::array<std::atomic<char*>, 16> ActivityStrings{};
 static bool UnattendedRun = false;
 #if !MOBILEAPP
 static int SignalLogFD = STDERR_FILENO; ///< The FD where signalLogs are dumped.
@@ -85,6 +85,20 @@ static SigUtil::SigChildHandler SigChildHandle;
 
 namespace SigUtil
 {
+
+void uninitialize()
+{
+    for (size_t i = 0; i < ActivityStrings.size(); ++i)
+    {
+        char* old = ActivityStrings[i].exchange(nullptr);
+        free(old);
+    }
+
+#if !MOBILEAPP
+    free(VersionInfo);
+#endif
+}
+
 #ifndef IOS
 bool getShutdownRequestFlag() { return RunStateFlag >= RunState::ShutDown; }
 

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -75,6 +75,9 @@ namespace SigUtil
     /// and WTERMSIG(stat_loc), if it were SEGV, ABRT, or BUS.
     std::pair<int, int> reapZombieChild(int pid);
 
+    /// Uninitialize and free memory.
+    void uninitialize();
+
 #if !MOBILEAPP
 
     /// Open the signalLog file.

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -349,6 +349,7 @@ void SocketPoll::checkAndReThread()
 
 void SocketPoll::removeFromWakeupArray()
 {
+    if (_wakeup[1] != -1)
     {
         std::lock_guard<std::mutex> lock(getPollWakeupsMutex());
         auto it = std::find(getWakeupsArray().begin(),

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -71,13 +71,13 @@ private:
 class MemoryStatsTask;
 
 /// An admin command processor.
-class Admin : public SocketPoll
+class Admin final : public SocketPoll
 {
     Admin(const Admin &) = delete;
     Admin& operator = (const Admin &) = delete;
     Admin();
 public:
-    virtual ~Admin();
+    ~Admin() override;
 
     static Admin& instance()
     {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4055,6 +4055,8 @@ void COOLWSD::cleanup([[maybe_unused]] int returnValue)
         FileRequestHandler.reset();
         JWTAuth::cleanup();
 
+        Util::forcedExit(returnValue);
+
         TraceDumper.reset();
 
         Socket::InhibitThreadChecks = true;

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4006,9 +4006,13 @@ int COOLWSD::innerMain()
 
     SigUtil::addActivity("terminated unused children");
 
+    ClientRequestDispatcher::uninitialize();
+
 #if !MOBILEAPP
     if (!Util::isKitInProcess())
     {
+        SigUtil::addActivity("waiting for forkit to exit");
+
         // Wait for forkit process finish.
         LOG_INF("Waiting for forkit process to exit");
         int status = 0;

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3883,6 +3883,12 @@ int COOLWSD::innerMain()
     // atexit handlers tend to free Admin before Documents
     LOG_INF("Exiting. Cleaning up lingering documents.");
 #if !MOBILEAPP
+    if (remoteFontConfigThread)
+    {
+        LOG_DBG("Stopping remote font config thread");
+        remoteFontConfigThread->stop();
+    }
+
     if (!SigUtil::getShutdownRequestFlag())
     {
         // This shouldn't happen, but it's fail safe to always cleanup properly.

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1377,24 +1377,24 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
 
     const auto logToFile = ConfigUtil::getConfigValue<bool>(conf, "logging.file[@enable]", false);
     std::map<std::string, std::string> logProperties;
-    for (std::size_t i = 0; ; ++i)
-    {
-        const std::string confPath = "logging.file.property[" + std::to_string(i) + ']';
-        const std::string confName = config().getString(confPath + "[@name]", "");
-        if (!confName.empty())
-        {
-            const std::string value = config().getString(confPath, "");
-            logProperties.emplace(confName, value);
-        }
-        else if (!config().has(confPath))
-        {
-            break;
-        }
-    }
-
-    // Setup the logfile envar for the kit processes.
     if (logToFile)
     {
+        for (std::size_t i = 0;; ++i)
+        {
+            const std::string confPath = "logging.file.property[" + std::to_string(i) + ']';
+            const std::string confName = config().getString(confPath + "[@name]", "");
+            if (!confName.empty())
+            {
+                const std::string value = config().getString(confPath, "");
+                logProperties.emplace(confName, value);
+            }
+            else if (!config().has(confPath))
+            {
+                break;
+            }
+        }
+
+        // Setup the logfile envar for the kit processes.
         const auto it = logProperties.find("path");
         if (it != logProperties.end())
         {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4066,6 +4066,8 @@ void COOLWSD::cleanup([[maybe_unused]] int returnValue)
             DocBrokers.clear();
         }
 
+        SigUtil::uninitialize();
+
 #if ENABLE_SSL
         // Finally, we no longer need SSL.
         if (ConfigUtil::isSslEnabled())

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4030,10 +4030,6 @@ int COOLWSD::innerMain()
 
     SigUtil::addActivity("finished with status " + std::to_string(returnValue));
 
-    // At least on centos7, Poco deadlocks while
-    // cleaning up its SSL context singleton.
-    Util::forcedExit(returnValue);
-
     return returnValue;
 #endif
 }
@@ -4059,10 +4055,27 @@ void COOLWSD::cleanup([[maybe_unused]] int returnValue)
         FileRequestHandler.reset();
         JWTAuth::cleanup();
 
+        TraceDumper.reset();
+
+        Socket::InhibitThreadChecks = true;
+        SocketPoll::InhibitThreadChecks = true;
+
+        // Delete these while the static Admin instance is still alive.
+        {
+            std::lock_guard<std::mutex> docBrokersLock(DocBrokersMutex);
+            DocBrokers.clear();
+        }
+
 #if ENABLE_SSL
         // Finally, we no longer need SSL.
         if (ConfigUtil::isSslEnabled())
         {
+#if !ENABLE_DEBUG
+            // At least on centos7, Poco deadlocks while
+            // cleaning up its SSL context singleton.
+            Util::forcedExit(returnValue);
+#endif // !ENABLE_DEBUG
+
             Poco::Net::uninitializeSSL();
             Poco::Crypto::uninitializeCrypto();
             ssl::Manager::uninitializeClientContext();
@@ -4070,15 +4083,6 @@ void COOLWSD::cleanup([[maybe_unused]] int returnValue)
         }
 #endif
 #endif
-
-        TraceDumper.reset();
-
-        Socket::InhibitThreadChecks = true;
-        SocketPoll::InhibitThreadChecks = true;
-
-        // Delete these while the static Admin instance is still alive.
-        std::lock_guard<std::mutex> docBrokersLock(DocBrokersMutex);
-        DocBrokers.clear();
     }
     catch (const std::exception& ex)
     {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1406,26 +1406,27 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
     }
 
     // Do the same for ui command logging
-    const auto logToFileUICmd = ConfigUtil::getConfigValue<bool>(conf, "logging_ui_cmd.file[@enable]", false);
+    const bool logToFileUICmd =
+        ConfigUtil::getConfigValue<bool>(conf, "logging_ui_cmd.file[@enable]", false);
     std::map<std::string, std::string> logPropertiesUICmd;
-    for (std::size_t i = 0; ; ++i)
-    {
-        const std::string confPath = "logging_ui_cmd.file.property[" + std::to_string(i) + ']';
-        const std::string confName = config().getString(confPath + "[@name]", "");
-        if (!confName.empty())
-        {
-            const std::string value = config().getString(confPath, "");
-            logPropertiesUICmd.emplace(confName, value);
-        }
-        else if (!config().has(confPath))
-        {
-            break;
-        }
-    }
-
-    // Setup the logfile envar for the kit processes.
     if (logToFileUICmd)
     {
+        for (std::size_t i = 0;; ++i)
+        {
+            const std::string confPath = "logging_ui_cmd.file.property[" + std::to_string(i) + ']';
+            const std::string confName = config().getString(confPath + "[@name]", "");
+            if (!confName.empty())
+            {
+                const std::string value = config().getString(confPath, "");
+                logPropertiesUICmd.emplace(confName, value);
+            }
+            else if (!config().has(confPath))
+            {
+                break;
+            }
+        }
+
+        // Setup the logfile envar for the kit processes.
         const auto it = logPropertiesUICmd.find("path");
         if (it != logPropertiesUICmd.end())
         {

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -282,7 +282,7 @@ protected:
     int main(const std::vector<std::string>& args) override;
 
     /// Handle various global static destructors.
-    static void cleanup();
+    static void cleanup(int returnValue);
 
 private:
 #if !MOBILEAPP

--- a/wsd/ClientRequestDispatcher.hpp
+++ b/wsd/ClientRequestDispatcher.hpp
@@ -25,14 +25,20 @@
 class ClientRequestDispatcher final : public SimpleSocketHandler
 {
 public:
-    ClientRequestDispatcher() {}
-
     static void InitStaticFileContentCache()
     {
         StaticFileContentCache["discovery.xml"] = getDiscoveryXML();
     }
 
     typedef std::function<void(bool)> AsyncFn;
+
+    /// Uninitialize static data.
+    static void uninitialize()
+    {
+        StaticFileContentCache.clear();
+
+        RequestVettingStations.clear();
+    }
 
 private:
     /// Set the socket associated with this ResponseClient.

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -90,8 +90,6 @@ public:
         return false;
     }
 
-    ClientDeltaTracker _tracker;
-
     void resetTileSeq(const TileDesc &desc)
     {
         _tracker.resetTileSeq(desc);
@@ -398,6 +396,9 @@ private:
 
     /// Sockets to send binary selection content to
     std::vector<std::weak_ptr<StreamSocket>> _clipSockets;
+
+    /// Delta tile tracker.
+    ClientDeltaTracker _tracker;
 
     /// Visible area of the client
     Util::Rectangle _clientVisibleArea;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2330,7 +2330,7 @@ bool DocumentBroker::isStorageOutdated() const
             << " and the last uploaded file was modified at " << lastModifiedTime << ", which are "
             << (currentModifiedTime == lastModifiedTime ? "identical" : "different"));
 
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG
     if (_storageManager.getLastUploadedFileModifiedTime() != _saveManager.getLastModifiedTime())
     {
         const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();

--- a/wsd/TileCache.hpp
+++ b/wsd/TileCache.hpp
@@ -347,15 +347,14 @@ private:
 
 /// Tracks view-port area tiles to track which we last
 /// sent to avoid re-sending an existing delta causing grief
-class ClientDeltaTracker final {
-public:
+class ClientDeltaTracker final
+{
     // FIXME: could be a simple 2d TileWireId array for better packing.
     std::unordered_set<TileDesc,
                        TileDescCacheHasher,
                        TileDescCacheCompareEq> _cache;
-    ClientDeltaTracker() {
-    }
 
+public:
     // FIXME: only need to store this for the current viewports
     void updateViewPort( /* ... */ )
     {

--- a/wsd/TileDesc.hpp
+++ b/wsd/TileDesc.hpp
@@ -268,8 +268,8 @@ public:
 
     /// Serialize this instance into a string.
     /// Optionally prepend a prefix.
-    std::string serialize(const std::string& prefix = std::string(),
-                          const std::string& suffix = std::string()) const
+    std::string serialize(std::string_view prefix = std::string_view(),
+                          std::string_view suffix = std::string_view()) const
     {
         std::ostringstream oss;
         oss << prefix
@@ -393,7 +393,7 @@ public:
     }
 
     /// Deserialize a TileDesc from a string format.
-    static TileDesc parse(const std::string& message)
+    static TileDesc parse(std::string_view message)
     {
         return parse(StringVector::tokenize(message.data(), message.size()));
     }
@@ -598,8 +598,8 @@ public:
 
     /// Serialize this instance into a string.
     /// Optionally prepend a prefix.
-    std::string serialize(const std::string& prefix = std::string(),
-                          const std::string &suffix = std::string()) const
+    std::string serialize(std::string_view prefix = std::string_view(),
+                          std::string_view suffix = std::string_view()) const
     {
         std::ostringstream oss;
         int num = 0;
@@ -757,7 +757,7 @@ public:
     }
 
     /// Deserialize a TileDesc from a string format.
-    static TileCombined parse(const std::string& message)
+    static TileCombined parse(std::string_view message)
     {
         return parse(StringVector::tokenize(message.data(), message.size()));
     }

--- a/wsd/wopi/WopiStorage.hpp
+++ b/wsd/wopi/WopiStorage.hpp
@@ -253,14 +253,6 @@ protected:
                                                std::string responseString);
 
 private:
-    /// Initialize an HTTPRequest instance with the common settings and headers.
-    /// Older Poco versions don't support copying HTTPRequest objects, so we can't generate them.
-    void initHttpRequest(Poco::Net::HTTPRequest& request, const Poco::URI& uri,
-                         const Authorization& auth) const;
-
-    /// Create an http::Request with the common headers.
-    http::Request initHttpRequest(const Poco::URI& uri, const Authorization& auth) const;
-
     /// Download the document from the given URI.
     /// Does not add authorization tokens or any other logic.
     std::string downloadDocument(const Poco::URI& uriObject, const std::string& uriAnonym,


### PR DESCRIPTION
Various improvements to getting a cleaner valgrind memcheck report.

- **wsd: don't process logging_ui_cmd config if disabled**
- **wsd: don't process logging config if disabled**
- **wsd: clean up remote font config thread before exiting**
- **wsd: unique_ptr needs the size of the pointee**
- **wsd: addStorageDebugCookie in StorageConnectionManager**
- **wsd: replace WopiStorage::initHttpRequest() with StorageConnectionManager**
- **wsd: Admin class cosmetics**
- **wsd: overwrite coolwsd exit code with unit-test result**
- **wsd: clean up as much as possible before forced exit**
- **wsd: add SigUtil::uninitialize()**
- **wsd: string_view in TileDesc**
- **wsd: privatize ClientDeltaTracker**
- **wsd: log active ClientSession in DocBroker dtor**
- **wsd: uninitialize ClientRequestDispatcher**
- **wsd: check the value of ENABLE_DEBUG**
