### PR TITLE
Calc: Call _syncTileContainerSize after changing document size.

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -256,7 +256,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 
 		this._map.fire('scrolllimits', newSizePx.clone());
 
-		if (limitWidth || limitHeight || extendedLimit)
+		if (!this._syncTileContainerSize() && (limitWidth || limitHeight || extendedLimit))
 			app.sectionContainer.requestReDraw();
 	},
 
@@ -382,9 +382,9 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 	},
 
 	_syncTileContainerSize: function() {
-		if (!this._map) return;
+		if (!this._map) return false;
 
-		if (!this._container) return;
+		if (!this._container) return false;
 
 		// Document container size is up to date as of now.
 		const documentContainerSize = this._getDocumentContainerSize();
@@ -425,7 +425,10 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		if (heightIncreased || widthIncreased) {
 			app.sectionContainer.requestReDraw();
 			this._map.fire('sizeincreased');
+			return true;
 		}
+
+		return false;
 	},
 
 	_onStatusMsg: function (textMsg) {


### PR DESCRIPTION
_syncTileContainerSize returns true if it calls requestRedraw. In that case "_restrictDocumentSize" will not call it again.

Issue: Adding a new sheet while zoomed out or switching sheets may result in a smaller view than expected.


Change-Id: Id3663e360b57b433ffede2213b32cb4d4bcd492b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

