### PR TITLE
'_blank' target stripped during sanitize

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -16,6 +16,15 @@ declare var L: any;
 declare var Autolinker: any;
 declare var DOMPurify : any;
 
+// By default DOMPurify will strip all targets, so set everything
+// as target=_blank with rel=noopener
+DOMPurify.addHook('afterSanitizeAttributes', function (node: HTMLElement) {
+	if (node.tagName === 'A') {
+		node.setAttribute('target', '_blank');
+		node.setAttribute('rel', 'noopener');
+	}
+});
+
 namespace cool {
 
 /*


### PR DESCRIPTION
By default DOMPurify will strip all targets, so set everything as target=_blank with rel=noopener

See:
https: //github.com/cure53/DOMPurify/issues/317
https: //github.com/cure53/DOMPurify/blob/main/demos/hooks-target-blank-demo.html

Change-Id: I10dc8fd25db23bb55c0d805ecd11718e828361ee


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

