### PR TITLE
add a WaitLoad phase to this test

### DIFF
--- a/test/UnitWOPIHttpRedirect.cpp
+++ b/test/UnitWOPIHttpRedirect.cpp
@@ -24,7 +24,7 @@
 
 class UnitWopiHttpRedirect : public WopiTestServer
 {
-    STATE_ENUM(Phase, Load, Redirected, GetFile, Redirected2, Done) _phase;
+    STATE_ENUM(Phase, Load, WaitLoad, Redirected, GetFile, Redirected2, Done) _phase;
 
     const std::string params = "access_token=anything";
 
@@ -56,7 +56,7 @@ public:
 
             assertCheckFileInfoRequest(request);
 
-            LOK_ASSERT_STATE(_phase, Phase::Load);
+            LOK_ASSERT_STATE(_phase, Phase::WaitLoad);
             TRANSITION_STATE(_phase, Phase::Redirected);
 
             http::Response httpResponse(http::StatusCode::Found);
@@ -137,12 +137,15 @@ public:
         {
             case Phase::Load:
             {
+                TRANSITION_STATE(_phase, Phase::WaitLoad);
+
                 initWebsocket("/wopi/files/1?" + params);
 
                 WSD_CMD("load url=" + getWopiSrc());
 
                 break;
             }
+            case Phase::WaitLoad:
             case Phase::Redirected:
             case Phase::Redirected2:
             case Phase::GetFile:


### PR DESCRIPTION
so we don't call initWebsocket multiple times once the first is launched.

Signed-off-by: Caolán McNamara <caolan.mcnamara@collabora.com>
Change-Id: I2418cdb660b3cd46ec3d09cbc777387f84b0e674 (cherry picked from commit 78a6e3c873a98d6a9e0081634f600d4014d57809)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

