### PR TITLE
httpecho fuzzer: fix this to work with net::AsyncDNS

### DIFF
--- a/fuzzer/HttpEcho.cpp
+++ b/fuzzer/HttpEcho.cpp
@@ -27,6 +27,7 @@
 #include <net/ServerSocket.hpp>
 #include <net/DelaySocket.hpp>
 #include <net/HttpRequest.hpp>
+#include <net/AsyncDNS.hpp>
 #include <FileUtil.hpp>
 #include <Util.hpp>
 #include <fuzzer/Common.hpp>
@@ -54,6 +55,7 @@ public:
         : _pollServerThread("HttpServerPoll")
         , _poller("HttpSynReqPoll")
     {
+        net::AsyncDNS::startAsyncDNS();
         _poller.runOnClientThread();
 
         std::map<std::string, std::string> logProperties;
@@ -97,6 +99,7 @@ public:
     {
         _pollServerThread.stop();
         _socket.reset();
+        net::AsyncDNS::stopAsyncDNS();
     }
 
     const std::string& localUri() const { return _localUri; }


### PR DESCRIPTION
Otherwise with fail in a non-interesting way:

	net/NetUtil.cpp:443:21: runtime error: member call on null pointer of type 'net::AsyncDNS'
	    #0 0x5639c3c2ea77 in net::AsyncDNS::lookup(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::function<void (net::HostEntry const&)> const&, std::function<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> ()> const&) /home/vmiklos/git/collaboraonline/online-fuzz/net/NetUtil.cpp:443:21
	    #1 0x5639c3c2e5a1 in net::syncResolveDNS(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /home/vmiklos/git/collaboraonline/online-fuzz/net/NetUtil.cpp:213:5
	    #2 0x5639c3c395d3 in net::connect(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool, std::shared_ptr<ProtocolHandlerInterface> const&) /home/vmiklos/git/collaboraonline/online-fuzz/net/NetUtil.cpp:578:25
	    #3 0x5639c36d11e4 in http::Session::connect() /home/vmiklos/git/collaboraonline/online-fuzz/./net/HttpRequest.hpp:1713:13
	    #4 0x5639c36cf47a in http::Session::syncRequestImpl(SocketPoll&) /home/vmiklos/git/collaboraonline/online-fuzz/./net/HttpRequest.hpp:1446:52
	    #5 0x5639c36ce50b in http::Session::syncRequest(http::Request const&, SocketPoll&) /home/vmiklos/git/collaboraonline/online-fuzz/./net/HttpRequest.hpp:1285:9

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I4281172e2d20b85eaec0a68fb627f4ce3da8f3c2
