### PR TITLE
fix: Remove unsupported warning on audio multimedia

### DIFF
--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -396,7 +396,7 @@ class ShapeHandlesSection extends CanvasSectionObject {
 
 			video.addEventListener('playing', function() {
 				window.setTimeout(function() {
-					if (video.webkitDecodedFrameCount === 0) {
+					if (video.webkitDecodedFrameCount === 0 && video.webkitAudioDecodedByteCount === 0) {
 						this.showUnsupportedVideoWarning();
 					}
 				}.bind(this), 1000);

--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -397,25 +397,25 @@ class ShapeHandlesSection extends CanvasSectionObject {
 			video.addEventListener('playing', function() {
 				window.setTimeout(function() {
 					if (video.webkitDecodedFrameCount === 0 && video.webkitAudioDecodedByteCount === 0) {
-						this.showUnsupportedVideoWarning();
+						this.showUnsupportedMediaWarning();
 					}
 				}.bind(this), 1000);
 			}.bind(this));
 
 			video.addEventListener('error', function() {
-				this.showUnsupportedVideoWarning();
+				this.showUnsupportedMediaWarning();
 			}.bind(this));
 
 			if (sources.length) {
 				sources[0].addEventListener('error', function(error: string) {
-					this.showUnsupportedVideoWarning();
+					this.showUnsupportedMediaWarning();
 				}.bind(this));
 			}
 		}
 	}
 
-	showUnsupportedVideoWarning() {
-		var videoWarning = _('Document contains unsupported video');
+	showUnsupportedMediaWarning() {
+		var videoWarning = _('Document contains unsupported media');
 		L.Map.THIS.uiManager.showSnackbar(videoWarning);
 	}
 


### PR DESCRIPTION
Previously, we could upload any multimedia files (video or audio-only) but audio files would show an "unsupported video" warning when played in the editor in Chromium-based browsers.

That turns out to be because we test for "video.webkitDecodedFrameCount" which is a Chromium-specific property to see whether any video frames have been decoded. If the property exists and is 0 we assume that, since as no video has been decoded, the file is corrupted or unsupported. As audio doesn't have any video frames to decode, we will always see it as undecodeable and therefore always corrupted.

To fix this we can check webkitAudioDecodedByteCount to see if we have decoded any audio. Since as some videos can have no audio track we still need to check video as well, however corrupted or unsupported videos will not read any audio *or* video frames.


Change-Id: Id223a1893743ce1b3d41fd954f6a23ce3f8f51a3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

