### PR TITLE
merge SocketPoll::InhibitThreadChecks and Socket::InhibitThreadChecks

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1545,6 +1545,8 @@ private:
 
     void onConnect(const std::shared_ptr<StreamSocket>& socket) override
     {
+        ASSERT_CORRECT_THREAD();
+
         if (socket)
         {
             _fd = socket->getFD();
@@ -1582,6 +1584,7 @@ private:
     int getPollEvents(std::chrono::steady_clock::time_point /*now*/,
                       int64_t& /*timeoutMaxMicroS*/) override
     {
+        ASSERT_CORRECT_THREAD();
         int events = POLLIN;
         if (_request.stage() != Request::Stage::Finished)
             events |= POLLOUT;
@@ -1591,6 +1594,7 @@ private:
     void handleIncomingMessage(SocketDisposition& disposition) override
     {
         LOG_TRC("handleIncomingMessage");
+        ASSERT_CORRECT_THREAD();
         std::shared_ptr<StreamSocket> socket = _socket.lock();
         if (isConnected() && socket)
         {
@@ -1628,6 +1632,7 @@ private:
 
     void performWrites(std::size_t capacity) override
     {
+        ASSERT_CORRECT_THREAD();
         // We may get called after disconnecting and freeing the Socket instance.
         std::shared_ptr<StreamSocket> socket = _socket.lock();
         if (socket)
@@ -1676,6 +1681,7 @@ private:
     // result while it is still available
     void onHandshakeFail() override
     {
+        ASSERT_CORRECT_THREAD();
         std::shared_ptr<StreamSocket> socket = _socket.lock();
         if (socket)
         {
@@ -1689,6 +1695,7 @@ private:
 
     void onDisconnect() override
     {
+        ASSERT_CORRECT_THREAD();
         // Make sure the socket is disconnected and released.
         std::shared_ptr<StreamSocket> socket = _socket.lock();
         if (socket)
@@ -1708,6 +1715,7 @@ private:
 
     std::shared_ptr<StreamSocket> connect()
     {
+        ASSERT_CORRECT_THREAD();
         _socket.reset(); // Reset to make sure we are disconnected.
         std::shared_ptr<StreamSocket> socket =
             net::connect(_host, _port, isSecure(), shared_from_this());
@@ -1731,6 +1739,7 @@ private:
 
     void asyncConnectSuccess(const std::shared_ptr<StreamSocket> &socket, net::AsyncConnectResult result)
     {
+        ASSERT_CORRECT_THREAD();
         assert(socket && _fd == socket->getFD() && "The socket FD must have been set in onConnect");
 
         _socket = socket; // Hold a weak pointer to it.
@@ -1743,6 +1752,7 @@ private:
 
     void asyncConnect(const std::weak_ptr<SocketPoll>& poll)
     {
+        ASSERT_CORRECT_THREAD();
         _socket.reset(); // Reset to make sure we are disconnected.
 
         auto pushConnectCompleteToPoll =
@@ -1780,6 +1790,7 @@ private:
 
     bool checkTimeout(std::chrono::steady_clock::time_point now) override
     {
+        ASSERT_CORRECT_THREAD();
         if (!_response || _response->done())
             return false;
 
@@ -2052,6 +2063,7 @@ public:
 private:
     void onConnect(const std::shared_ptr<StreamSocket>& socket) override
     {
+        ASSERT_CORRECT_THREAD();
         _connected = false; // Assume disconnected by default.
         _socket = socket;
         if (socket)
@@ -2105,6 +2117,7 @@ private:
     int getPollEvents(std::chrono::steady_clock::time_point /*now*/,
                       int64_t& /*timeoutMaxMicroS*/) override
     {
+        ASSERT_CORRECT_THREAD();
         int events = POLLIN;
         if (_fd >= 0 || _pos >= 0)
             events |= POLLOUT;
@@ -2113,6 +2126,7 @@ private:
 
     void handleIncomingMessage(SocketDisposition& /*disposition*/) override
     {
+        ASSERT_CORRECT_THREAD();
         if (!isConnected())
         {
             LOG_ERR("handleIncomingMessage called when not connected.");
@@ -2126,6 +2140,7 @@ private:
 
     void performWrites(std::size_t capacity) override
     {
+        ASSERT_CORRECT_THREAD();
         // We may get called after disconnecting and freeing the Socket instance.
         if (_socket)
         {
@@ -2169,6 +2184,7 @@ private:
 
     void onDisconnect() override
     {
+        ASSERT_CORRECT_THREAD();
         // Make sure the socket is disconnected and released.
         if (_socket)
         {

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -66,8 +66,10 @@
 constexpr std::chrono::microseconds SocketPoll::DefaultPollTimeoutMicroS;
 constexpr std::chrono::microseconds WebSocketHandler::InitialPingDelayMicroS;
 
-std::atomic<bool> SocketPoll::InhibitThreadChecks(false);
-std::atomic<bool> Socket::InhibitThreadChecks(false);
+namespace ThreadChecks
+{
+    std::atomic<bool> Inhibit(false);
+}
 
 std::unique_ptr<Watchdog> SocketPoll::PollWatchdog;
 
@@ -335,7 +337,7 @@ SocketPoll::~SocketPoll()
 
 void SocketPoll::checkAndReThread()
 {
-    if (InhibitThreadChecks)
+    if (ThreadChecks::Inhibit)
         return; // in late shutdown
     const std::thread::id us = std::this_thread::get_id();
     if (_owner == us)

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -132,13 +132,17 @@ private:
 
 class SocketThreadOwnerChange;
 
+namespace ThreadChecks
+{
+    extern std::atomic<bool> Inhibit;
+}
+
 /// A non-blocking, streaming socket.
 class Socket
 {
 public:
     static constexpr int DefaultSendBufferSize = 16 * 1024;
     static constexpr int MaximumSendBufferSize = 128 * 1024;
-    static std::atomic<bool> InhibitThreadChecks;
 
     enum class Type : uint8_t { IPv4, IPv6, All, Unix };
     static constexpr std::string_view toString(Type t);
@@ -383,7 +387,7 @@ public:
     /// Asserts in the debug builds, otherwise just logs.
     void assertCorrectThread(const char* fileName = "", int lineNo = 0) const
     {
-        if (!InhibitThreadChecks)
+        if (!ThreadChecks::Inhibit)
             Util::assertCorrectThread(_owner, fileName, lineNo);
     }
 
@@ -758,7 +762,6 @@ public:
 
     /// Default poll time - useful to increase for debugging.
     static constexpr std::chrono::microseconds DefaultPollTimeoutMicroS = std::chrono::seconds(64);
-    static std::atomic<bool> InhibitThreadChecks;
 
     /// Stop the polling thread.
     void stop()
@@ -808,7 +811,7 @@ public:
     /// Asserts in the debug builds, otherwise just logs.
     void assertCorrectThread(const char* fileName = "?", int lineNo = 0) const
     {
-        if (!InhibitThreadChecks && isAlive())
+        if (!ThreadChecks::Inhibit && isAlive())
             Util::assertCorrectThread(_owner, fileName, lineNo);
     }
 

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -177,6 +177,7 @@ protected:
     /// Implementation of the ProtocolHandlerInterface.
     void onConnect(const std::shared_ptr<StreamSocket>& socket) override
     {
+        ASSERT_CORRECT_THREAD();
         LOG_ASSERT_MSG(socket, "Invalid socket passed to WebSocketHandler::onConnect");
 
         _socket = socket;
@@ -225,6 +226,7 @@ protected:
 
     void shutdown(bool goingAway, const std::string &statusMessage) override
     {
+        ASSERT_CORRECT_THREAD();
         shutdownImpl(_socket.lock(),
                      goingAway ? WebSocketHandler::StatusCodes::ENDPOINT_GOING_AWAY :
                      WebSocketHandler::StatusCodes::NORMAL_CLOSE, statusMessage,
@@ -558,6 +560,7 @@ protected:
     /// Implementation of the ProtocolHandlerInterface.
     void handleIncomingMessage(SocketDisposition&) override
     {
+        ASSERT_CORRECT_THREAD();
         std::shared_ptr<StreamSocket> socket = _socket.lock();
 
         if constexpr (Util::isMobileApp())
@@ -594,6 +597,7 @@ protected:
     int getPollEvents([[maybe_unused]] std::chrono::steady_clock::time_point now,
                       [[maybe_unused]] int64_t& timeoutMaxMicroS) override
     {
+        ASSERT_CORRECT_THREAD();
 #if !MOBILEAPP
         if (!_isClient)
         {
@@ -657,6 +661,7 @@ public:
     /// Do we need to handle a timeout ?
     bool checkTimeout([[maybe_unused]] std::chrono::steady_clock::time_point now) override
     {
+        ASSERT_CORRECT_THREAD();
 #if !MOBILEAPP
         if (_isClient)
             return false;
@@ -676,12 +681,14 @@ public:
 public:
     void performWrites(std::size_t capacity) override
     {
+        ASSERT_CORRECT_THREAD();
         if (_msgHandler)
             _msgHandler->writeQueuedMessages(capacity);
     }
 
     void onDisconnect() override
     {
+        ASSERT_CORRECT_THREAD();
         if (_msgHandler)
             _msgHandler->onDisconnect();
     }
@@ -700,12 +707,14 @@ public:
     /// Implementation of the ProtocolHandlerInterface.
     int sendTextMessage(const char* msg, const size_t len, bool flush = false) const override
     {
+        ASSERT_CORRECT_THREAD();
         return sendMessage(msg, len, WSOpCode::Text, flush);
     }
 
     /// Implementation of the ProtocolHandlerInterface.
     int sendBinaryMessage(const char *data, const size_t len, bool flush = false) const override
     {
+        ASSERT_CORRECT_THREAD();
         return sendMessage(data, len, WSOpCode::Binary, flush);
     }
 
@@ -729,6 +738,7 @@ public:
 
     bool processInputEnabled() const override
     {
+        ASSERT_CORRECT_THREAD();
         std::shared_ptr<StreamSocket> socket = _socket.lock();
         if (socket)
             return socket->processInputEnabled();

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3279,8 +3279,7 @@ public:
     void dumpState(std::ostream& os) const
     {
         // FIXME: add some stop-world magic before doing the dump(?)
-        Socket::InhibitThreadChecks = true;
-        SocketPoll::InhibitThreadChecks = true;
+        ThreadChecks::Inhibit = true;
 
         std::string version, hash;
         Util::getVersionInfo(version, hash);
@@ -3388,8 +3387,7 @@ public:
 
         os << "\nDone COOLWSDServer state dumping.\n";
 
-        Socket::InhibitThreadChecks = false;
-        SocketPoll::InhibitThreadChecks = false;
+        ThreadChecks::Inhibit = false;
     }
 
 private:
@@ -3930,8 +3928,7 @@ int COOLWSD::innerMain()
     }
 
     // Disable thread checking - we'll now cleanup lots of things if we can
-    Socket::InhibitThreadChecks = true;
-    SocketPoll::InhibitThreadChecks = true;
+    ThreadChecks::Inhibit = true;
 
     // Wait for the DocumentBrokers. They must be saving/uploading now.
     // Do not stop them! Otherwise they might not save/upload the document.
@@ -4064,8 +4061,7 @@ void COOLWSD::cleanup([[maybe_unused]] int returnValue)
 
         TraceDumper.reset();
 
-        Socket::InhibitThreadChecks = true;
-        SocketPoll::InhibitThreadChecks = true;
+        ThreadChecks::Inhibit = true;
 
         // Delete these while the static Admin instance is still alive.
         {

--- a/wsd/ProxyProtocol.cpp
+++ b/wsd/ProxyProtocol.cpp
@@ -256,12 +256,14 @@ int ProxyProtocolHandler::sendMessage(const char *msg, const size_t len, bool te
 
 int ProxyProtocolHandler::sendTextMessage(const char *msg, const size_t len, bool flush) const
 {
+    ASSERT_CORRECT_THREAD();
     LOG_TRC("ProxyHack - send text msg " + std::string(msg, len));
     return const_cast<ProxyProtocolHandler *>(this)->sendMessage(msg, len, true, flush);
 }
 
 int ProxyProtocolHandler::sendBinaryMessage(const char *data, const size_t len, bool flush) const
 {
+    ASSERT_CORRECT_THREAD();
     LOG_TRC("ProxyHack - send binary msg len " << len);
     return const_cast<ProxyProtocolHandler *>(this)->sendMessage(data, len, false, flush);
 }
@@ -295,6 +297,7 @@ void ProxyProtocolHandler::dumpProxyState(std::ostream& os)
 int ProxyProtocolHandler::getPollEvents(std::chrono::steady_clock::time_point /* now */,
                                         int64_t &/* timeoutMaxMs */)
 {
+    ASSERT_CORRECT_THREAD();
     int events = POLLIN;
     if (_msgHandler && _msgHandler->hasQueuedMessages())
         events |= POLLOUT;
@@ -312,6 +315,7 @@ bool ProxyProtocolHandler::slurpHasMessages(std::size_t capacity)
 
 void ProxyProtocolHandler::performWrites(std::size_t capacity)
 {
+    ASSERT_CORRECT_THREAD();
     if (!slurpHasMessages(capacity))
         return;
 


### PR DESCRIPTION
Add ASSERT_CORRECT_THREAD checks to methods of ProtocolHandlerInteface api (avoiding getIOStats called by dumpState)

Merge Socket::InhibitThreadChecks and SocketPoll::InhibitThreadChecks as ThreadChecks::Inhibit (both are always toggled together) and reuse that for this.

Make Socket setThreadOwner/resetThreadOwner protected and virtual so StreamSocket can override and additionally call the protocolHandler equivalents.

Set a ProtocolHandlerInterface's threadowner to that of the owning StreamSocket in StreamSocket::setHandler