### PR TITLE
fix(iOS): Correct unranged multimedia response

### DIFF
--- a/ios/Mobile/CoolURLSchemeHandler.mm
+++ b/ios/Mobile/CoolURLSchemeHandler.mm
@@ -163,7 +163,7 @@
                     static_cast<long>(size)]
          forKey:@"Content-Range"];
         errorResponse = true;
-    } else {
+    } else if (rangeHeader != nil) {
         responseStatus = 206;
         NSInteger totalSize = size;
         std::tie(start, end, size) = rangePositionsAndSize.value();

--- a/ios/Mobile/CoolURLSchemeHandler.mm
+++ b/ios/Mobile/CoolURLSchemeHandler.mm
@@ -148,7 +148,6 @@
     
     NSInteger responseStatus = 200;
     NSInteger start = 0;
-    NSInteger end = size - 1; // 'end' is considered to be *inclusive* here to match the range header
     
     bool errorResponse = false;
 
@@ -166,6 +165,7 @@
     } else if (rangeHeader != nil) {
         responseStatus = 206;
         NSInteger totalSize = size;
+        NSInteger end;
         std::tie(start, end, size) = rangePositionsAndSize.value();
         [responseHeaders
          setObject:[NSString


### PR DESCRIPTION
Previously we would send a ranged media request whether the server
requested it or not. This is incorrect, and can be skipped pretty easily
by just missing out the header.

I do not know of a time when Safari will avoid sending a range header
for media, but it is technically possible and I know that Safari does
require the right type of response in some cases.

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: I012c3295101e0bea675d5d05af929c006082abb8* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

