### PR TITLE
jsdialog: close in layouting task

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -200,13 +200,21 @@ L.Control.JSDialog = L.Control.extend({
 	},
 
 	fadeOutDialog: function(instance) {
-		if (instance.id && this.dialogs[instance.id]) {
-			var container = this.dialogs[instance.id].container;
+		if (!instance.id)
+			return;
+
+		const dialogInfo = this.dialogs[instance.id];
+		if (!dialogInfo)
+			return;
+
+		const container = dialogInfo.container;
+
+		app.layoutingService.appendLayoutingTask(() => {
 			L.DomUtil.addClass(container, 'fadeout');
-			container.onanimationend = function() { instance.that.close(instance.id, false); };
-			// be sure it will be removed
-			setTimeout(function() { instance.that.close(instance.id, false); }, 700);
-		}
+			container.onanimationend = () => { instance.that.close(instance.id, false); };
+			// be sure it will be removed if onanimationend will not be executed
+			setTimeout(() => { instance.that.close(instance.id, false); }, 700);
+		});
 	},
 
 	getOrCreateOverlay: function(instance) {

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -62,22 +62,27 @@ L.Control.JSDialog = L.Control.extend({
 	},
 
 	clearDialog: function(id) {
-		var builder = this.dialogs[id].builder;
+		const dialogInfo = this.dialogs[id];
+		const builder = dialogInfo.builder;
 
-		L.DomUtil.remove(this.dialogs[id].container);
+		app.layoutingService.appendLayoutingTask(() => {
+			L.DomUtil.remove(dialogInfo.container);
 
-		if (this.dialogs[id].overlay && !this.dialogs[id].isSubmenu)
-			L.DomUtil.remove(this.dialogs[id].overlay);
+			if (dialogInfo.overlay && !dialogInfo.isSubmenu)
+				L.DomUtil.remove(dialogInfo.overlay);
 
-		delete this.dialogs[id];
+			delete this.dialogs[id];
+		});
 
 		return builder;
 	},
 
 	close: function(id, sendCloseEvent) {
 		if (id !== undefined && this.dialogs[id]) {
-			if (!sendCloseEvent && this.dialogs[id].overlay && !this.dialogs[id].isSubmenu)
-				L.DomUtil.remove(this.dialogs[id].overlay);
+			if (!sendCloseEvent && this.dialogs[id].overlay && !this.dialogs[id].isSubmenu) {
+				app.layoutingService.appendLayoutingTask(
+					() => { L.DomUtil.remove(this.dialogs[id].overlay); });
+			}
 
 			if (this.dialogs[id].timeoutId)
 				clearTimeout(this.dialogs[id].timeoutId);
@@ -166,12 +171,14 @@ L.Control.JSDialog = L.Control.extend({
 	},
 
 	focusToLastElement: function(id) {
-		try {
-			this.dialogs[id].lastFocusedElement.focus();
-		}
-		catch (error) {
-			this.map.focus();
-		}
+		app.layoutingService.appendLayoutingTask(() => {
+			try {
+				this.dialogs[id].lastFocusedElement.focus();
+			}
+			catch (error) {
+				this.map.focus();
+			}
+		});
 	},
 
 	setTabs: function() {


### PR DESCRIPTION
- fixes snackbar interaction
- creation was in the task but not closing, when it happened too quickly - we didn't get correct dialog to close