### PR TITLE
cid#362805 Dereference after null check

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1027,15 +1027,21 @@ bool DocumentBroker::download(
         if (!wopiFileInfo)
         {
             std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-            auto poller = std::make_shared<TerminatingPoll>("CFISynReqPoll");
-            poller->runOnClientThread();
-            auto checkFileInfo = std::make_shared<CheckFileInfo>(poller, session->getPublicUri(), [](CheckFileInfo&) {});
-            checkFileInfo->checkFileInfoSync(HTTP_REDIRECTION_LIMIT);
-            wopiFileInfo = checkFileInfo->wopiFileInfo(session->getPublicUri());
+
+            if (!session)
+                LOG_ERR("No session for CheckFileInfo");
+            else
+            {
+                auto poller = std::make_shared<TerminatingPoll>("CFISynReqPoll");
+                poller->runOnClientThread();
+                auto checkFileInfo = std::make_shared<CheckFileInfo>(poller, session->getPublicUri(), [](CheckFileInfo&) {});
+                checkFileInfo->checkFileInfoSync(HTTP_REDIRECTION_LIMIT);
+                wopiFileInfo = checkFileInfo->wopiFileInfo(session->getPublicUri());
+            }
             if (!wopiFileInfo)
             {
                 throw std::runtime_error(
-                    "CheckFileInfo failed or timed out while adding session #" + session->getId());
+                    "CheckFileInfo failed or timed out while adding session #" + sessionId);
             }
 
             checkFileInfoCallDurationMs = std::chrono::duration_cast<std::chrono::milliseconds>(


### PR DESCRIPTION
we check session for null/empty everywhere else


Change-Id: I4853fbeda7d952eb9745e8114c9367d36dd43460


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

