### PR TITLE
Navigator: remove duplicated background-color

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -485,7 +485,7 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	width: 330px;
 	display: none;
 	border-inline-end: 1px solid var(--color-border);
-	background-color: var(--color-background-lighter);
+	/* bg set in #sidebar-dock-wrapper, #navigator-dock-wrapper */
 }
 
 #navigation-sidebar.visible {


### PR DESCRIPTION
Already being set in #sidebar-dock-wrapper, #navigator-dock-wrapper

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Id0220e7254eb788d83e662569cbecc971122f8d6
