### PR TITLE
GC tiles based on their distance from the visible area

### DIFF
--- a/browser/src/canvas/sections/PreloadMapSection.ts
+++ b/browser/src/canvas/sections/PreloadMapSection.ts
@@ -119,7 +119,7 @@ class PreloadMapSection extends app.definitions.canvasSectionObject {
 							canvas.fillStyle = 'rgba(255, 255, 0, 0.8)'; // yellow
 						else if (!tile.canvas)
 							canvas.fillStyle = 'rgba(0, 96, 0, 0.8)'; // dark green
-						else if (!tile.current)
+						else if (tile.distanceFromView !== 0)
 							canvas.fillStyle = 'rgba(0, 192, 0, 0.8)'; // green
 						// present
 						else canvas.fillStyle = 'rgba(0, 255, 0, 0.5)'; // light green


### PR DESCRIPTION
Tiles were previously GC'd based on their last render time, which was generally inaccurate. Instead, GC them based on their distance from the visible area (including split panes).

* Target version: master 

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

