### PR TITLE
Replace Tile canvas backing store with ImageBitmap

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -483,10 +483,11 @@ class TileManager {
 					keyframeDeltaSize,
 					keyframeImage,
 					e.wireMessage,
-					true,
 				);
 
-				bitmaps.push(createImageBitmap(tile.imgDataCache));
+				bitmaps.push(
+					createImageBitmap(tile.imgDataCache, { premultiplyAlpha: 'none' }),
+				);
 				pendingDeltas.push(e);
 			}
 
@@ -533,7 +534,6 @@ class TileManager {
 		oldData: any,
 		width: any,
 		height: any,
-		needsUnpremultiply: any,
 	) {
 		var pixSize = width * height * 4;
 		if (this.debugDeltas)
@@ -605,8 +605,6 @@ class TileManager {
 						);
 					i += 4;
 					span *= 4;
-					if (needsUnpremultiply)
-						L.CanvasTileUtils.unpremultiply(delta, span, i);
 					for (var j = 0; j < span; ++j) imgData.data[offset++] = delta[i + j];
 					i += span;
 					// imgData.data[offset - 2] = 256; // debug - blue terminator
@@ -938,7 +936,6 @@ class TileManager {
 		keyframeDeltaSize: any,
 		keyframeImage: any,
 		wireMessage: any,
-		deltasNeedUnpremultiply: any,
 	) {
 		// 'Uint8Array' rawDelta
 
@@ -1056,7 +1053,6 @@ class TileManager {
 				oldData,
 				this.tileSize,
 				this.tileSize,
-				deltasNeedUnpremultiply,
 			);
 			if (this.debugDeltas)
 				window.app.console.log(
@@ -2062,10 +2058,11 @@ class TileManager {
 						x.keyframeDeltaSize,
 						keyframeImage,
 						x.wireMessage,
-						false,
 					);
 
-					bitmaps.push(createImageBitmap(tile.imgDataCache));
+					bitmaps.push(
+						createImageBitmap(tile.imgDataCache, { premultiplyAlpha: 'none' }),
+					);
 					pendingDeltas.push(x);
 				}
 

--- a/browser/src/canvas/sections/PreloadMapSection.ts
+++ b/browser/src/canvas/sections/PreloadMapSection.ts
@@ -117,7 +117,7 @@ class PreloadMapSection extends app.definitions.canvasSectionObject {
 							canvas.fillStyle = 'rgba(255, 0, 0, 0.8)'; // red
 						else if (tile.needsFetch())
 							canvas.fillStyle = 'rgba(255, 255, 0, 0.8)'; // yellow
-						else if (!tile.canvas)
+						else if (!tile.image)
 							canvas.fillStyle = 'rgba(0, 96, 0, 0.8)'; // dark green
 						else if (tile.distanceFromView !== 0)
 							canvas.fillStyle = 'rgba(0, 192, 0, 0.8)'; // green

--- a/browser/src/canvas/sections/TilesSection.ts
+++ b/browser/src/canvas/sections/TilesSection.ts
@@ -579,7 +579,7 @@ export class TilesSection extends CanvasSectionObject {
 			var relScale = this.map.getZoomScale(zoom, areaZoom);
 
 			this.forEachTileInArea(areaAtZoom, zoom, part, mode, ctx, function(tile, coords, section) {
-				if (tile && tile.canvas) {
+				if (tile && tile.image) {
 					var tilePos = coords.getPos();
 
 					if (app.file.fileBasedView) {
@@ -619,18 +619,11 @@ export class TilesSection extends CanvasSectionObject {
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-	public ensureCanvas(tile: any): void
-	{
-		TileManager.ensureCanvas(tile, false);
-	}
-
-	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public drawTileToCanvas(tile: any, canvas: CanvasRenderingContext2D,
 							dx: number, dy: number, dWidth: number, dHeight: number): void
 	{
-		this.ensureCanvas(tile);
 		this.drawTileToCanvasCrop(tile, canvas,
-								  0, 0, tile.canvas.width, tile.canvas.height,
+								  0, 0, TileManager.tileSize, TileManager.tileSize,
 								  dx, dy, dWidth, dHeight);
 	}
 
@@ -671,12 +664,13 @@ export class TilesSection extends CanvasSectionObject {
 								sx: number, sy: number, sWidth: number, sHeight: number,
 								dx: number, dy: number, dWidth: number, dHeight: number): void
 	{
-		this.ensureCanvas(tile);
+		TileManager.touchImage(tile);
 
 		/* if (!(tile.wireId % 4)) // great for debugging tile grid alignment.
 				canvas.drawImage(this.checkpattern, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
 		else */
-		canvas.drawImage(tile.canvas, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
+		if (tile.image)
+			canvas.drawImage(tile.image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
 
 		if (this.map._debug.tileOverlaysOn)
 		{

--- a/browser/src/layer/tile/CanvasTileUtils.ts
+++ b/browser/src/layer/tile/CanvasTileUtils.ts
@@ -11,24 +11,6 @@ declare var L: any;
 
 namespace cool {
 	export abstract class CanvasTileUtils {
-		public static unpremultiply(
-			data: Uint8Array,
-			byteLength: number,
-			byteOffset: number = 0,
-		): void {
-			for (var i = byteOffset; i < byteOffset + byteLength; i += 4) {
-				// premultiplied rgba -> unpremultiplied rgba
-				var alpha = data[i + 3];
-				if (alpha === 0) {
-					data.fill(0, i, i + 3);
-				} else if (alpha !== 255) {
-					data[i] = Math.ceil((data[i] * 255) / alpha);
-					data[i + 1] = Math.ceil((data[i + 1] * 255) / alpha);
-					data[i + 2] = Math.ceil((data[i + 2] * 255) / alpha);
-				}
-			}
-		}
-
 		private static lastPixel = new Uint8Array(4);
 
 		public static unrle(
@@ -48,8 +30,6 @@ namespace cool {
 				const rleMaskSizeBytes = 256 / 8;
 
 				offset += rleMaskSizeBytes;
-
-				if (rleSize > 0) this.unpremultiply(data, rleSize * 4, offset);
 
 				// It would be rather nice to have real 64bit types [!]
 				this.lastPixel.fill(0);

--- a/browser/src/layer/tile/CanvasTileWorkerSrc.js
+++ b/browser/src/layer/tile/CanvasTileWorkerSrc.js
@@ -48,32 +48,6 @@ if ('undefined' === typeof window) {
 						buffers.push(tile.keyframeBuffer.buffer);
 					}
 
-					// Unpremultiply delta updates
-					var stop = false;
-					for (var i = tile.keyframeDeltaSize; i < deltas.length && !stop; ) {
-						switch (deltas[i]) {
-							case 99: // 'c': // copy row
-								i += 4;
-								break;
-							case 100: // 'd': // new run
-								var span = deltas[i + 3] * 4;
-								i += 4;
-								L.CanvasTileUtils.unpremultiply(deltas, span, i);
-								i += span;
-								break;
-							case 116: // 't': // terminate delta
-								stop = true;
-								i++;
-								break;
-							default:
-								console.error(
-									'[' + i + ']: ERROR: Unknown delta code ' + deltas[i],
-								);
-								i = deltas.length;
-								break;
-						}
-					}
-
 					// Now wrap as Uint8ClampedArray as that's what ImageData requires. Don't do
 					// it earlier to avoid unnecessarily incurring bounds-checking penalties.
 					tile.deltas = new Uint8ClampedArray(


### PR DESCRIPTION
Instead of using canvas elements as a tile image backing store, use ImageBitmap. As ImageBitmap is a light wrapper around graphics memory, this has the benefit of reducing resource usage, simplifying the code and dramatically improving performance.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

