### PR TITLE
cool#11347 cypress desktop: restore the last test in writer/scrolling_spec.js

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
@@ -57,9 +57,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		desktopHelper.assertScrollbarPosition('horizontal', 430, 653);
 	});
 
-	// TODO: fix this test, it seems like scrollWriterDocumentToTop is not scrolling to the top
-	// visually
-	it.skip('Check if we jump the view on change of formatting mark', function() {
+	it('Check if we jump the view on change of formatting mark', function() {
 		desktopHelper.switchUIToNotebookbar();
 
 		desktopHelper.selectZoomLevel('40', false);


### PR DESCRIPTION
This was removed in commit 0acb3d515fe4d2a020c91ed833db1c3a72a09cfb
(cypres: fix broken test after switching to 25.04 core branch,
2025-03-14), but the underlying problem is fixed with core.git commit
2490d8fc97b9ec9819755a3b81a6e464431c7cdb (cool#11347 sw lok: avoid view
jump on showing formatting marks, 2025-03-14), so this can be restored.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ifdabf3a4f7f193dc257568df3bb1e6658422efff
