### PR TITLE
extend DocumentBroker lifecycle until preset callbacks no longer need it

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1663,7 +1663,12 @@ void DocumentBroker::asyncInstallPresets(const std::shared_ptr<ClientSession>& s
     };
     _asyncInstallTask = asyncInstallPresets(*_poll, configId, userSettingsUri,
                                             presetsPath, session, installFinishedCB);
-    _asyncInstallTask->appendCallback([selfWeak = weak_from_this(), this](bool){
+    _asyncInstallTask->appendCallback([selfWeak = weak_from_this(), this,
+                                       keepPollAlive=_poll](bool){
+        // For the edge case where the DocumentBroker lifecycle ends before the document
+        // gets loaded, extend life of _poll to ensure it exists until any pending
+        // asyncConnect have completed (which require the poll to exist), and their
+        // callbacks detect that the DocumentBroker has been destroyed.
         std::shared_ptr<DocumentBroker> selfLifecycle = selfWeak.lock();
         if (!selfLifecycle)
             return;


### PR DESCRIPTION
```
 #0  0x00007f82abc16d2b in raise () from /lib64/libc.so.6
 #1  0x00007f82abc183e5 in abort () from /lib64/libc.so.6
 #2  0x00000000005bf80f in Poco::SignalHandler::handleSignal(int) [clone .cold] ()
 #3  <signal handler called>
 #4  0x00007f82abd4dfdf in __memmove_avx_unaligned_erms () from /lib64/libc.so.6
 #5  0x00007f82ac0a8a48 in std::basic_streambuf<char, std::char_traits<char> >::xsputn(char const*, long) () from /usr/lib64/libstdc++.so.6
 #6  0x00007f82ac09ab5d in std::basic_ostream<char, std::char_traits<char> >& std::__ostream_insert<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*, long) () from /usr/lib64/libstdc++.so.6
 #7  0x0000000000601243 in std::operator<< <char, std::char_traits<char>, std::allocator<char> > (__str="", __os=...) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/cow_string.h:335
 #8  SocketPoll::wakeup (this=this@entry=0x7f829800bd80) at ./net/Socket.hpp:828
 #9  0x000000000066f0dd in SocketPoll::addCallback(std::function<void ()> const&) (fn=..., this=0x7f829800bd80) at ./net/Socket.hpp:890
 #10 http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}::operator()(std::shared_ptr<StreamSocket>, net::AsyncConnectResult) const (result=<optimized out>, socket=...,
     __closure=<optimized out>) at ./net/HttpRequest.hpp:1752
 #11 std::__invoke_impl<void, http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}&, std::shared_ptr<StreamSocket>, net::AsyncConnectResult>(std::__invoke_other, http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}&, std::shared_ptr<StreamSocket>&&, net::AsyncConnectResult&&) (__f=...) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/invoke.h:61
 #12 std::__invoke_r<void, http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}&, std::shared_ptr<StreamSocket>, net::AsyncConnectResult>(http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}&, std::shared_ptr<StreamSocket>&&, net::AsyncConnectResult&&) (__fn=...) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/invoke.h:111
 #13 std::_Function_handler<void (std::shared_ptr<StreamSocket>, net::AsyncConnectResult), http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}>::_M_invoke(std::_Any_data const&, std::shared_ptr<StreamSocket>&&, net::AsyncConnectResult&&) (__functor=..., __args#0=..., __args#1=<optimized out>) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:290
 #14 0x000000000084adf9 in std::function<void (std::shared_ptr<StreamSocket>, net::AsyncConnectResult)>::operator()(std::shared_ptr<StreamSocket>, net::AsyncConnectResult) const (__args#1=net::AsyncConnectResult::Ok,
     __args#0=std::shared_ptr<StreamSocket> (empty) = {...}, this=0x7f8298019a78) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:591
 #15 operator() (__closure=0x7f8298019a50, hostEntry=...) at net/NetUtil.cpp:535
 #16 0x000000000084e4dd in std::function<void (net::HostEntry const&)>::operator()(net::HostEntry const&) const (__args#0=..., this=0x491c838) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:591
 #17 net::AsyncDNS::resolveDNS (this=0x491c770) at net/NetUtil.cpp:392
 #18 0x0000000000c27fd3 in execute_native_thread_routine ()
 #19 0x00007f82abdcd6ea in start_thread () from /lib64/libpthread.so.0
 #20 0x00007f82abce458f in clone () from /lib64/libc.so.6
```

Signed-off-by: Caolán McNamara <caolan.mcnamara@collabora.com>
Change-Id: I352ac7020af8aebe6731147084633e324d2d08df (cherry picked from commit 0c30c09526401fbf7c00a6cfc278c7a8fa96b30a)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

