### PR TITLE
add a new focus cycle to jump to the current tab

### DIFF
--- a/browser/src/control/jsdialog/Util.FocusCycle.js
+++ b/browser/src/control/jsdialog/Util.FocusCycle.js
@@ -36,16 +36,12 @@ function getFocusableElements(container) {
 	if (!container)
 		return null;
 
-	var ret = container.querySelectorAll('[tabIndex="0"]:not(.jsdialog-begin-marker, .jsdialog-end-marker):not([disabled]):not(.hidden)');
-	if (!ret.length)
-		ret = container.querySelectorAll('input:not([disabled]):not(.hidden)');
-	if (!ret.length)
-		ret = container.querySelectorAll('textarea:not([disabled]):not(.hidden)');
-	if (!ret.length)
-		ret = container.querySelectorAll('select:not([disabled]):not(.hidden)');
-	if (!ret.length)
-		ret = container.querySelectorAll('button:not([disabled]):not(.hidden)');
-	return ret;
+	return container.querySelectorAll('input:not([disabled]):not(.hidden),' +
+                                          'textarea:not([disabled]):not(.hidden),' +
+                                          'select:not([disabled]):not(.hidden),' +
+                                          'button:not([disabled]):not(.hidden),' +
+                                          '[tabIndex="0"]:not(.jsdialog-begin-marker,' +
+                                          '.jsdialog-end-marker, .ui-grid-cell):not([disabled]):not(.hidden)');
 }
 
 // Utility function to check if an element is focusable


### PR DESCRIPTION
- **browser: accessibility: add a getter function 'getTabsContainer'**
- **browser: accessibility: avoid setting the tabindex property for the arrow button.**
- **browser: accessibility: force the img element in the icon view to be focusable**
- **browser: accessibility: Add the parameter 'customFocusFunc' to the focus cycle utility**
- **browser: accessibility: avoid setting the tabindex property for the combobox button.**
- **browser: accessibility: Add tabindex='0' to the tabs container to make it currently focusable.**
- **browser: accessibility: fix the focus cycle for the first element.**
- **browser: accessibility: add a new focus cycle to jump to the current tab.**
