### PR TITLE
Fix touchpad scrolling causing uncapped drawing

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -2111,6 +2111,8 @@ class CanvasSectionContainer {
 			options (possible values are separated by the '|' char):
 				// Developer can set the duration for the animation, in milliseconds. There are also other ways to stop the animation.
 				duration: 2000 | null // 2 seconds | null.
+				// The animation can start after a requestAnimationFrame
+				defer: boolean
 		*/
 
 		if (!this.getAnimatingSectionName()) {
@@ -2122,7 +2124,10 @@ class CanvasSectionContainer {
 			this.elapsedTime = 0;
 			this.frameCount = 0;
 
-			this.animate(performance.now());
+			if (options.defer)
+				requestAnimationFrame(this.animate.bind(this));
+			else
+				this.animate(performance.now());
 			return true;
 		}
 		else {

--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -112,6 +112,7 @@ export class ScrollSection extends CanvasSectionObject {
 		this.sectionProperties.scrollAnimationDelta = [0, 0];
 		this.sectionProperties.scrollAnimationVelocity = [0, 0];
 		this.sectionProperties.scrollAnimationDisableTimeout = null;
+		this.sectionProperties.scrollWheelDelta = [0, 0];	// Used for non-animated scrolling
 
 		this.sectionProperties.pointerSyncWithVerticalScrollBar = true;
 		this.sectionProperties.pointerSyncWithHorizontalScrollBar = true;
@@ -564,13 +565,27 @@ export class ScrollSection extends CanvasSectionObject {
 				this.scrollHorizontalWithOffset(deltas[0]);
 			if (deltas[1] !== 0)
 				this.scrollVerticalWithOffset(deltas[1]);
-
-			if (this.sectionProperties.scrollAnimationDelta.reduce((a: number, x: number) => a + x, 0) === 0) {
-				// Animated scroll is an endless animation, so if no other animations
-				// are running, make sure to stop animating.
-				this.containerObject.stopAnimating();
-				this.sectionProperties.animatingScroll = false;
+		} else {
+			if (this.sectionProperties.scrollWheelDelta[0] !== 0) {
+				const delta = this.sectionProperties.scrollWheelDelta[0];
+				this.sectionProperties.scrollWheelDelta[0] = 0;
+				this.scrollHorizontalWithOffset(delta);
 			}
+			if (this.sectionProperties.scrollWheelDelta[1] !== 0) {
+				const delta = this.sectionProperties.scrollWheelDelta[1];
+				this.sectionProperties.scrollWheelDelta[1] = 0;
+				this.scrollVerticalWithOffset(delta);
+			}
+		}
+
+		if (this.isAnimating) {
+			const animatingScrollbar =
+				(this.sectionProperties.animatingHorizontalScrollBar
+				|| this.sectionProperties.animatingVerticalScrollBar) &&
+				elapsedTime && (elapsedTime < this.sectionProperties.fadeOutDuration);
+			const animatingScroll = this.sectionProperties.animatingScroll
+				&& this.sectionProperties.scrollAnimationDelta.reduce((a: number, x: number) => a + x, 0) !== 0;
+			if (!animatingScrollbar && !animatingScroll) this.containerObject.stopAnimating();
 		}
 	}
 
@@ -589,7 +604,8 @@ export class ScrollSection extends CanvasSectionObject {
 		}
 		else {
 			var options: any = {
-				duration: this.sectionProperties.idleDuration
+				duration: this.sectionProperties.idleDuration,
+				defer: true
 			};
 
 			this.sectionProperties.animatingHorizontalScrollBar = this.startAnimating(options);
@@ -603,7 +619,8 @@ export class ScrollSection extends CanvasSectionObject {
 		}
 		else {
 			var options: any = {
-				duration: this.sectionProperties.idleDuration
+				duration: this.sectionProperties.idleDuration,
+				defer: true
 			};
 
 			this.sectionProperties.animatingVerticalScrollBar = this.startAnimating(options);
@@ -761,36 +778,51 @@ export class ScrollSection extends CanvasSectionObject {
 
 		if (app.file.fileBasedView) this.map._docLayer._checkSelectedPart();
 
+		if (!this.sectionProperties.drawVerticalScrollBar) {
+			if (this.isAnimating) {
+				this.resetAnimation();
+				this.sectionProperties.animatingVerticalScrollBar = true;
+			}
+			else
+				this.fadeOutVerticalScrollBar();
+		}
+
 		return true;
 	}
 
-	public scrollHorizontalWithOffset (offset: number): void {
+	public scrollHorizontalWithOffset (offset: number): boolean {
 		this.calculateXMinMax();
 
-		if (this.isRTL()) {
-			offset = -offset;
-		}
+		if (this.isRTL()) offset = -offset;
 
-		var go = true;
 		if (offset > 0) {
 			if (this.documentTopLeft[0] + offset > this.sectionProperties.xMax)
 				offset = this.sectionProperties.xMax - this.documentTopLeft[0];
 			if (offset <= 0)
-				go = false;
+				return false;
 		}
 		else {
 			if (this.documentTopLeft[0] + offset < this.sectionProperties.xMin)
 				offset = this.sectionProperties.xMin - this.documentTopLeft[0];
 			if (offset >= 0)
-				go = false;
+				return false;
 		}
 
-		if (go) {
-			app.sectionContainer.pauseDrawing();
-			this.map.scroll(offset / app.dpiScale, 0, {});
-			this.onUpdateScrollOffset();
-			app.sectionContainer.resumeDrawing();
+		app.sectionContainer.pauseDrawing();
+		this.map.scroll(offset / app.dpiScale, 0, {});
+		this.onUpdateScrollOffset();
+		app.sectionContainer.resumeDrawing();
+
+		if (!this.sectionProperties.drawHorizontalScrollBar) {
+			if (this.isAnimating) {
+				this.resetAnimation();
+				this.sectionProperties.animatingHorizontalScrollBar = true;
+			}
+			else
+				this.fadeOutHorizontalScrollBar();
 		}
+
+		return true;
 	}
 
 	private isMouseInsideDocumentAnchor (point: Array<number>): boolean {
@@ -1089,30 +1121,6 @@ export class ScrollSection extends CanvasSectionObject {
 		this.onMouseMove(point, null, e);
 	}
 
-	private performVerticalScroll (delta: number): void {
-		this.scrollVerticalWithOffset(delta);
-		if (!this.sectionProperties.drawVerticalScrollBar) {
-			if (this.isAnimating) {
-				this.resetAnimation();
-				this.sectionProperties.animatingVerticalScrollBar = true;
-			}
-			else
-				this.fadeOutVerticalScrollBar();
-		}
-	}
-
-	private performHorizontalScroll (delta: number): void {
-		this.scrollHorizontalWithOffset(delta);
-		if (!this.sectionProperties.drawHorizontalScrollBar) {
-			if (this.isAnimating) {
-				this.resetAnimation();
-				this.sectionProperties.animatingHorizontalScrollBar = true;
-			}
-			else
-				this.fadeOutHorizontalScrollBar();
-		}
-	}
-
 	public onClick(point: Array<number>, e: MouseEvent): void {
 		if (this.isAnimating && this.sectionProperties.animatingWheelScrollVertical)
 			this.containerObject.stopAnimating();
@@ -1139,9 +1147,9 @@ export class ScrollSection extends CanvasSectionObject {
 
 		if (!this.sectionProperties.animatingScroll) {
 			// We're about to start a duration-less animation, so we need to
-			// make sure the animation is reset first.
-			this.resetAnimation();
-			this.startAnimating({});
+			// ensure the animation is reset.
+			if (!this.startAnimating({'defer': true}))
+				this.resetAnimation();
 			this.sectionProperties.animatingScroll = true;
 		}
 	}
@@ -1173,15 +1181,18 @@ export class ScrollSection extends CanvasSectionObject {
 		if (shouldAnimate)
 			this.animateScroll([hscroll, vscroll]);
 		else {
-			this.containerObject.stopAnimating();
+			this.sectionProperties.animatingScroll = false;
+
 			if (this.sectionProperties.scrollAnimationDisableTimeout)
 				clearTimeout(this.sectionProperties.scrollAnimationDisableTimeout);
 			this.sectionProperties.scrollAnimationDisableTimeout =
 				setTimeout(() => { this.sectionProperties.scrollAnimationDisableTimeout = null; },
 					ScrollSection.scrollDirectTimeoutMs);
 
-			if (hscroll !== 0) this.performHorizontalScroll(hscroll);
-			if (vscroll !== 0) this.performVerticalScroll(vscroll);
+			this.sectionProperties.scrollWheelDelta[0] += hscroll;
+			this.sectionProperties.scrollWheelDelta[1] += vscroll;
+
+			if (!this.isAnimating) this.startAnimating({'defer': true});
 		}
 	}
 }


### PR DESCRIPTION
Touchpad scrolling was immediately redrawing the screen on every event. Fix this by storing the scroll delta and deferring redraw until a requestAnimationFrame callback.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

