### PR TITLE
Only draw once per frame

### DIFF
--- a/browser/mocha_tests/CanvasSectionContainer.test.ts
+++ b/browser/mocha_tests/CanvasSectionContainer.test.ts
@@ -23,11 +23,13 @@
 var jsdom = require('jsdom');
 var assert = require('assert').strict;
 
-var dom = new jsdom.JSDOM(canvasDomString());
+var dom = new jsdom.JSDOM(canvasDomString(), { pretendToBeVisual: true });
 
 addMockCanvas(dom.window);
 global.window = dom.window;
 global.document = dom.window.document;
+global.requestAnimationFrame = dom.window.requestAnimationFrame;
+global.cancelAnimationFrame = dom.window.cancelAnimationFrame;
 
 const canvasWidth = 1024;
 const canvasHeight = 768;

--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -834,16 +834,6 @@ class TileManager {
 		if (app.map && emptyTilesCountChanged && this.emptyTilesCount === 0) {
 			app.map.fire('statusindicator', { statusType: 'alltilesloaded' });
 		}
-
-		// Don't paint the tile, only dirty the sectionsContainer if it is in the visible area.
-		// _emitSlurpedTileEvents() will repaint (if it is dirty).
-		const tileVisible = app.isRectangleVisibleInTheDisplayedArea(
-			this.pixelCoordsToTwipTileBounds(coords),
-		);
-
-		// Also check the scale because incoming tile may not be in the same zoom level.
-		if (tileVisible && this.tileZoomIsCurrent(coords))
-			app.sectionContainer.setDirty(coords);
 	}
 
 	private static createTile(coords: TileCoordData, key: string) {

--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -203,8 +203,6 @@ class CanvasSectionContainer {
 	// Above 2 properties can be used with documentBounds.
 	private drawingPaused: number = 0;
 	private drawingEnabled: boolean = true;
-	private dirty: DirtyType = DirtyType.NotDirty;
-	private dirtySubset: Set<any> = null; // If not null this is the set of coords that need redrawing.
 	private sectionsDirty: boolean = false;
 	private paintedEver: boolean = false;
 	private framesRendered: number = 0; // Total frame count for debugging
@@ -360,16 +358,12 @@ class CanvasSectionContainer {
 		this.drawingEnabled = true;
 		if (this.drawingPaused === 0) {
 			// Trigger a forced repaint as drawing is not paused currently.
-			this.setDirty(null);
 			this.paintOnResumeOrEnable();
 		}
 	}
 
 	pauseDrawing () {
-
-		if (this.drawingPaused++ === 0) {
-			this.clearDirty();
-		}
+		this.drawingPaused++;
 	}
 
 	// set topLevel if we are sure that we are the top of call nesting
@@ -398,34 +392,7 @@ class CanvasSectionContainer {
 		if (scrollSection)
 			scrollSection.completePendingScroll(); // No painting, only dirtying.
 
-		if (this.dirty) {
-			this.requestReDraw(this.dirtySubset);
-			this.clearDirty();
-		}
-	}
-
-	private clearDirty() {
-		this.dirty = DirtyType.NotDirty;
-		this.dirtySubset = null;
-	}
-
-	private setDirty(coords: any) {
-		if (this.dirty == DirtyType.All)
-			return;
-		if (coords === null ||
-		    // multi-clip needed for split-panes in drawSections.
-		    app.map._docLayer.getSplitPanesContext())
-		{
-			this.dirty = DirtyType.All;
-			this.dirtySubset = null;
-		}
-		else
-		{
-			this.dirty = DirtyType.TileRange;
-			if (this.dirtySubset === null)
-				this.dirtySubset = new Set<any>();
-			this.dirtySubset.add(coords);
-		}
+		this.requestReDraw();
 	}
 
 	/**
@@ -652,15 +619,12 @@ class CanvasSectionContainer {
 		}
 	}
 
-	requestReDraw(tileSubset: Set<any> = null) {
-		if (!this.drawingAllowed()) {
-			// Someone requested a redraw, but we're paused => schedule a redraw.
-			this.setDirty(null);
-			return;
-		}
+	requestReDraw() {
+		// Someone requested a redraw, but we're paused => schedule a redraw.
+		if (!this.drawingAllowed()) return;
 
 		if (!this.getAnimatingSectionName())
-			this.drawSections(null, null, tileSubset);
+			this.drawSections(null, null);
 	}
 
 	private propagateCursorPositionChanged() {
@@ -1772,7 +1736,7 @@ class CanvasSectionContainer {
 	    return section.isLocated && section.showSection && (!section.documentObject || section.isVisible);
 	}
 
-	private drawSections (frameCount: number = null, elapsedTime: number = null, tileSubset: Set<any> = null) {
+	private drawSections (frameCount: number = null, elapsedTime: number = null) {
 
 //              Un-comment to debug duplicate rendering problems:
 //		const stack = new Error().stack;
@@ -1782,23 +1746,6 @@ class CanvasSectionContainer {
 			app.map._debug.setOverlayMessage('top-frames', 'Frames: ' + this.framesRendered++);
 
 		this.context.setTransform(1, 0, 0, 1, 0, 0);
-
-		var subsetBounds: cool.Bounds = null;
-		// if there is a tileSubset we only want to draw the minimum region of its bounds
-		if (tileSubset) {
-			const tileSection: cool.TilesSection = (this.getSectionWithName(L.CSections.Tiles.name) as any) as cool.TilesSection;
-			if (tileSection && this.shouldDrawSection((tileSection as any) as CanvasSectionObject)) {
-				subsetBounds = tileSection.getSubsetBounds(this.context, tileSubset);
-			}
-			if (subsetBounds) {
-				this.context.save();
-
-				// FIXME: needs re-thinking for split-panes
-				this.context.translate(tileSection.myTopLeft[0], tileSection.myTopLeft[1]);
-				tileSection.clipSubsetBounds(this.context, subsetBounds);
-				this.context.translate(-tileSection.myTopLeft[0], -tileSection.myTopLeft[1]);
-			}
-		}
 
 		if (!this.zoomChanged) {
 			this.clearCanvas();
@@ -1815,7 +1762,7 @@ class CanvasSectionContainer {
 					this.context.globalAlpha = 1;
 				}
 
-				this.sections[i].onDraw(frameCount, elapsedTime, subsetBounds);
+				this.sections[i].onDraw(frameCount, elapsedTime, null);
 				if (this.sections[i].borderColor) { // If section's border is set, draw its borders after section's "onDraw" function is called.
 					var offset = this.sections[i].getLineOffset();
 					this.context.lineWidth = this.sections[i].getLineWidth();
@@ -1825,10 +1772,6 @@ class CanvasSectionContainer {
 
 				this.context.translate(-this.sections[i].myTopLeft[0], -this.sections[i].myTopLeft[1]);
 			}
-		}
-
-		if (subsetBounds) {
-			this.context.restore();
 		}
 
 		this.paintedEver = true;
@@ -2013,10 +1956,6 @@ class CanvasSectionContainer {
 		if (this.drawingAllowed()) {
 			this.updateBoundSectionLists();
 			this.reNewAllSections();
-		}
-		else {
-			this.sectionsDirty = true;
-			this.setDirty(null);
 		}
 	}
 

--- a/browser/src/canvas/CanvasSectionObject.ts
+++ b/browser/src/canvas/CanvasSectionObject.ts
@@ -80,6 +80,7 @@ class CanvasSectionObject {
 	onResize(): void { return; }
 	onDraw(frameCount?: number, elapsedTime?: number): void { return; }
 	onDrawArea(area?: cool.Bounds, paneTopLeft?: cool.Point, canvasContext?: CanvasRenderingContext2D): void { return; } // area is the area to be painted using canvasContext.
+	onAnimate(frameCount: number, elapsedTime: number): void { return; }
 	onAnimationEnded(frameCount: number, elapsedTime: number): void { return; } // frameCount, elapsedTime. Sections that will use animation, have to have this function defined.
 	onNewDocumentTopLeft(size: Array<number>): void { return; }
 	onRemove(): void { return; } // This Function is called right before section is removed.

--- a/browser/src/canvas/CanvasSectionObject.ts
+++ b/browser/src/canvas/CanvasSectionObject.ts
@@ -78,7 +78,7 @@ class CanvasSectionObject {
 	onMultiTouchMove(point: Array<number>, dragDistance: number, e: TouchEvent): void { return; }
 	onMultiTouchEnd(e: TouchEvent): void { return; }
 	onResize(): void { return; }
-	onDraw(frameCount?: number, elapsedTime?: number, subsetBounds?: cool.Bounds): void { return; }
+	onDraw(frameCount?: number, elapsedTime?: number): void { return; }
 	onDrawArea(area?: cool.Bounds, paneTopLeft?: cool.Point, canvasContext?: CanvasRenderingContext2D): void { return; } // area is the area to be painted using canvasContext.
 	onAnimationEnded(frameCount: number, elapsedTime: number): void { return; } // frameCount, elapsedTime. Sections that will use animation, have to have this function defined.
 	onNewDocumentTopLeft(size: Array<number>): void { return; }

--- a/browser/src/canvas/sections/CalcGridSection.ts
+++ b/browser/src/canvas/sections/CalcGridSection.ts
@@ -176,7 +176,7 @@ class CalcGridSection extends app.definitions.canvasSectionObject {
 		}
 	}
 
-    onDraw(frameCount?: number, elapsedTime?: number, subsetBounds?: Bounds): void {
+    onDraw(frameCount?: number, elapsedTime?: number): void {
 		if (this.containerObject.isInZoomAnimation() || this.sectionProperties.tsManager.waitForTiles())
 			return;
 

--- a/browser/src/canvas/sections/HTMLObjectSection.ts
+++ b/browser/src/canvas/sections/HTMLObjectSection.ts
@@ -80,7 +80,7 @@ class HTMLObjectSection extends CanvasSectionObject {
 			this.sectionProperties.objectDiv.style.top = top;
 	}
 
-	onDraw(frameCount?: number, elapsedTime?: number, subsetBounds?: Bounds): void {
+	onDraw(frameCount?: number, elapsedTime?: number): void {
 		this.adjustHTMLObjectPosition();
 	}
 

--- a/browser/src/canvas/sections/OtherViewCellCursorSection.ts
+++ b/browser/src/canvas/sections/OtherViewCellCursorSection.ts
@@ -41,7 +41,7 @@ class OtherViewCellCursorSection extends CanvasSectionObject {
         this.sectionProperties.popUpTimer = null;
     }
 
-    onDraw(frameCount?: number, elapsedTime?: number, subsetBounds?: Bounds): void {
+    onDraw(frameCount?: number, elapsedTime?: number): void {
         if (app.map._docLayer._isZooming)
             return;
 

--- a/browser/src/canvas/sections/OtherViewGraphicSelectionSection.ts
+++ b/browser/src/canvas/sections/OtherViewGraphicSelectionSection.ts
@@ -35,7 +35,7 @@ class OtherViewGraphicSelectionSection extends CanvasSectionObject {
         this.sectionProperties.mode = mode;
     }
 
-    onDraw(frameCount?: number, elapsedTime?: number, subsetBounds?: Bounds): void {
+    onDraw(frameCount?: number, elapsedTime?: number): void {
         this.context.strokeStyle = this.sectionProperties.color;
         this.context.lineWidth = 2;
         this.context.strokeRect(-0.5, -0.5, this.size[0], this.size[1]);

--- a/browser/src/canvas/sections/PixelGridSection.ts
+++ b/browser/src/canvas/sections/PixelGridSection.ts
@@ -19,7 +19,7 @@ class PixelGridSection extends app.definitions.canvasSectionObject {
 
     constructor () { super(); }
 
-    onDraw(frameCount?: number, elapsedTime?: number, subsetBounds?: Bounds): void {
+    onDraw(frameCount?: number, elapsedTime?: number): void {
 		var offset = 8;
 		var count;
 		this.context.lineWidth = 1;

--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -536,7 +536,9 @@ export class ScrollSection extends CanvasSectionObject {
 		if ((this.sectionProperties.drawHorizontalScrollBar || this.sectionProperties.animatingHorizontalScrollBar)) {
 			this.drawHorizontalScrollBar();
 		}
+	}
 
+	public onAnimate(frameCount: number, elapsedTime: number): void {
 		if (this.sectionProperties.animatingScroll) {
 			const lineHeight = this.containerObject.getScrollLineHeight();
 			const accel = lineHeight * ScrollSection.scrollAnimationAcceleration;
@@ -578,15 +580,13 @@ export class ScrollSection extends CanvasSectionObject {
 			}
 		}
 
-		if (this.isAnimating) {
-			const animatingScrollbar =
-				(this.sectionProperties.animatingHorizontalScrollBar
-				|| this.sectionProperties.animatingVerticalScrollBar) &&
-				elapsedTime && (elapsedTime < this.sectionProperties.fadeOutDuration);
-			const animatingScroll = this.sectionProperties.animatingScroll
-				&& this.sectionProperties.scrollAnimationDelta.reduce((a: number, x: number) => a + x, 0) !== 0;
-			if (!animatingScrollbar && !animatingScroll) this.containerObject.stopAnimating();
-		}
+		const animatingScrollbar =
+			(this.sectionProperties.animatingHorizontalScrollBar
+			|| this.sectionProperties.animatingVerticalScrollBar) &&
+			elapsedTime && (elapsedTime < this.sectionProperties.fadeOutDuration);
+		const animatingScroll = this.sectionProperties.animatingScroll
+			&& this.sectionProperties.scrollAnimationDelta.reduce((a: number, x: number) => a + x, 0) !== 0;
+		if (!animatingScrollbar && !animatingScroll) this.containerObject.stopAnimating();
 	}
 
 	public onAnimationEnded (frameCount: number, elapsedTime: number): void {
@@ -605,7 +605,6 @@ export class ScrollSection extends CanvasSectionObject {
 		else {
 			var options: any = {
 				duration: this.sectionProperties.idleDuration,
-				defer: true
 			};
 
 			this.sectionProperties.animatingHorizontalScrollBar = this.startAnimating(options);
@@ -620,7 +619,6 @@ export class ScrollSection extends CanvasSectionObject {
 		else {
 			var options: any = {
 				duration: this.sectionProperties.idleDuration,
-				defer: true
 			};
 
 			this.sectionProperties.animatingVerticalScrollBar = this.startAnimating(options);
@@ -771,10 +769,8 @@ export class ScrollSection extends CanvasSectionObject {
 				return false;
 		}
 
-		app.sectionContainer.pauseDrawing();
 		this.map.scroll(0, offset / app.dpiScale, {});
 		this.onUpdateScrollOffset();
-		app.sectionContainer.resumeDrawing();
 
 		if (app.file.fileBasedView) this.map._docLayer._checkSelectedPart();
 
@@ -808,10 +804,8 @@ export class ScrollSection extends CanvasSectionObject {
 				return false;
 		}
 
-		app.sectionContainer.pauseDrawing();
 		this.map.scroll(offset / app.dpiScale, 0, {});
 		this.onUpdateScrollOffset();
-		app.sectionContainer.resumeDrawing();
 
 		if (!this.sectionProperties.drawHorizontalScrollBar) {
 			if (this.isAnimating) {
@@ -1146,11 +1140,10 @@ export class ScrollSection extends CanvasSectionObject {
 		}
 
 		if (!this.sectionProperties.animatingScroll) {
+			this.sectionProperties.animatingScroll = true;
 			// We're about to start a duration-less animation, so we need to
 			// ensure the animation is reset.
-			if (!this.startAnimating({'defer': true}))
-				this.resetAnimation();
-			this.sectionProperties.animatingScroll = true;
+			if (!this.startAnimating({})) this.resetAnimation();
 		}
 	}
 
@@ -1192,7 +1185,7 @@ export class ScrollSection extends CanvasSectionObject {
 			this.sectionProperties.scrollWheelDelta[0] += hscroll;
 			this.sectionProperties.scrollWheelDelta[1] += vscroll;
 
-			if (!this.isAnimating) this.startAnimating({'defer': true});
+			if (!this.isAnimating) this.startAnimating({});
 		}
 	}
 }

--- a/browser/src/canvas/sections/ShapeHandleCustomSubSection.ts
+++ b/browser/src/canvas/sections/ShapeHandleCustomSubSection.ts
@@ -34,7 +34,7 @@ class ShapeHandleCustomSubSection extends CanvasSectionObject {
 		this.sectionProperties.mapPane = (<HTMLElement>(document.querySelectorAll('.leaflet-map-pane')[0]));
 	}
 
-	onDraw(frameCount?: number, elapsedTime?: number, subsetBounds?: cool.Bounds): void {
+	onDraw(frameCount?: number, elapsedTime?: number): void {
 		this.context.fillStyle = 'yellow';
 		this.context.strokeStyle = 'black';
 		this.context.beginPath();

--- a/browser/src/canvas/sections/ShapeHandleGluePointSubSection.ts
+++ b/browser/src/canvas/sections/ShapeHandleGluePointSubSection.ts
@@ -26,7 +26,7 @@ class ShapeHandleGluePointSubSection extends CanvasSectionObject {
 		this.sectionProperties.ownInfo = ownInfo;
 	}
 
-    onDraw(frameCount?: number, elapsedTime?: number, subsetBounds?: Bounds): void {
+    onDraw(frameCount?: number, elapsedTime?: number): void {
         this.context.fillStyle = '#EE3E3E';
         this.context.beginPath();
         this.context.arc(0, 0, this.size[0] * 0.5, 0, Math.PI * 2);

--- a/browser/src/canvas/sections/ShapeHandleRotationSubSection.ts
+++ b/browser/src/canvas/sections/ShapeHandleRotationSubSection.ts
@@ -75,7 +75,7 @@ class ShapeHandleRotationSubSection extends CanvasSectionObject {
 		this.sectionProperties.mapPane.style.cursor = this.sectionProperties.previousCursorStyle;
 	}
 
-	onDraw(frameCount?: number, elapsedTime?: number, subsetBounds?: cool.Bounds): void {
+	onDraw(frameCount?: number, elapsedTime?: number): void {
 		this.context.fillStyle = 'white';
 		this.context.strokeStyle = 'black';
 		this.context.beginPath();

--- a/browser/src/canvas/sections/ShapeHandleScalingSubSection.ts
+++ b/browser/src/canvas/sections/ShapeHandleScalingSubSection.ts
@@ -58,7 +58,7 @@ class ShapeHandleScalingSubSection extends CanvasSectionObject {
 		}
 	}
 
-	onDraw(frameCount?: number, elapsedTime?: number, subsetBounds?: cool.Bounds): void {
+	onDraw(frameCount?: number, elapsedTime?: number): void {
 		this.context.fillStyle = 'wheat';
 		this.context.strokeStyle = 'black';
 		this.context.beginPath();

--- a/browser/src/canvas/sections/SplitSection.ts
+++ b/browser/src/canvas/sections/SplitSection.ts
@@ -23,7 +23,7 @@ class SplitSection extends app.definitions.canvasSectionObject {
 
     constructor () { super(); }
 
-    onDraw(frameCount?: number, elapsedTime?: number, subsetBounds?: Bounds): void {
+    onDraw(frameCount?: number, elapsedTime?: number): void {
 		var splitPanesContext = this.sectionProperties.docLayer.getSplitPanesContext();
 		if (splitPanesContext) {
 			var splitPos = splitPanesContext.getSplitPos();

--- a/browser/src/canvas/sections/TilesSection.ts
+++ b/browser/src/canvas/sections/TilesSection.ts
@@ -423,7 +423,7 @@ export class TilesSection extends CanvasSectionObject {
 		}
 	}
 
-	public onDraw (frameCount: number = null, elapsedTime: number = null, subsetBounds: cool.Bounds = null): void {
+	public onDraw (frameCount: number = null, elapsedTime: number = null): void {
 		if (this.containerObject.isInZoomAnimation())
 			return;
 
@@ -458,10 +458,6 @@ export class TilesSection extends CanvasSectionObject {
 		this.forEachTileInView(zoom, part, mode, ctx, function (tile: any, coords: TileCoordData): boolean {
 
 			if (doneTiles.has(coords.key()))
-				return true;
-
-			// We can skip this tile if we only want to draw a subset, and it falls outside that
-			if (subsetBounds && !subsetBounds.intersects(docLayer._coordsToPixBounds(coords)))
 				return true;
 
 			// Ensure tile is within document bounds.

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -380,7 +380,6 @@ app.definitions.Socket = L.Class.extend({
 		var completeEventWholeFunction = this.createCompleteTraceEvent('emitSlurped-' + String(queueLength),
 									       {'_slurpQueue.length' : String(queueLength)});
 		if (this._map && this._map._docLayer) {
-			this._map._docLayer.pauseDrawing();
 			TileManager.beginTransaction();
 			this._inLayerTransaction = true;
 
@@ -465,9 +464,6 @@ app.definitions.Socket = L.Class.extend({
 
 		if (this._map) {
 			var completeCallback = () => {
-				if (this._map._docLayer)
-					this._map._docLayer.resumeDrawing(true);
-
 				// Let other layers / overlays catch up.
 				this._map.fire('messagesdone');
 

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -231,27 +231,6 @@ L.TileSectionManager = L.Class.extend({
 		sourceElement.addEventListener('touchcancel', function (e) { app.sectionContainer.onTouchCancel(e); }, true);
 	},
 
-	startUpdates: function () {
-		if (this._updatesRunning === true) {
-			return false;
-		}
-
-		this._updatesRunning = true;
-		this._updateWithRAF();
-		return true;
-	},
-
-	stopUpdates: function () {
-		if (this._updatesRunning) {
-			app.util.cancelAnimFrame(this._canvasRAF);
-			this.update();
-			this._updatesRunning = false;
-			return true;
-		}
-
-		return false;
-	},
-
 	dispose: function () {
 		this.stopUpdates();
 	},
@@ -325,12 +304,6 @@ L.TileSectionManager = L.Class.extend({
 	_removePreloadMap: function () {
 		app.sectionContainer.removeSection(L.CSections.Debug.PreloadMap.name);
 		app.sectionContainer.reNewAllSections(true);
-	},
-
-	_updateWithRAF: function () {
-		// update-loop with requestAnimationFrame
-		this._canvasRAF = app.util.requestAnimFrame(this._updateWithRAF, this, false /* immediate */);
-		app.sectionContainer.requestReDraw();
 	},
 
 	update: function () {
@@ -726,10 +699,6 @@ L.CanvasTileLayer = L.Layer.extend({
 				setTimeout(this.update.bind(this), 200);
 			}, this._painter);
 		}
-		else if (this._docType !== 'spreadsheet') { // See scroll section. panBy is used for spreadsheets while scrolling.
-			this._map.on('movestart', this._painter.startUpdates, this._painter);
-			this._map.on('moveend', this._painter.stopUpdates, this._painter);
-		}
 		this._map.on('zoomend', this._painter.update, this._painter);
 		this._map.on('splitposchanged', this._painter.update, this._painter);
 		this._map.on('sheetgeometrychanged', this._painter.update, this._painter);
@@ -902,6 +871,7 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		TileManager.update();
 		TileManager.resetPreFetching(true);
+		app.sectionContainer.requestReDraw();
 	},
 
 	_isLatLngInView: function (position) {


### PR DESCRIPTION
* Resolves: #11545 
* Target version: master 

### Summary

Drawing is usually done synchronously and draw calls are sprinkled quite liberally around. This is bad for performance, there's no reason to draw more than once per frame given we're locked to the monitor's refresh. This is work-in-progress, see the TODO below.

### TODO

- [ ] Currently this causes a 1-frame lag between DOM position of some things (comments) and rendered content
- [ ] Audit where redrawing is requested to see if it's actually necessary
- [ ] Audit where full-invalidation redrawing is requested to see if it's actually necessary

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

