### PR TITLE
fd leak with --with-infobar-url

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3536,6 +3536,8 @@ void COOLWSD::processFetchUpdate(SocketPoll& poll)
         request.add("Accept", "application/json");
 
         FetchHttpSession->setFinishedHandler([](const std::shared_ptr<http::Session>& httpSession) {
+            httpSession->asyncShutdown();
+
             std::shared_ptr<http::Response> httpResponse = httpSession->response();
 
             FetchHttpSession.reset();


### PR DESCRIPTION
If I munge fetchUpdateCheck to make this happen once a second instead of the default every 10 hours I can see this rapidly accumulates hundreds of open fds: ls /proc/`pidof coolwsd`/fd|wc

Unlikely to be very significant in a normal setup.


Change-Id: Ib5041835d2bbd10a52aa98997cbc806a25f06e3a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

