### PR TITLE
TreeView: Add check for tooltip text before setting attribute

### DIFF
--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -539,7 +539,7 @@ class TreeViewControl {
 		// regular columns
 		for (const index in entry.columns) {
 			td = L.DomUtil.create('div', '', tr);
-			td.setAttribute('data-cooltip', entry.text);
+			if (entry.text) td.setAttribute('data-cooltip', entry.text);
 			L.control.attachTooltipEventListener(td, builder.map);
 			rowElements.push(td);
 


### PR DESCRIPTION
Change-Id: Ib89dd448bf583bff4fb385e10c0eae51eed0ce96

Prevent setting a tooltip attribute if there is no text available, which was producing an "Undefined" tooltip in some scenarios (e.g., formula suggestions).

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

