### PR TITLE
disconnect methods of Session/ServerSession are unused

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1388,16 +1388,6 @@ public:
         return std::string();
     }
 
-    void disconnect()
-    {
-        LOG_TRC("disconnect");
-        std::shared_ptr<StreamSocket> socket = _socket.lock();
-        if (socket)
-        {
-            socket->shutdownConnection();
-        }
-    }
-
     net::AsyncConnectResult connectionResult()
     {
         return _result;
@@ -2015,15 +2005,6 @@ public:
         if (_socket)
         {
             _socket->shutdown();
-        }
-    }
-
-    void disconnect()
-    {
-        LOG_TRC("disconnect");
-        if (_socket)
-        {
-            _socket->shutdownConnection();
         }
     }
 


### PR DESCRIPTION
Change-Id: I814cc1d584cfc2cdd0612bcd118f1473ff532a1c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

