### PR TITLE
Sidebar: fix color widget dropdown alignment

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -125,7 +125,6 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 
 .sidebar.ui-grid.ui-grid-cell .menubutton {
 	justify-content: space-between;
-	justify-self: end;
 	padding: 0;
 	margin-right: 1px;
 }


### PR DESCRIPTION
This - "justify-self: end;" - seems to be an old declaration when we
were attempting fixing alignments by incorrectly aligning everything
to the right -> remove it.

for the majority of ".sidebar.ui-grid.ui-grid-cell .menubutton" that
declaration was rendered inactive (for menu icon buttons) but for the
dropdown (color widget) it was active, resulting in misalignment

1. Open a presentation file
2. Open sidebar
3. In the slide section set the background dropdown to color
4. Notice the misalignment

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I2dc569f008bc4cad63a29469d81bfd36d7b9c7c7

![image](https://github.com/user-attachments/assets/c219b171-f49a-4952-8852-81ba44ab3979)

