### PR TITLE
feat(impress): Pause videos when presenting

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -612,6 +612,14 @@ class SlideShowPresenter {
 			return false;
 		}
 
+		// if we're playing a video, it'll continue *under* the presentation if we aren't careful
+		// that's not a problem for visuals, but the audio of the video will also play
+		// we don't currently need to do this for <audio> elements, since as we just use <video> tags for that anyway
+		const videos = document.getElementsByTagName('video');
+		for (const video of Array.from(videos)) {
+			video.pause();
+		}
+
 		if (!this._map['wopi'].DownloadAsPostMessage) {
 			if (inWindow) {
 				this._doInWindowPresentation();


### PR DESCRIPTION
Previously we would let videos run underneath a presentation, causing audio from the video to mangle any presentation audio.


Change-Id: I50c86b9fa68cd8ad5774eacf4df0b0fbdf0ab3d5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

