### PR TITLE
jsdialog: notebookbar: encapsulate inline label bahavior

### DIFF
--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -840,6 +840,10 @@ $(control.label).unbind('click');
 				childObject = parent;
 			}
 
+			// allow to detect single toolbuttons stacked on each other
+			if (childType === 'toolbox')
+				childData.hasVerticalParent = hasVerticalParent;
+
 			var handler = this._controlHandlers[childType];
 			var twoPanelsAsChildren =
 			    childData.children && childData.children.length == 2
@@ -851,13 +855,8 @@ $(control.label).unbind('click');
 				processChildren = handler(childObject, childData.children, this);
 			} else {
 				if (handler) {
-					if (childType === 'toolbox' && hasVerticalParent === true && childData.children.length === 1)
-						this.options.useInLineLabelsForUnoButtons = true;
-
 					processChildren = handler(childObject, childData, this);
 					this.postProcess(childObject, childData);
-
-					this.options.useInLineLabelsForUnoButtons = false;
 				} else
 					window.app.console.warn('NotebookbarBuilder: Unsupported control type: "' + childType + '"');
 

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -130,6 +130,10 @@ interface GridWidgetJSON extends ContainerWidgetJSON {
 	rows: number; // numer of grid rows
 }
 
+interface ToolboxWidgetJSON extends WidgetJSON {
+	hasVerticalParent: boolean;
+}
+
 interface PanelWidgetJSON extends WidgetJSON {
 	hidden: boolean; // is hidden
 	command: string; // command to trigger options for a panel

--- a/browser/src/control/jsdialog/Widget.Containers.ts
+++ b/browser/src/control/jsdialog/Widget.Containers.ts
@@ -122,7 +122,7 @@ JSDialog.grid = function (
 
 JSDialog.toolbox = function (
 	parentContainer: Element,
-	data: WidgetJSON,
+	data: ToolboxWidgetJSON,
 	builder: JSBuilder,
 ) {
 	const levelClass =
@@ -159,11 +159,18 @@ JSDialog.toolbox = function (
 	};
 	JSDialog.OnStateChange(toolbox, enabledCallback);
 
+	// builder modifiers
 	const noLabels = builder.options.noLabelsForUnoButtons;
 	builder.options.noLabelsForUnoButtons = true;
 
+	const inlineLabels = builder.options.useInLineLabelsForUnoButtons;
+	if (data.hasVerticalParent === true && data.children.length === 1)
+		builder.options.useInLineLabelsForUnoButtons = true;
+
 	builder.build(toolbox, data.children, false);
 
+	// reset modifiers
+	builder.options.useInLineLabelsForUnoButtons = inlineLabels;
 	builder.options.noLabelsForUnoButtons = noLabels;
 
 	return false;


### PR DESCRIPTION
let toolbox decide itself if children require label tested with cypress already in commit e90ac0462e2e237bc230fc7800343202c570683b jsdialogs: notebookbar: preserve labels state when building
