### PR TITLE
fix: preProcessedFileSubstitution replacing to ""

### DIFF
--- a/test/FileServeWhiteBoxTests.cpp
+++ b/test/FileServeWhiteBoxTests.cpp
@@ -43,6 +43,8 @@ class FileServeTests : public CPPUNIT_NS::TestFixture
 
     void preProcessedFileSubstitution(const std::string& testname,
                                       std::unordered_map<std::string, std::string> variables);
+    // helper for replacements with the empty map
+    std::string& replaceOrKeep(std::string& str, const std::string& from, const std::string& to);
 };
 
 void FileServeTests::testUIDefaults()
@@ -391,28 +393,39 @@ void FileServeTests::preProcessedFileSubstitution(
 
             const std::string recon = ppf.substitute(variables);
 
-            Poco::replaceInPlace(orig, std::string("%ACCESS_TOKEN%"), variables["ACCESS_TOKEN"]);
-            Poco::replaceInPlace(orig, std::string("%ACCESS_TOKEN_TTL%"),
+            replaceOrKeep(orig, std::string("%ACCESS_TOKEN%"), variables["ACCESS_TOKEN"]);
+            replaceOrKeep(orig, std::string("%ACCESS_TOKEN_TTL%"),
                                  variables["ACCESS_TOKEN_TTL"]);
-            Poco::replaceInPlace(orig, std::string("%ACCESS_HEADER%"), variables["ACCESS_HEADER"]);
-            Poco::replaceInPlace(orig, std::string("%UI_DEFAULTS%"), variables["UI_DEFAULTS"]);
-            Poco::replaceInPlace(orig, std::string("<!--%CSS_VARIABLES%-->"),
+            replaceOrKeep(orig, std::string("%ACCESS_HEADER%"), variables["ACCESS_HEADER"]);
+            replaceOrKeep(orig, std::string("%UI_DEFAULTS%"), variables["UI_DEFAULTS"]);
+            replaceOrKeep(orig, std::string("<!--%CSS_VARIABLES%-->"),
                                  variables["CSS_VARIABLES"]);
-            Poco::replaceInPlace(orig, std::string("%POSTMESSAGE_ORIGIN%"),
+            replaceOrKeep(orig, std::string("%POSTMESSAGE_ORIGIN%"),
                                  variables["POSTMESSAGE_ORIGIN"]);
-            Poco::replaceInPlace(orig, std::string("%BRANDING_THEME%"),
+            replaceOrKeep(orig, std::string("%BRANDING_THEME%"),
                                  variables["BRANDING_THEME"]);
-            Poco::replaceInPlace(orig, std::string("<!--%BRANDING_JS%-->"),
+            replaceOrKeep(orig, std::string("<!--%BRANDING_JS%-->"),
                                  variables["BRANDING_JS"]);
-            Poco::replaceInPlace(orig, std::string("%FOOTER%"), variables["FOOTER"]);
-            Poco::replaceInPlace(orig, std::string("%CHECK_FILE_INFO_OVERRIDE%"),
+            replaceOrKeep(orig, std::string("%FOOTER%"), variables["FOOTER"]);
+            replaceOrKeep(orig, std::string("%CHECK_FILE_INFO_OVERRIDE%"),
                                  variables["CHECK_FILE_INFO_OVERRIDE"]);
-            Poco::replaceInPlace(orig, std::string("%BUYPRODUCT_URL%"),
+            replaceOrKeep(orig, std::string("%BUYPRODUCT_URL%"),
                                  variables["BUYPRODUCT_URL"]);
 
             LOK_ASSERT_EQUAL(orig, recon);
         }
     }
+}
+
+// Replace each occurence of from in str to to except if to is the empty string
+std::string& FileServeTests::replaceOrKeep(std::string& str, const std::string& from,
+                                           const std::string& to)
+{
+    if (to.empty())
+    {
+        return str;
+    }
+    return Poco::replaceInPlace(str, from, to);
 }
 
 void FileServeTests::testPreProcessedFileSubstitution()


### PR DESCRIPTION
* Resolves: the issue in  https://github.com/NixOS/nixpkgs/pull/393618#issuecomment-2759159587
* Target version: master 

### Summary

preProcessedFileSubstitution did not work correctly if an empty map was given. In this case `variables["ACCESS_TOKEN"]` would be read as `""` as that key was not present in the map.

Poco::replaceInPlace would in turn replace the `%ACCESS_TOKEN%` with `""`, while it should just keep the not specified parts as is.

I chose to add a function rather than ifs in the body to prevent future mistakes from happening.

Before this change I got an error when runnign the unittests from nix (see https://github.com/NixOS/nixpkgs/pull/393618#issuecomment-2759159587
):


```diff
< orig (the one that is made with Poco::replaceInPlace)
> recon (the one that is made by .substitute(...))
10c10
< collabora-online>   <input type="hidden" id="init-buy-product-url" value="" />
---
> collabora-online>   <input type="hidden" id="init-buy-product-url" value="%BUYPRODUCT_URL%" />
12c12
< collabora-online>   <input type="hidden" id="init-css-vars" value="" />
---
> collabora-online>   <input type="hidden" id="init-css-vars" value="<!--%CSS_VARIABLES%-->" />
16c16
< collabora-online> <input type="hidden" id="init-branding-name" value="" />
---
> collabora-online> <input type="hidden" id="init-branding-name" value="%BRANDING_THEME%" />
145,148c145,148
< collabora-online>       data-access-token = ""
< collabora-online>       data-access-token-ttl = ""
< collabora-online>       data-access-header = ""
< collabora-online>       data-post-message-origin-ext = ""
---
> collabora-online>       data-access-token = "%ACCESS_TOKEN%"
> collabora-online>       data-access-token-ttl = "%ACCESS_TOKEN_TTL%"
> collabora-online>       data-access-header = "%ACCESS_HEADER%"
> collabora-online>       data-post-message-origin-ext = "%POSTMESSAGE_ORIGIN%"
167,168c167,168
< collabora-online>       data-ui-defaults = ""
< collabora-online>       data-check-file-info-override = ""
---
> collabora-online>       data-ui-defaults = "%UI_DEFAULTS%"
> collabora-online>       data-check-file-info-override = "%CHECK_FILE_INFO_OVERRIDE%"
181c181
< collabora-online>  <!-- logo onclick handler -->
---
> collabora-online> <!--%BRANDING_JS%--> <!-- logo onclick handler -->
182a183,184
> collabora-online> - orig != recon
> collabora-online> Failures !!!
```


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check` -> ran through nix
- [x] I have issued `make run` and manually verified that everything looks okay -> even ran it through nextcloud
- [x] Documentation (manuals or wiki) has been updated or is not required

