### PR TITLE
Removed last modification indicator in Compact View

### DIFF
--- a/browser/src/control/Control.Menubar.js
+++ b/browser/src/control/Control.Menubar.js
@@ -390,8 +390,7 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('Send Feedback'), id: 'feedback', type: 'action', mobileapp: false},
 				{name: _('Server audit'), id: 'serveraudit', type: 'action', mobileapp: false},
 				{name: _('About'), id: 'about', type: 'action'}]
-			},
-			{name: _('Last modification'), id: 'last-mod', type: 'action', tablet: false}
+			}
 		],
 
 		presentation: [
@@ -566,8 +565,7 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('Send Feedback'), id: 'feedback', type: 'action', mobileapp: false},
 				{name: _('Server audit'), id: 'serveraudit', type: 'action', mobileapp: false},
 				{name: _('About'), id: 'about', type: 'action'}]
-			},
-			{name: _('Last modification'), id: 'last-mod', type: 'action', tablet: false}
+			}
 		],
 
 		drawing: [
@@ -703,8 +701,7 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('Send Feedback'), id: 'feedback', type: 'action', mobileapp: false},
 				{name: _('Server audit'), id: 'serveraudit', type: 'action', mobileapp: false},
 				{name: _('About'), id: 'about', type: 'action'}]
-			},
-			{name: _('Last modification'), id: 'last-mod', type: 'action', tablet: false}
+			}
 		],
 
 		spreadsheet: [
@@ -993,8 +990,7 @@ L.Control.Menubar = L.Control.extend({
 				{name: _('Send Feedback'), id: 'feedback', type: 'action', mobileapp: false},
 				{name: _('Server audit'), id: 'serveraudit', type: 'action', mobileapp: false},
 				{name: _('About'), id: 'about', type: 'action'}]
-			},
-			{name: _('Last modification'), id: 'last-mod', type: 'action', tablet: false}
+			}
 		],
 
 		mobiletext:  [


### PR DESCRIPTION
Change-Id: If49a2e6ea6ca16e9551e38cd4179bafd3b716292


* Resolves: #11050
* Target version: master 

### TODO

- [ ] If the approch that I took is right then, need to remove dead code i.e. css related to last modifications

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

