### PR TITLE
Fix double-resize on CanvasSectionContainer

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1338,8 +1338,10 @@ class CanvasSectionContainer {
 		newWidth = Math.floor(newWidth * app.dpiScale);
 		newHeight = Math.floor(newHeight * app.dpiScale);
 
-		if (this.width === newWidth && this.height === newHeight && this.documentAnchor)
+		if (this.width === newWidth && this.height === newHeight && this.documentAnchor) {
+			this.reNewAllSections(false);
 			return;
+		}
 
 		// Drawing may happen asynchronously so backup the old contents to avoid
 		// showing a blank canvas.
@@ -1366,7 +1368,7 @@ class CanvasSectionContainer {
 		this.width = this.canvas.width;
 		this.height = this.canvas.height;
 
-		this.reNewAllSections();
+		this.reNewAllSections(false);
 	}
 
 	findSectionContainingPoint (point: Array<number>): any {


### PR DESCRIPTION
### Summary

When a resize is handled by CanvasTileLayer, two resizes may end up being triggered on CanvasSectionContainer. In this situation, the first happens prematurely and causes drawing to happen before the map is updated, while the second is ignored because the canvas size change was already handled.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required