### PR TITLE
hold weak_ptr of StreamSocket in RenderSearchResultBroker

### DIFF
--- a/wsd/SpecialBrokers.cpp
+++ b/wsd/SpecialBrokers.cpp
@@ -319,7 +319,12 @@ bool RenderSearchResultBroker::handleInput(const std::shared_ptr<Message>& messa
                 httpResponse.setBody(std::string(_responseData.data(), _responseData.size()),
                                      "image/png");
                 httpResponse.header().setConnectionToken(http::Header::ConnectionToken::Close);
-                _socket->sendAndShutdown(httpResponse);
+
+                std::shared_ptr<StreamSocket> socket(_socket.lock());
+                if (socket)
+                    socket->sendAndShutdown(httpResponse);
+                else
+                    LOG_ERR("Invalid socket while sending rendersearchresult response");
 
                 removeSession(_clientSession);
                 stop("Finished RenderSearchResult handler.");

--- a/wsd/SpecialBrokers.hpp
+++ b/wsd/SpecialBrokers.hpp
@@ -161,7 +161,7 @@ class RenderSearchResultBroker final : public StatelessBatchBroker
 {
     std::shared_ptr<std::vector<char>> _searchResultContent;
     std::vector<char> _responseData;
-    std::shared_ptr<StreamSocket> _socket;
+    std::weak_ptr<StreamSocket> _socket;
 
 public:
     RenderSearchResultBroker(std::string const& uri, Poco::URI const& uriPublic,


### PR DESCRIPTION
this Socket belongs to the DocumentBroker poll.


Change-Id: I582d3a4c0659324cdb814f9b4cdf5d1d644013cd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

