### PR TITLE
Fix double-resize on CanvasSectionContainer

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1371,8 +1371,10 @@ class CanvasSectionContainer {
 		newWidth = Math.floor(newWidth * app.dpiScale);
 		newHeight = Math.floor(newHeight * app.dpiScale);
 
-		if (this.right === newWidth && this.bottom === newHeight && this.documentAnchor)
+		if (this.right === newWidth && this.bottom === newHeight && this.documentAnchor) {
+			this.reNewAllSections(false);
 			return;
+		}
 
 		// Drawing may happen asynchronously so backup the old contents to avoid
 		// showing a blank canvas.
@@ -1402,7 +1404,7 @@ class CanvasSectionContainer {
 		this.right = this.canvas.width;
 		this.bottom = this.canvas.height;
 
-		this.reNewAllSections();
+		this.reNewAllSections(false);
 	}
 
 	findSectionContainingPoint (point: Array<number>): any {


### PR DESCRIPTION
When a resize is handled by CanvasTileLayer, two resizes may end up being triggered on CanvasSectionContainer. In this situation, the first happens prematurely and causes drawing to happen before the map is updated, while the second is ignored because the canvas size change was already handled. The same error is also in CalcTileLayer.