### PR TITLE
browsersetting: fix: failed to update `WSDWelcomeDisabledDate` (backport)

### DIFF
--- a/browser/src/map/handler/Map.Welcome.js
+++ b/browser/src/map/handler/Map.Welcome.js
@@ -10,7 +10,7 @@ L.Map.mergeOptions({
 
 L.Map.Welcome = L.Handler.extend({
 
-	_getLocalWelcomeUrl: function() {
+	_getLocalWelcomeUrl: function () {
 		var welcomeLocation = app.LOUtil.getURL('/welcome/welcome.html');
 		if (window.socketProxy)
 			welcomeLocation = window.makeWsUrl(welcomeLocation);
@@ -32,10 +32,10 @@ L.Map.Welcome = L.Handler.extend({
 		this.remove();
 	},
 
-	isGuest: function() {
+	isGuest: function () {
 		var docLayer = this._map._docLayer || {};
 		var viewInfo = this._map._viewInfo[docLayer._viewId];
-		return  viewInfo && viewInfo.userextrainfo && viewInfo.userextrainfo.is_guest;
+		return viewInfo && viewInfo.userextrainfo && viewInfo.userextrainfo.is_guest;
 	},
 
 	onUpdateList: function () {
@@ -44,11 +44,11 @@ L.Map.Welcome = L.Handler.extend({
 		}
 	},
 
-	shouldWelcome: function() {
+	shouldWelcome: function () {
 		var storedVersion = window.prefs.get('WSDWelcomeVersion');
 		var currentVersion = app.socket.WSDServer.Version;
 		var welcomeDisabledCookie = window.prefs.getBoolean('WSDWelcomeDisabled');
-		var welcomeDisabledDate = window.prefs.get('WSDWelcomeDisabledDate');
+		var welcomeDisabledDate = window.prefs.get('WSDWelcomeDisabledDate').replaceAll('-', ' ');
 		var isWelcomeDisabled = false;
 
 		if (welcomeDisabledCookie && welcomeDisabledDate) {
@@ -70,12 +70,12 @@ L.Map.Welcome = L.Handler.extend({
 		return false;
 	},
 
-	showWelcomeDialog: function() {
+	showWelcomeDialog: function () {
 		if (this._iframeWelcome && this._iframeWelcome.queryContainer())
 			this.remove();
 
 		var uiTheme = window.prefs.getBoolean('darkTheme') ? 'dark' : 'light';
-		var params = [{'ui_theme' : uiTheme}];
+		var params = [{ 'ui_theme': uiTheme }];
 
 		this._iframeWelcome = L.iframeDialog(this._url, params, null, { prefix: 'iframe-welcome' });
 		this._iframeWelcome._iframe.title = _('Welcome Dialog');
@@ -121,7 +121,7 @@ L.Map.Welcome = L.Handler.extend({
 			} else if (this._fallback) {
 				var currentDate = new Date();
 				window.prefs.set('WSDWelcomeDisabled', true);
-				window.prefs.set('WSDWelcomeDisabledDate', currentDate.toDateString());
+				window.prefs.set('WSDWelcomeDisabledDate', currentDate.toDateString().replaceAll(' ', '-'));
 				this.remove();
 			} else {
 				// fallback

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1367,16 +1367,16 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         {
             std::string json;
             getTokenString(tokens[2], "json", json);
-            updateBrowserSettingsJSON(json);
-            COOLWSD::syncUsersBrowserSettings(getUserId(), docBroker->getPid(), json);
             try
             {
+                updateBrowserSettingsJSON(json);
+                COOLWSD::syncUsersBrowserSettings(getUserId(), docBroker->getPid(), json);
                 uploadBrowserSettingsToWopiHost();
             }
             catch (const std::exception& exc)
             {
                 LOG_WRN("Failed to upload browsersetting json for session ["
-                        << getId() << ']');
+                        << getId() << "] with error[" << exc.what() << ']');
             }
         }
     }


### PR DESCRIPTION
- we tokenize messages in ClientSession with ' ' as delimeter. If message has extra spaces the json parsing will break
- this patch replaces ' '(space) in date string with '-' when sending setting `WSDWelcomeDisabledDate`. Also replaces '-' with ' '(space) when getting the preference


Change-Id: Ie903bd2f3c13c151029de9a262f8ec5261744311

* Target version: master 
