### PR TITLE
Misc

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3592,6 +3592,7 @@ bool DocumentBroker::sendUnoSave(const std::shared_ptr<ClientSession>& session,
 
     // We do not want save to terminate editing mode if we are in edit mode now.
     // We want to terminate if forced by the user, otherwise autosave doesn't terminate.
+    // Note: We always force terminating edit when saving in the background.
     dontTerminateEdit = dontTerminateEdit && background == false;
 
     oss << "\"DontTerminateEdit\" : { \"type\":\"boolean\", \"value\":"

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -5302,8 +5302,11 @@ void DocumentBroker::dumpState(std::ostream& os)
     else
         os << " none";
 
-    os << '\n';
-    _lockCtx->dumpState(os);
+    if (_lockCtx)
+    {
+        os << '\n';
+        _lockCtx->dumpState(os);
+    }
 
     if (_tileCache)
     {
@@ -5311,8 +5314,11 @@ void DocumentBroker::dumpState(std::ostream& os)
         _tileCache->dumpState(os);
     }
 
-    os << '\n';
-    _poll->dumpState(os);
+    if (_poll)
+    {
+        os << '\n';
+        _poll->dumpState(os);
+    }
 
 #if !MOBILEAPP
     // Bit nasty - need a cleaner way to dump state.

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1240,9 +1240,10 @@ bool DocumentBroker::doDownloadDocument(const Authorization& auth,
     }
 #endif //!MOBILEAPP
 
-    const std::string localFilePath = Poco::Path(FileUtil::buildLocalPathToJail(COOLWSD::EnableMountNamespaces,
-                                                                                getJailRoot(),
-                                                                                localPath)).toString();
+    std::string localFilePath =
+        Poco::Path(FileUtil::buildLocalPathToJail(COOLWSD::EnableMountNamespaces, getJailRoot(),
+                                                  localPath))
+            .toString();
     std::ifstream istr(localFilePath, std::ios::binary);
     Poco::SHA1Engine sha1;
     Poco::DigestOutputStream dos(sha1);
@@ -1773,7 +1774,7 @@ DocumentBroker::asyncInstallPresets(const std::shared_ptr<SocketPoll>& poll, con
     std::shared_ptr<http::Session> httpSession(StorageConnectionManager::getHttpSession(settingsUri));
     http::Request request(settingsUri.getPathAndQuery());
 
-    const std::string uriAnonym = COOLWSD::anonymizeUrl(userSettingsUri);
+    std::string uriAnonym = COOLWSD::anonymizeUrl(userSettingsUri);
     LOG_DBG("Getting settings from [" << uriAnonym << ']');
 
     auto presetTasks = std::make_shared<PresetsInstallTask>(poll, configId, presetsPath,
@@ -1836,7 +1837,7 @@ void DocumentBroker::asyncInstallPreset(
     const std::function<void(const std::string&, bool)>& finishedCB,
     const std::shared_ptr<ClientSession>& session)
 {
-    const std::string uriAnonym = COOLWSD::anonymizeUrl(presetUri);
+    std::string uriAnonym = COOLWSD::anonymizeUrl(presetUri);
     LOG_DBG("Getting preset from [" << uriAnonym << ']');
 
     const Poco::URI uri{presetUri};
@@ -4554,16 +4555,17 @@ void DocumentBroker::handleMediaRequest(const std::string_view range,
         {
             // For now, we only support file:// schemes.
             // In the future, we may/should support http.
-            const std::string localPath = url.substr(sizeof("file:///") - 1);
+            std::string localPath = url.substr(sizeof("file:///") - 1);
 #if !MOBILEAPP
             // We always extract media files in /tmp. Normally, we are in jail (chroot),
             // and this would need to be accessed from WSD through the JailRoot path.
             // But, when we have NoCapsForKit there is no jail, so the media file ends
             // up in the host (AppImage) /tmp
-            const std::string path = COOLWSD::NoCapsForKit ? "/" + localPath :
-                FileUtil::buildLocalPathToJail(
-                    COOLWSD::EnableMountNamespaces, COOLWSD::ChildRoot + _jailId,
-                    std::move(localPath));
+            std::string path = COOLWSD::NoCapsForKit
+                                   ? "/" + localPath
+                                   : FileUtil::buildLocalPathToJail(COOLWSD::EnableMountNamespaces,
+                                                                    COOLWSD::ChildRoot + _jailId,
+                                                                    std::move(localPath));
 #else
             const std::string path = getJailRoot() + "/" + localPath;
 #endif
@@ -5415,7 +5417,7 @@ std::string DocumentBroker::getEmbeddedMediaPath(const std::string& id)
         return std::string();
     }
 
-    const std::string localPath = url.substr(sizeof("file:///") - 1);
+    std::string localPath = url.substr(sizeof("file:///") - 1);
 
 #if !MOBILEAPP
     // We always extract media files in /tmp. Normally, we are in jail (chroot),

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -150,7 +150,7 @@ namespace
 class SharedSettings
 {
 public:
-    SharedSettings(const Poco::JSON::Object::Ptr wopiInfo)
+    explicit SharedSettings(const Poco::JSON::Object::Ptr& wopiInfo)
     {
         if (auto settingsJSON = wopiInfo->getObject("SharedSettings"))
         {
@@ -187,7 +187,7 @@ void RequestVettingStation::launchInstallPresets()
     if (sharedSettings.getUri().empty())
         return;
 
-    std::string configId = sharedSettings.getConfigId();
+    const std::string& configId = sharedSettings.getConfigId();
 
     auto finishedCallback = [selfWeak = weak_from_this(), this, configId](bool success)
     {


### PR DESCRIPTION
- **wsd: safer DocumentBroker::dumpState()**
- **wsd: remove const to allow for moving**
- **wsd: avoid copying where unnecessary**
- **wsd: comment that we force terminating edit with bgsv**
