### PR TITLE
wsd: url encode file path

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -720,7 +720,7 @@ inline std::string getLaunchURI(const std::string &document, bool readonly = fal
     oss << COOLWSD_TEST_COOL_UI;
     oss << "?file_path=";
     oss << DEBUG_ABSSRCDIR "/";
-    oss << document;
+    oss << Uri::encode(document);
     if (readonly)
         oss << "&permission=readonly";
 


### PR DESCRIPTION
Change-Id: I23ddbce215d8404d8422473564460a2501aeadb7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

So that links in output in terminal are correct, even if path contained spaces.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

