### PR TITLE
save: pass args also for background save

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2282,7 +2282,8 @@ bool ChildSession::unoCommand(const StringVector& tokens)
                           tokens.equals(1, ".uno:OpenHyperlink") ||
                           tokens.startsWith(1, "vnd.sun.star.script:"));
 
-    LOG_TRC("uno command " << tokens[1] << " " << tokens.cat(' ', 2) << " notify: " << bNotify);
+    const std::string saveArgs = tokens.cat(' ', 2);
+    LOG_TRC("uno command " << tokens[1] << " " << saveArgs << " notify: " << bNotify);
 
     // check that internal UNO commands don't make it to the core
     assert (!tokens.equals(1, ".uno:AutoSave"));
@@ -2292,22 +2293,13 @@ bool ChildSession::unoCommand(const StringVector& tokens)
     if (tokens.equals(1, ".uno:Copy") || tokens.equals(1, ".uno:CopyHyperlinkLocation"))
         _copyToClipboard = true;
 
-    if (tokens.size() == 2)
+    if (tokens.size() == 2 && tokens.equals(1, ".uno:fakeDiskFull"))
     {
-        if (tokens.equals(1, ".uno:fakeDiskFull"))
-        {
-            _docManager->alertAllUsers("internal", "diskfull");
-        }
-        else
-        {
-            getLOKitDocument()->postUnoCommand(tokens[1].c_str(), nullptr, bNotify);
-        }
-    }
-    else
-    {
-        getLOKitDocument()->postUnoCommand(tokens[1].c_str(), tokens.cat(' ', 2).c_str(), bNotify);
+        _docManager->alertAllUsers("internal", "diskfull");
+        return true;
     }
 
+    getLOKitDocument()->postUnoCommand(tokens[1].c_str(), saveArgs.c_str(), bNotify);
     return true;
 }
 


### PR DESCRIPTION
This fixes below bug:

- Open Impress
- Edit textbox but do not accept it by pressing Enter
- Click Save
- Exit Presentation

Result: file doesn't have edits typed to the textbox
Expected: no data is lost, content was autosaved

The behavior is caused by the background save which got null parameters so we didn't support DontTerminateFlag
or DontSaveIfUnmodified for example. Missing DontTerminateFlag wasn't considered as: please terminate editing in the core. It has to be explicit false to force it. So far it was used in Calc but I also prepared Impress support for it: https://gerrit.libreoffice.org/c/core/+/183652

In case of background save it can be ignored and set to false because it doesn't impact user session (it's a fork).
