### PR TITLE
wsd: invalidate the token only for authorization failures

### DIFF
--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -455,14 +455,18 @@ void WopiStorage::updateLockStateAsync(const Authorization& auth, LockContext& l
              httpResponse->statusLine().statusCode() == http::StatusCode::Forbidden ||
              httpResponse->statusLine().statusCode() == http::StatusCode::NotFound);
 
+        const StorageBase::LockUpdateResult::Status status =
+            unauthorized ? LockUpdateResult::Status::UNAUTHORIZED
+                         : LockUpdateResult::Status::FAILED;
+
         LOG_ERR("Un-successful " << wopiLog << " with " << (unauthorized ? "expired token, " : "")
                                  << "HTTP status " << httpResponse->statusLine().statusCode()
                                  << ", failure reason: [" << failureReason << "] and response: ["
                                  << responseString << ']');
 
-        return asyncLockStateCallback(AsyncLockUpdate(
-            AsyncLockUpdate::State::Error,
-            LockUpdateResult(LockUpdateResult::Status::UNAUTHORIZED, lock, std::move(failureReason))));
+        return asyncLockStateCallback(
+            AsyncLockUpdate(AsyncLockUpdate::State::Error,
+                            LockUpdateResult(status, lock, std::move(failureReason))));
     };
 
     _lockHttpSession->setFinishedHandler(std::move(finishedCallback));


### PR DESCRIPTION
It's rather common to get various errors,
including timeouts, when making lock-refresh
requests. We shouldn't consider these as
"unauthorized" responses.

This patch limits the invalidation of the
user's access token to responses that
are specifically authorization-related
and not for other unrelated failures.

Change-Id: I50e5e2449f129dd811b2f8defe5fb3cd57897339
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
