### PR TITLE
feat(android): Support loading video

### DIFF
--- a/android/lib/src/main/cpp/androidapp.cpp
+++ b/android/lib/src/main/cpp/androidapp.cpp
@@ -563,4 +563,12 @@ Java_org_libreoffice_androidlib_LOActivity_paste(JNIEnv *env, jobject, jstring i
     env->ReleaseStringUTFChars(inMimeType, mimeType);
 }
 
+extern "C"
+JNIEXPORT jstring JNICALL
+Java_org_libreoffice_androidlib_COWebViewClient_getEmbeddedMediaPath(JNIEnv *env, jobject, jstring inTag) {
+    std::string tag = copyJavaString(env, inTag);
+    std::string mediaPath = getDocumentBrokerForAndroidOnly()->getEmbeddedMediaPath(tag);
+    return env->NewStringUTF(mediaPath.c_str());
+}
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab cinoptions=b1,g0,N-s cinkeys+=0=break: */

--- a/android/lib/src/main/java/org/libreoffice/androidlib/COWebView.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/COWebView.java
@@ -18,18 +18,22 @@ public class COWebView extends WebView {
     public COWebView(Context context) {
         super(context);
         mContext = context;
+        setWebViewClient(new COWebViewClient());
     }
 
     public COWebView(Context context, AttributeSet attrs) {
         super(context, attrs);
+        setWebViewClient(new COWebViewClient());
     }
 
     public COWebView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        setWebViewClient(new COWebViewClient());
     }
 
     public COWebView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
+        setWebViewClient(new COWebViewClient());
     }
 
     /*

--- a/android/lib/src/main/java/org/libreoffice/androidlib/COWebViewClient.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/COWebViewClient.java
@@ -1,0 +1,102 @@
+/* -*- tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.libreoffice.androidlib;
+import android.net.Uri;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebResourceResponse;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class COWebViewClient extends WebViewClient {
+    @Nullable
+    @Override
+    public WebResourceResponse shouldInterceptRequest(WebView view, WebResourceRequest request) {
+        if (!Objects.equals(request.getUrl().getScheme(), "cool")) {
+            return super.shouldInterceptRequest(view, request);
+        }
+
+        Uri uriDecoded = Uri.parse(Uri.decode(request.getUrl().toString())); // We have to do this weird-looking decoding step as presentation mode gives us a broken (i.e. parameters are encoded, including the & delimiter, etc.) URI
+        String tag = uriDecoded.getQueryParameter("Tag");
+
+        if (tag == null) {
+            return super.shouldInterceptRequest(view, request);
+        }
+
+        String mediaPath = getEmbeddedMediaPath(tag);
+
+        Map<String, String> responseHeaders = new HashMap<>();
+
+        if (mediaPath.isEmpty()) {
+            responseHeaders.put("Content-Length", "0");
+
+            ByteArrayInputStream data = new ByteArrayInputStream(new byte[0]);
+
+            return new WebResourceResponse(
+                    null,
+                    null,
+                    404,
+                    "Not Found",
+                    responseHeaders,
+                    data
+            );
+        }
+
+        File media = new File(mediaPath);
+
+        if (!media.exists()) {
+            responseHeaders.put("Content-Length", "0");
+
+            ByteArrayInputStream data = new ByteArrayInputStream(new byte[0]);
+
+            return new WebResourceResponse(
+                    null,
+                    null,
+                    404,
+                    "Not Found",
+                    responseHeaders,
+                    data
+            );
+        }
+
+        String reasonPhrase = "OK";
+
+       	responseHeaders.put("Content-Length", Long.toString(media.length()));
+ 
+        FileInputStream data;
+        try {
+            data = new FileInputStream(media);
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+
+        return new WebResourceResponse(
+            null,
+            null,
+            200,
+            reasonPhrase,
+            responseHeaders,
+            data
+        );
+    }
+
+    private native String getEmbeddedMediaPath(String tag);
+}

--- a/android/lib/src/main/java/org/libreoffice/androidlib/COWebViewClient.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/COWebViewClient.java
@@ -44,6 +44,7 @@ public class COWebViewClient extends WebViewClient {
         String mediaPath = getEmbeddedMediaPath(tag);
 
         Map<String, String> responseHeaders = new HashMap<>();
+        responseHeaders.put("Access-Control-Allow-Origin", "null"); // Yes, the origin really is 'null' for 'file:' origins
 
         if (mediaPath.isEmpty()) {
             responseHeaders.put("Content-Length", "0");

--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -1082,9 +1082,6 @@ public class LOActivity extends AppCompatActivity {
                     }
                 });
                 return false;
-            case "SLIDESHOW":
-                initiateSlideShow();
-                return false;
             case "SAVE":
                 copyTempBackToIntent();
                 sendBroadcast(messageAndParam[0], messageAndParam[1]);
@@ -1348,28 +1345,6 @@ public class LOActivity extends AppCompatActivity {
         PrintManager printManager = (PrintManager) getSystemService(PRINT_SERVICE);
         PrintDocumentAdapter printAdapter = new PrintAdapter(LOActivity.this);
         printManager.print("Document", printAdapter, new PrintAttributes.Builder().build());
-    }
-
-    private void initiateSlideShow() {
-        mProgressDialog.indeterminate(R.string.loading);
-
-        nativeHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                Log.v(TAG, "saving svg for slideshow by " + Thread.currentThread().getName());
-                final String slideShowFileUri = new File(LOActivity.this.getCacheDir(), "slideShow.svg").toURI().toString();
-                LOActivity.this.saveAs(slideShowFileUri, "svg", null);
-                LOActivity.this.runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        mProgressDialog.dismiss();
-                        Intent slideShowActIntent = new Intent(LOActivity.this, SlideShowActivity.class);
-                        slideShowActIntent.putExtra(SlideShowActivity.SVG_URI_KEY, slideShowFileUri);
-                        LOActivity.this.startActivity(slideShowActIntent);
-                    }
-                });
-            }
-        });
     }
 
     /** Send message back to the shell (for example for the cloud save). */

--- a/browser/src/map/handler/Map.SlideShow.js
+++ b/browser/src/map/handler/Map.SlideShow.js
@@ -55,11 +55,6 @@ L.Map.SlideShow = L.Handler.extend({
 			return;
 		}
 
-		if (window.ThisIsTheAndroidApp) {
-			window.postMobileMessage('SLIDESHOW');
-			return;
-		}
-
 		if (app.impress.areAllSlidesHidden()) {
 			this._map.uiManager.showInfoModal('allslidehidden-modal', _('Empty Slide Show'),
 					'All slides are hidden!', '', _('OK'), function () { }, false, 'allslidehidden-modal-response');

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -582,11 +582,6 @@ class SlideShowPresenter {
 			return false;
 		}
 
-		if ((window as any).ThisIsTheAndroidApp) {
-			window.postMobileMessage('SLIDESHOW');
-			return false;
-		}
-
 		if (app.impress.notesMode) {
 			console.debug(
 				'SlideShowPresenter._onPrepareScreen: notes mode is enabled, exiting',

--- a/browser/src/slideshow/VideoRenderer.ts
+++ b/browser/src/slideshow/VideoRenderer.ts
@@ -95,6 +95,7 @@ abstract class VideoRenderer {
 
 		video.playsInline = true;
 		video.loop = true;
+		video.crossOrigin = 'anonymous';
 
 		video.addEventListener(
 			'playing',

--- a/ios/Mobile/CoolURLSchemeHandler.mm
+++ b/ios/Mobile/CoolURLSchemeHandler.mm
@@ -124,6 +124,7 @@
     std::string mediaPath = [self getDocumentBroker]->getEmbeddedMediaPath(tag);
     
     NSMutableDictionary<NSString*, NSString*> * responseHeaders = [[NSMutableDictionary alloc] init];
+    [responseHeaders setObject:@"null" forKey:@"Access-Control-Allow-Origin"]; // Yes, the origin really is 'null' for 'file:' origins
         
     if (mediaPath.empty() || !std::filesystem::exists(mediaPath)) {
         [responseHeaders setObject:@"0" forKey:@"Content-Length"];

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -118,7 +118,7 @@ using JsonUtil::makePropertyValue;
 
 extern "C" { void dump_kit_state(void); /* easy for gdb */ }
 
-#ifdef IOS
+#if MOBILEAPP
 extern std::map<std::string, std::shared_ptr<DocumentBroker>> DocBrokers;
 extern std::mutex DocBrokersMutex;
 #endif
@@ -1985,6 +1985,12 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
         _loKitDocument.reset(_loKit->documentLoad(pURL, options.c_str()));
 #ifdef __ANDROID__
         _loKitDocumentForAndroidOnly = _loKitDocument;
+        {
+            std::unique_lock<std::mutex> docBrokersLock(DocBrokersMutex);
+            auto docBrokerIt = DocBrokers.find(_docKey);
+            assert(docBrokerIt != DocBrokers.end());
+            _documentBrokerForAndroidOnly = docBrokerIt->second;
+        }
 #endif
         const auto duration = std::chrono::steady_clock::now() - start;
         const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
@@ -2824,10 +2830,16 @@ void flushTraceEventRecordings()
 #ifdef __ANDROID__
 
 std::shared_ptr<lok::Document> Document::_loKitDocumentForAndroidOnly = std::shared_ptr<lok::Document>();
+std::weak_ptr<DocumentBroker> Document::_documentBrokerForAndroidOnly;
 
 std::shared_ptr<lok::Document> getLOKDocumentForAndroidOnly()
 {
     return Document::_loKitDocumentForAndroidOnly;
+}
+
+std::shared_ptr<DocumentBroker> getDocumentBrokerForAndroidOnly()
+{
+    return Document::_documentBrokerForAndroidOnly.lock();
 }
 
 #endif

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -461,6 +461,7 @@ private:
     std::shared_ptr<lok::Document> _loKitDocument;
 #ifdef __ANDROID__
     static std::shared_ptr<lok::Document> _loKitDocumentForAndroidOnly;
+    static std::weak_ptr<DocumentBroker> _documentBrokerForAndroidOnly;
 #endif
     std::unique_ptr<KitQueue> _queue;
 
@@ -501,6 +502,7 @@ private:
     std::map<int, UserInfo> _sessionUserInfo;
 #ifdef __ANDROID__
     friend std::shared_ptr<lok::Document> getLOKDocumentForAndroidOnly();
+    friend std::shared_ptr<DocumentBroker> getDocumentBrokerForAndroidOnly();
 #endif
 
     const unsigned _mobileAppDocId;
@@ -530,6 +532,7 @@ TileWireId getCurrentWireId(bool increment = false);
 #ifdef __ANDROID__
 /// For the Android app, for now, we need access to the one and only document open to perform eg. saveAs() for printing.
 std::shared_ptr<lok::Document> getLOKDocumentForAndroidOnly();
+std::shared_ptr<DocumentBroker> getDocumentBrokerForAndroidOnly();
 #endif
 
 extern _LibreOfficeKit* loKitPtr;

--- a/wsd/ServerURL.hpp
+++ b/wsd/ServerURL.hpp
@@ -93,7 +93,7 @@ public:
 
     std::string getSubURLForEndpoint(const std::string &path) const
     {
-#ifdef IOS
+#if MOBILEAPP
         return std::string("cool:") + _pathPlus + path;
 #else
         return std::string("http") + (_ssl ? "s" : "") + "://" + _schemeAuthority + _pathPlus + path;


### PR DESCRIPTION
This is the android counterpart to #11214 

There's a few things I'm unhappy about here...
- Slideshow doesn't close when android back gesture is used - instead the whole document closes
- It's pretty annoying to have video in presentations - it starts as soon as it loads, can't be paused, and loops at the end. We could do much better
- ~~I'm fairly sure the *iOS* protocol handler code is unsound - see what happens when you don't provide a range (-> this never happens on iOS, but might be easy to fix), the end variable is redundant earlier on ... - and needs to be fixed~~ I've determined that these problems never happen in a real case, so decided to strike them from this PR... I'll make another PR tweaking a few things that are Wrong code
- ~~I would like to Just Refactor The Range Header Code into one bit of C++ code, since as this is the 3rd time I've written it and I'm getting a bit bored~~ -> I have decided that I shouldn't use the range header in Android, since as the webview doesn't properly implement it so it's needless complexity, so I've deleted the code