### PR TITLE
Don't share ownership of Socket with RequestVettingStation

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -528,7 +528,6 @@ private:
 class SocketThreadOwnerChange
 {
 private:
-    friend class DocumentBroker; // TODO: remove this case?
     friend class SocketDisposition;
     friend class SocketPoll;
 

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -76,7 +76,7 @@ class SocketPoll;
 /// between polls to clarify thread ownership.
 class SocketDisposition final
 {
-    STATE_ENUM(Type, CONTINUE, CLOSED, MOVE, TRANSFER);
+    STATE_ENUM(Type, CONTINUE, CLOSED, TRANSFER);
 
 public:
     typedef std::function<void(const std::shared_ptr<Socket> &)> MoveFunction;
@@ -89,12 +89,6 @@ public:
     ~SocketDisposition()
     {
         assert (!_socketMove);
-    }
-    // not the method you want.
-    void setMove(MoveFunction moveFn)
-    {
-        _socketMove = std::move(moveFn);
-        _disposition = Type::MOVE;
     }
     /** move, correctly change ownership of and insert into a new poll.
      * @transferFn is called as a callback inside the new poll, which
@@ -115,7 +109,6 @@ public:
     {
         return _socket;
     }
-    bool isMove() const { return _disposition == Type::MOVE; }
     bool isClosed() const { return _disposition == Type::CLOSED; }
     bool isTransfer() const { return  _disposition == Type::TRANSFER; }
     bool isContinue() const { return _disposition == Type::CONTINUE; }
@@ -1683,7 +1676,7 @@ public:
                 disposition.setClosed();
             }
 
-            if (disposition.isMove() || disposition.isTransfer())
+            if (disposition.isTransfer())
                 return;
         }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -265,19 +265,10 @@ void DocumentBroker::setupTransfer(SocketDisposition &disposition,
     disposition.setTransfer(*_poll, std::move(transferFn));
 }
 
-void DocumentBroker::setupTransfer(const std::shared_ptr<StreamSocket>& socket,
+void DocumentBroker::setupTransfer(SocketPoll& from, const std::weak_ptr<StreamSocket>& socket,
                                    const SocketDisposition::MoveFunction& transferFn)
 {
-    // Drop pretentions of ownership before _socketMove.
-    SocketThreadOwnerChange::resetThreadOwner(*socket);
-
-    _poll->startThread();
-    _poll->addCallback(
-        [this, socket, transferFn]()
-        {
-            _poll->insertNewSocket(socket);
-            transferFn(socket);
-        });
+    from.transferSocketTo(socket, getPoll(), transferFn);
 }
 
 static std::chrono::seconds getLimitLoadSecs()

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -257,7 +257,7 @@ public:
                        SocketDisposition::MoveFunction transferFn);
 
     /// setup the transfer of a socket into this DocumentBroker poll.
-    void setupTransfer(const std::shared_ptr<StreamSocket>& socket,
+    void setupTransfer(SocketPoll& from, const std::weak_ptr<StreamSocket>& socket,
                        const SocketDisposition::MoveFunction& transferFn);
 
     /// Flag for termination. Note that this doesn't save any unsaved changes in the document

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -84,7 +84,7 @@ private:
 
     void createClientSession(const std::shared_ptr<DocumentBroker>& docBroker,
                              const std::string& docKey, const std::string& url,
-                             const Poco::URI& uriPublic, bool isReadOnly);
+                             const Poco::URI& uriPublic);
 
     /// Send unauthorized error to the client and disconnect the socket.
     /// Includes SSL verification status, if available, as the error code.
@@ -97,7 +97,7 @@ private:
 #if !MOBILEAPP
     void launchInstallPresets();
 
-    void checkFileInfo(const Poco::URI& uri, bool isReadOnly, int redirectionLimit);
+    void checkFileInfo(const Poco::URI& uri, int redirectionLimit);
     std::shared_ptr<CheckFileInfo> _checkFileInfo;
     std::shared_ptr<PresetsInstallTask> _asyncInstallTask;
 #endif // !MOBILEAPP

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -48,14 +48,15 @@ public:
         : _requestDetails(requestDetails)
         , _poll(poll)
         , _mobileAppDocId(0)
+        , _logContextFD(-1)
     {
     }
 
     inline void logPrefix(std::ostream& os) const
     {
-        if (_socket)
+        if (_logContextFD > -1)
         {
-            os << '#' << _socket->getFD() << ": ";
+            os << '#' << _logContextFD << ": ";
         }
     }
 
@@ -114,9 +115,10 @@ private:
     std::string _id;
     std::shared_ptr<TerminatingPoll> _poll;
     std::shared_ptr<WebSocketHandler> _ws;
-    std::shared_ptr<StreamSocket> _socket;
+    std::weak_ptr<StreamSocket> _socket;
     Util::Stopwatch _birthday;
     unsigned _mobileAppDocId;
+    int _logContextFD;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -68,6 +68,14 @@ public:
                        const std::shared_ptr<StreamSocket>& socket, unsigned mobileAppDocId,
                        SocketDisposition& disposition);
 
+#if !MOBILEAPP
+    /// Attempt to create a DocBroker and setup a transfer via disposition
+    /// of disposition's Socket to the DocBrokers SocketPoll
+    void transferToDocBroker(const std::string& url,
+                             const std::string& configId,
+                             const std::string& sslVerifyResult);
+#endif
+
     /// Returns true iff we are older than the given age.
     template <typename T>
     bool aged(T minAge,


### PR DESCRIPTION
Reorganize so that the SocketPoll remains in the sole ownership of its current SocketPoll until it can be transferred to ownership of the DocumentBroker SocketPoll.

With parallel CheckFileInfo it might not be possible to create the DocumentBroker, and transfer ownership of the Socket to its poll, at the ideal ClientRequestDispatcher::handleClientWsUpgrade opportunity.

If so, wait until the CheckFileInfo results are available before creating the DocumentBroker and doing the Socket transfer to its SocketPoll.

Add a method to ProtocolHandlerInterface (similar to checkTimeout) to enable a ProtocolHandler to trigger a transfer of Socket via the usual SocketDisposition mechanism, which ClientRequestDispatcher can use to execute the transfer in the delayed CheckFileInfo result case.


Change-Id: I863b92c1df4bb74a17d7f4a51db393c67838dd15


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

