### PR TITLE
save: pass args also for background save

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2278,7 +2278,8 @@ bool ChildSession::unoCommand(const StringVector& tokens)
                           tokens.equals(1, ".uno:OpenHyperlink") ||
                           tokens.startsWith(1, "vnd.sun.star.script:"));
 
-    LOG_TRC("uno command " << tokens[1] << " " << tokens.cat(' ', 2) << " notify: " << bNotify);
+    const std::string saveArgs = tokens.cat(' ', 2);
+    LOG_TRC("uno command " << tokens[1] << " " << saveArgs << " notify: " << bNotify);
 
     // check that internal UNO commands don't make it to the core
     assert (!tokens.equals(1, ".uno:AutoSave"));
@@ -2288,22 +2289,13 @@ bool ChildSession::unoCommand(const StringVector& tokens)
     if (tokens.equals(1, ".uno:Copy") || tokens.equals(1, ".uno:CopyHyperlinkLocation"))
         _copyToClipboard = true;
 
-    if (tokens.size() == 2)
+    if (tokens.size() == 2 && tokens.equals(1, ".uno:fakeDiskFull"))
     {
-        if (tokens.equals(1, ".uno:fakeDiskFull"))
-        {
-            _docManager->alertAllUsers("internal", "diskfull");
-        }
-        else
-        {
-            getLOKitDocument()->postUnoCommand(tokens[1].c_str(), nullptr, bNotify);
-        }
-    }
-    else
-    {
-        getLOKitDocument()->postUnoCommand(tokens[1].c_str(), tokens.cat(' ', 2).c_str(), bNotify);
+        _docManager->alertAllUsers("internal", "diskfull");
+        return true;
     }
 
+    getLOKitDocument()->postUnoCommand(tokens[1].c_str(), saveArgs.c_str(), bNotify);
     return true;
 }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3597,17 +3597,26 @@ bool DocumentBroker::sendUnoSave(const std::shared_ptr<ClientSession>& session,
     // Invalidate the timestamp to force persisting.
     _saveManager.setLastModifiedTime(std::chrono::system_clock::time_point());
 
+    static const bool forceBackgroundEnv = !!getenv("COOL_FORCE_BGSAVE");
+    constexpr std::size_t MaxFailureCountForBackgroundSaving = 2; // Give only 1 extra chance.
+
+    // Note: It's odd to capture these here, but this function is used from ClientSession too.
+    const bool autosave = isAutosave || (_unitWsd && _unitWsd->isAutosave());
+    const bool backgroundConfigured = (autosave && _backgroundAutoSave) || _backgroundManualSave;
+    const bool canBackground = forceBackgroundEnv || (!finalWrite && backgroundConfigured);
+    const bool background = canBackground && _saveManager.lastSaveSuccessful() &&
+                            _saveManager.saveFailureCount() < MaxFailureCountForBackgroundSaving;
+
     std::ostringstream oss;
     // arguments init
     oss << '{';
 
-    if (dontTerminateEdit)
-    {
-        // We do not want save to terminate editing mode if we are in edit mode now.
-        //TODO: Perhaps we want to terminate if forced by the user,
-        // otherwise autosave doesn't terminate?
-        oss << "\"DontTerminateEdit\" : { \"type\":\"boolean\", \"value\":true }";
-    }
+    // We do not want save to terminate editing mode if we are in edit mode now.
+    // We want to terminate if forced by the user, otherwise autosave doesn't terminate.
+    dontTerminateEdit = dontTerminateEdit && background == false;
+
+    oss << "\"DontTerminateEdit\" : { \"type\":\"boolean\", \"value\":"
+        << (dontTerminateEdit ? "true" : "false") << " }";
 
     if (dontSaveIfUnmodified)
     {
@@ -3623,16 +3632,6 @@ bool DocumentBroker::sendUnoSave(const std::shared_ptr<ClientSession>& session,
     // At this point, if we have any potential modifications, we need to capture the fact.
     // If Core does report something different after saving, we'll update this flag.
     _nextStorageAttrs.setUserModified(isModified() || haveModifyActivityAfterSaveRequest());
-
-    static const bool forceBackgroundEnv = !!getenv("COOL_FORCE_BGSAVE");
-
-    // Note: It's odd to capture these here, but this function is used from ClientSession too.
-    const bool autosave = isAutosave || (_unitWsd && _unitWsd->isAutosave());
-    const bool backgroundConfigured = (autosave && _backgroundAutoSave) || _backgroundManualSave;
-    const bool canBackground = forceBackgroundEnv || (!finalWrite && backgroundConfigured);
-    constexpr std::size_t MaxFailureCountForBackgroundSaving = 2; // Give only 1 extra chance.
-    const bool background = canBackground && _saveManager.lastSaveSuccessful() &&
-                            _saveManager.saveFailureCount() < MaxFailureCountForBackgroundSaving;
 
     if (finalWrite)
         LOG_TRC("suspected final save: don't do background write");


### PR DESCRIPTION
This fixes below bug:
- Open Impress
- Edit textbox but do not accept it by pressing Enter
- Click Save
- Exit Presentation

Result: file doesn't have edits typed to the textbox
Expected: no data is lost, content was autosaved

The behavior is caused by the background save which got null parameters so we didn't support DontTerminateFlag
or DontSaveIfUnmodified for example. Missing DontTerminateFlag wasn't considered as: please terminate editing in the core. It has to be explicit false to force it. So far it was used in Calc but I also prepared Impress support for it: https://gerrit.libreoffice.org/c/core/+/183652

In case of background save it can be ignored and set to false because it doesn't impact user session (it's a fork).