### PR TITLE
backport: cool#11649 - avoid triggering re-draws on key-press with split-panes.

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4978,13 +4978,14 @@ L.CanvasTileLayer = L.Layer.extend({
 					+ ' splitx=' + Math.round(splitPos.x)
 					+ ' splity=' + Math.round(splitPos.y);
 
-		if (this._ySplitter) {
-			this._ySplitter.onPositionChange();
-		}
-		if (this._xSplitter) {
-			this._xSplitter.onPositionChange();
-		}
 		if (this._clientVisibleArea !== newClientVisibleArea || forceUpdate) {
+			// Only update on some change
+			if (this._ySplitter) {
+				this._ySplitter.onPositionChange();
+			}
+			if (this._xSplitter) {
+				this._xSplitter.onPositionChange();
+			}
 			// Visible area is dirty, update it on the server
 			app.socket.sendMessage(newClientVisibleArea);
 			if (!this._map._fatal && app.idleHandler._active && app.socket.connected())


### PR DESCRIPTION
This is a trivial backport of #11650