### PR TITLE
fix(iOS): Stop selecting font faces in a family

### DIFF
--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -660,7 +660,7 @@ static IMP standardImpOfInputAccessoryView = nil;
             }
         } else if ([message.body isEqualToString:@"FONTPICKER"]) {
             UIFontPickerViewControllerConfiguration *configuration = [[UIFontPickerViewControllerConfiguration alloc] init];
-            configuration.includeFaces = YES;
+            configuration.includeFaces = NO;
             UIFontPickerViewController *picker = [[UIFontPickerViewController alloc] initWithConfiguration:configuration];
             picker.delegate = self;
             [self presentViewController:picker


### PR DESCRIPTION
Previously we would let you select individual font faces. This meant, for example, if you had the font "American Typewriter" which has individual bold/regular/etc. faces you could select "American Typewriter-bold" as your font family.

Problem is, there's no "American Typewriter-bold" family: the family is "American Typewriter" which wasn't selectable.

Luckily, iOS has an option for showing individual faces; if we turn that off then we'll always be selecting a family so this won't be an issue. We can still select fonts without separate faces as normal.


Change-Id: I0328d5a4a7795e997b76fb21a11da2c05e905c4d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

