### PR TITLE
De-Duplicate Lock Result Handling

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1902,13 +1902,13 @@ void ClientSession::sendFileMode(const bool readOnly, const bool editComments)
     sendTextFrame(result);
 }
 
-void ClientSession::setLockFailed(const std::string& sReason)
+void ClientSession::setLockFailed(const std::string& reason)
 {
     // TODO: make this "read-only" a special one with a notification (infobar? balloon tip?)
     //       and a button to unlock
     _isLockFailed = true;
     setReadOnly(true);
-    sendTextFrame("lockfailed:" + sReason);
+    sendTextFrame("lockfailed:" + reason);
 }
 
 bool ClientSession::attemptLock(const std::shared_ptr<DocumentBroker>& docBroker)

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -42,7 +42,7 @@ public:
 
     void sendFileMode(bool readOnly, bool editComments);
 
-    void setLockFailed(const std::string& sReason);
+    void setLockFailed(const std::string& reason);
 
     STATE_ENUM(SessionState,
                DETACHED, // initial

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -647,7 +647,8 @@ private:
                                      StorageBase::LockState lock, std::string& error);
 
     /// Handle the Un/Lock request result.
-    void handleLockResult(ClientSession& session, const StorageBase::LockUpdateResult& result);
+    /// Returns false on failure/unauthorized.
+    bool handleLockResult(ClientSession& session, const StorageBase::LockUpdateResult& result);
 
     std::size_t getIdleTimeSecs() const
     {

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -646,6 +646,9 @@ private:
     bool updateStorageLockStateAsync(const std::shared_ptr<ClientSession>& session,
                                      StorageBase::LockState lock, std::string& error);
 
+    /// Handle the Un/Lock request result.
+    void handleLockResult(ClientSession& session, const StorageBase::LockUpdateResult& result);
+
     std::size_t getIdleTimeSecs() const
     {
         const auto duration = (std::chrono::steady_clock::now() - _lastActivityTime);


### PR DESCRIPTION
Non-functional changes to de-duplicate Lock result handling and unify sync and async paths, with some logging improvements.

The commits try to minimize the diffs to make reviewing easier.

- **wsd: make updateStorageLockState similar to the async version**
- **wsd: extract handleLockResult**
- **wsd: deduplicate lock result handling**
- **wsd: no Hungarian notation**
