### PR TITLE
Don't use deprecated Poco::Net::NetworkInterface::NetworkInterfaceList

### DIFF
--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -294,8 +294,7 @@ bool HostEntry::isLocalhost() const
 
     try
     {
-        const Poco::Net::NetworkInterface::NetworkInterfaceList list =
-            Poco::Net::NetworkInterface::list(true, true);
+        const auto list = Poco::Net::NetworkInterface::list(true, true);
         for (const auto& netif : list)
         {
             std::string address = netif.address().toString();


### PR DESCRIPTION
### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required