### PR TITLE
mobile: do not use notebookbar

### DIFF
--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -77,6 +77,10 @@ L.Control.UIManager = L.Control.extend({
 	// UI initialization
 
 	getCurrentMode: function() {
+		// no notebookbar on mobile
+		if (window.mode.isMobile())
+			return 'classic';
+
 		return this.shouldUseNotebookbarMode() ? 'notebookbar' : 'classic';
 	},
 


### PR DESCRIPTION
on mobile there is no notebookbar but we still tried to use it in some cases - detected in cypress