### PR TITLE
fix(clipboard/write): Defer fetching and checking

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -1286,7 +1286,7 @@ L.Clipboard = L.Class.extend({
 
 		if (window.mode.isMobile() || window.mode.isTablet()) {
 			const p = document.createElement('p');
-			p.textContent = _('Please use the paste buttons on your on-screen keyboard.');
+			p.textContent = _('Your browser has very limited access to the clipboard, so please use the paste buttons on your on-screen keyboard instead.');
 			innerDiv.appendChild(p);
 		}
 		else {


### PR DESCRIPTION
Previously we were awaiting some of our operations - e.g. the fetch or
the _check - before calling navigator.clipboard.write. This worked in
most places, but unfortunately iOS seems to fail when we do this.

While it wasn't possible to tell from debugging whether it was a small
delay that caused the clipboard write to fail or whether awaiting some
promises cause the failure in-and-of, deferring the promises into the
clipboard item fixes the issue on iOS.

Doing this requires a bit of promise juggling - in particular, we need
to reject if we have a check failure to avoid writing to the clipboard.
Doing this, however, will cause a generic failure that we previously
interpreted as a permission error. To bypass this, we can await the
clipboard items afterwards to see if they would have failed, and assume
a check failure if they would have.

Altogether, the code ends up more ugly but works on iOS web. Oh well.
