### PR TITLE
plugin: enforce Socket shared_ptr semantics

### DIFF
--- a/clang/plugin.cpp
+++ b/clang/plugin.cpp
@@ -193,6 +193,7 @@ public:
         return fieldDecl(
                     hasType(
                         classTemplateSpecializationDecl(
+                            hasName("std::shared_ptr"),
                             hasAnyTemplateArgument(
                                 refersToType(
                                     recordType(


### PR DESCRIPTION
Change-Id: I2e3dd88b3ca6122de18cd0ed154ae34b821e91d5


Implement requirement from caolan:

We've bootstrapped some rough notes on the "Socket" class in online
where we basically want to set a claim along the lines that only
"SocketPoll" should have std::shared_ptr<Socket> as a member and that
everything else should have std::weak_ptr<Socket> of those[1].

https://github.com/CollaboraOnline/online/blob/master/dev-notes/socket-ownership.md

And the question is if there is a possibility to express something like
those rules as a clang plugin? (there is an existing clang plugin in
online FWIW)

[1] Though I'm sure there will be exceptions.

