### PR TITLE
wsd: do not start the service with invalid quarantine path

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1803,25 +1803,8 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
                 LOG_WRN("Quarantine path is relative. Please use an absolute path for better "
                         "reliability");
 
-            Poco::File p(path);
-            try
-            {
-                LOG_TRC("Creating quarantine directory [" + path << ']');
-                p.createDirectories();
-
-                LOG_DBG("Created quarantine directory [" + path << ']');
-            }
-            catch (const std::exception& ex)
-            {
-                LOG_WRN("Failed to create quarantine directory [" << path
-                                                                  << "]. Disabling quaratine");
-            }
-
-            if (FileUtil::Stat(path).exists())
-            {
-                LOG_INF("Initializing quarantine at [" + path << ']');
-                Quarantine::initialize(path);
-            }
+            LOG_DBG("Initializing quarantine at [" + path << ']');
+            Quarantine::initialize(path);
         }
     }
     else


### PR DESCRIPTION
When the quarantine path is invalid or read-only,
the issue remains hidden and hard to debug.

This validates the path and exists with
a fatal error when it's either invalid or
inaccessible (no write permissions), giving
the user immediate feedback to allow them
to fix the issue (or disable the feature).

Change-Id: Ifbde1cea4594ac3c9f9fc92810a41813fef0b69f
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
