### PR TITLE
wsd: reduce clipboard-cache expiry check frequency

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3838,7 +3838,7 @@ int COOLWSD::innerMain()
         }
 
 #if !MOBILEAPP
-        SavedClipboards->checkexpiry();
+        SavedClipboards->checkexpiry(timeNow);
 
         const std::chrono::milliseconds durationFetch
             = std::chrono::duration_cast<std::chrono::milliseconds>(timeNow - stampFetch);


### PR DESCRIPTION
Entries in the clipboard cache expire in 10
minutes.
There is little point in taking a mutex and
checking every entry for expiry on each and
every poll.

We now check once every minute, which is more
than reasonable.

We also skip the check if the lock is taken,
which can happen if there is a concurrent
{insert,get}Clipboard().

Finally, we avoid an extra steady_clock::now()
and remove a string concatenation during logging.

Change-Id: I1a3c799ae9387dfdf54b65d48345a7a95d989251
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
