### PR TITLE
Improve tile prefetch behaviour

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -1437,15 +1437,9 @@ class TileManager {
 			new L.Point(tile.coords.x, tile.coords.y),
 			new L.Point(tile.coords.x + this.tileSize, tile.coords.y + this.tileSize),
 		);
-		if (tileBounds.intersectsAny(visibleRanges)) {
-			tile.distanceFromView = 0;
-			return;
-		}
-
-		const tileCenter = tileBounds.getCenter();
-		tile.distanceFromView = tileCenter.distanceTo(visibleRanges[0].getCenter());
+		tile.distanceFromView = tileBounds.distanceTo(visibleRanges[0]);
 		for (let i = 1; i < visibleRanges.length; ++i) {
-			const distance = tileCenter.distanceTo(visibleRanges[i].getCenter());
+			const distance = tileBounds.distanceTo(visibleRanges[i]);
 			if (distance < tile.distanceFromView) tile.distanceFromView = distance;
 		}
 	}

--- a/browser/src/geometry/Bounds.ts
+++ b/browser/src/geometry/Bounds.ts
@@ -169,6 +169,31 @@ export class Bounds {
 		return xIntersects && yIntersects;
 	}
 
+	public distanceTo(bounds: Bounds): number {
+		var min = this.min;
+		var max = this.max;
+		var min2 = bounds.min;
+		var max2 = bounds.max;
+		var xIntersects = (max2.x >= min.x) && (min2.x <= max.x);
+		var yIntersects = (max2.y >= min.y) && (min2.y <= max.y);
+		
+		if (xIntersects) {
+			if (yIntersects) return 0;
+			if (max2.y < min.y) return min.y - max2.y;
+			return min2.y - max.y;
+		}
+
+		if (yIntersects) {
+			if (max2.x < min.x) return min.x - max2.x;
+			return min2.x - max.x;
+		}
+
+		var xdist = (min.x > max2.x) ? (min.x - max2.x) : (min2.x - max.x);
+		var ydist = (min.y > max2.y) ? (min.y - max2.y) : (min2.y - max.y);
+
+		return Math.sqrt(xdist * xdist + ydist * ydist);
+	}
+
 	// non-destructive, returns a new Bounds
 	public add(point: Point): Bounds {
 		return this.clone()._add(point);


### PR DESCRIPTION
### Summary

This set of changes makes it so that pre-fetched tiles are not immediately decompressed and the 'current' area (which will be decompressed) is expanded around the visible region. The intended change in behaviour is that tiles that are necessary for a consistent feeling experience are prioritised and not considered for GC, and we don't waste so much worker time decompressing tiles that may never be seen.

This can increase memory pressure on 4k screens as it will maintain all on-screen tiles and the expanded area tiles (currently set at 2 tiles around the visible region). I think this may be necessary long-term, but have some ideas to mitigate this. I'm also going to look at prototyping use of ImageBitmap instead of canvas for tiles, which ought to significantly reduce resource pressure (and hopefully be feasible...)

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

