### PR TITLE
Missing "," seperator in json save message

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3620,10 +3620,7 @@ bool DocumentBroker::sendUnoSave(const std::shared_ptr<ClientSession>& session,
 
     if (dontSaveIfUnmodified)
     {
-        if (dontTerminateEdit)
-            oss << ',';
-
-        oss << "\"DontSaveIfUnmodified\" : { \"type\":\"boolean\", \"value\":true }";
+        oss << ",\"DontSaveIfUnmodified\" : { \"type\":\"boolean\", \"value\":true }";
     }
 
     // arguments end


### PR DESCRIPTION
so we got:

uno command .uno:Save {"DontTerminateEdit" : { "type":"boolean", "value":false }"DontSaveIfUnmodified" : { "type":"boolean", "value":true }}

instead of

uno command .uno:Save {"DontTerminateEdit" : { "type":"boolean", "value":false },"DontSaveIfUnmodified" : { "type":"boolean", "value":true }}

since:

commit d851318a86b515a9c7c39a89c60a9b7680f4b411
CommitDate: Tue Apr 8 09:18:32 2025 +0200

    save: pass args also for background save

which always outputs DontTerminateEdit of true/false now so we always need the separator if there is DontSaveIfUnmodified

Signed-off-by: Caolán McNamara <caolan.mcnamara@collabora.com>
Change-Id: Ie66068d2b79d2cf17c4fba9bc3dd0050e47135a1 (cherry picked from commit de1ae0b12ee89d119de2162c10ad95e4c3e4d020)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

