### PR TITLE
private/vmiklos/master

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -53,6 +53,10 @@ QUIET_CMP = $(QUIET_CMP_$(V))
 QUIET_CMP_ = $(QUIET_CMP_$(AM_DEFAULT_VERBOSITY))
 QUIET_CMP_0 = @echo "  CMP     " $@;
 
+QUIET_JSCPCD = $(QUIET_JSCPCD_$(V))
+QUIET_JSCPCD_ = $(QUIET_JSCPCD_$(AM_DEFAULT_VERBOSITY))
+QUIET_JSCPCD_0 = @echo "  JSCPCD  " $@;
+
 MOCHA_DIR = $(srcdir)/mocha_tests
 MOCHA_JS_DIR = $(MOCHA_DIR)/workdir
 MOCHA_TS_FILES = $(wildcard $(MOCHA_DIR)/*.ts)
@@ -1122,9 +1126,8 @@ check-local: $(MOCHA_TS_JS_FILES)
 		exit 1; \
 	fi
 
-	@echo "Checking code duplication..."
 	@echo > ${DUPLICATION_TEST_LOG}
-	@if npm run duplication 2> ${DUPLICATION_TEST_LOG} 1>&2; then \
+	$(QUIET_JSCPCD) if npm run duplication 2> ${DUPLICATION_TEST_LOG} 1>&2; then \
 		echo "Code duplication tests finished successfully."; \
 	else \
 		cat ${DUPLICATION_TEST_LOG}; \

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -407,8 +407,12 @@ L.Control.Notebookbar = L.Control.extend({
 		}
 	},
 
-	shouldIgnoreContextChange(contextes) {
-		const ignored = [['NotesPage', 'DrawPage'], ['DrawPage', 'NotesPage']];
+	shouldIgnoreContextChange(contextes, appId) {
+		// New -> old context name pairs.
+		let ignored = [['NotesPage', 'DrawPage'], ['DrawPage', 'NotesPage']];
+		if (appId === 'com.sun.star.text.TextDocument') {
+			ignored.push(['Text', '']);
+		}
 
 		for (let i = 0; i < ignored.length; i++) {
 			if (contextes[0] === ignored[i][0] && contextes[1] === ignored[i][1])
@@ -550,7 +554,7 @@ L.Control.Notebookbar = L.Control.extend({
 		if (detail.context === detail.oldContext)
 			return;
 
-		if (this.shouldIgnoreContextChange([detail.context, detail.oldContext]))
+		if (this.shouldIgnoreContextChange([detail.context, detail.oldContext], detail.appId))
 			return;
 
 		this.updateTabsVisibilityForContext(detail.context);

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -407,7 +407,7 @@ L.Control.Notebookbar = L.Control.extend({
 		}
 	},
 
-	shouldIgnoreContextChange(contextes, appId) {
+	shouldIgnoreContextChange(contexts, appId) {
 		// New -> old context name pairs.
 		let ignored = [['NotesPage', 'DrawPage'], ['DrawPage', 'NotesPage']];
 		if (appId === 'com.sun.star.text.TextDocument') {
@@ -415,7 +415,7 @@ L.Control.Notebookbar = L.Control.extend({
 		}
 
 		for (let i = 0; i < ignored.length; i++) {
-			if (contextes[0] === ignored[i][0] && contextes[1] === ignored[i][1])
+			if (contexts[0] === ignored[i][0] && contexts[1] === ignored[i][1])
 				return true;
 		}
 

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -483,8 +483,13 @@ L.Control.Notebookbar = L.Control.extend({
 		var contextTab = null;
 		var defaultTab = null;
 		let alreadySelected = null;
+		// Currently selected tab name, part of the element's ID.
+		let currentlySelectedTabName = null;
 		for (var tab in tabs) {
 			var tabElement = $('#' + tabs[tab].name + '-tab-label');
+			if (tabElement.hasClass('selected')) {
+				currentlySelectedTabName = tabs[tab].name;
+			}
 			if (tabs[tab].context) {
 				tabElement.hide();
 				var contexts = tabs[tab].context.split('|');
@@ -521,7 +526,13 @@ L.Control.Notebookbar = L.Control.extend({
 		}
 
 		if (contextTab) {
-			contextTab.click();
+			// Switch to the tab of the context, unless we currently show the review tab
+			// for text documents, where jumping to the next change would possibly
+			// switch to the Home or Table tabs, which is not wanted.
+			var docType = this._map.getDocType();
+			if (docType !== 'text' || currentlySelectedTabName !== 'Review') {
+				contextTab.click();
+			}
 			const tabId = contextTab.attr('id');
 			this.updateButtonVisibilityForContext(requestedContext, tabId);
 			return tabId;

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -522,7 +522,7 @@ L.Control.Notebookbar = L.Control.extend({
 		if (alreadySelected) {
 			const tabId = alreadySelected.attr('id');
 			this.updateButtonVisibilityForContext(requestedContext, tabId);
-			return tabId;
+			return;
 		}
 
 		if (contextTab) {
@@ -535,14 +535,14 @@ L.Control.Notebookbar = L.Control.extend({
 			}
 			const tabId = contextTab.attr('id');
 			this.updateButtonVisibilityForContext(requestedContext, tabId);
-			return tabId;
+			return;
 		}
 
 		if (defaultTab) {
 			defaultTab.click();
 			const tabId = defaultTab.attr('id');
 			this.updateButtonVisibilityForContext(requestedContext, tabId);
-			return tabId;
+			return;
 		}
 	},
 


### PR DESCRIPTION
- **automake silent rules: handle jscpcd**
- **cool#11617 browser, notebookbar: ignore '' -> Text context transition for text documents**
- **cool#11617 browser, notebookbar: don't automatically switch from Review for text documents**
- **browser, notebookbar: fix 'contextes' typo**
- **browser, notebookbar: updateTabsVisibilityForContext() return value is unused**
