### PR TITLE
jsdialog: fade in dialogs

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1826,8 +1826,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	.fadeout {
 		animation: fade 0.7s;
 	}
-
-	.jsdialog-overlay {
+	.fadein {
+		animation: fade reverse 0.15s;
+	}
+	.fsdialog-overlay {
 		animation: fade reverse .3s;
 	}
 }

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -774,10 +774,12 @@ L.Control.JSDialog = L.Control.extend({
 			app.layoutingService.appendLayoutingTask(() => {
 				// dialog built - add to DOM now
 				const existingNode = dialogDomParent.querySelector('[id="' + instance.container.id + '"]');
-				if (existingNode)
+				if (existingNode) {
 					existingNode.replaceWith(instance.container);
-				else
+				} else {
+					instance.container.classList.add('fadein');
 					dialogDomParent.append(instance.container);
+				}
 
 				// do in task to apply correct focus when already shown
 				this.addHandlers(instance);

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -748,11 +748,12 @@ L.Control.JSDialog = L.Control.extend({
 			if (instance.isModalPopUp || instance.isDocumentAreaPopup)
 				this.getOrCreateOverlay(instance);
 
-			if (this.dialogs[instance.id]) {
-				instance.posx = this.dialogs[instance.id].startX;
-				instance.posy = this.dialogs[instance.id].startY;
-				var toRemove = this.dialogs[instance.id].container;
-				L.DomUtil.remove(toRemove);
+			// Sometimes we get another full update for the same dialog
+			const existingNode = this.dialogs[instance.id];
+
+			if (existingNode) {
+				instance.posx = existingNode.startX;
+				instance.posy = existingNode.startY;
 			}
 
 			// We show some dialogs such as Macro Security Warning Dialog and Text Import Dialog (csv)
@@ -773,9 +774,8 @@ L.Control.JSDialog = L.Control.extend({
 
 			app.layoutingService.appendLayoutingTask(() => {
 				// dialog built - add to DOM now
-				const existingNode = dialogDomParent.querySelector('[id="' + instance.container.id + '"]');
 				if (existingNode) {
-					existingNode.replaceWith(instance.container);
+					existingNode.container.replaceWith(instance.container);
 				} else {
 					instance.container.classList.add('fadein');
 					dialogDomParent.append(instance.container);

--- a/cypress_test/integration_tests/desktop/writer/jsdialog_widgets_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/jsdialog_widgets_spec.js
@@ -13,6 +13,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'JSDialog widgets visual te
 			.should('not.be.empty')
 			.contains('#js-dialog a', 'View widgets')
 			.click();
+
+			cy.wait(500); // be sure we finished all animations
 	});
 
 	it('Combobox', function() {

--- a/cypress_test/integration_tests/desktop/writer/navigator_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/navigator_spec.js
@@ -24,7 +24,8 @@ describe(['tagdesktop'], 'Scroll through document, modify heading', function() {
 	it('Navigator visual test', function() {
 		cy.wait(500); // wait to make fully rendered
 		cy.cGet('#navigator-dock-wrapper').scrollTo(0,0,{ ensureScrollable: false });
-		cy.cGet('#navigator-dock-wrapper').compareSnapshot('navigator_writer', 0.06);
+		cy.wait(500); // wait for animations
+		cy.cGet('#navigator-dock-wrapper').compareSnapshot('navigator_writer', 0.065);
 	});
 
 	it('Jump to element. Navigator -> Document', function() {
@@ -34,8 +35,11 @@ describe(['tagdesktop'], 'Scroll through document, modify heading', function() {
 		expandSecion('Frames');
 		expandSecion('Images');
 
+		cy.wait(500);
+
 		//Scroll back to Top
 		cy.cGet('#navigator-dock-wrapper').scrollTo(0,0, { ensureScrollable: false });
+		cy.wait(500);
 
 		// Doubleclick several items, and check if the document is scrolled to the right page
 		cy.cGet('#contenttree').contains('.jsdialog.sidebar.ui-treeview-cell-text', 'Feedback').dblclick();


### PR DESCRIPTION
We have more animated elements now in the UI, this PR frinds fade-in effect for dialogs to make the appearing less "sharp". This especially matters for large dialogs which load embedded tabs later and do a blink. Thanks to animation it is not visible now.

Toghether with previous DOM layout sync in JSDialogs it reduces flicker and "moving elements" around the screen while loading dialogs and popups.