### PR TITLE
DocumentBroker::dumpState seen to crash

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -5282,7 +5282,10 @@ void DocumentBroker::dumpState(std::ostream& os)
     _nextStorageAttrs.dumpState(os, "\n      ");
 
     os << "\n  Storage:";
-    _storage->dumpState(os, "\n    ");
+    if (_storage)
+        _storage->dumpState(os, "\n    ");
+    else
+        os << " none";
 
     os << '\n';
     _lockCtx->dumpState(os);


### PR DESCRIPTION
hard to find what is crashing in a optimized build, but:

print _storage._M_t._M_t._M_head_impl
$13 = (StorageBase *) 0x0

points to recently added _storage->dumpState()


Change-Id: Iab3595bdfb3fa2a494dce5f54873313db4be500a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

