### PR TITLE
wsd: support reaping zombies safely on SIGCHLD

### DIFF
--- a/common/SigUtil.cpp
+++ b/common/SigUtil.cpp
@@ -181,28 +181,33 @@ void requestShutdown()
         UnattendedRun = true;
     }
 
-    std::pair<int, int> reapZombieChild(int pid)
+    std::pair<int, int> reapZombieChild(int pid, bool sighandler)
     {
-        LOG_TRC("Reaping " << pid << " with (WUNTRACED | WNOHANG)");
+        if (!sighandler)
+            LOG_TRC("Reaping " << pid << " with (WUNTRACED | WNOHANG)");
 
         int status = 0;
         pid_t ret = 0;
         if ((ret = ::waitpid(pid, &status, WUNTRACED | WNOHANG)) > 0)
         {
-            LOG_DBG("Child " << ret << " terminated with status " << status);
+            if (!sighandler)
+                LOG_DBG("Child " << ret << " terminated with status " << status);
+
             if (WIFSIGNALED(status) && (WTERMSIG(status) == SIGSEGV || WTERMSIG(status) == SIGBUS ||
                                         WTERMSIG(status) == SIGABRT))
             {
-                LOG_WRN("Zombie child " << ret << " has exited due to "
-                                        << signalName(WTERMSIG(status)));
+                if (!sighandler)
+                    LOG_WRN("Zombie child " << ret << " has exited due to "
+                                            << signalName(WTERMSIG(status)));
                 return std::make_pair(ret, WTERMSIG(status));
             }
         }
         else if (pid > 0 && errno != 0) // Don't complain if the process is reaped already.
         {
             // Log errno if we had a child pid we expected to reap.
-            LOG_WRN("Failed to reap child process " << pid << " (" << Util::symbolicErrno(errno)
-                                                    << ": " << std::strerror(errno) << ')');
+            if (!sighandler)
+                LOG_WRN("Failed to reap child process " << pid << " (" << Util::symbolicErrno(errno)
+                                                        << ": " << std::strerror(errno) << ')');
         }
 
         return std::make_pair(ret, 0);

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -73,7 +73,9 @@ namespace SigUtil
     /// Reap one or more children.
     /// Returns a pair of the return value of waitpid(2)
     /// and WTERMSIG(stat_loc), if it were SEGV, ABRT, or BUS.
-    std::pair<int, int> reapZombieChild(int pid);
+    /// @sighandler is true if we are invoked from a signal handler.
+    /// This is needed to comply with signal handler requirements.
+    std::pair<int, int> reapZombieChild(int pid, bool sighandler);
 
     /// Uninitialize and free memory.
     void uninitialize();

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1604,7 +1604,7 @@ void Document::reapZombieChildren()
     /// Here, we reap any zombies that might exist--at most 1.
     for (;;)
     {
-        const auto [ret, sig] = SigUtil::reapZombieChild(-1);
+        const auto [ret, sig] = SigUtil::reapZombieChild(-1, /*sighandler=*/false);
         if (ret <= 0)
         {
             break;
@@ -3180,7 +3180,7 @@ extern "C"
     static void sigChildHandler(int pid)
     {
         // Reap the child; will log failures.
-        SigUtil::reapZombieChild(pid);
+        SigUtil::reapZombieChild(pid, /*sighandler=*/true);
     }
 }
 

--- a/kit/KitWebSocket.cpp
+++ b/kit/KitWebSocket.cpp
@@ -333,7 +333,7 @@ void BgSaveParentWebSocketHandler::onDisconnect()
     LOG_TRC("Disconnected background web socket to child " << _childPid);
 
     // reap and de-zombify children.
-    const auto [ret, sig] = SigUtil::reapZombieChild(_childPid);
+    const auto [ret, sig] = SigUtil::reapZombieChild(_childPid, /*sighandler=*/false);
     if (sig)
         reportFailedSave(std::string("crashed with status ") + SigUtil::signalName(sig));
     else if (ret <= 0)


### PR DESCRIPTION
Memory operations are not safe from
signal handlers as they can lead to
dead-locks. The zombie reaping logs
and to generate log entries, strings
are created, which allocate.

This has indeed been observed:
 #0  0x00007f6415ca187c in __lll_lock_wait_private () from /lib64/libc.so.6
 https://github.com/CollaboraOnline/online/pull/1  0x00007f6415c1dba2 in _L_lock_16654 () from /lib64/libc.so.6
 https://github.com/CollaboraOnline/online/pull/2  0x00007f6415c1a7e3 in malloc () from /lib64/libc.so.6
 ...
 https://github.com/CollaboraOnline/online/pull/7  0x0000000000729727 in std::string::_S_construct<char const*> (__beg=__beg@entry=0x7ffdf02654b0 "kit-43991-43991 2025-04-14 12:50:32.942788 +0000 [ kitbroker_003 ] TRC  ", __end=<optimized out>, __a=...) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/cow_string.h:3096
 https://github.com/CollaboraOnline/online/pull/8  0x000000000072c3e0 in SigUtil::reapZombieChild (pid=44021) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/basic_ios.h:282
 https://github.com/CollaboraOnline/online/pull/9  <signal handler called>
 https://github.com/CollaboraOnline/online/pull/10 0x00007f6415c177c2 in _int_malloc () from /lib64/libc.so.6
 https://github.com/CollaboraOnline/online/pull/11 0x00007f6415c1a78c in malloc () from /lib64/libc.so.6