### PR TITLE
Fix invalidation when dpiScale is not equal to one

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -1542,7 +1542,7 @@ class TileManager {
 
 	private static pixelCoordsToTwipTileBounds(coords: TileCoordData): number[] {
 		// We need to calculate pixelsToTwips for the scale of this tile. 15 is the ratio between pixels and twips when the scale is 1.
-		const pixelsToTwipsForTile = 15 / coords.scale;
+		const pixelsToTwipsForTile = 15 / app.dpiScale / coords.scale;
 		const x = coords.x * pixelsToTwipsForTile;
 		const y = coords.y * pixelsToTwipsForTile;
 		const width = app.tile.size.pX * pixelsToTwipsForTile;


### PR DESCRIPTION
TileManager.pixelCoordsToTwipTileBounds needs to take into account app.dpiScale.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required