### PR TITLE
fix: prevent unintended SettingIframe initialization on non-iframe pages

### DIFF
--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -563,8 +563,10 @@ class SettingIframe {
 	}
 }
 
-(window as any).settingIframe = new SettingIframe();
-
 document.addEventListener('DOMContentLoaded', () => {
-	(window as any).settingIframe.init();
+	const adminContainer = document.getElementById('allConfigSection');
+	if (adminContainer) {
+		(window as any).settingIframe = new SettingIframe();
+		(window as any).settingIframe.init();
+	}
 });


### PR DESCRIPTION
Change-Id: I14ef4d05a88d1ae991673bbefc6f7322e1094bfc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

When we open the admin page, we keep getting a "shared config URL is missing" error because we bundle everything into the admin bundle, so we have prevented calling it unless it is actually the settings iframe page.
![image](https://github.com/user-attachments/assets/40644be0-477c-426d-b8e9-92352c6ce975)
