### PR TITLE
Sidebar: ui-drawing-area: avoid hard coded pixels

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -17,7 +17,7 @@ img.sidebar.ui-image {
 }
 
 /* Impress -> Master Slides images should fit in the visible width */
-img.sidebar.ui-drawing-area {
+#SdLayoutsPanelPanelExpander img.sidebar.ui-drawing-area {
 	width: 300px;
 }
 


### PR DESCRIPTION
Before this change, the daRatioTop images was forced to be at huge
300px size.

The 300px was introduced in 07bbf1d38f6d18d383fd1c71bc47e0f1ca38bc5b
to make sure that the Master slide thumbnails do not get cropped, at
that time we didn't have things like daRatioTop

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Idcf73ef59bcf2dcc44cda43b8b116506c324f448

![image](https://github.com/user-attachments/assets/0fbbf38c-214c-4504-b5c0-8064236d21e7)

