### PR TITLE
feat(video): basic playback controls

### DIFF
--- a/browser/src/slideshow/LayerDrawing.ts
+++ b/browser/src/slideshow/LayerDrawing.ts
@@ -215,12 +215,12 @@ class LayerDrawing {
 		}
 	}
 
-	public playVideos(slideHash: string) {
+	public loadVideos(slideHash: string) {
 		const videoRenderers = this.videoRenderers.get(slideHash);
 		if (!videoRenderers) return;
 
 		for (const videoRenderer of videoRenderers) {
-			videoRenderer.playVideo();
+			videoRenderer.loadVideo();
 		}
 	}
 
@@ -230,6 +230,19 @@ class LayerDrawing {
 
 		for (const videoRenderer of videoRenderers) {
 			videoRenderer.pauseVideo();
+		}
+	}
+
+	public getVideoRenderer(
+		slideHash: string,
+		videoInfo: VideoInfo,
+	): VideoRenderer {
+		const videoRenderers = this.videoRenderers.get(slideHash);
+
+		for (const videoRenderer of videoRenderers) {
+			if (videoRenderer.videoInfoId === videoInfo.id) {
+				return videoRenderer;
+			}
 		}
 	}
 
@@ -746,7 +759,7 @@ class LayerDrawing {
 	public notifyTransitionEnd(slideHash: string) {
 		this.handleVideos(slideHash);
 		if (this.videoRenderers.has(slideHash)) {
-			this.playVideos(slideHash);
+			this.loadVideos(slideHash);
 		}
 	}
 }

--- a/browser/src/slideshow/LayersCompositor.ts
+++ b/browser/src/slideshow/LayersCompositor.ts
@@ -135,6 +135,13 @@ class LayersCompositor extends SlideCompositor {
 		return this.layerDrawing.getLayerRendererContext();
 	}
 
+	public getVideoRenderer(
+		slideHash: string,
+		videoInfo: VideoInfo,
+	): VideoRenderer {
+		return this.layerDrawing.getVideoRenderer(slideHash, videoInfo);
+	}
+
 	public getAnimatedSlide(slideIndex: number): ImageBitmap {
 		return this.layerDrawing.getAnimatedSlide(slideIndex);
 	}

--- a/browser/src/slideshow/SlideCompositor.ts
+++ b/browser/src/slideshow/SlideCompositor.ts
@@ -61,6 +61,11 @@ abstract class SlideCompositor {
 
 	public abstract getLayerRendererContext(): RenderContext;
 
+	public abstract getVideoRenderer(
+		slideHash: string,
+		videoInfo: VideoInfo,
+	): VideoRenderer;
+
 	public abstract deleteResources(): void;
 
 	public abstract pauseVideos(slideHash: string): void;

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -245,6 +245,13 @@ class SlideShowPresenter {
 		return info.notes;
 	}
 
+	public getVideoRenderer(
+		slideHash: string,
+		videoInfo: VideoInfo,
+	): VideoRenderer {
+		return this._slideCompositor.getVideoRenderer(slideHash, videoInfo);
+	}
+
 	_onFullScreenChange() {
 		this._fullscreen = document.fullscreenElement;
 		if (this._fullscreen) {

--- a/browser/src/slideshow/VideoRenderer.ts
+++ b/browser/src/slideshow/VideoRenderer.ts
@@ -49,6 +49,7 @@ abstract class VideoRenderer {
 	protected _context: RenderContext;
 	protected _slideRenderer: SlideRenderer;
 	protected videoRenderInfo: VideoRenderInfo;
+	public videoInfoId: number;
 
 	constructor(
 		sId: string,
@@ -69,6 +70,11 @@ abstract class VideoRenderer {
 		docWidth: number,
 		docHeight: number,
 	): void;
+
+	public loadVideo() {
+		if (!this.videoRenderInfo) return;
+		this.videoRenderInfo.videoElement.load();
+	}
 
 	public playVideo(reset: boolean = true) {
 		if (!this.videoRenderInfo) return;
@@ -159,6 +165,7 @@ class VideoRenderer2d extends VideoRenderer {
 			docHeight,
 		);
 		this.videoRenderInfo = video;
+		this.videoInfoId = videoInfo.id;
 	}
 
 	public render(): void {
@@ -255,6 +262,7 @@ class VideoRendererGl extends VideoRenderer {
 			),
 		);
 		this.videoRenderInfo = video;
+		this.videoInfoId = videoInfo.id;
 	}
 
 	private initTexture() {

--- a/browser/src/slideshow/VideoRenderer.ts
+++ b/browser/src/slideshow/VideoRenderer.ts
@@ -405,7 +405,7 @@ class VideoRendererGl extends VideoRenderer {
 		gl.activeTexture(gl.TEXTURE0);
 
 		const video = this.videoRenderInfo;
-		if (video.playing && video.videoElement.currentTime > 0) {
+		if (!video.ended && video.videoElement.currentTime > 0) {
 			gl.bindVertexArray(video.getVao());
 			gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
 			this.updateTexture(video.getTexture(), video.videoElement);

--- a/browser/src/slideshow/VideoRenderer.ts
+++ b/browser/src/slideshow/VideoRenderer.ts
@@ -101,7 +101,6 @@ abstract class VideoRenderer {
 		const video = document.createElement('video');
 
 		video.playsInline = true;
-		video.loop = true;
 		video.crossOrigin = 'anonymous';
 
 		video.addEventListener(

--- a/browser/src/slideshow/VideoRenderer.ts
+++ b/browser/src/slideshow/VideoRenderer.ts
@@ -19,6 +19,7 @@ class VideoRenderInfo {
 	private vao: WebGLVertexArrayObject = null;
 	public pos2d: number[];
 	public playing: boolean;
+	public ended: boolean;
 
 	public getTexture(): WebGLTexture {
 		return this.texture;
@@ -94,6 +95,16 @@ abstract class VideoRenderer {
 		this.videoRenderInfo.deleteResources(this._context);
 	}
 
+	public handleClick(): void {
+		if (this.videoRenderInfo.playing) {
+			this.pauseVideo();
+		} else if (this.videoRenderInfo.ended) {
+			this.playVideo(true);
+		} else {
+			this.playVideo(false);
+		}
+	}
+
 	protected setupVideo(
 		videoRenderInfo: VideoRenderInfo,
 		url: string,
@@ -107,6 +118,7 @@ abstract class VideoRenderer {
 			'playing',
 			() => {
 				videoRenderInfo.playing = true;
+				videoRenderInfo.ended = false;
 				this._slideRenderer.notifyVideoStarted(this.sId);
 			},
 			true,
@@ -116,6 +128,16 @@ abstract class VideoRenderer {
 			'pause',
 			() => {
 				videoRenderInfo.playing = false;
+				this._slideRenderer.notifyVideoEnded(this.sId);
+			},
+			true,
+		);
+
+		video.addEventListener(
+			'ended',
+			() => {
+				videoRenderInfo.playing = false;
+				videoRenderInfo.ended = true;
 				this._slideRenderer.notifyVideoEnded(this.sId);
 			},
 			true,

--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -358,7 +358,7 @@ class SlideShowNavigator {
 					slideInfo.hash,
 					videoInfo,
 				);
-				video.playVideo();
+				video.handleClick();
 			} else {
 				this.dispatchEffect();
 			}

--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -326,11 +326,13 @@ class SlideShowNavigator {
 	private clickHandler(aEvent: MouseEvent) {
 		if (aEvent.button === 0) {
 			const slideInfo = this.theMetaPres.getSlideInfoByIndex(this.currentSlide);
-			if (
-				!slideInfo ||
-				!slideInfo.interactions ||
-				slideInfo.interactions.length == 0
-			) {
+			const slideHasInteractions =
+				slideInfo &&
+				slideInfo.interactions &&
+				slideInfo.interactions.length > 0;
+			const slideHasVideos =
+				slideInfo && slideInfo.videos && slideInfo.videos.length > 0;
+			if (!slideHasInteractions && !slideHasVideos) {
 				this.dispatchEffect();
 				return;
 			}
@@ -346,8 +348,17 @@ class SlideShowNavigator {
 			const shape = slideInfo.interactions.find((shape) =>
 				hitTest(shape.bounds, x, y),
 			);
+			const videoInfo = slideInfo.videos.find((videoInfo) =>
+				hitTest(videoInfo, x, y),
+			);
 			if (shape) {
 				this._onExecuteInteraction(shape.clickAction);
+			} else if (videoInfo) {
+				const video = this.presenter.getVideoRenderer(
+					slideInfo.hash,
+					videoInfo,
+				);
+				video.playVideo();
 			} else {
 				this.dispatchEffect();
 			}


### PR DESCRIPTION
Previously we gave the user no control at all over video playback - although these aren't full player controls, they should at least make it a bit nicer to use video in presentations.

We probably want some visuals for these ... things like darkening the video frame when we're paused, showing a paused icon, showing a play icon when the video has loaded, showing a spinner when the video is loading, showing a replay button at the end of the video, etc. ... consider it a followup :)

Additionally, and from what I said at the start of this PR message you might've guessed this, it would be really nice to have full player controls! A seek bar/going back and forwards is a big one, as is volume. Other than that, a restart button, some play time indication, etc. would be very nice too! Probably those should be shown when the video is paused or when we hover over them. It doesn't have to be anything particularly fancy, but since as we lose all player controls by using our gl rendering bits for video the user has no video controls other than what we give them...

Finally, there are still some UX bits to iron out here and there. Stuff like "what happens when the video is fullscreen" or "can I play the video with my keyboard?". I suspect I'd like a discussion with Pedro about this when he's back from holiday to get some answers for some of those questions...