### PR TITLE
Fix tile scale comparison mismatch

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -874,6 +874,11 @@ class TileManager {
 		++this.inTransaction;
 	}
 
+	private static tileZoomIsCurrent(coords: TileCoordData) {
+		const scale = Math.pow(1.2, app.map.getZoom() - 10);
+		return Math.round(coords.scale * 1000) === Math.round(scale * 1000);
+	}
+
 	private static tileReady(coords: TileCoordData) {
 		var key = coords.key();
 
@@ -897,10 +902,7 @@ class TileManager {
 		);
 
 		// Also check the scale because incoming tile may not be in the same zoom level.
-		if (
-			tileVisible &&
-			Math.round(coords.scale * 1000) === Math.round(app.getScale() * 1000)
-		)
+		if (tileVisible && this.tileZoomIsCurrent(coords))
 			app.sectionContainer.setDirty(coords);
 	}
 
@@ -1602,7 +1604,7 @@ class TileManager {
 				coords.part === part &&
 				coords.mode === mode &&
 				(invalidatedRectangle.intersectsRectangle(tileRectangle) ||
-					(calc && coords.scale !== scale)) // In calc, we invalidate all tiles with different zoom levels.
+					(calc && !this.tileZoomIsCurrent(coords))) // In calc, we invalidate all tiles with different zoom levels.
 			) {
 				if (app.isRectangleVisibleInTheDisplayedArea(tileRectangle))
 					needsNewTiles = true;


### PR DESCRIPTION
app.getScale() and TileCoordData.scale are not in the same coordinate space, remove those comparisons and replace with a utility function, 'tileZoomIsCurrent' that hopefully does the correct thing.

This fixes an infinite tile invalidation loop in calc.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

