### PR TITLE
rename server::Session to ServerSession

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1829,15 +1829,12 @@ get(const std::string& url, const std::string& path,
     return httpSession->syncRequest(http::Request(path), timeout);
 }
 
-namespace server
-{
-
 /// A server http Session to make asynchronous HTTP responses.
-class Session final : public ProtocolHandlerInterface
+class ServerSession final : public ProtocolHandlerInterface
 {
 public:
-    /// Construct a Session instance.
-    Session()
+    /// Construct a ServerSession instance.
+    ServerSession()
         : _timeout(getDefaultTimeout())
         , _pos(-1)
         , _size(0)
@@ -1864,7 +1861,7 @@ public:
     std::chrono::microseconds getTimeout() const { return _timeout; }
 
     /// The onFinished callback handler signature.
-    using FinishedCallback = std::function<void(const std::shared_ptr<Session>& session)>;
+    using FinishedCallback = std::function<void(const std::shared_ptr<ServerSession>& session)>;
 
     /// Set a callback to handle onFinished events from this session.
     /// onFinished is triggered whenever a request has finished,
@@ -1873,9 +1870,9 @@ public:
 
     /// Start an asynchronous upload from a file.
     /// Return true when it dispatches the socket to the SocketPoll.
-    /// Note: when reusing this Session, it is assumed that the socket
+    /// Note: when reusing this ServerSession, it is assumed that the socket
     /// is already added to the SocketPoll on a previous call (do not
-    /// use multiple SocketPoll instances on the same Session).
+    /// use multiple SocketPoll instances on the same ServerSession).
     bool asyncUpload(std::string fromFile, std::string mimeType, int start, int end, bool startIsSuffix, http::StatusCode statusCode = http::StatusCode::OK)
     {
         _start = start;
@@ -2016,7 +2013,7 @@ public:
     void dumpState(std::ostream& os, const std::string& indent) const override
     {
         const auto now = std::chrono::steady_clock::now();
-        os << indent << "http::server::Session: #" << _fd << " (" << (_socket ? "have" : "no")
+        os << indent << "http::ServerSession: #" << _fd << " (" << (_socket ? "have" : "no")
            << " socket)";
         os << indent << "\tconnected: " << std::boolalpha << _connected;
         os << indent << "\tstartTime: " << Util::getTimeForLog(now, _startTime);
@@ -2194,7 +2191,6 @@ private:
     FinishedCallback _onFinished;
     std::shared_ptr<StreamSocket> _socket; ///< Must be the last member.
 };
-}
 
 inline std::ostream& operator<<(std::ostream& os, const http::Header& header)
 {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4564,7 +4564,7 @@ void DocumentBroker::handleMediaRequest(const std::string_view range,
             const std::string path = getJailRoot() + "/" + localPath;
 #endif
 
-            auto session = std::make_shared<http::server::Session>();
+            auto session = std::make_shared<http::ServerSession>();
             session->asyncUpload(std::move(path), "video/mp4", range);
             streamSocket->setHandler(std::static_pointer_cast<ProtocolHandlerInterface>(session));
         }


### PR DESCRIPTION
avoid confusion on reading net/HttpRequest.hpp on seeing two "Session" classes


Change-Id: Ie6685cff58722f6e966f71670c7fd12de7a151ed


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

