### PR TITLE
Reduce Compiler Directives

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -115,3 +115,11 @@
 /* Makes config variables conditionally static, only in non-debug builds, to allow for overriding them in unit-tests. */
 #undef CONFIG_STATIC
 
+/* Controls whether or not we allow loading documents from the local filesystem. */
+#ifndef ENABLE_LOCAL_FILESYSTEM
+#if MOBILEAPP || ENABLE_DEBUG
+#define ENABLE_LOCAL_FILESYSTEM 1
+#else
+#define ENABLE_LOCAL_FILESYSTEM 0
+#endif
+#endif

--- a/ios/config.h.in
+++ b/ios/config.h.in
@@ -124,5 +124,14 @@
 #define CONFIG_STATIC static
 #endif
 
+/* Controls whether or not we allow loading documents from the local filesystem. */
+#ifndef ENABLE_LOCAL_FILESYSTEM
+#if MOBILEAPP || ENABLE_DEBUG
+#define ENABLE_LOCAL_FILESYSTEM 1
+#else
+#define ENABLE_LOCAL_FILESYSTEM 0
+#endif
+#endif
+
 /* Version number of package */
 /* #undef VERSION */

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -290,44 +290,46 @@ public:
     /// Returns true on success only.
     bool setSocketBufferSize(const int size)
     {
-#if !MOBILEAPP
-        int rc = ::setsockopt(_fd, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size));
-
-        _sendBufferSize = getSocketBufferSize();
-        if (rc != 0 || _sendBufferSize < 0 )
+        if constexpr (!Util::isMobileApp())
         {
-            _sendBufferSize = DefaultSendBufferSize;
-            LOG_SYS("Error getting socket buffer size. Using default size of " << _sendBufferSize
-                                                                               << " bytes.");
-            return false;
+            int rc = ::setsockopt(_fd, SOL_SOCKET, SO_SNDBUF, &size, sizeof(size));
+
+            _sendBufferSize = getSocketBufferSize();
+            if (rc != 0 || _sendBufferSize < 0)
+            {
+                _sendBufferSize = DefaultSendBufferSize;
+                LOG_SYS("Error getting socket buffer size. Using default size of "
+                        << _sendBufferSize << " bytes.");
+                return false;
+            }
+
+            if (_sendBufferSize > MaximumSendBufferSize * 2)
+            {
+                LOG_TRC("Clamped send buffer size to " << MaximumSendBufferSize << " from "
+                                                       << _sendBufferSize);
+                _sendBufferSize = MaximumSendBufferSize;
+            }
+            else
+                LOG_TRC("Set socket buffer size to " << _sendBufferSize);
+
+            return true;
         }
 
-        if (_sendBufferSize > MaximumSendBufferSize * 2)
-        {
-            LOG_TRC("Clamped send buffer size to " << MaximumSendBufferSize << " from "
-                                                   << _sendBufferSize);
-            _sendBufferSize = MaximumSendBufferSize;
-        }
-        else
-            LOG_TRC("Set socket buffer size to " << _sendBufferSize);
-
-        return true;
-#else
         return false;
-#endif
     }
 
     /// Gets the actual send buffer size in bytes, -1 for failure.
     int getSocketBufferSize() const
     {
-#if !MOBILEAPP
-        int size;
-        unsigned int len = sizeof(size);
-        const int rc = ::getsockopt(_fd, SOL_SOCKET, SO_SNDBUF, &size, &len);
-        return rc == 0 ? size : -1;
-#else
+        if constexpr (!Util::isMobileApp())
+        {
+            int size;
+            socklen_t len = sizeof(size);
+            const int rc = ::getsockopt(_fd, SOL_SOCKET, SO_SNDBUF, &size, &len);
+            return rc == 0 ? size : -1;
+        }
+
         return -1;
-#endif
     }
 
     /// Gets our fast cache of the socket buffer size

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -25,6 +25,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <sstream>
 #include <sysexits.h>
 
 #include <Poco/DigestStream.h>
@@ -1062,6 +1063,7 @@ bool DocumentBroker::download(
     }
     else
 #endif
+#if ENABLE_LOCAL_FILESYSTEM
     {
         LocalStorage* localStorage = dynamic_cast<LocalStorage*>(_storage.get());
         if (localStorage != nullptr)
@@ -1103,7 +1105,18 @@ bool DocumentBroker::download(
                 session->setUserName(localfileinfo->getUsername());
             }
         }
+        else
+        {
+            LOG_FTL("Unknown or unsupported storage");
+            Util::forcedExit(EX_SOFTWARE);
+        }
     }
+#else // !ENABLE_LOCAL_FILESYSTEM
+    {
+        LOG_FTL("Unknown or unsupported storage");
+        Util::forcedExit(EX_SOFTWARE);
+    }
+#endif // !ENABLE_LOCAL_FILESYSTEM
 
     if (session)
     {

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3653,13 +3653,12 @@ std::string DocumentBroker::getJailRoot() const
 {
     if constexpr (!Util::isMobileApp())
     {
-        if (_jailId.empty())
+        if (!_jailId.empty())
         {
-            LOG_WRN("Trying to get the jail root of a not yet downloaded document.");
-            return std::string();
+            return Poco::Path(COOLWSD::ChildRoot, _jailId).toString();
         }
 
-        return Poco::Path(COOLWSD::ChildRoot, _jailId).toString();
+        LOG_WRN("Trying to get the jail root of a not yet downloaded document (no jailId)");
     }
 
     return std::string();

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -524,6 +524,8 @@ public:
     void removeEmbeddedMedia(const std::string& json);
 
     std::string getEmbeddedMediaPath(const std::string& id);
+    /// Returns the absolute media path given the local path of the media file.
+    std::string getAbsoluteMediaPath(std::string localPath);
 
     void onUrpMessage(const char* data, size_t len);
 

--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -98,10 +98,13 @@ void RequestVettingStation::handleRequest(const std::string& id)
             sendUnauthorizedErrorAndShutdown();
             break;
 
+#if ENABLE_LOCAL_FILESYSTEM
         case StorageBase::StorageType::FileSystem:
             LOG_INF("URI [" << COOLWSD::anonymizeUrl(uriPublic.toString()) << "] on docKey ["
                             << docKey << "] is for a FileSystem document");
             break;
+#endif // ENABLE_LOCAL_FILESYSTEM
+
 #if !MOBILEAPP
         case StorageBase::StorageType::Wopi:
             LOG_INF("URI [" << COOLWSD::anonymizeUrl(uriPublic.toString()) << "] on docKey ["
@@ -269,6 +272,7 @@ void RequestVettingStation::handleRequest(const std::string& id,
             sendUnauthorizedErrorAndShutdown();
             break;
 
+#if ENABLE_LOCAL_FILESYSTEM
         case StorageBase::StorageType::FileSystem:
             LOG_INF("URI [" << COOLWSD::anonymizeUrl(uriPublic.toString()) << "] on docKey ["
                             << docKey << "] is for a FileSystem document");
@@ -292,6 +296,8 @@ void RequestVettingStation::handleRequest(const std::string& id,
                     }
                 });
             break;
+#endif // ENABLE_LOCAL_FILESYSTEM
+
 #if !MOBILEAPP
         case StorageBase::StorageType::Wopi:
             LOG_INF("URI [" << COOLWSD::anonymizeUrl(uriPublic.toString()) << "] on docKey ["

--- a/wsd/Storage.hpp
+++ b/wsd/Storage.hpp
@@ -450,10 +450,12 @@ public:
     STATE_ENUM(StorageType,
                Unsupported, ///< An unsupported type.
                Unauthorized, ///< The host is not allowed by the admin.
+#if ENABLE_LOCAL_FILESYSTEM
                FileSystem, ///< File-System storage. Only for testing.
+#endif
 #if !MOBILEAPP
                Wopi ///< WOPI-like storage.
-#endif //!MOBILEAPP
+#endif
     );
 
     /// Validates the given URI.
@@ -525,8 +527,12 @@ private:
     std::string _jailedFilePathAnonym;
     bool _isDownloaded;
 
+#if ENABLE_LOCAL_FILESYSTEM
     static bool FilesystemEnabled;
+#endif
 };
+
+#if ENABLE_LOCAL_FILESYSTEM
 
 /// Trivial implementation of local storage that does not need do anything.
 class LocalStorage : public StorageBase
@@ -607,6 +613,8 @@ private:
     bool _isCopy;
     static std::atomic<unsigned> LastLocalStorageId;
 };
+
+#endif // ENABLE_LOCAL_FILESYSTEM
 
 /// Represents whether the underlying file is locked
 /// and with what token.

--- a/wsd/wopi/WopiProxy.cpp
+++ b/wsd/wopi/WopiProxy.cpp
@@ -78,6 +78,7 @@ void WopiProxy::handleRequest([[maybe_unused]] const std::shared_ptr<Terminating
             HttpHelper::sendErrorAndShutdown(http::StatusCode::Unauthorized, socket);
             break;
 
+#if ENABLE_LOCAL_FILESYSTEM
         case StorageBase::StorageType::FileSystem:
         {
             LOG_INF("URI [" << COOLWSD::anonymizeUrl(uriPublic.toString()) << "] on docKey ["
@@ -98,6 +99,8 @@ void WopiProxy::handleRequest([[maybe_unused]] const std::shared_ptr<Terminating
             }
             break;
         }
+#endif // ENABLE_LOCAL_FILESYSTEM
+
 #if !MOBILEAPP
         case StorageBase::StorageType::Wopi:
             LOG_INF("URI [" << COOLWSD::anonymizeUrl(uriPublic.toString()) << "] on docKey ["


### PR DESCRIPTION
Excludes local filesystem storage at compile-time and replaces many MOBILEAPP directives.

Requires #11699 to build.

- **wsd: reduce ifdef MOBILEAPP in Socket.hpp**
- **wsd: exclude filesystem storage when unnecessary**
- **wsd: reduce ifdef MOBILEAPP in DocumentBroker**
- **wsd: linearize implementation of DocumentBroker::getJailRoot()**
- **wsd: reduce ifdef MOBILEAPP in DocumentBroker**
- **wsd: refactor DocumentBroker::getAbsoluteMediaPath()**
- **wsd: reduce ifdef MOBILEAPP in Kit.cpp**
