### PR TITLE
re-hydrate tiles in areas we are pre-loading.

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -1296,7 +1296,7 @@ class TileManager {
 					this._pixelBounds.getSize().y * direction[1],
 				);
 
-				var queue = this.getMissingTiles(this._pixelBounds, this._zoom, false);
+				var queue = this.getMissingTiles(this._pixelBounds, this._zoom, false, true);
 
 				if (this._docLayer.isCalc() || queue.length === 0) {
 					// pre-load more aggressively
@@ -1305,7 +1305,7 @@ class TileManager {
 						(this._pixelBounds.getSize().y * direction[1]) / 2,
 					);
 					queue = queue.concat(
-						this.getMissingTiles(this._pixelBounds, this._zoom, false),
+						this.getMissingTiles(this._pixelBounds, this._zoom, false, true),
 					);
 				}
 
@@ -1423,6 +1423,7 @@ class TileManager {
 		pixelBounds: any,
 		zoom: number,
 		updateCurrent: boolean,
+		rehydrate: boolean = false
 	) {
 		var tileRanges = this.pxBoundsToTileRanges(pixelBounds);
 		var queue = [];
@@ -1452,6 +1453,8 @@ class TileManager {
 					var tile = this.tiles[key];
 
 					if (!tile || tile.needsFetch()) queue.push(coords);
+					else if (rehydrate && tile.needsRehydration())
+						this.rehydrateTile(tile);
 					else if (updateCurrent)
 						didRehydrate = this.makeTileCurrent(tile) || didRehydrate;
 				}


### PR DESCRIPTION
Previously we assumed that such areas would have new tiles, but this avoids flicker caused by async re-hydration when moving to areas we have just visited.


Change-Id: I33150e629f2d4d93d00775af8117f316c9f17ec4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

