### PR TITLE
jsdialogs: notebookbar: preserve labels state when building

### DIFF
--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -772,6 +772,9 @@ $(control.label).unbind('click');
 		if (!data.length)
 			return;
 
+		const inlineLabels = this.options.useInLineLabelsForUnoButtons;
+		this.options.useInLineLabelsForUnoButtons = false;
+
 		data = data[0];
 
 		var type = data.type;
@@ -791,7 +794,7 @@ $(control.label).unbind('click');
 			$('#' + data.id).addClass('hidden-from-event');
 		}
 
-		this.options.useInLineLabelsForUnoButtons = false;
+		this.options.useInLineLabelsForUnoButtons = inlineLabels;
 	},
 
 	// replaces widget in-place with new instance with updated data
@@ -848,21 +851,21 @@ $(control.label).unbind('click');
 				processChildren = handler(childObject, childData.children, this);
 			} else {
 				if (handler) {
+					if (childType === 'toolbox' && hasVerticalParent === true && childData.children.length === 1)
+						this.options.useInLineLabelsForUnoButtons = true;
+
 					processChildren = handler(childObject, childData, this);
 					this.postProcess(childObject, childData);
+
+					this.options.useInLineLabelsForUnoButtons = false;
 				} else
 					window.app.console.warn('NotebookbarBuilder: Unsupported control type: "' + childType + '"');
 
-				if (childType === 'toolbox' && hasVerticalParent === true && childData.children.length === 1)
-					this.options.useInLineLabelsForUnoButtons = true;
-
 				if (processChildren && childData.children != undefined)
-					this.build(childObject, childData.children, isVertical, hasManyChildren);
+					this.build(childObject, childData.children, isVertical);
 				else if (childData.visible && (childData.visible === false || childData.visible === 'false')) {
 					$('#' + childData.id).addClass('hidden-from-event');
 				}
-
-				this.options.useInLineLabelsForUnoButtons = false;
 			}
 		}
 	}

--- a/cypress_test/integration_tests/desktop/writer/notebookbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/notebookbar_spec.js
@@ -28,4 +28,15 @@ describe(['tagdesktop'], 'Notebookbar tests.', function() {
 		helper.copy();
 		cy.cGet('#copy-paste-container p b').should('exist');
 	});
+
+	it('Check label showing heuristic', function() {
+		// no label
+		cy.cGet('.notebookbar .unoBold').should('be.visible');
+		cy.cGet('.notebookbar .unoBold span').should('not.exist');
+
+		// with label
+		cy.cGet('.notebookbar #Review-tab-label').click();
+		cy.cGet('.notebookbar .unoSpellOnline').should('be.visible');
+		cy.cGet('.notebookbar .unoSpellOnline span').contains('Automatic Spell Checking');
+	});
 });


### PR DESCRIPTION
In notebookbar we have heuristic to detect when we want label for an icon and when not. We should not modify the state permanently, when we exit current context, we should recover old value.

This fixes regression from commit 61d9f6767c37f2ad163970634b9ed6cb906ce952 notebookbar: correctly setup toolbox after update

Labels in the Review tab disappeared for some icons.