### PR TITLE
Better Dumping And Reduced Noise

### DIFF
--- a/common/Clipboard.hpp
+++ b/common/Clipboard.hpp
@@ -139,22 +139,18 @@ public:
         os << "Saved clipboards: " << _cache.size() << '\n';
         size_t totalSize = 0;
         auto now = std::chrono::steady_clock::now();
-        for (auto &it : _cache)
+        for (const auto &it : _cache)
         {
             std::shared_ptr<std::string> data = it.second._rawData;
+            std::string_view string = *data;
 
-            os << "  size: " << data->size() << " bytes, lifetime: " <<
+            os << "  size: " << string.size() << " bytes, lifetime: " <<
                 std::chrono::duration_cast<std::chrono::seconds>(
                     now - it.second._inserted).count() << " seconds\n";
-            if (data->size() <= 256)
-                Util::dumpHex(os, *data, "", "  ");
-            else
-            {
-                std::string tmp = data->substr(0,256);
-                Util::dumpHex(os, tmp, "", "  ");
-            }
-            totalSize += data->size();
+			Util::dumpHex(os, string.substr(0, 256), "", "  ");
+            totalSize += string.size();
         }
+
         os << "Saved clipboard total size: " << totalSize << '\n';
     }
 

--- a/common/Clipboard.hpp
+++ b/common/Clipboard.hpp
@@ -151,7 +151,7 @@ public:
             totalSize += string.size();
         }
 
-        os << "Saved clipboard total size: " << totalSize << '\n';
+        os << "Saved clipboard total size: " << totalSize << " bytes\n";
     }
 
     void insertClipboard(const std::string key[2],

--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -329,6 +329,14 @@ const std::unordered_map<std::string, std::string>& getDefaultAppConfig() { retu
 void extract(const std::string& parentKey, const Poco::Util::AbstractConfiguration& config,
              std::map<std::string, std::string>& map)
 {
+    if (parentKey.empty() || !config.has(parentKey))
+    {
+        // For some unclear reason, we sometimes get
+        // an empty key. This results in all entries
+        // have a leading '.', which is unexpected.
+        return;
+    }
+
     std::vector<std::string> keys;
     config.keys(parentKey, keys);
     const std::string parentKeyDot = parentKey + '.';
@@ -349,12 +357,9 @@ std::map<std::string, std::string> extractAll(const Poco::Util::AbstractConfigur
 
     std::vector<std::string> keys;
     config.keys(keys);
-    for (const auto& key : keys)
+    for (const std::string& key : keys)
     {
-        if (config.has(key))
-        {
-            extract(key, config, map);
-        }
+        extract(key, config, map);
     }
 
     // These keys have no values, but Poco gives us the values of

--- a/common/Message.hpp
+++ b/common/Message.hpp
@@ -69,17 +69,11 @@ public:
     uint32_t getHash() const { return _hash; }
     void setHash(uint32_t hash) { _hash = hash; }
 
-    /// Find a subarray in the raw message.
-    int find(const char* sub, const std::size_t subLen) const
+    /// Returns true iff the subarray exists in the raw message.
+    bool contains(const std::string_view msg) const
     {
-        return Util::findSubArray(_data.data(), _data.size(), sub, subLen);
+        return std::string_view(_data.data(), _data.size()).find(msg) != std::string::npos;
     }
-
-    /// Returns true iff the subarray exists in the raw message.
-    bool contains(const char* p, const std::size_t len) const { return find(p, len) >= 0; }
-
-    /// Returns true iff the subarray exists in the raw message.
-    bool contains(const std::string &msg) const { return contains(msg.c_str(), msg.size()); }
 
     const std::string& firstLine()
     {

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <array>
 #include <cassert>
 #include <cerrno>
 #include <chrono>
@@ -428,10 +429,10 @@ namespace Util
 
     std::string getVersionJSON(bool enableExperimental, const std::string& timezone);
 
-    inline constexpr unsigned short hexFromByte(unsigned char byte)
+    inline constexpr std::array<char, 2> hexFromByte(unsigned char byte)
     {
         constexpr auto hex = "0123456789ABCDEF";
-        return (hex[byte >> 4] << 8) | hex[byte & 0xf];
+        return { hex[byte >> 4], hex[byte & 0xf] };
     }
 
     inline std::string bytesToHexString(const uint8_t* data, size_t size)
@@ -440,10 +441,10 @@ namespace Util
         s.resize(size * 2); // Each byte is two hex digits.
         for (size_t i = 0; i < size; ++i)
         {
-            const unsigned short hex = hexFromByte(data[i]);
+            const std::array<char, 2> hex = hexFromByte(data[i]);
             const size_t off = i * 2;
-            s[off] = hex >> 8;
-            s[off + 1] = hex & 0xff;
+            s[off] = hex[0];
+            s[off + 1] = hex[1];
         }
 
         return s;
@@ -550,9 +551,9 @@ namespace Util
                 str.push_back(' ');
             if ((offset + i) < buffer.size())
             {
-                const unsigned short hex = hexFromByte(buffer[offset+i]);
-                str.push_back(hex >> 8);
-                str.push_back(hex & 0xff);
+                const std::array<char, 2> hex = hexFromByte(buffer[offset + i]);
+                str.push_back(hex[0]);
+                str.push_back(hex[1]);
                 str.push_back(' ');
             }
             else

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1145,14 +1145,6 @@ int main(int argc, char**argv)
         std::memcpy(vector.data() + vlen, data, dataLen);
     }
 
-    /// Append a number as hexadecimal to a vector
-    inline void vectorAppendHex(std::vector<char> &vector, uint64_t number)
-    {
-        char output[32];
-        snprintf(output, sizeof(output), "%" PRIx64, number);
-        vectorAppend(vector, output);
-    }
-
     /// Splits a URL into path (with protocol), filename, extension, parameters.
     /// All components are optional, depending on what the URL represents (can be a unix path).
     std::tuple<std::string, std::string, std::string, std::string> splitUrl(const std::string& url);

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1570,7 +1570,8 @@ bool ChildSession::getClipboard(const StringVector& tokens)
         {
             Util::vectorAppend(output, outMimeTypes[i]);
             Util::vectorAppend(output, "\n", 1);
-            Util::vectorAppendHex(output, outSizes[i]);
+            const std::array<char, 2> hex = Util::hexFromByte(outSizes[i]);
+            Util::vectorAppend(output, hex.data(), hex.size());
             Util::vectorAppend(output, "\n", 1);
             Util::vectorAppend(output, outStreams[i], outSizes[i]);
             Util::vectorAppend(output, "\n", 1);

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -103,7 +103,8 @@ void dump_forkit_state()
         << "  MasterLocation: " << MasterLocation
         << "\n";
 
-    oss << "\nMalloc info [" << getpid() << "]: \n" << Util::getMallocInfo() << '\n';
+    oss << "\nMalloc info [" << getpid() << "]: \n\t"
+        << Util::replace(Util::getMallocInfo(), "\n", "\n\t") << '\n';
 
     const std::string msg = oss.str();
     fprintf(stderr, "%s", msg.c_str());

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2680,7 +2680,7 @@ void Document::dumpState(std::ostream& oss)
     if (const ssize_t size = FileUtil::readFile("/proc/self/smaps_rollup", smap); size <= 0)
         oss << "\n\tsmaps_rollup: <unavailable>";
     else
-        oss << "\n\tsmaps_rollup: " << smap;
+        oss << "\n\tsmaps_rollup: " << Util::replace(smap, "\n", "\n\t");
     oss << '\n';
 
     // dumpState:
@@ -4136,7 +4136,8 @@ void dump_kit_state()
     std::ostringstream oss;
     KitSocketPoll::dumpGlobalState(oss);
 
-    oss << "\nMalloc info [" << getpid() << "]: \n" << Util::getMallocInfo() << '\n';
+    oss << "\nMalloc info [" << getpid() << "]: \n\t"
+        << Util::replace(Util::getMallocInfo(), "\n", "\n\t") << '\n';
 
     const std::string msg = oss.str();
     fprintf(stderr, "%s", msg.c_str());

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -524,6 +524,13 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS, bool justPoll)
     LOGA_TRC(Socket, "Poll completed with " << rc << " live polls max (" <<
              timeoutMaxMicroS << "us)" << ((rc==0) ? "(timedout)" : ""));
 
+    if (rc == 0)
+    {
+        // We timed out. Flush the thread-local log
+        // buffer to avoid falling too much behind.
+        Log::flush();
+    }
+
     // from now we want to race back to sleep.
     enableWatchdog();
 

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1087,14 +1087,20 @@ void SocketPoll::dumpState(std::ostream& os) const
     os << "\n  SocketPoll [" << name() << "] with " << pollSockets.size() << " socket"
        << (pollSockets.size() == 1 ? "" : "s") << " - wakeup rfd: " << _wakeup[0]
        << " wfd: " << _wakeup[1] << '\n';
-    const auto callbacks = _newCallbacks.size();
-    if (callbacks > 0)
-        os << "\tcallbacks: " << callbacks << '\n';
+
+    os << "\tcallbacks: " << _newCallbacks.size() << '\n';
+
     os << "\t\tfd\tevents\tstatus\trbuffered\trcapacity\twbuffered\twcapacity\trtotal\twtotal\tclie"
           "ntaddress\n";
+    std::size_t totalCapacity = 0;
     for (const std::shared_ptr<Socket>& socket : pollSockets)
+    {
         socket->dumpState(os);
-    os << "\n  Done [" << name() << "]\n";
+        totalCapacity += socket->totalBufferCapacity();
+    }
+
+    os << "\n  Total socket buffer capacity: " << totalCapacity / 1024 << " KB\n";
+    os << "\n  Done SocketPoll [" << name() << "]\n";
     THREAD_UNSAFE_DUMP_END
 }
 

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -247,6 +247,9 @@ public:
     /// Do we have internally queued incoming / outgoing data ?
     virtual bool hasBuffered() const { return false; }
 
+    /// Returns the total capacity of all data buffers.
+    virtual std::size_t totalBufferCapacity() const { return 0; }
+
     /// manage latency issues around packet aggregation
     void setNoDelay()
     {
@@ -1147,6 +1150,11 @@ public:
     bool hasBuffered() const override
     {
         return !_outBuffer.empty() || !_inBuffer.empty();
+    }
+
+    std::size_t totalBufferCapacity() const override
+    {
+        return _outBuffer.capacity() + _inBuffer.capacity();
     }
 
     /// Create a pair of connected stream sockets

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -32,35 +32,35 @@ AM_CXXFLAGS = $(CPPUNIT_CFLAGS) -DTDOC=\"$(abs_top_srcdir)/test/data\" -DTDIST=\
 # 'Finished in' in the `make check` output.
 # When adding new tests, please maintain order.
 all_la_unit_tests = \
+	unit-httpws.la \
 	unit-perf.la \
+	unit-wopi-async-slow.la \
+	unit-wopi-lock.la \
+	unit-tiletest.la \
+	unit-wopi-documentconflict.la \
+	unit-wopi-stuck-save.la \
+	unit-close.la \
+	unit-wopi-watermark.la \
+	unit-crash.la \
 	unit-proxy.la \
 	unit-synthetic-lok.la \
-	unit-wopi-async-slow.la \
-	unit-tiletest.la \
 	unit-wopi-fail-upload.la \
 	unit-each-view.la \
-	unit-wopi-stuck-save.la \
 	unit-load.la \
 	unit-integration.la \
-	unit-httpws.la \
 	unit-quarantine.la \
 	unit-multi-tenant.la \
 	unit-load-torture.la \
 	unit-save-torture.la \
 	unit-copy-paste.la \
 	unit-copy-paste-writer.la \
-	unit-crash.la \
 	unit-wopi-fileurl.la \
 	unit-wopi-save-on-exit.la \
-	unit-wopi-documentconflict.la \
-	unit-close.la \
 	unit-wopi-languages.la \
 	unit-insert-delete.la \
 	unit-password-protected.la \
 	unit-uno-command.la \
 	unit-wopi-httpredirect.la \
-	unit-wopi-watermark.la \
-	unit-wopi-lock.la \
 	unit-calc.la \
 	unit-http.la \
 	unit-wopi-temp.la \

--- a/test/UnitWOPIStuckSave.cpp
+++ b/test/UnitWOPIStuckSave.cpp
@@ -91,14 +91,14 @@ public:
     {
         LOG_TST("Filtering: [" << message->firstLine() << ']');
 
-        constexpr char unoSave[] = ".uno:Save";
-        constexpr char unoModifiedStatus[] = ".uno:ModifiedStatus";
-        if (message->contains(unoSave, sizeof(unoSave) - 1))
+        constexpr std::string_view unoSave = ".uno:Save";
+        constexpr std::string_view unoModifiedStatus = ".uno:ModifiedStatus";
+        if (message->contains(unoSave))
         {
             LOG_TST("Dropping .uno:Save to simulate stuck save");
             return true; // Do not process the message further.
         }
-        else if (message->contains(unoModifiedStatus, sizeof(unoModifiedStatus) - 1))
+        else if (message->contains(unoModifiedStatus))
         {
             if (message->tokens().size() > 1)
             {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3828,6 +3828,12 @@ int COOLWSD::innerMain()
         // Wake the prisoner poll to spawn some children, if necessary.
         PrisonerPoll->wakeup();
 
+        if (SigUtil::getShutdownRequestFlag())
+        {
+            // The code below can be unsafe as other threads start shutting down.
+            break;
+        }
+
         const auto timeNow = std::chrono::steady_clock::now();
         const std::chrono::milliseconds timeSinceStartMs
             = std::chrono::duration_cast<std::chrono::milliseconds>(timeNow - startStamp);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3349,7 +3349,7 @@ public:
         if (const ssize_t size = FileUtil::readFile("/proc/self/smaps_rollup", smap); size <= 0)
             os << "\n  smaps_rollup: <unavailable>";
         else
-            os << "\n  smaps_rollup: " << smap;
+            os << "\n  smaps_rollup: " << Util::replace(smap, "\n", "\n\t");
 
 #if !MOBILEAPP
         if (FetchHttpSession)
@@ -4241,7 +4241,8 @@ void dump_state()
     if (Server)
         Server->dumpState(oss);
 
-    oss << "\nMalloc info [" << getpid() << "]: \n" << Util::getMallocInfo() << '\n';
+    oss << "\nMalloc info [" << getpid() << "]: \n\t"
+        << Util::replace(Util::getMallocInfo(), "\n", "\n\t") << '\n';
 
     const std::string msg = oss.str();
     fprintf(stderr, "%s\n", msg.c_str());

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2454,7 +2454,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
             }
         }
 
-        if (payload->find("url", 3) >= 0)
+        if (payload->contains("url"))
         {
             std::string json(payload->data().data(), payload->size());
             const auto it = json.find('{');

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -716,8 +716,14 @@ void DocumentBroker::pollThread()
     {
         std::stringstream state;
         state << "DocBroker [" << _docKey << "] stopped "
-              << (reason.empty() ? "because of test failure" : ("although " + reason)) << ": ";
-        dumpState(state);
+              << (reason.empty() ? "because of test failure" : ("although " + reason));
+        if (!UnitWSD::isUnitTesting())
+        {
+            // When running unit-tests, we issue USR1.
+            state << ": ";
+            dumpState(state);
+        }
+
         LOG_WRN(state.str());
     }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -5222,8 +5222,8 @@ void DocumentBroker::dumpState(std::ostream& os)
            << std::chrono::duration_cast<std::chrono::seconds>(now - _createTime);
     int childPid = _childProcess ? _childProcess->getPid() : 0;
     os << "\n  child PID: " << childPid;
-    os << "\n  sent: " << sent;
-    os << "\n  recv: " << recv;
+    os << "\n  sent: " << sent << " bytes";
+    os << "\n  recv: " << recv << " bytes";
     os << "\n  jail id: " << _jailId;
     os << "\n  filename: " << COOLWSD::anonymizeUrl(_filename);
     os << "\n  public uri: " << _uriPublic.toString();

--- a/wsd/SenderQueue.hpp
+++ b/wsd/SenderQueue.hpp
@@ -154,7 +154,7 @@ private:
         else if (command == "progress:")
         {
             // find other progress commands with similar content
-            static const std::string setvalueTag = "\"id\":\"setvalue\"";
+            static constexpr std::string_view setvalueTag = "\"id\":\"setvalue\"";
             if (item->contains(setvalueTag))
             {
                 const auto& pos = std::find_if(_queue.begin(), _queue.end(),


### PR DESCRIPTION
- **wsd: return an array for hex conversion**
- **wsd: simplify Message::contains()**
- **wsd: replace single-use vectorAppendHex**
- **wsd: avoid copying the clipboard when dumping**
- **wsd: dump the total socket buffer size**
- **wsd: better state dumping**
- **wsd: use chrono for limit_load_secs**
- **make: shorter unit-test run time**
- **wsd: stop early when the shutdown flag is set**
- **wsd: skip empty config entries**
- **wsd: avoid duplicate state dumping with unit-tests**
- **wsd: flush thread-local log buffer on idle polling**
