### PR TITLE
cool#11649 - avoid triggering re-draws on key-press with split-panes.

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4265,13 +4265,14 @@ L.CanvasTileLayer = L.Layer.extend({
 					+ ' splitx=' + Math.round(splitPos.x)
 					+ ' splity=' + Math.round(splitPos.y);
 
-		if (this._ySplitter) {
-			this._ySplitter.onPositionChange();
-		}
-		if (this._xSplitter) {
-			this._xSplitter.onPositionChange();
-		}
 		if (this._clientVisibleArea !== newClientVisibleArea || forceUpdate) {
+			// Only update on some change
+			if (this._ySplitter) {
+				this._ySplitter.onPositionChange();
+			}
+			if (this._xSplitter) {
+				this._xSplitter.onPositionChange();
+			}
 			// Visible area is dirty, update it on the server
 			app.socket.sendMessage(newClientVisibleArea);
 			if (!this._map._fatal && app.idleHandler._active && app.socket.connected())


### PR DESCRIPTION
Arrow-down in a spreadsheet with split-panes is now smooth not jerky for me at least.


Change-Id: If9662826a959476564740251a5dac40e9e2d47a7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

