### PR TITLE
Use tile's own scale when getting bounds of a tile.

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -28,6 +28,12 @@ class TileCoordData {
 	part: number;
 	mode: number;
 
+	/*
+		No need to calculate the scale every time. We have the current scale, reachable via app.getScale().
+		We can compare these two when we need check if a tile is in the current scale. Assigned on creation.
+	*/
+	scale: number;
+
 	constructor(
 		left: number,
 		top: number,
@@ -40,6 +46,8 @@ class TileCoordData {
 		this.z = zoom !== null ? zoom : app.map.getZoom();
 		this.part = part !== null ? part : app.map._docLayer._selectedPart;
 		this.mode = mode !== undefined ? mode : 0;
+
+		this.scale = Math.pow(1.2, this.z - 10);
 	}
 
 	getPos() {
@@ -878,10 +886,14 @@ class TileManager {
 
 		// Don't paint the tile, only dirty the sectionsContainer if it is in the visible area.
 		// _emitSlurpedTileEvents() will repaint canvas (if it is dirty).
+		const tileVisible = app.isRectangleVisibleInTheDisplayedArea(
+			this.pixelCoordsToTwipTileBounds(coords),
+		);
+
+		// Also check the scale because incoming tile may not be in the same zoom level.
 		if (
-			app.isRectangleVisibleInTheDisplayedArea(
-				this.pixelCoordsToTwipTileBounds(coords),
-			)
+			tileVisible &&
+			Math.round(coords.scale * 1000) === Math.round(app.getScale() * 1000)
 		)
 			app.sectionContainer.setDirty(coords);
 	}
@@ -1546,10 +1558,12 @@ class TileManager {
 	}
 
 	private static pixelCoordsToTwipTileBounds(coords: TileCoordData): number[] {
-		const x = coords.x * app.pixelsToTwips;
-		const y = coords.y * app.pixelsToTwips;
-		const width = app.tile.size.twips[0];
-		const height = app.tile.size.twips[1];
+		// We need to calculate pixelsToTwips for the scale of this tile. 15 is the ratio between pixels and twips when the scale is 1.
+		const pixelsToTwipsForTile = 15 / coords.scale;
+		const x = coords.x * pixelsToTwipsForTile;
+		const y = coords.y * pixelsToTwipsForTile;
+		const width = this.tileSize * pixelsToTwipsForTile;
+		const height = this.tileSize * pixelsToTwipsForTile;
 
 		return [x, y, width, height];
 	}
@@ -1562,6 +1576,8 @@ class TileManager {
 		textMsg: string,
 	) {
 		let needsNewTiles = false;
+		const calc = app.map._docLayer.isCalc();
+		const scale = app.getScale();
 
 		for (const key in this.tiles) {
 			const coords: TileCoordData = this.tiles[key].coords;
@@ -1570,7 +1586,8 @@ class TileManager {
 			if (
 				coords.part === part &&
 				coords.mode === mode &&
-				invalidatedRectangle.intersectsRectangle(tileRectangle)
+				(invalidatedRectangle.intersectsRectangle(tileRectangle) ||
+					(calc && coords.scale !== scale)) // In calc, we invalidate all tiles with different zoom levels.
 			) {
 				if (app.isRectangleVisibleInTheDisplayedArea(tileRectangle))
 					needsNewTiles = true;


### PR DESCRIPTION
Also, when a tile is comes, compare its scale with the document's scale before setting the view dirty.

Issue: On Calc:

* Change background color of a cell.
* Zoom out.
* See that the background color of the cell is not updated.
* Because tile was not invalidated due to different zoom level and wrong calculation of bounds.


Change-Id: Iad4fcf99aaee5ad61e586687618f2f25da059522


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

