### PR TITLE
Fix slow scrolling when dpiScale is greater than 1

### DIFF
--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -1171,6 +1171,9 @@ export class ScrollSection extends CanvasSectionObject {
 			&& !this.sectionProperties.scrollAnimationDisableTimeout
 			&& Math.max(Math.abs(hscroll), Math.abs(vscroll)) % 1 === 0;
 
+		hscroll *= app.dpiScale;
+		vscroll *= app.dpiScale;
+		
 		if (shouldAnimate)
 			this.animateScroll([hscroll, vscroll]);
 		else {


### PR DESCRIPTION
Mousewheel coordinates need to take into account dpiScale. With this change, scrolling speed is independent of devicePixelRatio.

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

