### PR TITLE
Avoid potentially seeking before begin() of iterator

### DIFF
--- a/kit/KitQueue.cpp
+++ b/kit/KitQueue.cpp
@@ -552,7 +552,7 @@ namespace {
         }
 
         // erase from source all the dest inserted tiles in one fell swoop
-        tileQueue.erase(tileQueue.begin() + leftTile + 1, tileQueue.begin() + rightTile);
+        tileQueue.erase(tileQueue.begin() + (leftTile + 1), tileQueue.begin() + rightTile);
 
         return std::make_pair(leftGridX, rightGridX);
     }


### PR DESCRIPTION
The expression `tileQueue.begin() + leftTile + 1` can be compiled so that `tileQueue.begin() + leftTile` is evaluated first. (Or should that always happen, isn't the + operator left associative?) When leftTile is -1 that is obviously problematic. Use parens to make sure that `leftTile + 1` is evaluated first.


Change-Id: I47720f16832a9fabfb718c09fa5e793fe1462df3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

