### PR TITLE
Fix TileManager.garbageCollect

### DIFF
--- a/browser/src/app/MultiPageViewLayout.ts
+++ b/browser/src/app/MultiPageViewLayout.ts
@@ -174,6 +174,6 @@ class MultiPageViewLayout {
 		this.resetViewLayout();
 		app.map._docLayer._sendClientZoom();
 		const bounds = this.sendClientVisibleArea();
-		TileManager.udpateLayoutView(bounds);
+		TileManager.updateLayoutView(bounds);
 	}
 }

--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -2187,7 +2187,7 @@ class TileManager {
 		Checks the visible tiles in current zoom level.
 		Marks the visible ones as current.
 	*/
-	public static udpateLayoutView(bounds: any): any {
+	public static updateLayoutView(bounds: any): any {
 		const queue = this.getMissingTiles(bounds, Math.round(app.map.getZoom()));
 
 		if (queue.length > 0) this.addTiles(queue, false);

--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -152,8 +152,8 @@ class Tile {
 	invalidFrom: number = 0; // a wireId - for avoiding races on invalidation
 	lastRendered: Date = new Date();
 	private lastRequestTime: Date = undefined; // when did we last do a tilecombine request.
-	hasPendingDelta: 0;
-	hasPendingKeyframe: 0;
+	hasPendingDelta: number = 0;
+	hasPendingKeyframe: number = 0;
 
 	constructor(coords: TileCoordData) {
 		this.coords = coords;
@@ -172,7 +172,7 @@ class Tile {
 	}
 
 	hasKeyframe(): boolean {
-		return this.rawDeltas && this.rawDeltas.length > 0;
+		return !!this.rawDeltas && this.rawDeltas.length > 0;
 	}
 
 	hasPendingUpdate(): boolean {

--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -136,7 +136,7 @@ class PaneBorder {
 
 class Tile {
 	coords: TileCoordData;
-	current: boolean = true; // is this currently visible
+	current: boolean = false; // is this currently visible
 	canvas: any = null; // canvas ready to render
 	ctx: CanvasRenderingContext2D | null = null; // canvas context to render onto
 	imgDataCache: any = null; // flat byte array of canvas data
@@ -366,27 +366,35 @@ class TileManager {
 		   highDeltaMemory = 1024*1024; lowDeltaMemory = 1024*128;
 		   highTileCount = 100; lowTileCount = 50; */
 
-		// FIXME: should we sort by wireId - which is monotonic server ~time
-		// sort by oldest
+		// sort by lastRendered.
+		// FIXME: This is a really coarse sort, we probably want to sort by distance
+		//        to the view centre.
 		var keys = Object.keys(this.tiles).sort((a: any, b: any) => {
 			return this.tiles[a].lastRendered - this.tiles[b].lastRendered;
 		});
 
 		var canvasKeys = [];
 		var totalSize = 0;
+		var n_canvases = 0;
 		for (var i = 0; i < keys.length; ++i) {
 			var tile = this.tiles[keys[i]];
-			// Don't GC tiles that are visible or that have pending deltas. In
-			// the latter case, those tiles would just be immediately recreated
-			// and the former case can cause visible flicker.
-			if (tile.canvas && !tile.current && tile.hasPendingDelta === 0)
-				canvasKeys.push(keys[i]);
+			// Don't GC tiles that are visible or that have pending deltas. We don't have
+			// a mechanism to immediately rehydrate tiles, so GC'ing visible tiles would
+			// cause flickering, and the same would happen for tiles with pending deltas.
+			if (tile.canvas) {
+				++n_canvases;
+				if (!tile.current && !tile.hasPendingDelta) canvasKeys.push(keys[i]);
+			}
 			totalSize += tile.rawDeltas ? tile.rawDeltas.length : 0;
 		}
 
 		// Trim ourselves down to size.
-		if (canvasKeys.length > highNumCanvases) {
-			for (var i = 0; i < canvasKeys.length - lowNumCanvases; ++i) {
+		if (n_canvases > highNumCanvases) {
+			var n_to_reclaim = Math.min(
+				canvasKeys.length,
+				n_canvases - lowNumCanvases,
+			);
+			for (var i = 0; i < n_to_reclaim; ++i) {
 				var key = canvasKeys[i];
 				var tile = this.tiles[key];
 				if (this.debugDeltas)
@@ -394,8 +402,12 @@ class TileManager {
 						'Reclaim canvas ' + key + ' last rendered: ' + tile.lastRendered,
 					);
 				this.reclaimTileCanvasMemory(tile);
+				--n_canvases;
 			}
 		}
+
+		// FIXME: We should consider resorting keys by wireId now -
+		// 	      which is monotonic server ~time
 
 		// Trim memory down to size.
 		if (totalSize > highDeltaMemory) {
@@ -426,16 +438,17 @@ class TileManager {
 			for (var i = 0; i < keys.length - lowTileCount; ++i) {
 				const key = keys[i];
 				const tile: Tile = this.tiles[key];
-				if (!tile.current) this.removeTile(keys[i]);
+				if (!tile.current) {
+					if (tile.canvas) --n_canvases;
+					this.removeTile(keys[i]);
+				}
 			}
 		}
 
-		// Canvases are returned to a cache when reclaimed. Given
-		// (highNumCanvases - lowNumCanvases) canvases may regularly be returned to
-		// the cache, ensure the cache stays about that size.
-		// Under regular circumstances, this should do nothing and is a failsafe.
-		const canvasCacheTargetSize = highNumCanvases - lowNumCanvases;
-		if (this.canvasCache.size > canvasCacheTargetSize * 1.5)
+		// Canvases are returned to a cache when reclaimed. Try to keep the total
+		// number of alive canvases within the specified limits.
+		const canvasCacheTargetSize = highNumCanvases - n_canvases;
+		if (this.canvasCache.size > canvasCacheTargetSize)
 			this.canvasCache.trim(canvasCacheTargetSize);
 	}
 
@@ -1240,7 +1253,7 @@ class TileManager {
 					this._pixelBounds.getSize().y * direction[1],
 				);
 
-				var queue = this.getMissingTiles(this._pixelBounds, this._zoom);
+				var queue = this.getMissingTiles(this._pixelBounds, this._zoom, false);
 
 				if (this._docLayer.isCalc() || queue.length === 0) {
 					// pre-load more aggressively
@@ -1249,7 +1262,7 @@ class TileManager {
 						(this._pixelBounds.getSize().y * direction[1]) / 2,
 					);
 					queue = queue.concat(
-						this.getMissingTiles(this._pixelBounds, this._zoom),
+						this.getMissingTiles(this._pixelBounds, this._zoom, false),
 					);
 				}
 
@@ -1363,13 +1376,21 @@ class TileManager {
 		return boundList.map(this.pxBoundsToTileRange, this);
 	}
 
-	private static getMissingTiles(pixelBounds: any, zoom: number) {
+	private static getMissingTiles(
+		pixelBounds: any,
+		zoom: number,
+		updateCurrent: boolean,
+	) {
 		var tileRanges = this.pxBoundsToTileRanges(pixelBounds);
 		var queue = [];
 
+		if (updateCurrent) {
+			for (var key in this.tiles) this.tiles[key].current = false;
+		}
+
 		// create a queue of coordinates to load tiles from
 		this.beginTransaction();
-		var redraw = false;
+		let didRehydrate = false;
 		for (var rangeIdx = 0; rangeIdx < tileRanges.length; ++rangeIdx) {
 			var tileRange = tileRanges[rangeIdx];
 			for (var j = tileRange.min.y; j <= tileRange.max.y; ++j) {
@@ -1388,14 +1409,21 @@ class TileManager {
 
 					var key = coords.key();
 					var tile = this.tiles[key];
-					if (tile && !tile.needsFetch())
-						redraw = redraw || this.makeTileCurrent(tile);
-					else queue.push(coords);
+					if (tile && !tile.needsFetch()) {
+						if (tile.needsRehydration()) {
+							this.rehydrateTile(tile);
+							didRehydrate = true;
+						}
+					} else queue.push(coords);
+
+					if (tile && updateCurrent) tile.current = true;
 				}
 			}
 		}
 		this.endTransaction(
-			redraw ? () => app.sectionContainer.requestReDraw() : null,
+			updateCurrent && didRehydrate && queue.length === 0
+				? () => app.sectionContainer.requestReDraw()
+				: null,
 		);
 
 		return queue;
@@ -1429,6 +1457,7 @@ class TileManager {
 	private static addTiles(
 		coordsQueue: Array<TileCoordData>,
 		preFetch: boolean = false,
+		isCurrent: boolean = false,
 	) {
 		// Remove irrelevant tiles from the queue earlier.
 		this.removeIrrelevantsFromCoordsQueue(coordsQueue);
@@ -1436,8 +1465,6 @@ class TileManager {
 		// If we're pre-fetching, we may end up rehydrating tiles, so begin a transaction
 		// so that they're grouped together.
 		if (preFetch) this.beginTransaction();
-
-		let redraw: boolean = false;
 
 		for (let i = 0; i < coordsQueue.length; i++) {
 			const key = coordsQueue[i].key();
@@ -1451,15 +1478,12 @@ class TileManager {
 				// opportunity to create an up to date
 				// canvas for the tile in advance.
 				this.ensureCanvas(tile, true, false);
-				redraw = redraw || tile.hasPendingUpdate();
 			}
+
+			tile.current = isCurrent;
 		}
 
-		if (preFetch) {
-			this.endTransaction(
-				redraw ? () => app.sectionContainer.requestReDraw() : null,
-			);
-		}
+		if (preFetch) this.endTransaction(null);
 
 		// sort the tiles by the rows
 		coordsQueue.sort(function (a, b) {
@@ -1928,7 +1952,7 @@ class TileManager {
 		var zoom = Math.round(app.map.getZoom());
 		var pixelBounds = app.map.getPixelBoundsCore(app.map.getCenter(), zoom);
 
-		var queue = this.getMissingTiles(pixelBounds, zoom);
+		var queue = this.getMissingTiles(pixelBounds, zoom, false);
 
 		return queue.length;
 	}
@@ -2008,24 +2032,13 @@ class TileManager {
 			zoom = Math.round(map.getZoom());
 		}
 
-		for (var key in this.tiles) {
-			var thiscoords = TileCoordData.keyToTileCoords(key);
-			if (
-				thiscoords.z !== zoom ||
-				thiscoords.part !== app.map._docLayer._selectedPart ||
-				thiscoords.mode !== app.map._docLayer._selectedMode
-			) {
-				this.tiles[key].current = false;
-			}
-		}
-
 		var pixelBounds = map.getPixelBoundsCore(center, zoom);
-		var queue = this.getMissingTiles(pixelBounds, zoom);
+		var queue = this.getMissingTiles(pixelBounds, zoom, true);
 
 		app.map._docLayer._sendClientVisibleArea();
 		app.map._docLayer._sendClientZoom();
 
-		if (queue.length !== 0) this.addTiles(queue, false);
+		if (queue.length !== 0) this.addTiles(queue, false, true);
 
 		if (app.map._docLayer.isCalc() || app.map._docLayer.isWriter())
 			this.initPreFetchAdjacentTiles();
@@ -2178,9 +2191,13 @@ class TileManager {
 		Marks the visible ones as current.
 	*/
 	public static updateLayoutView(bounds: any): any {
-		const queue = this.getMissingTiles(bounds, Math.round(app.map.getZoom()));
+		const queue = this.getMissingTiles(
+			bounds,
+			Math.round(app.map.getZoom()),
+			true,
+		);
 
-		if (queue.length > 0) this.addTiles(queue, false);
+		if (queue.length > 0) this.addTiles(queue, false, true);
 	}
 
 	public static getVisibleCoordList(

--- a/browser/src/canvas/sections/PreloadMapSection.ts
+++ b/browser/src/canvas/sections/PreloadMapSection.ts
@@ -117,8 +117,12 @@ class PreloadMapSection extends app.definitions.canvasSectionObject {
 							canvas.fillStyle = 'rgba(255, 0, 0, 0.8)'; // red
 						else if (tile.needsFetch())
 							canvas.fillStyle = 'rgba(255, 255, 0, 0.8)'; // yellow
+						else if (!tile.canvas)
+							canvas.fillStyle = 'rgba(0, 96, 0, 0.8)'; // dark green
+						else if (!tile.current)
+							canvas.fillStyle = 'rgba(0, 192, 0, 0.8)'; // green
 						// present
-						else canvas.fillStyle = 'rgba(0, 255, 0, 0.5)'; // green
+						else canvas.fillStyle = 'rgba(0, 255, 0, 0.5)'; // light green
 					} // outside document range
 					else canvas.fillStyle = 'rgba(0, 0, 0, 0.3)'; // dark grey
 

--- a/browser/src/canvas/sections/TilesSection.ts
+++ b/browser/src/canvas/sections/TilesSection.ts
@@ -712,6 +712,8 @@ export class TilesSection extends CanvasSectionObject {
 				canvas.fillStyle = 'rgba(255, 0, 0, 0.8)';   // red
 			else if (tile.needsFetch())
 				canvas.fillStyle = 'rgba(255, 255, 0, 0.8)'; // yellow
+			else if (tile.hasPendingUpdate())
+				canvas.fillStyle = 'rgba(0, 160, 0, 0.8)'; // dark green
 			else // present
 				canvas.fillStyle = 'rgba(0, 255, 0, 0.5)';   // green
 			canvas.fillRect(ox + dx + 1.5, oy + dy + 1.5, 12, 12);

--- a/browser/src/canvas/sections/TilesSection.ts
+++ b/browser/src/canvas/sections/TilesSection.ts
@@ -68,7 +68,7 @@ export class TilesSection extends CanvasSectionObject {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-	paintWithPanes (tile: any, ctx: any, async: boolean, now: Date): void {
+	paintWithPanes (tile: any, ctx: any, async: boolean): void {
 		var tileTopLeft = tile.coords.getPos();
 		var tileBounds = new L.Bounds(tileTopLeft, tileTopLeft.add(new L.Point(TileManager.tileSize, TileManager.tileSize)));
 
@@ -88,7 +88,7 @@ export class TilesSection extends CanvasSectionObject {
 				paneOffset.x = Math.min(paneOffset.x, viewBounds.min.x);
 				paneOffset.y = Math.min(paneOffset.y, viewBounds.min.y);
 
-				this.drawTileInPane(tile, tileBounds, paneBounds, paneOffset, this.context, async, now);
+				this.drawTileInPane(tile, tileBounds, paneBounds, paneOffset, this.context, async);
 			}
 		}
 	}
@@ -149,7 +149,7 @@ export class TilesSection extends CanvasSectionObject {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-	drawTileInPane (tile: any, tileBounds: any, paneBounds: any, paneOffset: any, canvasCtx: CanvasRenderingContext2D, clearBackground: boolean, now: Date): void {
+	drawTileInPane (tile: any, tileBounds: any, paneBounds: any, paneOffset: any, canvasCtx: CanvasRenderingContext2D, clearBackground: boolean): void {
 		// intersect - to avoid state thrash through clipping
 		var crop = new L.Bounds(tileBounds.min, tileBounds.max);
 		crop.min.x = Math.max(paneBounds.min.x, tileBounds.min.x);
@@ -175,7 +175,7 @@ export class TilesSection extends CanvasSectionObject {
 			}
 
 			this.beforeDraw(canvasCtx);
-			this.drawTileToCanvasCrop(tile, now, canvasCtx,
+			this.drawTileToCanvasCrop(tile, canvasCtx,
 									  crop.min.x - tileBounds.min.x,
 									  crop.min.y - tileBounds.min.y,
 									  cropWidth, cropHeight,
@@ -196,7 +196,7 @@ export class TilesSection extends CanvasSectionObject {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-	paintSimple (tile: any, ctx: any, async: boolean, now: Date): void {
+	paintSimple (tile: any, ctx: any, async: boolean): void {
 		ctx.viewBounds.round();
 		var offset = new L.Point(tile.coords.getPos().x - ctx.viewBounds.min.x, tile.coords.getPos().y - ctx.viewBounds.min.y);
 
@@ -215,11 +215,11 @@ export class TilesSection extends CanvasSectionObject {
 			offset.y = tile.coords.part * partHeightPixels + tile.coords.y - this.documentTopLeft[1];
 		}
 
-		this.drawTileToCanvas(tile, now, this.context, offset.x, offset.y, TileManager.tileSize, TileManager.tileSize);
+		this.drawTileToCanvas(tile, this.context, offset.x, offset.y, TileManager.tileSize, TileManager.tileSize);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-	public paint (tile: any, ctx: any, async: boolean, now: Date): void {
+	public paint (tile: any, ctx: any, async: boolean): void {
 		if (this.containerObject.isInZoomAnimation() || this.sectionProperties.tsManager.waitForTiles())
 			return;
 
@@ -229,9 +229,9 @@ export class TilesSection extends CanvasSectionObject {
 		this.containerObject.setPenPosition(this);
 
 		if (ctx.paneBoundsActive === true)
-			this.paintWithPanes(tile, ctx, async, now);
+			this.paintWithPanes(tile, ctx, async);
 		else
-			this.paintSimple(tile, ctx, async, now);
+			this.paintSimple(tile, ctx, async);
 	}
 
 	private forEachTileInView(zoom: number, part: number, mode: number, ctx: any,
@@ -407,7 +407,6 @@ export class TilesSection extends CanvasSectionObject {
 
 					this.drawTileToCanvasCrop(
 						TileManager.get(coords.key()),
-						new Date(),
 						this.context,
 						sX, sY,
 						intersection[2],
@@ -455,7 +454,6 @@ export class TilesSection extends CanvasSectionObject {
 
 		var docLayer = this.sectionProperties.docLayer;
 		var doneTiles = new Set();
-		var now = new Date();
 		this.forEachTileInView(zoom, part, mode, ctx, function (tile: any, coords: TileCoordData): boolean {
 
 			if (doneTiles.has(coords.key()))
@@ -469,7 +467,7 @@ export class TilesSection extends CanvasSectionObject {
 			if (tile && TileManager.isValidTile(coords)) {
 				if (!this.isJSDOM) { // perf-test code
 					if (tile.isReadyToDraw() || this.map._debug.tileOverlaysOn) { // Ensure tile is loaded
-						this.paint(tile, ctx, false /* async? */, now);
+						this.paint(tile, ctx, false /* async? */);
 					}
 				}
 			}
@@ -621,17 +619,17 @@ export class TilesSection extends CanvasSectionObject {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-	public ensureCanvas(tile: any, now: Date): void
+	public ensureCanvas(tile: any): void
 	{
-		TileManager.ensureCanvas(tile, now, false);
+		TileManager.ensureCanvas(tile, false);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-	public drawTileToCanvas(tile: any, now: Date, canvas: CanvasRenderingContext2D,
+	public drawTileToCanvas(tile: any, canvas: CanvasRenderingContext2D,
 							dx: number, dy: number, dWidth: number, dHeight: number): void
 	{
-		this.ensureCanvas(tile, now);
-		this.drawTileToCanvasCrop(tile, now, canvas,
+		this.ensureCanvas(tile);
+		this.drawTileToCanvasCrop(tile, canvas,
 								  0, 0, tile.canvas.width, tile.canvas.height,
 								  dx, dy, dWidth, dHeight);
 	}
@@ -669,11 +667,11 @@ export class TilesSection extends CanvasSectionObject {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-	public drawTileToCanvasCrop(tile: any, now: Date, canvas: CanvasRenderingContext2D,
+	public drawTileToCanvasCrop(tile: any, canvas: CanvasRenderingContext2D,
 								sx: number, sy: number, sWidth: number, sHeight: number,
 								dx: number, dy: number, dWidth: number, dHeight: number): void
 	{
-		this.ensureCanvas(tile, now);
+		this.ensureCanvas(tile);
 
 		/* if (!(tile.wireId % 4)) // great for debugging tile grid alignment.
 				canvas.drawImage(this.checkpattern, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
@@ -865,7 +863,6 @@ export class TilesSection extends CanvasSectionObject {
 			var relScale = (bestZoomSrc == zoom) ? 1 : this.map.getZoomScale(bestZoomSrc, zoom);
 
 			this.beforeDraw(canvasContext);
-			var now = new Date();
 			this.forEachTileInArea(docRangeScaled, bestZoomSrc, part, mode, ctx, function (tile, coords, section): boolean {
 				if (!tile || !tile.isReadyToDraw() || !TileManager.isValidTile(coords))
 					return false;
@@ -891,7 +888,7 @@ export class TilesSection extends CanvasSectionObject {
 				var paneOffset = crop.min.subtract(docRangeScaled.min.subtract(destPosScaled));
 				if (cropWidth && cropHeight) {
 						section.drawTileToCanvasCrop(
-								tile, now, canvasContext,
+								tile, canvasContext,
 								tileOffset.x, tileOffset.y, // source x, y
 								cropWidth, cropHeight, // source size
 								// Destination x, y, w, h (In non-Chrome browsers it leaves lines without the 0.5 correction).


### PR DESCRIPTION
* Target version: master 

### Summary
This appears to have been comprehensively broken for a while. This commit fixes these issues:
- Tile.current should reflect whether the tile is in the visible area
- Various tile update functions were unnecessarily redrawing the screen
- Tile.hasPendingDelta and Tile.hasPendingKeyframe were not initialised
- Tile.lastRendered was not stored or updated efficiently
- TileManager.garbageCollect was not sorting tiles correctly
- TileManager.garbageCollect was not respecting highNumCanvases correctly
- Tile preload map was not visualising current or canvas-GC'd tiles
- TileManager.updateLayoutView was typo'd as 'udpateLayoutView'
    
Fixing garbage collection has the knock-on effect of markedly enhancing performance on 4k screens and possibly fixing some OOM situations.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

