### PR TITLE
Better Conversion Failure Handling

### DIFF
--- a/fuzzer/HttpEcho.cpp
+++ b/fuzzer/HttpEcho.cpp
@@ -78,6 +78,13 @@ public:
                 break;
         }
 
+        if (!socket)
+        {
+            std::cerr << "Failed to create server socket on any port and gave up at port #" << port
+                      << std::endl;
+            exit(1);
+        }
+
         _localUri = "http://127.0.0.1:" + std::to_string(port);
         _pollServerThread.startThread();
         _pollServerThread.insertNewSocket(socket);

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -971,18 +971,18 @@ bool ChildSession::loadDocument(const StringVector& tokens)
 
     if (!getDocTemplate().empty())
     {
-        static constexpr auto Protocol = "file://";
-
         // If we aren't chroot-ed, we need to use the absolute path.
         // Because that's where Storage in WSD expects the document.
         std::string url;
         if (!_jailRoot.empty())
         {
-            url = Protocol + _jailRoot;
+            static constexpr std::string_view Protocol = "file://";
+
+            url = std::string(Protocol) + _jailRoot;
             if (getJailedFilePath().starts_with(url))
                 url = getJailedFilePath(); // JailedFilePath is already the absolute path.
             else if (getJailedFilePath().starts_with(Protocol))
-                url += getJailedFilePath().substr(sizeof(Protocol) - 1);
+                url += getJailedFilePath().substr(Protocol.size());
             else
                 url += getJailedFilePath();
         }

--- a/test/UnitProxy.cpp
+++ b/test/UnitProxy.cpp
@@ -11,13 +11,11 @@
 
 #include <config.h>
 
-#include <iostream>
-
 #include <Common.hpp>
+#include <FileUtil.hpp>
 #include <Protocol.hpp>
 #include <Unit.hpp>
 #include <Util.hpp>
-#include <FileUtil.hpp>
 #include <helpers.hpp>
 #include <net/HttpRequest.hpp>
 
@@ -48,10 +46,10 @@ public:
 
         httpSession->setTimeout(std::chrono::seconds(9));
 
-        TST_LOG("Attempt proxy URL fetch");
-
         // Request from rating.collaboraonline.com.
         _req = http::Request("/browser/a90f83c/foo/remote/static/lokit-extra-img.svg");
+
+        TST_LOG("Attempt proxy URL fetch " << httpSession->getUrl() << _req.getUrl());
 
         httpSession->setConnectFailHandler([this](const std::shared_ptr<http::Session>&) {
             LOK_ASSERT_FAIL("Unexpected connection failure");

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -741,11 +741,11 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
             handledByUnitTesting = UnitWSD::get().handleHttpRequest(request, message, socket);
             if (!handledByUnitTesting)
             {
-                LOG_DBG("Unit-Test: parallelizeCheckInfo" << request.getURI());
+                LOG_DBG("Unit-Test: parallelizeCheckInfo: " << request.getURI());
                 auto mapAccessDetails = UnitWSD::get().parallelizeCheckInfo(request, message, socket);
                 if (!mapAccessDetails.empty())
                 {
-                    LOG_DBG("Unit-Test: launchAsyncCheckFileInfo" << request.getURI());
+                    LOG_DBG("Unit-Test: launchAsyncCheckFileInfo: " << request.getURI());
                     auto accessDetails = FileServerRequestHandler::ResourceAccessDetails(
                         mapAccessDetails.at("wopiSrc"),
                         mapAccessDetails.at("accessToken"),

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1158,20 +1158,16 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(const Poco::Net::HTTP
 
     LOG_DBG("Wopi Access Check request: " << request.getURI());
 
-    Poco::MemoryInputStream startmessage(&socket->getInBuffer()[0], socket->getInBuffer().size());
-    StreamSocket::MessageMap map;
-
-    Poco::JSON::Object::Ptr jsonObject;
-
     std::string text(std::istreambuf_iterator<char>(message), {});
     LOG_TRC("Wopi Access Check request text: " << text);
 
     std::string callbackUrlStr;
 
+    Poco::JSON::Object::Ptr jsonObject;
     if (!JsonUtil::parseJSON(text, jsonObject))
     {
-        LOG_WRN_S("Wopi Access Check request error, json object expected got ["
-                  << text << "] on request to URL: " << request.getURI());
+        LOG_WRN("Wopi Access Check request error, json object expected got ["
+                << text << "] on request to URL: " << request.getURI());
 
         HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
         return false;
@@ -1179,8 +1175,8 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(const Poco::Net::HTTP
 
     if (!JsonUtil::findJSONValue(jsonObject, "callbackUrl", callbackUrlStr))
     {
-        LOG_WRN_S("Wopi Access Check request error, missing key callbackUrl expected got ["
-                  << text << "] on request to URL: " << request.getURI());
+        LOG_WRN("Wopi Access Check request error, missing key callbackUrl expected got ["
+                << text << "] on request to URL: " << request.getURI());
 
         HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
         return false;
@@ -1190,12 +1186,13 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(const Poco::Net::HTTP
 
     std::string scheme, host, portStr, pathAndQuery;
     if (!net::parseUri(callbackUrlStr, scheme, host, portStr, pathAndQuery)) {
-        LOG_WRN_S("Wopi Access Check request error, invalid url ["
-                  << callbackUrlStr << "] on request to URL: " << request.getURI() << scheme);
+        LOG_WRN("Wopi Access Check request error, invalid url ["
+                << callbackUrlStr << "] on request to URL: " << request.getURI() << scheme);
 
         HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
         return false;
     }
+
     http::Session::Protocol protocol = http::Session::Protocol::HttpSsl;
     ulong port = 443;
     if (scheme == "https://" || scheme.empty()) {
@@ -1204,8 +1201,8 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(const Poco::Net::HTTP
         protocol = http::Session::Protocol::HttpUnencrypted;
         port = 80;
     } else {
-        LOG_WRN_S("Wopi Access Check request error, bad request protocol ["
-                  << text << "] on request to URL: " << request.getURI() << scheme);
+        LOG_WRN("Wopi Access Check request error, bad request protocol ["
+                << text << "] on request to URL: " << request.getURI() << scheme);
 
         HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
         return false;
@@ -1220,9 +1217,8 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(const Poco::Net::HTTP
             HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
             return false;
         } catch(std::exception &exception) {
-
-            LOG_WRN_S("Wopi Access Check request error, bad request invalid porl ["
-                  << text << "] on request to URL: " << request.getURI());
+            LOG_WRN("Wopi Access Check request error, bad request invalid porl ["
+                    << text << "] on request to URL: " << request.getURI());
 
             HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
             return false;

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -354,6 +354,10 @@ private:
 
     std::string getIsAdminUserStatus() const;
 
+    /// Abort conversion due to failure.
+    void abortConversion(const std::shared_ptr<DocumentBroker>& docBroker,
+                         const std::shared_ptr<StreamSocket>& saveAsSocket, std::string errorKind);
+
 private:
     /// URI with which client made request to us
     const Poco::URI _uriPublic;

--- a/wsd/ProxyRequestHandler.hpp
+++ b/wsd/ProxyRequestHandler.hpp
@@ -11,8 +11,16 @@
 
 #pragma once
 
+#include <chrono>
+#include <memory>
 #include <string>
-#include "Socket.hpp"
+#include <unordered_map>
+
+class StreamSocket;
+namespace http
+{
+class Response;
+}
 
 class ProxyRequestHandler
 {
@@ -20,11 +28,14 @@ public:
     static void handleRequest(const std::string& relPath,
                               const std::shared_ptr<StreamSocket>& socket,
                               const std::string& serverUri);
-    static std::string getProxyRatingServer() { return ProxyRatingServer; }
+    static const std::string& getProxyRatingServer()
+    {
+        static const std::string ProxyRatingServer = "https://rating.collaboraonline.com";
+        return ProxyRatingServer;
+    }
 
 private:
     static std::chrono::system_clock::time_point MaxAge;
-    static constexpr auto ProxyRatingServer = "https://rating.collaboraonline.com";
     static std::unordered_map<std::string, std::shared_ptr<http::Response>> CacheFileHash;
 };
 

--- a/wsd/RequestDetails.hpp
+++ b/wsd/RequestDetails.hpp
@@ -260,7 +260,7 @@ public:
         return (_isGet || _isHead) && _uriString == path;
     }
 
-    bool equals(std::size_t index, const char* string) const
+    bool equals(std::size_t index, const std::string_view string) const
     {
         return _pathSegs.equals(index, string);
     }
@@ -290,10 +290,10 @@ public:
         return it != _fields.end() ? it->second : std::string();
     }
 
-    bool equals(const Field field, const char* string) const
+    bool equals(const Field field, const std::string_view string) const
     {
         const auto it = _fields.find(field);
-        return it != _fields.end() ? it->second == string : (string == nullptr || *string == '\0');
+        return it != _fields.end() ? it->second == string : string.empty();
     }
 
     std::string toString() const


### PR DESCRIPTION
- **wsd: c-string -> string_view in RequestDetails**
- **wsd: cleanup ClientRequestDispatcher::handleWopiAccessCheckRequest()**
- **wsd: factor out conversion aborting**
- **wsd: abort conversion on save-as errors**
