### PR TITLE
Calc: Remove other view's username popup if they switch to another sh…

### DIFF
--- a/browser/src/canvas/sections/OtherViewCellCursorSection.ts
+++ b/browser/src/canvas/sections/OtherViewCellCursorSection.ts
@@ -168,6 +168,9 @@ class OtherViewCellCursorSection extends CanvasSectionObject {
         if (section.showSection && !newSection)
             section.showUsernamePopUp();
 
+        if (!section.showSection)
+            section.hideUsernamePopUp();
+
         app.sectionContainer.requestReDraw();
     }
 


### PR DESCRIPTION
…eet.

Issue: When a collaborating user switches to another sheet, their username popup may still visible for others in previous sheet.


Change-Id: I22711a2d31f08e639e3b32113c0cc7dfc86cd4bb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

