### PR TITLE
Added toggle expander state with aria-expanded for a11y

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -714,9 +714,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 					L.DomUtil.addClass(label, 'hidden');
 				builder.postProcess(expander, data.children[0]);
 
-				if (data.children.length > 1 && expanded)
-					$(label).addClass('expanded');
-
 				var toggleFunction = function () {
 					if (customCallback)
 						customCallback();
@@ -724,6 +721,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 						builder.callback('expander', 'toggle', data, null, builder);
 					$(label).toggleClass('expanded');
 					$(expander).siblings().toggleClass('expanded');
+
+					// Toggle aria-expanded attribute
+					const currentState = expander.getAttribute('aria-expanded') === 'true';
+					expander.setAttribute('aria-expanded', (!currentState).toString());
 				};
 
 				$(expander).click(toggleFunction);
@@ -736,9 +737,17 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			}
 
 			var expanderChildren = L.DomUtil.create('div', 'ui-expander-content ' + builder.options.cssClass, container);
-
-			if (expanded)
-				$(expanderChildren).addClass('expanded');
+		
+			if (expanded) {
+				if (data.children.length > 1) {
+					label.classList.add('expanded');
+					expander.setAttribute('aria-expanded', 'true');
+				}
+				expanderChildren.classList.add('expanded');
+			}
+			else {
+				expander.setAttribute('aria-expanded', 'false');
+			}
 
 			var children = [];
 			var startPos = 1;


### PR DESCRIPTION
- Added aria-expanded attribute toggle to reflect expanded/collapsed state.
- Improves accessibility for keyboard and assistive tech users


Change-Id: I2ef563417c6f510c8c417880c45faa535a5068ad


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

