### PR TITLE
Don't cache null canvases in TilesMiddleware.CanvasCache

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -261,7 +261,7 @@ class CanvasCache {
 	}
 
 	trim(limit: number) {
-		while (this._canvasList.length > limit) {
+		while (this._canvasList.length > Math.max(0, limit)) {
 			const item = this._canvasList.pop();
 
 			// Fix for cool#5876 allow immediate reuse of canvas context memory


### PR DESCRIPTION
releaseCanvas can be called on tiles with no canvas, make sure to check a canvas and context are non-null before adding them to the cache.

Backport #11364, a dependency for other necessary backports.