### PR TITLE
esign: clean up two unused members in ESignature

### DIFF
--- a/browser/src/control/Control.ESignature.ts
+++ b/browser/src/control/Control.ESignature.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -62,17 +61,13 @@ namespace cool {
 		clientId: string;
 
 		// Timestamp of the hash extraction
-		signatureTime: number;
+		signatureTime: number = 0;
 
 		// Identifier of the document on the eIDEasy side
-		docId: string;
+		docId: string = '';
 
 		// The popup window we opened.
-		popup: Window;
-
-		availableProviderIDs: Array<string>;
-
-		availableCountryCodes: Array<string>;
+		popup: Window | null = null;
 
 		showSignaturesOnNextUpdate = false;
 
@@ -117,7 +112,7 @@ namespace cool {
 		};
 
 		// Country code to name map
-		static countryNames: { [name: string]: string } = undefined;
+		static countryNames: { [name: string]: string } | null = null;
 
 		constructor(url: string, clientId: string) {
 			this.url = url;
@@ -280,11 +275,11 @@ namespace cool {
 			}
 
 			this.docId = response.doc_id;
-			this.availableProviderIDs = response.available_methods;
+			const availableProviderIDs = response.available_methods;
 			const availableProviderConfigs = response.method_configs;
 			const countries = this.createCountryList(availableProviderConfigs);
 			const providers = this.createProviders(
-				this.availableProviderIDs,
+				availableProviderIDs,
 				availableProviderConfigs,
 			);
 			const dialog = JSDialog.eSignatureDialog(countries, providers);
@@ -354,7 +349,7 @@ namespace cool {
 					this.popup.close();
 				}
 			} catch (error) {
-				app.console.log('failed to close the signing popup: ' + error.message);
+				app.console.log('failed to close the signing popup: ' + error);
 				return false;
 			}
 
@@ -446,10 +441,11 @@ namespace cool {
 				}
 			}
 			codes = [...new Set(codes)];
-			this.availableCountryCodes = codes;
 
 			return codes.map((code) => {
-				const countryName = ESignature.countryNames[code];
+				const countryName = ESignature.countryNames
+					? ESignature.countryNames[code]
+					: null;
 				if (countryName) {
 					return { code: code, name: countryName };
 				}


### PR DESCRIPTION
availableProviderIDs doesn't have to be a member since commit
4d42b1e3e47ad0183649678d2aa931b44c5ffe10 (cool#10630 doc electronic
sign: return dialog result without an index, 2024-12-17).

availableCountryCodes was write-only since the same commit.

And fix the remaining lints in the file, so strict mode can be enabled
here.

Actual esign with the config from
<https://github.com/CollaboraOnline/online/issues/10630#issuecomment-2606548860>
continues to work.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I55a023261bc51f69150426c6fdb4fa8a5dc4f777
