### PR TITLE
Revert "Don't use deprecated Poco::Net::NetworkInterface::NetworkInte…

### DIFF
--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -294,7 +294,8 @@ bool HostEntry::isLocalhost() const
 
     try
     {
-        const auto list = Poco::Net::NetworkInterface::list(true, true);
+        const Poco::Net::NetworkInterface::NetworkInterfaceList list =
+            Poco::Net::NetworkInterface::list(true, true);
         for (const auto& netif : list)
         {
             std::string address = netif.address().toString();


### PR DESCRIPTION
…rfaceList"

This reverts commit c91c9b850b2ca4d9da7a7da3f7ad166c99fe3a9e.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

