### PR TITLE
Focus cell: reduce opacity

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -1159,9 +1159,9 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 			var reference = new CPolygon(pointSet, {
 				pointerEvents: 'none',
 				fillColor: strColor,
-				fillOpacity: 0.25,
+				fillOpacity: 0.15,
 				weight: 2 * app.dpiScale,
-				opacity: 0.25});
+				opacity: 0.15});
 
 			references.push({mark: reference, part: part, type: 'focuscell'});
 			this._referencesAll.push(references[i]);


### PR DESCRIPTION
In some case - when cell have background color and text color - it can
be hard to see the content.

Follow up:

Ideally we would also change the lateral lines to match the same css
var ('--column-row-highlight') or a
new ('--column-row-highlight-border') but I couldn't figure out a way
to do it elegantly.

I do see the possibility to change for the whole Calc:
@@ -3919,7 +3919,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		if (this.isCalc()) {
 			var cursorStyle = new CStyleData(this._cursorDataDiv);
 			var weight = cursorStyle.getFloatPropWithoutUnit('border-top-width') * app.dpiScale;
-			var color = cursorStyle.getPropValue('border-top-color');
+			var color =
getComputedStyle(document.documentElement).getPropertyValue('--column-row-highlight');

Which it would be nice to do it so, we could use --doc-type css var

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I8fa3d23e1c744965641da5a53feedbbc6bf79938
