### PR TITLE
fix(regression): disable 'Add' button for duplicate words in wordbook

### DIFF
--- a/browser/admin/src/integrator/WordBook.ts
+++ b/browser/admin/src/integrator/WordBook.ts
@@ -340,9 +340,14 @@ class WordBook {
 		);
 
 		addButton.disabled = true;
-		newWordInput.addEventListener('input', () => {
+		newWordInput.addEventListener('change', () => {
 			const newWord = newWordInput.value.trim();
-			addButton.disabled = newWord === '';
+
+			const wordExists = this.currWordbookFile.words.some(
+				(word) => word.toLowerCase() === newWord.toLowerCase(),
+			);
+
+			addButton.disabled = newWord === '' || wordExists;
 		});
 
 		addButton.addEventListener('click', () => {


### PR DESCRIPTION
Change-Id: I1df6ca6287fdf34e26f4ee5ac8942c1ab762eaa6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
