### PR TITLE
clipboard length should be number encoded as hex

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1570,7 +1570,9 @@ bool ChildSession::getClipboard(const StringVector& tokens)
         {
             Util::vectorAppend(output, outMimeTypes[i]);
             Util::vectorAppend(output, "\n", 1);
-            const std::array<char, 2> hex = Util::hexFromByte(outSizes[i]);
+            std::stringstream sstream;
+            sstream << std::hex << outSizes[i];
+            std::string hex = sstream.str();
             Util::vectorAppend(output, hex.data(), hex.size());
             Util::vectorAppend(output, "\n", 1);
             Util::vectorAppend(output, outStreams[i], outSizes[i]);


### PR DESCRIPTION
a problem since:

commit 2178f959e775afe7f430b9bef9e2c19a0a1caf6c
CommitDate: Mon Mar 31 16:24:10 2025 +0100

    wsd: replace single-use vectorAppendHex

    Luckily, it's a single liner.


Change-Id: Ia6b41aa637bf03d5b11c51cc31cd022b4e0b621b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

