### PR TITLE
Fix DefinePrintArea and DeletePrintArea name, remove bogus parameter

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -1194,8 +1194,8 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('See revision history'), id: 'rev-history', type: 'action'},
 				{type: 'separator'},
 				{name: _UNO('.uno:Print', 'spreadsheet'), id: 'print', type: 'action'},
-				{name: _('Define print area', 'spreadsheet'), uno: '.uno:DefinePrintArea' },
-				{name: _('Remove print area', 'spreadsheet'), uno: '.uno:DeletePrintArea' },
+				{name: _('Define print area'), uno: '.uno:DefinePrintArea' },
+				{name: _('Remove print area'), uno: '.uno:DeletePrintArea' },
 			]},
 			{name: !window.ThisIsAMobileApp ? _('Download as') : _('Export as'), id:'downloadas', type: 'menu', menu: [
 				{name: _('PDF Document (.pdf)'), id: !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf', type: 'action'},


### PR DESCRIPTION
No need to add the additional second parameter for the string (as it's
not coming from core).

regression introduce in 34b4ff6a4efc3429ecd7ecf4bfbf9ca0e1803a98 with
Mobile: spreadsheet: Allow user to define and remove print area #5882
 - https://github.com/CollaboraOnline/online/pull/5882

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ic7f1fdcdfc2f1bfb57652a1d3559b67a21a8ec24
