### PR TITLE
Menubutton: don't set background for disabled buttons

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -1,6 +1,6 @@
 /* For btns hover status see device-desktop.css */
 
-.jsdialog *[disabled] {
+.jsdialog:not(.sidebar) *[disabled] {
 	color: var(--color-text-lighter) !important;
 	background: var(--color-background-lighter);
 }

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1492,7 +1492,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 .jsdialog.menubutton[disabled] {
-	background-color: var(--color-background-lighter) !important;
+	background-color: transparent !important;
 	color: var(--color-text-lighter) !important;
 }
 


### PR DESCRIPTION
All active buttons have already a background that is different than its
container so, better to set the bg transparent for the hover
state. This way, the background of the container doesn't matter and
the disabled button will always look disabled.

Before this commit, we were setting the background of the button as
the same background of the container:
- the problem is, we have different containers (sidebar, dialogs)
- and when integrator has a different background in
the sidebar, the disabled button would actually be emphasized, looking
more active and disabled.

Another alternative would be to set additional rules, targeting dialog
and then the sidebar, which seems less elegant.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ib5b416b82f2c5a8953f49f5b77e4e5b3fc3f7337
