### PR TITLE
LayoutingService: flush with canvas frame

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -621,9 +621,18 @@ class CanvasSectionContainer {
 		}
 	}
 
+	private flushLayoutingTasks() {
+		const layoutingService = app.layoutingService;
+		if (layoutingService.hasTasksPending())
+			layoutingService.cancelFrame();
+
+		while (layoutingService.runTheTopTask());
+	}
+
 	private redrawCallback(timestamp: number) {
 		this.drawRequest = null;
 		this.drawSections();
+		this.flushLayoutingTasks();
 	}
 
 	public requestReDraw() {


### PR DESCRIPTION
related to https://github.com/CollaboraOnline/online/issues/11124

If we already do a canvas animation frame - process also other tasks we gathered (to the end) and cancel scheduled LayoutingService frame.

Merged this way as agreed with Gokay, thinking was:
1. canvas rerender may happen on document content change
2. layouting service may happen on document content change or just dialog change

so in case 2. we possibly don't need to rerender canvas, let's then just do the tasks from layouting service,
canvas will request frame if needed
