### PR TITLE
Navigator: full width treeview entries

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -688,24 +688,29 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 
 /* tree grid */
 
-.ui-treeview div[aria-level='1'] + .ui-treeview-expanded-content {
-	margin-left: 2.5ch;
+.ui-treeview div[aria-level='1'] + .ui-treeview-expanded-content > .ui-treeview-entry {
+	padding-left: 2.5ch;
+	width: auto;
 }
 
-.ui-treeview div[aria-level='2'] + .ui-treeview-expanded-content {
-	margin-left: 3.5ch;
+.ui-treeview div[aria-level='2'] + .ui-treeview-expanded-content > .ui-treeview-entry {
+	padding-left: 3.5ch;
+	width: auto;
 }
 
-.ui-treeview div[aria-level='3'] + .ui-treeview-expanded-content {
-	margin-left: 4.5ch;
+.ui-treeview div[aria-level='3'] + .ui-treeview-expanded-content > .ui-treeview-entry {
+	padding-left: 4.5ch;
+	width: auto;
 }
 
-.ui-treeview div[aria-level='4'] + .ui-treeview-expanded-content {
-	margin-left: 5.5ch;
+.ui-treeview div[aria-level='4'] + .ui-treeview-expanded-content > .ui-treeview-entry {
+	padding-left: 5.5ch;
+	width: auto;
 }
 
-.ui-treeview div[aria-level='5'] + .ui-treeview-expanded-content {
-	margin-left: 6.5ch;
+.ui-treeview div[aria-level='5'] + .ui-treeview-expanded-content > .ui-treeview-entry {
+	padding-left: 6.5ch;
+	width: auto;
 }
 
 .ui-treeview div.ui-treeview-expander {

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -303,8 +303,6 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 	position: relative;
 	top: 0;
 	bottom: 10px;
-	left: 15px;
-	right: 10px;
 	border: none;
 	outline: none;
 }


### PR DESCRIPTION
Before this commit items in Navigator were being indented on a
parent level making the entries not interactive in the left most edge
(click and mouse hover was hitting the container and not the entry)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I60ccdde7adcbb0f1901bc0aa345f1093bf6bbce7
