### PR TITLE
make run mode fd leak

### DIFF
--- a/wsd/wopi/CheckFileInfo.cpp
+++ b/wsd/wopi/CheckFileInfo.cpp
@@ -41,6 +41,8 @@ void CheckFileInfo::checkFileInfo(int redirectLimit)
     http::Session::FinishedCallback finishedCallback =
         [selfWeak = weak_from_this(), this, startTime, uriAnonym, redirectLimit](const std::shared_ptr<http::Session>& session)
     {
+        session->asyncShutdown();
+
         std::shared_ptr<CheckFileInfo> selfLifecycle = selfWeak.lock();
         if (!selfLifecycle)
             return;


### PR DESCRIPTION
To reproduce: open a document through a debug link and close it to establish a baseline.

On each subsequent open and close:
$ ls /proc/`pidof coolwsd`/fd|wc
increments by 2

in ClientRequestDispatcher::handleIncomingMessage closeConnection is the default 'false' for this request and nothing otherwise explictly closes the socket on that side.

Anything similar is not seen in release mode with, e.g. a nextcloud instance.


Change-Id: I927138ba77f54ff6ae86a7c10f003abd89549653


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

