### PR TITLE
reset underlying capacity of previously large buffers

### DIFF
--- a/net/Buffer.hpp
+++ b/net/Buffer.hpp
@@ -28,6 +28,14 @@ class Buffer
     std::size_t _offset;  /// offset into _buffer of data
     std::vector<char> _buffer;
 
+    void resetOffset()
+    {
+        // reset underlying capacity of previously large buffers
+        if (_buffer.empty() && _buffer.capacity() > 32768)
+            _buffer.shrink_to_fit();
+        _offset = 0;
+    }
+
 public:
     Buffer() : _offset(0)
     {
@@ -73,7 +81,7 @@ public:
         }
 
         _buffer.erase(_buffer.begin(), _buffer.begin() + _offset + len);
-        _offset = 0;
+        resetOffset();
     }
 
     void append(const char *data, const int len)
@@ -103,7 +111,7 @@ public:
     void clear()
     {
         _buffer.clear();
-        _offset = 0;
+        resetOffset();
     }
 
     iterator begin() { return _buffer.begin() + _offset; }


### PR DESCRIPTION
large capacity but ~empty buffers can be reproduced by inserting a large jpg into a blank writer document and copying it to clipboard a few times and then: kill -SIGUSR 1 `pidof coolwsd`

```
rbuffered   rcapacity   wbuffered   wcapacity
        0        1993           0    19881378
```

Change-Id: Idc4020ffef5e3d4bc4801792412e2d1f706e2ef1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

