### PR TITLE
fix(soundness): Correct typeof comparison

### DIFF
--- a/browser/src/control/Control.MobileWizardBuilder.js
+++ b/browser/src/control/Control.MobileWizardBuilder.js
@@ -150,7 +150,7 @@ L.Control.MobileWizardBuilder = L.Control.JSDialogBuilder.extend({
 
 	_preventNonNumericalInput: function(e) {
 		e = e || window.event;
-		var charCode = (typeof e.which === undefined) ? e.keyCode : e.which;
+		var charCode = e.which === undefined ? e.keyCode : e.which;
 		var charStr = String.fromCharCode(charCode);
 
 		if (!charStr.match(/^[0-9.,]+$/) && charCode !== 13)


### PR DESCRIPTION
fix(soundness): Correct typeof comparison

Previously we were comparing typeof to `undefined`, however this is
invalid: typeof never evaluates to `undefined` as it is always a string.

The correct value should probably be the *string* `'undefined'`, so as
to make the expression this:

  var charCode = (typeof e.which === 'undefined') ? e.keyCode : e.which;

However this is still a bit of a weird expression - using typeof here is
unnecessary and it would be more normal to write the equivalent:

  var charCode = e.which === undefined ? e.keyCode : e.which;

I wanted to refactor this to use use the nullish coalescing operator,
which is equivalent as e.which will never be null, however our
javascript package versions are not high enough to parse this (despite
it being MDN baseline):

  var charCode = e.which ?? e.keyCode;

Change-Id: I45d7e93fd1577202c3c31e3b9b44403b0c9cd6e3
