### PR TITLE
esign: fix missing member initializers in ESignatureDialog

### DIFF
--- a/browser/src/control/Control.ESignatureDialog.ts
+++ b/browser/src/control/Control.ESignatureDialog.ts
@@ -1,4 +1,3 @@
-// @ts-strict-ignore
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -30,14 +29,14 @@ namespace cool {
 
 		availableCountries: Array<Country>;
 
-		defaultCountryCode: string;
+		defaultCountryCode: string = '';
 
-		defaultProviderId: string;
+		defaultProviderId: string = '';
 
 		availableProviders: Array<SignatureProvider>;
 
 		// Providers available in the selected country
-		filteredProviders: Array<SignatureProvider>;
+		filteredProviders: Array<SignatureProvider> = [];
 
 		constructor(
 			countries: Array<Country>,


### PR DESCRIPTION
This fixes the remaining lints in the file, so strict mode can be
enabled here.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I36c2da6b3348eade4407bde60299468ec973d86b
