### PR TITLE
Better filtering of bg save messages and logging.

### DIFF
--- a/common/TraceEvent.cpp
+++ b/common/TraceEvent.cpp
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-// To build a freestanding test executable for just Tracevent:
+// To build a freestanding test executable for just TraceEvent:
 // clang++ -Wall -Wextra -DTEST_TRACEEVENT_EXE TraceEvent.cpp -o TraceEvent -pthread
 
 #include "config.h"

--- a/kit/KitWebSocket.cpp
+++ b/kit/KitWebSocket.cpp
@@ -261,22 +261,23 @@ void BgSaveParentWebSocketHandler::reportFailedSave(const std::string &reason)
 
 void BgSaveParentWebSocketHandler::handleMessage(const std::vector<char>& data)
 {
-    LOG_DBG(_socketName << ": recv from parent [" <<
-            COOLProtocol::getAbbreviatedMessage(data));
-
     const StringVector tokens = StringVector::tokenize(data.data(), data.size());
 
-    // Should pass only:
-    // "error:", "forcedtracevent", "unocommandresult:"
-    // "statusindicator[start|finish|setvalue]"
-
-    // Badly don't want modified state coming from the background processx
-    if (tokens[1] == "statechanged:" ||
-        tokens[1] == "calcfunctionlist:")
+    // Only accept messages that make sense
+    if (tokens[1] != "error:" &&
+        tokens[1] != "jsdialog:" &&
+        tokens[1] != "progress:" &&
+        tokens[1] != "traceevent:" &&
+        tokens[1] != "forcedtraceevent:" &&
+        tokens[1] != "unocommandresult:")
     {
-        LOG_TRC("Don't send un-wanted message to parent: " << COOLProtocol::getAbbreviatedMessage(data));
+        LOG_TRC("Ignore un-wanted message from bg child: " <<
+                COOLProtocol::getAbbreviatedMessage(data));
         return;
     }
+
+    LOG_DBG(_socketName << ": recv from bg child [" <<
+            COOLProtocol::getAbbreviatedMessage(data));
 
     if (tokens[1] == "jsdialog:")
     {


### PR DESCRIPTION
Logging was confusing about whether this was the parent kit or the child process - so fix that.

Also there is a tiny subset of messages that make sense to accept from bgsave, avoid propagating some that came after saving and made no sense eg. viewcursorvisible and contentcontrol.

By changing from accept by default to deny by default improve future robustness.


Change-Id: I566e96141a4bcae2b51e5745fbe421acc2fff69f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

