### PR TITLE
wsd: Set window.frameAncestors with the CSP directive

### DIFF
--- a/wsd/ContentSecurityPolicy.hpp
+++ b/wsd/ContentSecurityPolicy.hpp
@@ -30,6 +30,12 @@ public:
     {
     }
 
+    /// Construct a CSP from a CSP string.
+    ContentSecurityPolicy(const std::string& csp)
+    {
+        merge(csp);
+    }
+
     /// Given a CSP string, merge it with the existing values.
     void merge(const std::string& csp)
     {
@@ -44,6 +50,15 @@ public:
                 const auto parts = Util::split(token);
                 appendDirective(std::string(parts.first), std::string(parts.second));
             }
+        }
+    }
+
+    /// Given a CSP object, merge it with the existing values.
+    void merge(const ContentSecurityPolicy& csp)
+    {
+        LOG_TRC("Merging CSP object");
+        for (auto directive : csp._directives) {
+            appendDirective(std::string(directive.first), std::string(directive.second));
         }
     }
 
@@ -72,6 +87,17 @@ public:
             LOG_TRC("Appending CSP directive [" << directive << "] = [" << value << ']');
             _directives[directive].append(' ' + value);
         }
+    }
+
+    /// Return an individual policy.
+    std::string getDirective(const std::string& directive) const
+    {
+        auto csp = _directives.find(directive);
+        if (csp == _directives.end())
+        {
+            return "";
+        }
+        return csp->second;
     }
 
     /// Returns the value of the CSP header.

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1870,7 +1870,8 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
     csp.appendDirectiveUrl("img-src", "https://www.collaboraoffice.com/");
 
     // Frame ancestors: Allow coolwsd host, wopi host and anything configured.
-    const std::string configFrameAncestor = config.getString("net.frame_ancestors", "");
+    // This is deprecated.
+    std::string configFrameAncestor = config.getString("net.frame_ancestors", "");
     if (!configFrameAncestor.empty())
     {
         static bool warned = false;
@@ -1881,6 +1882,14 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
                     "future. Please add 'frame-ancestors "
                     << configFrameAncestor << ";' in the net.content_security_policy config");
         }
+    }
+
+    ContentSecurityPolicy configCSP(config.getString("net.content_security_policy", ""));
+    // Get the frame ancestors out of the configured CSP.
+    auto configCspFrameAncestors = configCSP.getDirective("frame-ancestors");
+    if (!configCspFrameAncestors.empty())
+    {
+        configFrameAncestor += configCspFrameAncestors;
     }
 
     std::string frameAncestors = configFrameAncestor;
@@ -1961,7 +1970,7 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
     }
 #endif // !MOBILEAPP
 
-    csp.merge(config.getString("net.content_security_policy", ""));
+    csp.merge(configCSP);
 
     // Append CSP to response headers too
     httpResponse.add("Content-Security-Policy", csp.generate());


### PR DESCRIPTION
This in addition to the deprecated 'net.frame_ancestors'
Add a new ContentSecurityPolicy constructor from string.
Add a new ContentSecurityPolicy::merge() from a ContentSecurityPolicy


Change-Id: I89c02d820bd4d4bfc6ae7de6ebf75970997822c2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

