### PR TITLE
cypress: make mobile writer/annotation_spec.js more stable

### DIFF
--- a/cypress_test/integration_tests/mobile/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/annotation_spec.js
@@ -171,7 +171,7 @@ describe(['tagmobile'], 'Annotation tests.', function() {
 		cy.cGet('#response-ok').click();
 		helper.waitUntilIdle('#mobile-wizard-content', undefined);
 
-		cy.cGet('#comment-container-1').click();
+		cy.cGet('#comment-container-1').should('exist').click();
 		cy.cGet('#comment-container-2').should('exist');
 		cy.cGet('#annotation-content-area-2 a')
 			.should('exist')


### PR DESCRIPTION
Mobile wizard sometimes still uses old refresh-all signal. That may cause button to disappear and be recreated so check before click to avoid using detached element.