### PR TITLE
Impress: Disallow moving the table while selecting cells.

### DIFF
--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -911,7 +911,16 @@ class ShapeHandlesSection extends CanvasSectionObject {
 	}
 
 	onMouseMove(position: number[], dragDistance: number[]) {
-		if (this.containerObject.isDraggingSomething() && !app.file.textCursor.visible) {
+		let canDrag = !app.file.textCursor.visible;
+
+		if (canDrag && app.map.getDocType() === 'presentation') {
+			// Tables get selected when multiple cells are selected. In this case, we check if DeleteRows is disabled.
+			// Because in non-edit mode, deleteRows is disabled. So we can drag the table.
+			const deleteRowsState = app.map.stateChangeHandler.getItemValue('.uno:DeleteRows');
+			canDrag = deleteRowsState ? deleteRowsState === 'disabled': true;
+		}
+
+		if (this.containerObject.isDraggingSomething() && canDrag) {
 			(window as any).IgnorePanning = true;
 
 			if (this.sectionProperties.svg) {


### PR DESCRIPTION
Issue:
* Open an Impress file.
* Add a table.
* Select more than one cells.
* While selecting the cells, table moves.

Reason:
* We check if the text cursor is visible or not before moving the table.
* But while selecting multiple cells, table gets selected and text cursor is not visible.
* So while the user is selecting the cells, dragging gets enabled.
* For determining the table selection better, we check if the deleteRows is disabled or not.
* If table is selected (not selecting the cells), deleteRows should be disabled. In that case, we can drag the table.


Change-Id: Idb3ad256534a0b96bf5f8eb73f9d4c454f338160


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

