### PR TITLE
fix(mobile): don't attempt to use after move

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3255,12 +3255,12 @@ public:
 
     void start(std::shared_ptr<ServerSocket>&& serverSocket)
     {
-        _acceptPoll.startThread();
-        _acceptPoll.insertNewSocket(std::move(serverSocket));
-
 #if MOBILEAPP
         coolwsd_server_socket_fd = serverSocket->getFD();
 #endif
+
+        _acceptPoll.startThread();
+        _acceptPoll.insertNewSocket(std::move(serverSocket));
 
         WebServerPoll->startThread();
 


### PR DESCRIPTION
As of Id6d9e7bbfce7c750e4c7fc19f51bd795d7571103, "Don't store Socket in a non-SocketPoll Object", we were attempting to getFD from an already moved socket when starting COOLWSD on mobile. This caused a crash due to invalid memory access.

Refs: #11622

Change-Id: I82b0df8690db463946cd7b8460a849762216181f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

