### PR TITLE
browsersettting: fallback to localStorage/uiDefault for undefined setting

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -722,8 +722,11 @@ function getInitializerClass() {
 				let val = defaultValue;
 				if (Object.prototype.hasOwnProperty.call(global.prefs._userBrowserSetting, key))
 					val = global.prefs._userBrowserSetting[key];
-				global.prefs._localStorageCache[key] = val;
-				return val;
+
+				if(val !== undefined) {
+					global.prefs._localStorageCache[key] = val;
+					return val;
+				}
 			}
 
 			if (global.prefs.canPersist) {


### PR DESCRIPTION
browsersettting: fallback to localStorage/uiDefault for undefined setting

When a browser setting is not defined, use localStorage/uiDefault as a fallback. This fixes the regression related to the saveAsMode issue. bug: https://github.com/CollaboraOnline/online/issues/11297


Change-Id: Ic035f3a5af95f903aff4934e998dd0a38675ccdc


* Resolves: #11297 
* Target version: master 


