### PR TITLE
Don't cache null canvases in TilesMiddleware.CanvasCache

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -252,30 +252,29 @@ class CanvasCache {
 	}
 
 	releaseCanvas(tile: Tile) {
-		var item: CanvasItem = new CanvasItem();
-		item.canvas = tile.canvas;
-		item.ctx = tile.ctx;
+		if (tile.canvas && tile.ctx) {
+			var item: CanvasItem = new CanvasItem();
+			item.canvas = tile.canvas;
+			item.ctx = tile.ctx;
+			this._canvasList.push(item);
+		}
+
 		tile.canvas = null;
 		tile.ctx = null;
-		this._canvasList.push(item);
-
 		tile.imgDataCache = null;
 	}
 
 	trim(limit: number) {
 		while (this._canvasList.length > limit) {
 			const item = this._canvasList.pop();
-			if (!item) continue;
 
 			// Fix for cool#5876 allow immediate reuse of canvas context memory
 			// WKWebView has a hard limit on the number of bytes of canvas
 			// context memory that can be allocated. Reducing the canvas
 			// size to zero is a way to reduce the number of bytes counted
 			// against this limit.
-			if (item.canvas) {
-				item.canvas.width = 0;
-				item.canvas.height = 0;
-			}
+			item.canvas.width = 0;
+			item.canvas.height = 0;
 
 			delete item.canvas;
 		}


### PR DESCRIPTION
### Summary

`releaseCanvas` can be called on tiles with no canvas, make sure to check a canvas and context are non-null before adding them to the cache. This is follow-up from #11351 

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

