### PR TITLE
dev-notes: fix markup in socket-ownership.md

### DIFF
--- a/dev-notes/socket-ownership.md
+++ b/dev-notes/socket-ownership.md
@@ -1,31 +1,31 @@
 ## Socket Ownership
 
-Generally a Socket belongs to a SocketPoll which holds it by shared_ptr via
-_pollSockets.
+Generally a Socket belongs to a SocketPoll which holds it by `shared_ptr` via
+`_pollSockets`.
 
 A SocketPoll drops ownership of a Socket if:
 
 + SocketPoll::poll sees a Socket that reports isShutdown then SocketPoll
-  removes it from _pollSockets and the socket object is destroyed.
+  removes it from `_pollSockets` and the socket object is destroyed.
 + Socket::handlePoll sets its SocketDisposition argument to setClosed() which
   follow the same behaviour as above.
 + Socket::handlePoll uses the SocketDisposition argument to setup transferring
   ownership of the Socket to something else. The preferred approach being via
   SocketDisposition::setTransfer to transfer ownership to another SocketPoll.
 
-The expection is that with Sockets owned by a SocketPoll then long-lived
-references to Sockets elsewhere are held by weak_ptr.
+The expectation is that with Sockets owned by a SocketPoll then long-lived
+references to Sockets elsewhere are held by `weak_ptr`.
 
 ## Socket Handlers
 
-Sockets have SocketHandler's which the Socket hold by shared_ptr.
+Sockets have SocketHandler's which the Socket hold by `shared_ptr`.
 SocketHandlers derive from ProtocolHandlerInterface. If a SocketHandler
 requires a reference back to the Socket it is handling then holding that by
-shared_ptr creates a circular dependency problem, so typically a weak_ptr is
+`shared_ptr` creates a circular dependency problem, so typically a `weak_ptr` is
 expected.
 
 ## SocketPoll
 
 SocketPolls should have a single obvious owner. A SocketPoll should only be
-created as owned by shared_ptr (enforced by clang-plugin) and additional
-long-lived references to it held via weak_ptr.
+created as owned by `shared_ptr` (enforced by clang-plugin) and additional
+long-lived references to it held via `weak_ptr`.


### PR DESCRIPTION
A pair of underscores results in italics, unpaired underline is a syntax
error, so quite all of those using backticks. Also fix a typo.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: If2f1927d35b2803fc95a85744227703191defa5e
