### PR TITLE
formula-tab: add missing icons

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2688,23 +2688,27 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:ChangeFont', 'text'),
-				'command': '.uno:ChangeFont'
+				'command': '.uno:ChangeFont',
+				'icon': 'lc_fontdialog.svg'
 			},
 			{ type: 'separator', id: 'formula-changefont-break', orientation: 'vertical' },
 			{
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:ChangeFontSize', 'text'),
-				'command': '.uno:ChangeFontSize'
+				'command': '.uno:ChangeFontSize',
+				'icon': 'lc_fontheight.svg'
 			},
 			{
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:ChangeDistance', 'text'),
-				'command': '.uno:ChangeDistance'
+				'command': '.uno:ChangeDistance',
+				'icon': 'lc_spacing.svg',
 			},
 			{
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:ChangeAlignment', 'text'),
-				'command': '.uno:ChangeAlignment'
+				'command': '.uno:ChangeAlignment',
+				'icon': 'lc_fontworkalignmentfloater.svg'
 			}
         ];
 		return this.getTabPage(formulaTabName, content);


### PR DESCRIPTION
Change-Id: I14e0bffd450253303c477c15300df6d58285c0ed

* Target version: master 

### Summary
Add missing icons of formula bar. 


### Screenshots
![Screenshot from 2025-03-26 04-26-03](https://github.com/user-attachments/assets/3828c071-7f65-4c5a-b5f1-6e1a4624367f)


