### PR TITLE
on success responsibility for _ws _socket is passed to docBroker

### DIFF
--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -547,6 +547,10 @@ void RequestVettingStation::createClientSession(std::shared_ptr<DocumentBroker> 
                                      WebSocketHandler::StatusCodes::POLICY_VIOLATION);
             }
         });
+        // _socket is now the DocumentBroker poll's responsibility forget about it here
+        _socket.reset();
+        // _ws belongs to that socket, forget about it here
+        _ws.reset();
 }
 
 void RequestVettingStation::sendErrorAndShutdown(const std::shared_ptr<WebSocketHandler>& ws,


### PR DESCRIPTION
Signed-off-by: Caolán McNamara <caolan.mcnamara@collabora.com>
Change-Id: I48b7620f86c3dd515b0c9133b889ef04cd191cdc (cherry picked from commit 593a7ee084c3ab3ef543aa5008538e203593c2d7)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

