### PR TITLE
Idle popup shouldn't have titlebar

### DIFF
--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1599,7 +1599,7 @@ class UIManager extends L.Control {
 	/**
 	 * Constructs JSON for a modal dialog.
 	 * @param id - Base ID.
-	 * @param title - Dialog title.
+	 * @param title - Dialog title. No titlebar if missing.
 	 * @param cancellable - Whether the dialog is cancellable.
 	 * @param widgets - Array of widget configurations.
 	 * @param focusId - Optional focus element ID.
@@ -1607,7 +1607,7 @@ class UIManager extends L.Control {
 	 */
 	private _modalDialogJSON(
 		id: string,
-		title: string,
+		title: string | undefined,
 		cancellable: boolean,
 		widgets: any[],
 		focusId?: string,
@@ -1620,7 +1620,7 @@ class UIManager extends L.Control {
 			dialogid: id,
 			type: 'modalpopup',
 			title: title,
-			hasClose: true,
+			hasClose: title !== undefined,
 			hasOverlay: true,
 			cancellable: cancellable,
 			jsontype: 'dialog',
@@ -1649,7 +1649,7 @@ class UIManager extends L.Control {
 	/// withCancel - specifies if needs cancel button also
 	showInfoModal(
 		id: string,
-		title: string,
+		title: string | undefined,
 		message1: string,
 		message2: string,
 		buttonText: string,


### PR DESCRIPTION
Fixes regression from commit 1c3e2bffbfa059a0bf2732bdfa182c4b36aa7a68 jsdialog: allow no titlebar for formula usage popup

Before:
![popup](https://github.com/user-attachments/assets/292e3373-1ad2-4864-a39e-210ceea0d049)
