### PR TITLE
Fix garbage collection in 24.04

### DIFF
--- a/browser/src/canvas/sections/PreloadMapSection.ts
+++ b/browser/src/canvas/sections/PreloadMapSection.ts
@@ -119,8 +119,12 @@ class PreloadMapSection extends app.definitions.canvasSectionObject {
 							canvas.fillStyle = 'rgba(255, 0, 0, 0.8)'; // red
 						else if (tile.needsFetch())
 							canvas.fillStyle = 'rgba(255, 255, 0, 0.8)'; // yellow
+						else if (!tile.canvas)
+							canvas.fillStyle = 'rgba(0, 64, 0, 0.8)'; // dark green
 						// present
-						else canvas.fillStyle = 'rgba(0, 255, 0, 0.5)'; // green
+						else if (!tile.current)
+							canvas.fillStyle = 'rgba(0, 128, 0, 0.8)'; // green
+						else canvas.fillStyle = 'rgba(0, 255, 0, 0.5)'; // light green
 					} // outside document range
 					else canvas.fillStyle = 'rgba(0, 0, 0, 0.3)'; // dark grey
 

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4877,14 +4877,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		if (center === undefined) { center = map.getCenter(); }
 		if (zoom === undefined) { zoom = Math.round(map.getZoom()); }
 
-		for (var key in this._tiles) {
-			var thiscoords = this._keyToTileCoords(key);
-			if (thiscoords.z !== zoom ||
-				thiscoords.part !== this._selectedPart ||
-				thiscoords.mode !== this._selectedMode) {
-				this._tiles[key].current = false;
-			}
-		}
+		for (var key in this._tiles) this._tiles[key].current = false;
 
 		var pixelBounds = map.getPixelBoundsCore(center, zoom);
 		var queue = this._getMissingTiles(pixelBounds, zoom);
@@ -5111,6 +5104,7 @@ L.CanvasTileLayer = L.Layer.extend({
 					// canvas for the tile in advance.
 					this.ensureCanvas(tile, null, true);
 					redraw |= tile.hasPendingUpdate();
+					tile.current = false;
 				}
 			}
 		}


### PR DESCRIPTION
In quick testing, this seems to work well - GC is restored and 4k performance is much better because of it (not to the level it is in master, but much better). Presumably there's also a much lower chance of being OOM-killed :)

We need to watch out for tile invalidation issues this may cause. I haven't immediately spotted anything, but despite the tiny size, this isn't a low-risk patch (though at least it's easy to revert).

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

