### PR TITLE
wsd: support reaping zombies safely on SIGCHLD

### DIFF
--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -73,7 +73,9 @@ namespace SigUtil
     /// Reap one or more children.
     /// Returns a pair of the return value of waitpid(2)
     /// and WTERMSIG(stat_loc), if it were SEGV, ABRT, or BUS.
-    std::pair<int, int> reapZombieChild(int pid);
+    /// @sighandler is true if we are invoked from a signal handler.
+    /// This is needed to comply with signal handler requirements.
+    std::pair<int, int> reapZombieChild(int pid, bool sighandler);
 
 #if !MOBILEAPP
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1598,7 +1598,7 @@ void Document::reapZombieChildren()
     /// Here, we reap any zombies that might exist--at most 1.
     for (;;)
     {
-        const auto [ret, sig] = SigUtil::reapZombieChild(-1);
+        const auto [ret, sig] = SigUtil::reapZombieChild(-1, /*sighandler=*/false);
         if (ret <= 0)
         {
             break;
@@ -3158,7 +3158,7 @@ extern "C"
     static void sigChildHandler(int pid)
     {
         // Reap the child; will log failures.
-        SigUtil::reapZombieChild(pid);
+        SigUtil::reapZombieChild(pid, /*sighandler=*/true);
     }
 }
 

--- a/kit/KitWebSocket.cpp
+++ b/kit/KitWebSocket.cpp
@@ -332,7 +332,7 @@ void BgSaveParentWebSocketHandler::onDisconnect()
     LOG_TRC("Disconnected background web socket to child " << _childPid);
 
     // reap and de-zombify children.
-    const auto [ret, sig] = SigUtil::reapZombieChild(_childPid);
+    const auto [ret, sig] = SigUtil::reapZombieChild(_childPid, /*sighandler=*/false);
     if (sig)
         reportFailedSave(std::string("crashed with status ") + SigUtil::signalName(sig));
     else if (ret <= 0)


### PR DESCRIPTION
Memory operations are not safe from
signal handlers as they can lead to
dead-locks. The zombie reaping logs
and to generate log entries, strings
are created, which allocate.

This has indeed been observed:
 #0  0x00007f6415ca187c in __lll_lock_wait_private () from /lib64/libc.so.6
 #1  0x00007f6415c1dba2 in _L_lock_16654 () from /lib64/libc.so.6
 #2  0x00007f6415c1a7e3 in malloc () from /lib64/libc.so.6
 ...
 #7  0x0000000000729727 in std::string::_S_construct<char const*> (__beg=__beg@entry=0x7ffdf02654b0 "kit-43991-43991 2025-04-14 12:50:32.942788 +0000 [ kitbroker_003 ] TRC  ", __end=<optimized out>, __a=...) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/cow_string.h:3096
 #8  0x000000000072c3e0 in SigUtil::reapZombieChild (pid=44021) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/basic_ios.h:282
 #9  <signal handler called>
 #10 0x00007f6415c177c2 in _int_malloc () from /lib64/libc.so.6
 #11 0x00007f6415c1a78c in malloc () from /lib64/libc.so.6

Change-Id: Ia08b6892857088547864ed29e5cf74fb98847cf7
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
(cherry picked from commit 2e0f664e4be362e3cfa8572713310d621a245760)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

