### PR TITLE
abandon preset install if required poll is destroyed

### DIFF
--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -565,7 +565,8 @@ public:
 
     /// Start an asynchronous Installation of the user presets, e.g. autotexts etc, as
     /// described at userSettingsUri for installation into presetsPath
-    static std::shared_ptr<PresetsInstallTask> asyncInstallPresets(SocketPoll& poll,
+    static std::shared_ptr<PresetsInstallTask> asyncInstallPresets(
+                                    const std::shared_ptr<SocketPoll>& poll,
                                     const std::string& configId,
                                     const std::string& userSettingsUri,
                                     const std::string& presetsPath,
@@ -574,7 +575,8 @@ public:
 
     /// Start an asynchronous Installation of a user preset resource, e.g. an autotext
     /// file, to copy as presetFile
-    static void asyncInstallPreset(SocketPoll& poll, const std::string& configId,
+    static void asyncInstallPreset(const std::shared_ptr<SocketPoll>& poll,
+                                   const std::string& configId,
                                    const std::string& presetUri, const std::string& presetStamp,
                                    const std::string& presetFile, const std::string& id,
                                    const std::function<void(const std::string&, bool)>& finishedCB,

--- a/wsd/PresetsInstall.hpp
+++ b/wsd/PresetsInstall.hpp
@@ -26,7 +26,7 @@ private:
     std::string _configId;
     std::string _presetsPath;
     std::vector<std::function<void(bool)>> _installFinishedCBs;
-    SocketPoll& _poll;
+    std::weak_ptr<SocketPoll> _poll;
     int _idCount;
     bool _reportedStatus;
     bool _overallSuccess;
@@ -45,7 +45,7 @@ private:
                   std::vector<CacheQuery>& queries);
 
 public:
-    PresetsInstallTask(SocketPoll& poll, const std::string& configId,
+    PresetsInstallTask(const std::shared_ptr<SocketPoll>& poll, const std::string& configId,
                        const std::string& presetsPath,
                        const std::function<void(bool)>& installFinishedCB);
 

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -216,7 +216,7 @@ void RequestVettingStation::launchInstallPresets()
     Poco::File(Poco::Path(configIdPresets, "wordbook")).createDirectories();
     Poco::File(Poco::Path(configIdPresets, "template")).createDirectories();
     // ensure the server config is downloaded and populate a subforkit when config is available
-    _asyncInstallTask = DocumentBroker::asyncInstallPresets(*_poll, configId, sharedSettings.getUri(), configIdPresets,
+    _asyncInstallTask = DocumentBroker::asyncInstallPresets(_poll, configId, sharedSettings.getUri(), configIdPresets,
                                                             nullptr, finishedCallback);
 }
 


### PR DESCRIPTION
A minimal backport of https://github.com/CollaboraOnline/online/pull/11411 that only changes the presets async install case and leaves other uses of HttpRequest::asyncRequest untouched

Earlier effort of https://github.com/CollaboraOnline/online/pull/11421 is useless, that just keeps the poll alive until _asyncInstallTask is destroyed which doesn't help

```
 #3  <signal handler called>
 #4  __memcpy_ssse3 () at ../sysdeps/x86_64/multiarch/memcpy-ssse3.S:2942
 #5  0x00007f2d26fb8478 in std::basic_streambuf<char, std::char_traits<char> >::xsputn(char const*, long) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
 No symbol table info available.
 #6  0x00007f2d26fa8b84 in std::basic_ostream<char, std::char_traits<char> >& std::__ostream_insert<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*, long) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
 No symbol table info available.
 #7  0x0000000000600f73 in std::operator<< <char, std::char_traits<char>, std::allocator<char> > (__str="31.28.21.183", __os=...) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/cow_string.h:913
 #8  SocketPoll::wakeup (this=this@entry=0x7f2d04041b20) at ./net/Socket.hpp:828
         b_ = "wsd-05032-05065 2025-04-03 17:06:16.829492 +0000 [ asyncdns ] WRN  \000-\177\000\000\006\000\000\000\000\000\000\000\001\000\000\000\000\000\000\000p\341\307'-\177\000\000p\357\350%-\177\000\000\006\000\000\000\001\000\000\000\300\361\350%-\177\000\000\320\361\350%-\177\000\000\310\344\307'-\177\000\000\000ey\372\274[\264\216\360\361\350%-\177\000\000\360\361\350%-\177\000\000 \363\350%-\177\000\000+\177r\002\000\000\000\000+\177r\002\000\000\000\000D\364\350%-\177\000\000%BH&-\177\000\000"...
         oss_ = <incomplete type>
 #9  0x000000000066f32d in SocketPoll::addCallback(std::function<void ()> const&) (fn=..., this=0x7f2d04041b20) at ./net/Socket.hpp:890
         lock = <optimized out>
         wasEmpty = true
         lock = <optimized out>
         wasEmpty = <optimized out>
 #10 http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}::operator()(std::shared_ptr<StreamSocket>, net::AsyncConnectResult) const (result=<optimized out>, socket=..., __closure=<optimized out>) at ./net/HttpRequest.hpp:1752
         poll = <optimized out>
         this = <optimized out>
         poll = <optimized out>
         this = <optimized out>
 #11 std::__invoke_impl<void, http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}&, std::shared_ptr<StreamSocket>, net::AsyncConnectResult>(std::__invoke_other, http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}&, std::shared_ptr<StreamSocket>&&, net::AsyncConnectResult&&) (__f=...) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/invoke.h:61
 #12 std::__invoke_r<void, http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}&, std::shared_ptr<StreamSocket>, net::AsyncConnectResult>(void&&, (http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}&)...) (__fn=...) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/invoke.h:111
 #13 std::_Function_handler<void (std::shared_ptr<StreamSocket>, net::AsyncConnectResult), http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}>::_M_invoke(std::_Any_data const&, std::shared_ptr<StreamSocket>&&, net::AsyncConnectResult&&) (__functor=..., __args#0=..., __args#1=<optimized out>) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:290
 #14 0x000000000084ae79 in std::function<void (std::shared_ptr<StreamSocket>, net::AsyncConnectResult)>::operator()(std::shared_ptr<StreamSocket>, net::AsyncConnectResult) const (__args#1=net::AsyncConnectResult::Ok, __args#0=std::shared_ptr<StreamSocket> (empty) = {...}, this=0x7f2d1c01ba28) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:587
 #15 net::asyncConnect(std::string const&, std::string const&, bool, std::shared_ptr<ProtocolHandlerInterface> const&, std::function<void (std::shared_ptr<StreamSocket>, net::AsyncConnectResult)> const&)::{lambda(net::HostEntry const&)#1}::operator()(net::HostEntry const&) const () at net/NetUtil.cpp:535
         socket = std::shared_ptr<StreamSocket> (empty) = {get() = 0x7f2d1c02cce0}
         result = net::AsyncConnectResult::Ok
         asyncCb = {<std::_Maybe_unary_or_binary_function<void, std::shared_ptr<StreamSocket>, net::AsyncConnectResult>> = {<std::binary_function<std::shared_ptr<StreamSocket>, net::AsyncConnectResult, void>> = {<No data fields>}, <No data fields>}, <std::_Function_base> = {static _M_max_size = 16, static _M_max_align = 8, _M_functor = {_M_unused = {_M_object = 0x7f2c9005f890, _M_const_object = 0x7f2c9005f890, _M_function_pointer = 0x7f2c9005f890, _M_member_pointer = (void (std::_Undefined_class::*)(std::_Undefined_class * const)) 0x7f2c9005f890, this adjustment 139831317633824}, _M_pod_data = "\220\370\005\220,\177\000\000 \033\004\004-\177\000"}, _M_manager = 0x65f110 <std::_Function_handler<void (std::shared_ptr<StreamSocket>, net::AsyncConnectResult), http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}>::_M_manager(std::_Any_data&, std::_Function_handler<void (std::shared_ptr<StreamSocket>, net::AsyncConnectResult), http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}> const&, std::_Manager_operation)>}, _M_invoker = 0x66f0d0 <std::_Function_handler<void (std::shared_ptr<StreamSocket>, net::AsyncConnectResult), http::Session::asyncConnect(SocketPoll&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}>::_M_invoke(std::_Any_data const&, std::shared_ptr<StreamSocket>&&, net::AsyncConnectResult&&)>}
         protocolHandler = std::shared_ptr<ProtocolHandlerInterface> (use count 4, weak count 1) = {get() = 0x7f2c9005f890}
         port = "443"
         host = "cloud.swisdata.eu"
         isSSL = true
 #16 0x000000000084e55d in std::function<void (net::HostEntry const&)>::operator()(net::HostEntry const&) const (__args#0=..., this=0x4d30248) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:587
 #17 net::AsyncDNS::resolveDNS() () at net/NetUtil.cpp:392
         guard = {_M_device = 0x4d30198, _M_owns = true}
 #18 0x0000000000c28053 in execute_native_thread_routine ()
 No symbol table info available.
 #19 0x00007f2d266c76db in start_thread (arg=0x7f2d25ea0700) at pthread_create.c:463
         pd = 0x7f2d25ea0700
         now = <optimized out>
         unwind_buf = {cancel_jmp_buf = {{jmp_buf = {139831886350080, 7103572501067250758, 139831886282432, 0, 66281728, 140736160969792, -7147566254795473850, -7147571782673974202}, mask_was_saved = 0}}, priv = {pad = {0x0, 0x0, 0x0, 0x0}, data = {prev = 0x0, cleanup = 0x0, canceltype = 0}}}
         not_first_call = <optimized out>
 #20 0x00007f2d263f074f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

Change-Id: Ie54bceb4467c2a18cd81c48ecdf3a430ee9858b3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

