### PR TITLE
test for presets not installed yet at doc dtor time

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -550,6 +550,12 @@ public:
         return false;
     }
 
+    /// Called before uri is set as a preinstall settings asset
+    virtual void filterRegisterPresetAsset(std::string& /*uri*/) {}
+
+    /// Called before DNS resolves query
+    virtual void filterResolveDNS(std::string& /*query*/) {}
+
     // ---------------- WSD events ----------------
     virtual void onChildConnected(const int /* pid */, const std::string& /* sessionId */) {}
     /// When admin notify message is sent
@@ -573,6 +579,10 @@ public:
     virtual void onDocBrokerRemoveSession(const std::string&, const std::shared_ptr<ClientSession>&)
     {
     }
+    /// Called when document presets install is launched
+    virtual void onDocBrokerPresetsInstallStart() {}
+    /// Called when document presets install is finished
+    virtual void onDocBrokerPresetsInstallEnd(bool /*success*/) {}
 
 protected:
     /// Called when a DocumentBroker is destroyed (from the destructor).

--- a/net/AsyncDNS.hpp
+++ b/net/AsyncDNS.hpp
@@ -23,6 +23,8 @@
 
 #include <NetUtil.hpp>
 
+class UnitWSD;
+
 namespace net
 {
 
@@ -48,6 +50,7 @@ public:
                        const DNSThreadDumpStateFn& dumpState);
 
 private:
+    UnitWSD* const _unitWsd;
     std::atomic<bool> _exit;
     std::unique_ptr<DNSResolver> _resolver;
     std::unique_ptr<std::thread> _thread;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -99,6 +99,7 @@ all_la_unit_tests = \
 	unit-timeout_none.la \
 	unit-serversock_accept1.la \
 	unit-streamsock_ctor1.la \
+	unit-user-presets.la \
 	unit-base.la
 #	unit-admin.la
 #	unit-tilecache.la # Empty test.
@@ -342,6 +343,8 @@ unit_quarantine_la_SOURCES = UnitQuarantine.cpp
 unit_quarantine_la_LIBADD = $(CPPUNIT_LIBS)
 unit_multi_tenant_la_SOURCES = UnitMultiTenant.cpp
 unit_multi_tenant_la_LIBADD = $(CPPUNIT_LIBS)
+unit_user_presets_la_SOURCES = UnitUserPresets.cpp
+unit_user_presets_la_LIBADD = $(CPPUNIT_LIBS)
 unit_perf_la_SOURCES = UnitPerf.cpp
 unit_perf_la_LIBADD = $(CPPUNIT_LIBS) $(LIBPFM_LIBS)
 unit_proxy_la_SOURCES = UnitProxy.cpp

--- a/test/UnitUserPresets.cpp
+++ b/test/UnitUserPresets.cpp
@@ -1,0 +1,191 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "config.h"
+
+#include "WopiTestServer.hpp"
+#include "Unit.hpp"
+#include "lokassert.hpp"
+#include "testlog.hpp"
+#include "FileUtil.hpp"
+#include <wsd/DocumentBroker.hpp>
+#include <wsd/Process.hpp>
+
+#include <Poco/Net/HTTPRequest.h>
+#include <csignal>
+#include <ctime>
+
+/// This test ensures that a document which has presets, but whose load is
+/// canceled before the presets are installed, gracefully handles the case that
+/// the document broker poll no longer exists when the response from async dns
+/// arrives and the preset download attempt cannot be attached to the dead
+/// poll.
+class UnitEarlyDocDeath : public WopiTestServer
+{
+    using Base = WopiTestServer;
+
+    STATE_ENUM(Phase, Load, WaitDocPresetsInstallStart, DocPresetsInstallStart, WaitDocClose, ResumeDNS, Finish, Done) _phase;
+
+    std::mutex _dns_mutex;
+    std::condition_variable _dns_cv;
+
+public:
+    UnitEarlyDocDeath()
+        : Base("UnitEarlyDocDeath")
+        , _phase(Phase::Load)
+    {
+    }
+
+    void configure(Poco::Util::LayeredConfiguration& config) override
+    {
+        Base::configure(config);
+
+        // Set to 0 to immediately discard any unused subforkits
+        config.setUInt("serverside_config.idle_timeout_secs", 0);
+    }
+
+    // replace the preset asset uri so dns requests for them can
+    // be identified when they are queried so we can delay their
+    // resolution until the document load is abandoned.
+    void filterRegisterPresetAsset(std::string& uri) override
+    {
+        LOG_TST("filterRegisterPresetAsset before: " << uri);
+        uri = Util::replace(uri, "localhost", "presetasset");
+        LOG_TST("filterRegisterPresetAsset after: " << uri);
+    }
+
+    // delay the resolution of these queries so we can cancel
+    // the document load and let the dns complete when the
+    // document has cancelled to test we don't crash under
+    // this circumstance
+    void filterResolveDNS(std::string& query) override
+    {
+        if (query == "presetasset")
+        {
+            query = "localhost";
+            if (_phase != Phase::Finish)
+            {
+                LOG_TST("delaying dns resolution of preset host until document broker is destroyed");
+                std::unique_lock<std::mutex> lock(_dns_mutex);
+                bool ok = _dns_cv.wait_for(lock, std::chrono::seconds(10), [this]() { return _phase == Phase::ResumeDNS; });
+                LOG_TST("dns resumed: " << ok);
+                TRANSITION_STATE(_phase, Phase::Finish);
+            }
+        }
+    }
+
+    // as soon as presets install starts, then cancel the load of the
+    // document.
+    void onDocBrokerPresetsInstallStart() override
+    {
+        LOG_TST("onDocBrokerPresetsInstallStart");
+        LOK_ASSERT_STATE(_phase, Phase::WaitDocPresetsInstallStart);
+        TRANSITION_STATE(_phase, Phase::DocPresetsInstallStart);
+        SocketPoll::wakeupWorld();
+    }
+
+    // presets install is delayed until document should be destroyed
+    void onDocBrokerPresetsInstallEnd(bool /*success*/) override
+    {
+        failTest("Document should be destroyed before presets are installed");
+    }
+
+    void onDocBrokerDestroy(const std::string& /*docKey*/) override
+    {
+        LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
+        TRANSITION_STATE(_phase, Phase::ResumeDNS);
+        LOG_TST("resume dns resolution after doc broker was destroyed");
+        _dns_cv.notify_one();
+        SocketPoll::wakeupWorld();
+    }
+
+    // document shouldn't get loaded until presets are installed,
+    // and we delay preset installation via stalled dns lookup
+    // and cancel the load, so the doc should never get loaded
+    bool onDocumentLoaded(const std::string& message) override
+    {
+        LOG_TST("onDocumentLoaded: [" << message << ']');
+        failTest("Document should not get loaded.");
+        return true;
+    }
+
+    void configCheckFileInfo(const Poco::Net::HTTPRequest& request,
+                             Poco::JSON::Object::Ptr& fileInfo) override
+    {
+        const Poco::URI uriReq(request.getURI());
+        Poco::JSON::Object::Ptr userSettings = new Poco::JSON::Object();
+        std::string uri = helpers::getTestServerURI() + "/wopi/settings/userconfig.json?testname=UnitEarlyDocDeath";
+        userSettings->set("uri", Util::trim(uri));
+        userSettings->set("stamp", "something");
+        fileInfo->set("UserSettings", userSettings);
+    }
+
+    std::map<std::string, std::string>
+        parallelizeCheckInfo(const Poco::Net::HTTPRequest& request,
+                             Poco::MemoryInputStream& /*message*/,
+                             std::shared_ptr<StreamSocket>& /*socket*/) override
+    {
+        std::string uri = Uri::decode(request.getURI());
+        LOG_TST("parallelizeCheckInfo requested: " << uri);
+        return std::map<std::string, std::string>{
+            {"wopiSrc", "/wopi/files/0"},
+            {"accessToken", "anything"},
+            {"permission", ""},
+            {"configid", ""}
+        };
+    }
+
+    // on loading this document, a new subforkit is needed, so that should
+    // be created on demand, and then the document loaded via that subforkit
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                // Always transition before issuing commands.
+                TRANSITION_STATE(_phase, Phase::WaitDocPresetsInstallStart);
+
+                LOG_TST("Creating first connection");
+                initWebsocket("/wopi/files/0?access_token=anything");
+
+                LOG_TST("Loading view");
+                WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc());
+                break;
+            }
+            case Phase::DocPresetsInstallStart:
+                TRANSITION_STATE(_phase, Phase::WaitDocClose);
+                LOG_TST("Close document just after preset install starts");
+                WSD_CMD_BY_CONNECTION_INDEX(0, "closedocument");
+                break;
+            case Phase::WaitDocPresetsInstallStart:
+            case Phase::WaitDocClose:
+            case Phase::ResumeDNS:
+            case Phase::Done:
+            {
+                // just wait for the results
+                break;
+            }
+            case Phase::Finish:
+            {
+                TRANSITION_STATE(_phase, Phase::Done);
+                passTest("Document load successfully abandoned");
+            }
+        }
+    }
+};
+
+UnitBase** unit_create_wsd_multi(void)
+{
+    return new UnitBase*[2]{ new UnitEarlyDocDeath(), nullptr };
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1649,7 +1649,12 @@ void DocumentBroker::asyncInstallPresets(const std::shared_ptr<ClientSession>& s
             LOG_ERR("Failed to load all settings from [" << uriAnonym << ']');
             stop("configfailed");
         }
+
+        if (_unitWsd)
+            _unitWsd->onDocBrokerPresetsInstallEnd(success);
     };
+    if (_unitWsd)
+        _unitWsd->onDocBrokerPresetsInstallStart();
     _asyncInstallTask = asyncInstallPresets(_poll, configId, userSettingsUri,
                                             presetsPath, session, installFinishedCB);
     _asyncInstallTask->appendCallback([selfWeak = weak_from_this(), this,

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -608,6 +608,8 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
         Poco::JSON::Array::Ptr configDictionaries = new Poco::JSON::Array();
         Poco::JSON::Array::Ptr configXcu = new Poco::JSON::Array();
         Poco::JSON::Array::Ptr configTemplate = new Poco::JSON::Array();
+
+        UnitWSD* const unitWsd = UnitWSD::isUnitTesting() ? &UnitWSD::get() : nullptr;
         for (const auto& item : items)
         {
             Poco::JSON::Object::Ptr configEntry = new Poco::JSON::Object();
@@ -616,6 +618,8 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
             Util::trim(uri);
             if (!unittest.empty())
                 uri += "?testname=" + unittest;
+            if (unitWsd)
+                unitWsd->filterRegisterPresetAsset(uri);
             configEntry->set("uri", uri);
             configEntry->set("stamp", etagString);
             if (item.first == "autotext")


### PR DESCRIPTION
    add test for presets not installed yet at doc dtor time
    
    The DocBroker can be created, launch presets to be installed async, and
    then destroyed before the presets complete.
    
    If async dns was still handling a dns lookup on behalf of
    net::asyncConnect for http::Session::asyncConnect to attempt to install
    a preset when the DocBroker was destroyed, then the SocketPoll of the
    DocBroker was already destroyed when the pushConnectCompleteToPoll
    lambda of http::Session::asyncConnect was called and then attempted to
    use addCallback on the destroyed SocketPoll of the DocBroker.
    
    This test successfully triggers:
    [ asyncdns ] WRN  #20: asyncConnect completed after poll was destroyed| net/HttpRequest.hpp:1755
    
    while with:
    
    commit eebf9268ef8e83103fe1f32d7cb1b23a4c7d51d5
    CommitDate: Wed Mar 26 16:34:03 2025 +0100
    
        pass SocketPoll around as shared_ptr for asyncConnect
    
    reverted then the problem of calling addCallback on a deleted SocketPoll reproduces, e.g.
    
    [ prisoner_poll ] DBG  ~SocketPoll[this 0x7f86180016d0, thread[name docbroker_001, id[owner 0x7f864a7fc6c0, caller 0x7f86517d76c0]]]| net/Socket.cpp:324
    ...
    [ asyncdns ] DBG  #17: pushConnectCompleteToPoll to: 0x7f86180016d0| net/HttpRequest.hpp:1753
    [ asyncdns ] ERR  wakeup socket #-1 is closed at wakeup? (EBADF: Bad file descriptor)| net/Socket.hpp:8
