### PR TITLE
clang, test: cover SocketPoll subclass check

### DIFF
--- a/clang/test/refcounting.cpp
+++ b/clang/test/refcounting.cpp
@@ -4,6 +4,14 @@ class CheckFileInfo
 {
 };
 
+class SocketPoll
+{
+};
+
+class D : public SocketPoll
+{
+};
+
 int main() {
     {
         // expected-error@+1 {{instance allocated on the stack, create it with std::shared_ptr [coplugin:refcounting]}}
@@ -13,6 +21,16 @@ int main() {
     {
         // good
         auto checkFileInfo = std::make_shared<CheckFileInfo>();
+    }
+
+    {
+        // expected-error@+1 {{instance allocated on the stack, create it with std::shared_ptr [coplugin:refcounting]}}
+        D d;
+    }
+
+    {
+        // good
+        auto d = std::make_shared<D>();
     }
 }
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1404,8 +1404,11 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
         {
             setenv("COOL_LOGFILE", "1", true);
             setenv("COOL_LOGFILENAME", it->second.c_str(), true);
-            std::cerr << "\nLogging at " << LogLevel << " level to file: " << it->second.c_str()
-                      << std::endl;
+            if (!CleanupOnly)
+            {
+                std::cerr << "\nLogging at " << LogLevel << " level to file: " << it->second.c_str()
+                    << std::endl;
+            }
         }
     }
 
@@ -1436,7 +1439,10 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
         {
             setenv("COOL_LOGFILE_UICMD", "1", true);
             setenv("COOL_LOGFILENAME_UICMD", it->second.c_str(), true);
-            std::cerr << "\nLogging UI Commands to file: " << it->second.c_str() << std::endl;
+            if (!CleanupOnly)
+            {
+                std::cerr << "\nLogging UI Commands to file: " << it->second.c_str() << std::endl;
+            }
         }
         const bool merge = ConfigUtil::getConfigValue<bool>(conf, "logging_ui_cmd.merge", true);
         const bool logEndtime =


### PR DESCRIPTION
- **coolwsd --clean: don't produce error output on success**
- **clang, test: cover SocketPoll subclass check**
