### PR TITLE
silence worrying 'Waking up dead poll thread [main]' warning

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3747,6 +3747,7 @@ int COOLWSD::innerMain()
 
     /// The main-poll does next to nothing:
     std::shared_ptr<SocketPoll> mainWait = std::make_shared<SocketPoll>("main");
+    mainWait->runOnClientThread();
 
     SigUtil::addActivity("coolwsd accepting connections");
 


### PR DESCRIPTION
from --with-infobar-url feature:

[ asyncdns ] WRN Waking up dead poll thread [main], started: false, finished: false| net/Socket.hpp:830
[ coolwsd ] WRN  Waking up dead poll thread [main], started: false, finished: false| net/Socket.hpp:830


Change-Id: I23cd2981d70abf4d57907614eb9adf66926828fd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

