### PR TITLE
fix(multimedia): Insert multimedia at correct size

### DIFF
--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -442,22 +442,6 @@ class ShapeHandlesSection extends CanvasSectionObject {
 		source[0].src = decodeURIComponent(source[0].src);
 
 		this.addVideoSupportHandlers(videos);
-
-		function _fixSVGPos() {
-			var mat = this.sectionProperties.svg.getScreenCTM();
-			var boundingBox = this.context.canvas.getBoundingClientRect();
-			videoContainer.style.transform = 'matrix(' + [mat.a, mat.b, mat.c, mat.d, mat.e - boundingBox.x, mat.f - boundingBox.y].join(', ') + ')';
-		}
-		var fixSVGPos = _fixSVGPos.bind(this);
-
-		if (L.Browser.safari) {
-			fixSVGPos();
-			var observer = new MutationObserver(fixSVGPos);
-
-			observer.observe(this.context.canvas, {
-				attributes: true
-			});
-		}
 	}
 
 	removeTagFromHTML(data: string, startString: string, endString: string): string {

--- a/browser/src/map/handler/Map.FileInserter.js
+++ b/browser/src/map/handler/Map.FileInserter.js
@@ -109,11 +109,48 @@ L.Map.FileInserter = L.Handler.extend({
 		this._toInsertBackground = {};
 	},
 
-	_sendFile: function (name, file, type) {
+	_sendFile: async function (name, file, type) {
 		var socket = app.socket;
 		var map = this._map;
 		var sectionContainer = app.sectionContainer;
 		var url = this.getWopiUrl(map);
+
+		var size;
+
+		if (type === 'multimedia') {
+			const videoElement = document.createElement('video');
+			const objectURL = window.URL.createObjectURL(file);
+			videoElement.src = objectURL;
+
+			const videoLoadPromise = new Promise((resolve, reject) => {
+				videoElement.addEventListener("loadedmetadata", resolve);
+				videoElement.addEventListener("error", reject);
+			});
+
+			videoElement.load();
+
+			let videoLoaded = false;
+
+			try {
+				await videoLoadPromise;
+				videoLoaded = true;
+			} catch (_error) {
+				size = {
+					width: 0,
+					height: 0,
+				}; // 0, 0 will make core pick the minimum size - which was the behavior before we checked size like this
+			}
+
+			if (videoLoaded) {
+				size = {
+					width: videoElement.videoWidth,
+					height: videoElement.videoHeight,
+				};
+			}
+
+			videoElement.src = undefined;
+			window.URL.revokeObjectURL(objectURL);
+		}
 
 		if ('processCoolUrl' in window) {
 			url = window.processCoolUrl({ url: url, type: 'insertfile' });
@@ -140,8 +177,15 @@ L.Map.FileInserter = L.Handler.extend({
 					for (var i = 0; i < byteBuffer.length; i++) {
 						strBytes += String.fromCharCode(byteBuffer[i]);
 					}
-					window.postMobileMessage('insertfile name=' + aFile.name + ' type=' + type +
-										       ' data=' + window.btoa(strBytes));
+
+					if (type === 'multimedia') {
+						window.postMobileMessage('insertfile name=' + aFile.name + ' type=' + type +
+											       ' data=' + window.btoa(strBytes) +
+											       ' width=' + size.width + ' height=' + size.height);
+					} else {
+						window.postMobileMessage('insertfile name=' + aFile.name + ' type=' + type +
+											       ' data=' + window.btoa(strBytes));
+					}
 				};
 			})(file);
 			reader.onerror = function(e) {
@@ -165,6 +209,8 @@ L.Map.FileInserter = L.Handler.extend({
 						}
 						if (section && section.sectionProperties.picturePicker && type === 'graphic') {
 							socket.sendMessage('contentcontrolevent type=picture' + ' name=' + name);
+						} else if (type === 'multimedia') {
+							socket.sendMessage('insertfile name=' + name + ' type=' + type + ' width=' + size.width + ' height=' + size.height);
 						} else {
 							socket.sendMessage('insertfile name=' + name + ' type=' + type);
 						}

--- a/browser/src/map/handler/Map.FileInserter.js
+++ b/browser/src/map/handler/Map.FileInserter.js
@@ -146,6 +146,20 @@ L.Map.FileInserter = L.Handler.extend({
 					width: videoElement.videoWidth,
 					height: videoElement.videoHeight,
 				};
+
+				const maxSize = {
+					width: app.file.size.cX * map.getZoomScale(10),
+					height: app.file.size.cY * map.getZoomScale(10),
+				};
+
+				const shrinkToFitFactor = Math.min(
+					1,
+					maxSize.width / size.width,
+					maxSize.height / size.height
+				);
+
+				size.width *= shrinkToFitFactor;
+				size.height *= shrinkToFitFactor;
 			}
 
 			videoElement.src = undefined;

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1846,6 +1846,7 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
     csp.appendDirective("font-src", "'self'");
     csp.appendDirective("object-src", "'self'");
     csp.appendDirective("media-src", "'self'");
+    csp.appendDirective("media-src", "blob:");
     csp.appendDirectiveUrl("media-src", cnxDetails.getWebServerUrl());
     csp.appendDirective("img-src", "'self'");
     csp.appendDirective("img-src", "data:"); // Equivalent to unsafe-inline!
@@ -2409,6 +2410,7 @@ void FileServerRequestHandler::preprocessIntegratorAdminFile(const HTTPRequest& 
     csp.appendDirective("font-src", "'self'");
     csp.appendDirective("object-src", "'self'");
     csp.appendDirective("media-src", "'self'");
+    csp.appendDirective("media-src", "blob:");
     csp.appendDirectiveUrl("media-src", cnxDetails.getWebServerUrl());
     csp.appendDirectiveUrl("connect-src", cnxDetails.getWebServerUrl());
     csp.appendDirective("img-src", "'self'");


### PR DESCRIPTION
Previously we were not getting the size of multimedia we were inserting as we can't use gstreamer to do this job in core and we had no process for doing this in online. That meant that all videos were inserted with a fallback size, which happened to be small and square. As not all videos are small and square, this led to some videos having a box with a considerably different aspect ratio than the video itself.

This patch is probably not quite right - for instance if we insert a very large video it will end up much, much bigger than the slide - but it's probably a good jumping-off point to do nicer things.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

