### PR TITLE
Clear canvas when resizing to a larger size

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1336,10 +1336,10 @@ class CanvasSectionContainer {
 		this.canvas.style.height = cssHeight.toFixed(4) + 'px';
 
 		// Avoid black default background.
+		if (!oldImageData || this.width < newWidth || this.height < newHeight)
+			this.clearCanvas();
 		if (oldImageData)
 			this.context.putImageData(oldImageData, 0, 0);
-		else
-			this.clearCanvas();
 
 		this.clearMousePositions();
 		this.width = this.canvas.width;


### PR DESCRIPTION
* Target version: master 

### Summary

When canvas is being resized larger, clear it first to avoid showing black in the newly exposed area.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

