### PR TITLE
cid#318913 Not restoring ostream format

### DIFF
--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -341,8 +341,7 @@ void Session::getIOStats(uint64_t &sent, uint64_t &recv)
 
 void Session::dumpState(std::ostream& os)
 {
-    os << std::boolalpha
-       << "\n\t\tid: " << _id
+    os << "\n\t\tid: " << _id
        << "\n\t\tname: " << _name
        << "\n\t\tdisconnected: " << _disconnected
        << "\n\t\tisActive: " << _isActive

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1537,11 +1537,19 @@ int main(int argc, char**argv)
         return oss.str();
     }
 
+    // Create a ostringstream with desired ostream format set
+    inline std::ostringstream makeDumpStateStream()
+    {
+        std::ostringstream os;
+        os.setf(std::ios_base::boolalpha);
+        return os;
+    }
+
     /// Dump an object that supports .dumpState into a string.
     /// Helpful for logging.
     template <typename T> std::string dump(const T& object, const std::string& indent = ", ")
     {
-        std::ostringstream oss;
+        std::ostringstream oss(Util::makeDumpStateStream());
         object.dumpState(oss, indent);
         return oss.str().substr(indent.size());
     }

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1626,7 +1626,6 @@ bool ChildSession::setClipboard(const char* buffer, int length, const StringVect
         {
             data.read(stream);
         }
-//        data.dumpState(std::cerr);
 
         const size_t inCount = html.empty() ? data.size() : 1;
         std::vector<size_t> inSizes(inCount);

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2654,7 +2654,6 @@ void Document::flushAndExit(int code)
 void Document::dumpState(std::ostream& oss)
 {
     oss << "Kit Document:\n"
-        << std::boolalpha
         << "\n\tpid: " << getpid()
         << "\n\tstop: " << _stop
         << "\n\tjailId: " << _jailId
@@ -4133,7 +4132,7 @@ std::string anonymizeUsername(const std::string& username)
 
 void dump_kit_state()
 {
-    std::ostringstream oss;
+    std::ostringstream oss(Util::makeDumpStateStream());
     KitSocketPoll::dumpGlobalState(oss);
 
     oss << "\nMalloc info [" << getpid() << "]: \n\t"

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1411,7 +1411,7 @@ public:
         const auto now = std::chrono::steady_clock::now();
         os << indent << "http::Session: #" << _fd << " (" << (_socket.lock() ? "have" : "no")
            << " socket)";
-        os << indent << "\tconnected: " << std::boolalpha << _connected;
+        os << indent << "\tconnected: " << _connected;
         os << indent << "\ttimeout: " << _timeout;
         os << indent << "\thost: " << _host;
         os << indent << "\tport: " << _port;
@@ -2032,7 +2032,7 @@ public:
         const auto now = std::chrono::steady_clock::now();
         os << indent << "http::ServerSession: #" << _fd << " (" << (_socket ? "have" : "no")
            << " socket)";
-        os << indent << "\tconnected: " << std::boolalpha << _connected;
+        os << indent << "\tconnected: " << _connected;
         os << indent << "\tstartTime: " << Util::getTimeForLog(now, _startTime);
         os << indent << "\tmimeType: " << _mimeType;
         os << indent << "\tstatusCode: " << getReasonPhraseForCode(_statusCode);

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1767,7 +1767,7 @@ bool StreamSocket::compactChunks(MessageMap& map)
     map._messageSize -= gap;
 
 #if ENABLE_DEBUG
-    std::ostringstream oss;
+    std::ostringstream oss(Util::makeDumpStateStream());
     dumpState(oss);
     LOG_TRC("Socket state: " << oss.str());
 #endif

--- a/test/KitQueueTests.cpp
+++ b/test/KitQueueTests.cpp
@@ -432,7 +432,7 @@ void KitQueueTests::testSenderQueueLog()
         queue.enqueue(std::make_shared<Message>(msg, Message::Dir::Out));
     }
 
-    std::stringstream str;
+    std::ostringstream str(Util::makeDumpStateStream());
     queue.dumpState(str);
 
     std::string result = "\t\tqueue items: 9\n"

--- a/test/UnitCopyPaste.cpp
+++ b/test/UnitCopyPaste.cpp
@@ -105,7 +105,7 @@ public:
             std::istringstream responseStream(body);
             auto clipboard = std::make_shared<ClipboardData>();
             clipboard->read(responseStream);
-            std::ostringstream oss;
+            std::ostringstream oss(Util::makeDumpStateStream());
             clipboard->dumpState(oss);
 
             LOG_TST("getClipboard: got response. State:\n" << oss.str());

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4232,7 +4232,7 @@ void forwardSignal(const int signum);
 
 void dump_state()
 {
-    std::ostringstream oss;
+    std::ostringstream oss(Util::makeDumpStateStream());
 
     if (Server)
         Server->dumpState(oss);

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -687,7 +687,7 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
 #if 0 // debug a specific command's payload
         if (Util::findInVector(socket->getInBuffer(), "insertfile") != std::string::npos)
         {
-            std::ostringstream oss;
+            std::ostringstream oss(Util::makeDumpStateStream());
             oss << "Debug - specific command:\n";
             socket->dumpState(oss);
             LOG_INF(oss.str());

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1534,6 +1534,7 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
         overrideDocOption();
 
         std::ostringstream oss;
+        oss << std::boolalpha;
         oss << "load url=" << docBroker->getPublicUri().toString();
 
 #if ENABLE_SSL
@@ -1581,7 +1582,7 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
             oss << " serverprivateinfo=" << encodedServerPrivateInfo;
         }
 
-        oss << " readonly=" << isReadOnly();
+        oss << " readonly=" << (isReadOnly() ? 1 : 0);
 
         if (isAllowChangeComments())
         {
@@ -1639,7 +1640,7 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
 
         if (ConfigUtil::hasProperty("security.enable_macros_execution"))
         {
-            oss << " enableMacrosExecution=" << std::boolalpha
+            oss << " enableMacrosExecution="
                 << ConfigUtil::getConfigValue<bool>("security.enable_macros_execution", false);
         }
 
@@ -1656,7 +1657,7 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
 
         if (ConfigUtil::getConfigValue<bool>("accessibility.enable", false))
         {
-            oss << " accessibilityState=" << std::boolalpha << getAccessibilityState();
+            oss << " accessibilityState=" << getAccessibilityState();
         }
 
         if (!getDocOptions().empty())

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -714,7 +714,7 @@ void DocumentBroker::pollThread()
 
     if (!reason.empty() || (_unitWsd && _unitWsd->isFinished() && _unitWsd->failed()))
     {
-        std::stringstream state;
+        std::ostringstream state(Util::makeDumpStateStream());
         state << "DocBroker [" << _docKey << "] stopped "
               << (reason.empty() ? "because of test failure" : ("although " + reason));
         if (!UnitWSD::isUnitTesting())
@@ -5013,7 +5013,7 @@ void DocumentBroker::closeDocument(const std::string& reason)
         // But first signal the Kit, because we might kill it soon after returning.
         ::kill(getPid(), SIGUSR1);
 
-        std::ostringstream oss;
+        std::ostringstream oss(Util::makeDumpStateStream());
         dumpState(oss);
         LOG_WRN("OOM-closing Document [" << _docId << "]: " << oss.str());
     }
@@ -5221,7 +5221,6 @@ void DocumentBroker::dumpState(std::ostream& os)
 
     const auto now = std::chrono::steady_clock::now();
 
-    os << std::boolalpha;
     os << "\nDocumentBroker [" << _docId << "] Dump: [" << getDocKey() << "], pid: " << getPid();
     if (_docState.isMarkedToDestroy())
         os << " *** Marked to destroy ***";

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1041,7 +1041,7 @@ private:
         {
             if (Log::traceEnabled())
             {
-                std::ostringstream oss;
+                std::ostringstream oss(Util::makeDumpStateStream());
                 dumpState(oss, ", ");
                 LOG_TRC("Created SaveManager: " << oss.str());
             }
@@ -1201,15 +1201,15 @@ private:
         {
             const auto now = std::chrono::steady_clock::now();
             os << indent << "version: " << version();
-            os << indent << "isSaving now: " << std::boolalpha << isSaving();
-            os << indent << "idle-save enabled: " << std::boolalpha << isIdleSaveEnabled();
+            os << indent << "isSaving now: " << isSaving();
+            os << indent << "idle-save enabled: " << isIdleSaveEnabled();
             os << indent << "idle-save interval: " << idleSaveInterval();
-            os << indent << "auto-save enabled: " << std::boolalpha << isAutoSaveEnabled();
+            os << indent << "auto-save enabled: " << isAutoSaveEnabled();
             os << indent << "auto-save interval: " << autoSaveInterval();
             os << indent << "check interval: " << _checkInterval;
             os << indent
                << "last auto-save check time: " << Util::getTimeForLog(now, _lastAutosaveCheckTime);
-            os << indent << "auto-save check needed: " << std::boolalpha << needAutoSaveCheck();
+            os << indent << "auto-save check needed: " << needAutoSaveCheck();
 
             os << indent
                << "last save request: " << Util::getTimeForLog(now, lastSaveRequestTime());
@@ -1221,7 +1221,7 @@ private:
             os << indent
                << "file last modified time: " << Util::getTimeForLog(now, _lastModifiedTime);
             os << indent << "saving-timeout: " << getSavingTimeout();
-            os << indent << "last save timed-out: " << std::boolalpha << hasSavingTimedOut();
+            os << indent << "last save timed-out: " << hasSavingTimedOut();
             os << indent << "last save successful: " << lastSaveSuccessful();
             os << indent << "save failure count: " << saveFailureCount();
         }
@@ -1402,7 +1402,7 @@ private:
         void dumpState(std::ostream& os, const std::string& indent = "\n  ") const
         {
             const auto now = std::chrono::steady_clock::now();
-            os << indent << "isUploading now: " << std::boolalpha << isUploading();
+            os << indent << "isUploading now: " << isUploading();
             os << indent << "last upload request time: "
                << Util::getTimeForLog(now, _request.lastRequestTime());
             os << indent << "last upload response time: "
@@ -1412,8 +1412,7 @@ private:
             os << indent << "last modified time (on server): " << getLastModifiedTime();
             os << indent
                << "file last modified: " << Util::getTimeForLog(now, _lastUploadedFileModifiedTime);
-            os << indent << "last upload was successful: " << std::boolalpha
-               << lastUploadSuccessful();
+            os << indent << "last upload was successful: " << lastUploadSuccessful();
             os << indent << "upload failure count: " << uploadFailureCount();
             os << indent << "size on server: " << _sizeOnServer;
             os << indent << "last upload size: " << _sizeAsUploaded;

--- a/wsd/ProxyProtocol.cpp
+++ b/wsd/ProxyProtocol.cpp
@@ -111,7 +111,7 @@ bool ProxyProtocolHandler::parseEmitIncoming(
     Buffer& in = socket->getInBuffer();
 
 #if 0 // protocol debugging.
-    std::stringstream oss;
+    std::ostringstream oss(Util::makeDumpStateStream());
     socket->dumpState(oss);
     LOG_TRC("Parse message:\n" << oss.str());
 #endif
@@ -182,7 +182,7 @@ void ProxyProtocolHandler::handleRequest(bool isWaiting, const std::shared_ptr<S
             LOG_WRN("proxy: unusual - incoming message with no-one to handle it");
         else if (!parseEmitIncoming(streamSocket))
         {
-            std::stringstream oss;
+            std::ostringstream oss(Util::makeDumpStateStream());
             streamSocket->dumpState(oss);
             LOG_ERR("proxy: bad socket structure " << oss.str());
         }
@@ -227,7 +227,7 @@ void ProxyProtocolHandler::handleRequest(bool isWaiting, const std::shared_ptr<S
 
 void ProxyProtocolHandler::handleIncomingMessage(SocketDisposition &disposition)
 {
-    std::stringstream oss;
+    std::ostringstream oss(Util::makeDumpStateStream());
     disposition.getSocket()->dumpState(oss);
     LOG_ERR("If you got here, it means we failed to parse this properly in handleRequest: " << oss.str());
 }

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -174,10 +174,10 @@ public:
         void dumpState(std::ostream& os, const std::string& indent = "\n  ") const
         {
             os << indent << "StorageBase::Attributes:";
-            os << indent << "forced: " << std::boolalpha << isForced();
-            os << indent << "user-modified: " << std::boolalpha << isUserModified();
-            os << indent << "auto-save: " << std::boolalpha << isAutosave();
-            os << indent << "exit-save: " << std::boolalpha << isExitSave();
+            os << indent << "forced: " << isForced();
+            os << indent << "user-modified: " << isUserModified();
+            os << indent << "auto-save: " << isAutosave();
+            os << indent << "exit-save: " << isExitSave();
             os << indent << "extended-data: " << getExtendedData();
         }
 
@@ -471,7 +471,7 @@ public:
 
         os << indent << "StorageBase:";
         os << indent << "uri: " << _uri.toString();
-        os << indent << "isDownloaded: " << std::boolalpha << _isDownloaded;
+        os << indent << "isDownloaded: " << _isDownloaded;
         os << indent << "localStorePath: " << _localStorePath;
         os << indent << "jailPath: " << _jailPath;
         os << indent << "jailedFilePath: " << _jailedFilePath;


### PR DESCRIPTION
and

cid#318944 Not restoring ostream format
cid#410823 Not restoring ostream format
cid#410831 Not restoring ostream format
cid#427992 Not restoring ostream format
cid#516981 Not restoring ostream format

drop setting std::boolalpha in individual dumpStates and instead add a makeDumpStateStream which creates a std::ostringstream to dump to, which already has boolalpha set by default

ClientSession::loadDocument is a different case, a short lived std::ostringstream, just move the std::boolalpha to when its created.


Change-Id: I543fd819b8c7cfdd42f3ba13b6a689b316d6be68


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

