### PR TITLE
processFetchUpdate triggers SocketPoll::startThread assert

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1002,8 +1002,11 @@ void SocketDisposition::execute()
             _socketMove(_socket);
         } else {
             assert (isTransfer());
-            // Ensure the thread is running before adding callback.
-            _toPoll->startThread();
+            if (!_toPoll->isRunOnClientThread())
+            {
+                // Ensure the thread is running before adding callback.
+                _toPoll->startThread();
+            }
             _toPoll->addCallback([pollCopy = _toPoll, socket = _socket, socketMoveFn = std::move(_socketMove)]()
                 {
                     pollCopy->insertNewSocket(socket);

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -951,6 +951,11 @@ public:
         return false;
     }
 
+    bool isRunOnClientThread() const
+    {
+        return _runOnClientThread;
+    }
+
     void disableWatchdog();
     void enableWatchdog();
 


### PR DESCRIPTION
"main" poll runs on client thread, as in it doesn't use its own thread, so COOLWSD::processFetchUpdate triggers
assert(!_runOnClientThread) in SocketPoll::startThread since

commit 3cd36f1236c165c4bf1c1af769bf86b5fb2ec711
CommitDate: Mon Apr 7 21:09:09 2025 +0100

    use SocketDisposition to transfer Socket to SocketPoll

because SocketDisposition::execute unconditionally calls startThread


Change-Id: I3031f67007c2221f7d3adcd0b2f9e8c1bc7ad887


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

