### PR TITLE
Dialogs: Emphasize difference between tabs and sub tabs

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -365,6 +365,13 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	color: var(--color-text-darker) !important;
 }
 
+/* Sub Tabs: example Format Cells: Font */
+
+.ui-tabs-content .ui-tabs.jsdialog.ui-widget {
+	border-block-start: 1px solid var(--color-border-lighter);
+	padding-block-start: 24px
+}
+
 /* Expander */
 
 .jsdialog.ui-expander {


### PR DESCRIPTION
Example: Calc -> Format Cells: Font tab VS Western, Asian, Complex sub
tabs

Before this commit the sub tabs (e.g.: "Western", "Asian", "Complex")
could be confused and perceived as top level tabs. Plus the fact that
"Western" controls only the left part and "Asian/Complex" controls the
right part could have been more clear.

- Increase spacing: to increase the difference between levels
- Add border to emphasize ^ and to help distinguish which part of the
dialog the sub tabs control

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I04b4e04682c7d9d143ded2bcd9ef145c2d31935a
