### PR TITLE
Calc: Return early from _syncTileContainerSize if size doesn't need t…

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -401,6 +401,11 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 
 		const mapElement = document.getElementById('map'); // map's size = tiles section's size.
 		const oldMapSize = [mapElement.clientWidth, mapElement.clientHeight];
+
+		// Early exit. If there is no need to update the size, return here.
+		if (oldMapSize[0] === newMapSize[0] && oldMapSize[1] === newMapSize[1])
+			return false;
+
 		this._resizeMapElementAndTilesLayer(mapElement, marginLeft, marginTop, newMapSize);
 
 		app.sectionContainer.onResize(newCanvasSize[0], newCanvasSize[1]); // Canvas's size = documentContainer's size.


### PR DESCRIPTION
…o change.

Previously we were using _syncTileContainerSize after resizing event. Now we need to check it after restricDocumentSize function. If there is no need to resize the canvas and map elements, return early.


Change-Id: Ic56f4358327680fc52c9a788e48fe1750deeca9c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

