### PR TITLE
Improve Hide/show Menu_Item Command and Button errors

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -146,7 +146,7 @@ L.Control.Menubar = L.Control.extend({
 					{name: _('Hide Menu Bar'), id: 'togglemenubar', type: 'action'},
 					{name: _('Dark Mode'), id: 'toggledarktheme', type: 'action'},
 					{name: _('Invert Background'), id: 'invertbackground', type: 'action'},
-					{uno: '.uno:SidebarDeck.PropertyDeck', name: _UNO('.uno:Sidebar')},
+					{uno: '.uno:SidebarDeck.PropertyDeck', id: 'view-sidebar-property-deck', name: _UNO('.uno:Sidebar')},
 					{uno: '.uno:SidebarDeck.StyleListDeck', name: _('Style list')},
 					{uno: '.uno:Navigator', id: 'navigator'},
 					{type: 'separator'},
@@ -2477,6 +2477,9 @@ L.Control.Menubar = L.Control.extend({
 			if ($.inArray(targetId, this._hiddenItems) == -1)
 				this._hiddenItems.push(targetId);
 			$(item).css('display', 'none');
+			return true;
+		} else {
+			return false;
 		}
 	},
 
@@ -2486,6 +2489,9 @@ L.Control.Menubar = L.Control.extend({
 			if ($.inArray(targetId, this._hiddenItems) !== -1)
 				this._hiddenItems.splice(this._hiddenItems.indexOf(targetId), 1);
 			$(item).css('display', '');
+			return true;
+		} else {
+			return false;
 		}
 	},
 
@@ -2518,7 +2524,9 @@ L.Control.Menubar = L.Control.extend({
 				}
 			});
 			$(items).css('display', 'none');
+			return true;
 		}
+		return false;
 	},
 
 	showUnoItem: function(targetId) {
@@ -2531,7 +2539,9 @@ L.Control.Menubar = L.Control.extend({
 				}
 			});
 			$(items).css('display', '');
+			return true;
 		}
+		return false;
 	},
 
 	_initializeMenu: function(menu) {

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -357,10 +357,15 @@ L.Control.Notebookbar = L.Control.extend({
 
 	showNotebookbarButton: function(buttonId, show) {
 		var button = $(this.container).find('#' + buttonId);
-		if (show) {
-			button.show();
+		if (button) {
+			if (show) {
+				button.show();
+			} else {
+				button.hide();
+			}
+			return true;
 		} else {
-			button.hide();
+			return false;
 		}
 	},
 
@@ -372,11 +377,15 @@ L.Control.Notebookbar = L.Control.extend({
 			cssClass = commandId;
 		}
 		var button = $(this.container).find('div.' + cssClass);
-		if (show) {
-			button.show();
-		} else {
-			button.hide();
+		if (button) {
+			if (show) {
+				button.show();
+			} else {
+				button.hide();
+			}
+			return true;
 		}
+		return false;
 	},
 
 	setCurrentScrollPosition: function() {

--- a/browser/src/control/Control.UIManager.js
+++ b/browser/src/control/Control.UIManager.js
@@ -784,15 +784,13 @@ L.Control.UIManager = L.Control.extend({
 		if (topToolbarHas)
 			window.app.map.topToolbar.showItem(buttonId, show);
 
-		if (!found) {
-			window.app.console.error('Toolbar button with id "' + buttonId + '" not found.');
-			return;
-		}
+		return found;
 	},
 
 	showButton: function(buttonId, show) {
+		var found = false;
 		if (!this.notebookbar) {
-			this.showButtonInClassicToolbar(buttonId, show);
+			found = this.showButtonInClassicToolbar(buttonId, show);
 		} else {
 			if (show) {
 				delete this.hiddenButtons[buttonId];
@@ -800,7 +798,12 @@ L.Control.UIManager = L.Control.extend({
 				this.hiddenButtons[buttonId] = true;
 			}
 			this.notebookbar.reloadShortcutsBar();
-			this.notebookbar.showNotebookbarButton(buttonId, show);
+			found = this.notebookbar.showNotebookbarButton(buttonId, show);
+		}
+
+		if (!found) {
+			window.app.console.error('Button with id "' + buttonId + '" not found.');
+			return;
 		}
 	},
 
@@ -813,9 +816,9 @@ L.Control.UIManager = L.Control.extend({
 	showCommandInMenubar: function(command, show) {
 		var menubar = this._map.menubar;
 		if (show) {
-			menubar.showUnoItem(command);
+			return menubar.showUnoItem(command);
 		} else {
-			menubar.hideUnoItem(command);
+			return menubar.hideUnoItem(command);
 		}
 	},
 
@@ -840,10 +843,7 @@ L.Control.UIManager = L.Control.extend({
 			}.bind(this));
 		}.bind(this));
 
-		if (!found) {
-			window.app.console.error('Toolbar item with command "' + command + '" not found.');
-			return;
-		}
+		return found;
 	},
 
 	showCommand: function(command, show) {
@@ -852,12 +852,17 @@ L.Control.UIManager = L.Control.extend({
 		} else {
 			this.hiddenCommands[command] = true;
 		}
+		var found = false;
 		if (!this.notebookbar) {
-			this.showCommandInClassicToolbar(command, show);
-			this.showCommandInMenubar(command, show);
+			found |= this.showCommandInClassicToolbar(command, show);
+			found |= this.showCommandInMenubar(command, show);
 		} else {
 			this.notebookbar.reloadShortcutsBar();
-			this.notebookbar.showNotebookbarCommand(command, show);
+			found |= this.notebookbar.showNotebookbarCommand(command, show);
+		}
+
+		if (!found) {
+			window.app.console.error('Item with command "' + command + '" not found.');
 		}
 	},
 

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -450,9 +450,11 @@ L.Map.WOPI = L.Handler.extend({
 			}
 
 			if (msg.MessageId === 'Show_Menu_Item') {
-				this._map.menubar.showItem(msg.Values.id);
-			} else {
-				this._map.menubar.hideItem(msg.Values.id);
+				if (!this._map.menubar.showItem(msg.Values.id)) {
+					window.app.console.error('Menu entry with id "' + msg.Values.id + '" not found.');
+				}
+			} else if (!this._map.menubar.hideItem(msg.Values.id)) {
+				window.app.console.error('Menu entry with id "' + msg.Values.id + '" not found.');
 			}
 			return;
 		}


### PR DESCRIPTION
 * Show no errors when Hide/Show_Command, Hide/Show_Button and Hide/Show_Menu_Item found an item to show/hide
 * Set id for Sidebar Menu entry


Change-Id: I38c83cc8c6563e61a00c6b52ecc7366824b0e4a4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

To allow to hide the Sidebar using Hide_Button with the same "id" as used in the notebookbar in the compact style.
And have errors messages only when a button, menu or toolbar entry was not found.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

