### PR TITLE
Skew pxBounds tile range growth in the direction of travel.

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -2232,10 +2232,24 @@ class TileManager {
 	}
 
 	public static pxBoundsToTileRange(bounds: any, grow: number = 0) {
-		const growSize = new L.Point(grow, grow);
+		const direction = app.sectionContainer.getLastPanDirection();
+
+		const growSize = new L.Point(
+			grow * (1.0 + Math.abs(direction[0])),
+			grow * (1.0 + Math.abs(direction[1])),
+		);
+		const translate = new L.Point(
+			grow * 2.0 * direction[0],
+			grow * 2.0 * direction[1],
+		);
+
 		return new L.Bounds(
-			bounds.min.divideBy(this.tileSize).floor()._subtract(growSize),
-			bounds.max.divideBy(this.tileSize).floor()._add(growSize),
+			bounds.min
+				.divideBy(this.tileSize)
+				.floor()
+				._subtract(growSize)
+				.add(translate),
+			bounds.max.divideBy(this.tileSize).floor()._add(growSize).add(translate),
 		);
 	}
 

--- a/browser/src/canvas/sections/PreloadMapSection.ts
+++ b/browser/src/canvas/sections/PreloadMapSection.ts
@@ -93,7 +93,7 @@ class PreloadMapSection extends app.definitions.canvasSectionObject {
 		partBounds[preParts].max.y += viewHeight * mainYMultiply;
 
 		var offx: number = 50;
-		var offy: number = 400;
+		var offy: number = 200;
 		var voffset: number = 0;
 		for (var p = 0; p < partBounds.length; ++p) {
 			var range = partBounds[p];


### PR DESCRIPTION
This can reduce flicker by ensuring we de-hydrated by the time we get to the content.


Change-Id: I1b3952102ca0c394b0a907cfb52cc007df9ee226


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

