### PR TITLE
Log Improvements

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -184,6 +184,8 @@ namespace Log
         }
     };
 
+    void preFork() { flush(); }
+
     void postFork()
     {
         /// after forking we can end up with threads that

--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -217,6 +217,7 @@ namespace Log
             std::size_t size() const { return _size; }
             std::size_t available() const { return BufferSize - _size; }
 
+            /// Flush internal buffers, if any.
             inline void flush()
             {
                 if (_size)
@@ -297,6 +298,7 @@ namespace Log
 
         void close() override { flush(); }
 
+        /// Flush buffers, if any.
         static inline void flush() { _tlb.flush(); }
 
         void log(const Poco::Message& msg) override
@@ -796,15 +798,11 @@ namespace Log
         Poco::Logger::shutdown();
 
         flush();
+
+        ::fflush(nullptr); // Flush all open output streams.
     }
 
-    void flush()
-    {
-        BufferedConsoleChannel::flush();
-
-        fflush(stdout);
-        fflush(stderr);
-    }
+    void flush() { BufferedConsoleChannel::flush(); }
 
     void setThreadLocalLogLevel(const std::string& logLevel)
     {

--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -269,17 +269,10 @@ namespace Log
                 assert(_size <= BufferSize && "Buffer overflow");
             }
 
-        template <std::size_t N> inline void buffer(const char (&data)[N])
-        {
-            buffer(data, N - 1); // Minus the null.
-        }
-
-        inline void buffer(const std::string& string) { buffer(string.data(), string.size()); }
-
-    private:
-        char _buffer[BufferSize];
-        std::size_t _size;
-        std::int64_t _oldest_time_us; ///< The timestamp of the oldest buffered entry.
+        private:
+            char _buffer[BufferSize];
+            std::size_t _size;
+            std::int64_t _oldest_time_us; ///< The timestamp of the oldest buffered entry.
         };
 
     protected:
@@ -288,12 +281,7 @@ namespace Log
 
         inline void buffer(const char* data, std::size_t size) { _tlb.buffer(data, size); }
 
-        template <std::size_t N> inline void buffer(const char (&data)[N])
-        {
-            buffer(data, N - 1); // Minus the null.
-        }
-
-        inline void buffer(const std::string& string) { buffer(string.data(), string.size()); }
+        inline void buffer(const std::string_view string) { buffer(string.data(), string.size()); }
 
     public:
         ~BufferedConsoleChannel() { flush(); }

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -79,6 +79,9 @@ namespace Log
     /// Flush buffered console logs, if used.
     void flush();
 
+    /// Prepare for forking.
+    void preFork();
+
     /// Cleanup state after forking
     void postFork();
 

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -76,6 +76,7 @@ namespace Log
     /// Shutdown and release the logging system.
     void shutdown();
 
+    /// Flush buffered console logs, if used.
     void flush();
 
     /// Cleanup state after forking

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -459,6 +459,8 @@ static int forkKit(const std::function<void()> &childFunc,
     if (hasWatchDog)
         SocketPoll::PollWatchdog->joinThread();
 
+    Log::preFork();
+
     pid = fork();
     if (!pid)
     {

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1497,6 +1497,8 @@ bool Document::forkToSave(const std::function<void()> &childSave, int viewId)
     static size_t numSaves = 0;
     numSaves++;
 
+    Log::preFork();
+
     const pid_t pid = fork();
 
     if (!pid) // Child

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -556,18 +556,18 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS, bool justPoll)
     // First process the wakeup pipe (always the last entry).
     if (_pollFds[size].revents)
     {
-        LOGA_TRC(Socket, '#' << _pollFds[size].fd << ": Handling events of wakeup pipe: 0x" << std::hex
-                 << _pollFds[size].revents << std::dec);
+        LOGA_TRC(Socket, "Handling events of wakeup pipe (" << _pollFds[size].fd << "): 0x"
+                                                            << std::hex << _pollFds[size].revents
+                                                            << std::dec);
 
         // Clear the data.
-#if !MOBILEAPP
         int dump[32];
+#if !MOBILEAPP
         dump[0] = ::read(_wakeup[0], &dump, sizeof(dump));
-        LOGA_TRC(Socket, "Wakeup pipe read " << dump[0] << " bytes");
 #else
-        LOGA_TRC(Socket, "Wakeup pipe read");
-        int dump = fakeSocketRead(_wakeup[0], &dump, sizeof(dump));
+        dump[0] = fakeSocketRead(_wakeup[0], &dump, sizeof(dump));
 #endif
+        LOGA_TRC(Socket, "Wakeup pipe (" << _wakeup[0] << ") read " << dump[0] << " bytes");
 
         std::vector<CallbackFn> invoke;
         {
@@ -807,6 +807,9 @@ void SocketPoll::createWakeups()
     {
         throw std::runtime_error("Failed to allocate pipe for SocketPoll [" + _name + "] waking.");
     }
+
+    LOG_DBG("Created wakeup FDs for SocketPoll [" << _name << "], rfd: " << _wakeup[0]
+                                                  << ", wfd: " << _wakeup[1]);
 
     std::lock_guard<std::mutex> lock(getPollWakeupsMutex());
     getWakeupsArray().push_back(_wakeup[1]);

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1097,22 +1097,24 @@ void SocketPoll::dumpState(std::ostream& os) const
     // FIXME: NOT thread-safe! _pollSockets is modified from the polling thread!
     const std::vector<std::shared_ptr<Socket>> pollSockets = _pollSockets;
 
-    os << "\n  SocketPoll [" << name() << "] with " << pollSockets.size() << " socket"
-       << (pollSockets.size() == 1 ? "" : "s") << " - wakeup rfd: " << _wakeup[0]
+    os << "\n  SocketPoll [" << name() << "] with " << pollSockets.size() << " socket(s)" << " and "
+       << _newCallbacks.size() << " callback(s) - wakeup rfd: " << _wakeup[0]
        << " wfd: " << _wakeup[1] << '\n';
 
-    os << "\tcallbacks: " << _newCallbacks.size() << '\n';
-
-    os << "\t\tfd\tevents\tstatus\trbuffered\trcapacity\twbuffered\twcapacity\trtotal\twtotal\tclie"
-          "ntaddress\n";
-    std::size_t totalCapacity = 0;
-    for (const std::shared_ptr<Socket>& socket : pollSockets)
+    if (!pollSockets.empty())
     {
-        socket->dumpState(os);
-        totalCapacity += socket->totalBufferCapacity();
+        os << "\t\tfd\tevents\tstatus\trbuffered\trcapacity\twbuffered\twcapacity\trtotal\twtotal\t"
+              "clientaddress\n";
+        std::size_t totalCapacity = 0;
+        for (const std::shared_ptr<Socket>& socket : pollSockets)
+        {
+            socket->dumpState(os);
+            totalCapacity += socket->totalBufferCapacity();
+        }
+
+        os << "\n  Total socket buffer capacity: " << totalCapacity / 1024 << " KB\n";
     }
 
-    os << "\n  Total socket buffer capacity: " << totalCapacity / 1024 << " KB\n";
     os << "\n  Done SocketPoll [" << name() << "]\n";
     THREAD_UNSAFE_DUMP_END
 }

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -912,7 +912,7 @@ public:
         // There is a race when shutting down because
         // SocketPoll threads exit when shutting down.
         if (!isAlive() && !SigUtil::getShutdownRequestFlag())
-            LOG_WRN("Waking up dead poll thread ["
+            LOG_DBG("WARNING: Waking up dead poll thread ["
                     << _name << "], started: " << (_threadStarted ? "true" : "false")
                     << ", finished: " << _threadFinished);
 

--- a/test/UnitSaveTorture.cpp
+++ b/test/UnitSaveTorture.cpp
@@ -118,8 +118,8 @@ namespace {
         std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
         while (!SigUtil::getShutdownRequestFlag())
         {
-            if (std::chrono::duration_cast<std::chrono::seconds>(
-                    std::chrono::steady_clock::now() - start).count() > timeout.count())
+            if (std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() -
+                                                                 start) > timeout)
             {
                 LOK_ASSERT_FAIL("Timed out waiting for modified status change");
                 return false; // arbitrary but why not.

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -584,7 +584,8 @@ connectLOKit(const std::shared_ptr<SocketPoll>& socketPoll, const Poco::URI& uri
             auto ws = http::WebSocketSession::create(uri.toString());
 
             TST_LOG("Connection to " << uri.toString() << " is "
-                                     << (ws->secure() ? "secure" : "plain"));
+                                     << (ws->secure() ? "secure" : "plain")
+                                     << ", requesting: " << url);
 
             http::Request req(url);
             ws->asyncRequest(req, socketPoll);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1198,6 +1198,8 @@ void COOLWSD::setupChildRoot(const bool UseMountNamespaces)
     JailUtil::disableBindMounting(); // Default to assume failure
     JailUtil::disableMountNamespaces();
 
+    Log::preFork();
+
     pid_t pid = fork();
     if (!pid)
     {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1474,6 +1474,8 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
                 << LogLevel << "] until after WSD initialization.");
     }
 
+    Util::sleepFromEnvIfSet("Coolwsd", "SLEEPFORDEBUGGER");
+
     if (ConfigUtil::getConfigValue<bool>(conf, "browser_logging", false))
     {
         LogToken = Util::rng::getHexString(16);
@@ -1750,8 +1752,6 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
     std::ostringstream oss;
     KitXmlConfig->save(oss);
     setenv("COOL_CONFIG", oss.str().c_str(), true);
-
-    Util::sleepFromEnvIfSet("Coolwsd", "SLEEPFORDEBUGGER");
 
     // For some reason I can't get at this setting in ChildSession::loKitCallback().
     std::string fontsMissingHandling = ConfigUtil::getString("fonts_missing.handling", "log");


### PR DESCRIPTION
- **wsd: cleanup Socket::dumpState**
- **wsd: test: logging**
- **wsd: no point in warning for an unavoidable race**
- **wsd: test: cosmetic**
- **wsd: better logging of the wakeup FDs**
- **wsd: sleep-for-debugger much earlier**
- **wsd: better log flushing**
- **wsd: flush logs before forking**
- **wsd: simplify logging internals**
