### PR TITLE
Fix download progress after async JSDialog

### DIFF
--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -68,7 +68,9 @@ L.Control.DownloadProgress = L.Control.extend({
 			this._map.uiManager.showInfoModal(modalId, this._getDialogTitle(), msg, '',
 				buttonText, this._onStartDownload.bind(this), true, modalId + '-response');
 
-			this.setupKeyboardShortcutForDialog(modalId);
+			app.layoutingService.appendLayoutingTask(() => {
+				this.setupKeyboardShortcutForDialog(modalId);
+			});
 		}
 	},
 


### PR DESCRIPTION
had error:
```
Uncaught TypeError: Cannot read properties of null (reading 'focus')
    at NewClass.setupKeyboardShortcutForDialog (Control.DownloadProgress.js:151:36)
    at NewClass._showLargeCopyPasteWarning (Control.DownloadProgress.js:71:9)
    at NewClass.show (Control.DownloadProgress.js:174:9)
    at NewClass._startProgress (Clipboard.js:1230:26)
    at NewClass._onDownloadOnLargeCopyPaste (Clipboard.js:1239:9)
    at NewClass._getHtmlForClipboard (Clipboard.js:535:10)
    at NewClass.populateClipboard (Clipboard.js:552:19)
    at NewClass._doCopyCut (Clipboard.js:1111:10)
    at NewClass.copy (Clipboard.js:1142:35)
    at document.oncopy (Clipboard.js:82:49)
```