### PR TITLE
Prevent error on Path removal

### DIFF
--- a/browser/src/layer/vector/Path.js
+++ b/browser/src/layer/vector/Path.js
@@ -39,7 +39,10 @@ L.Path = L.Layer.extend({
 	},
 
 	onRemove: function () {
-		this._renderer._removePath(this);
+		if (this._renderer)
+			this._renderer._removePath(this);
+		else
+			console.debug('Path.onRemove: this._renderer missing');
 	},
 
 	getEvents: function () {


### PR DESCRIPTION
Seen logs:
bundle.js:22040 Uncaught TypeError: Cannot read properties of undefined (reading '_removePath')
    at NewClass.onRemove (bundle.js:22040:16)
    at NewClass.removeLayer (bundle.js:13578:87)
    at NewClass.removeLayer (bundle.js:21995:43)
    at NewClass.clearLayers (bundle.js:21997:75)
    at NewClass._clearSearchResults (bundle.js:19773:26)

which may be result of regression in
https://github.com/CollaboraOnline/online/pull/11276 (not sure)

make code more defensive
