### PR TITLE
Add closePopups function for closing the popups when user is zooming …

### DIFF
--- a/browser/src/canvas/sections/OtherViewCellCursorSection.ts
+++ b/browser/src/canvas/sections/OtherViewCellCursorSection.ts
@@ -41,6 +41,9 @@ class OtherViewCellCursorSection extends CanvasSectionObject {
     }
 
     onDraw(frameCount?: number, elapsedTime?: number, subsetBounds?: Bounds): void {
+        if (app.map._docLayer._isZooming)
+            return;
+
         this.adjustPopUpPosition();
 
         this.context.strokeStyle = this.sectionProperties.color;
@@ -129,7 +132,8 @@ class OtherViewCellCursorSection extends CanvasSectionObject {
     hideUsernamePopUp() {
         if (this.sectionProperties.popUpContainer) {
             this.sectionProperties.popUpShown = false;
-            this.sectionProperties.popUpContainer.style.display = 'none';
+            if (this.sectionProperties.popUpContainer.style.display !== 'none')
+                this.sectionProperties.popUpContainer.style.display = 'none';
         }
         this.clearPopUpTimer();
     }
@@ -180,9 +184,20 @@ class OtherViewCellCursorSection extends CanvasSectionObject {
     public static updateVisibilities() {
         for (let i = 0; i < OtherViewCellCursorSection.sectionPointers.length; i++) {
             const section = OtherViewCellCursorSection.sectionPointers[i];
-            section.setShowSection(section.checkMyVisibility());
+            const newState = section.checkMyVisibility();
+
+            if (newState !== section.showSection) {
+                section.setShowSection(newState);
+                if (newState === false)
+                    section.hideUsernamePopUp();
+            }
         }
         app.sectionContainer.requestReDraw();
+    }
+
+    public static closePopups() {
+        for (let i = 0; i < OtherViewCellCursorSection.sectionPointers.length; i++)
+            OtherViewCellCursorSection.sectionPointers[i].hideUsernamePopUp();
     }
 
     public static getViewCursorSection(viewId: number) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4101,6 +4101,9 @@ L.CanvasTileLayer = L.Layer.extend({
 	// Meant for desktop case, where the ending zoom and centers are all known in advance.
 	runZoomAnimation: function (zoomEnd, pinchCenter, mapUpdater, runAtFinish) {
 
+		if (this._map.getDocType() === 'spreadsheet')
+			OtherViewCellCursorSection.closePopups();
+
 		this.preZoomAnimation(pinchCenter);
 		this.zoomStep(this._map.getZoom(), pinchCenter);
 		var thisObj = this;

--- a/browser/src/map/handler/Map.Scroll.js
+++ b/browser/src/map/handler/Map.Scroll.js
@@ -3,7 +3,7 @@
  * L.Handler.Scroll is used by L.Map to enable mouse scroll wheel zoom on the map.
  */
 
-/* global app */
+/* global app OtherViewCellCursorSection */
 L.Map.mergeOptions({
 	scrollHandler: true,
 	wheelDebounceTime: 40,
@@ -79,6 +79,9 @@ L.Map.Scroll = L.Handler.extend({
 	}),
 
 	_performZoom: function () {
+		if (this._map.getDocType() === 'spreadsheet')
+			OtherViewCellCursorSection.closePopups();
+
 		var lastScrollTime = this._zoomScrollTime;
 		this._zoomScrollTime = new Date();
 		var map = this._map;


### PR DESCRIPTION
…or switching sheets.

Call the function from 2 different places that can start a zoom event.

Add guards into OtherViewCellCursorSection.ts to prevent unnecessery property changes.


Change-Id: I2c1b24e2e7d206bc8a27cc8aed376867875a38ea


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

