### PR TITLE
canvas: remove not exising function call

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -231,10 +231,6 @@ L.TileSectionManager = L.Class.extend({
 		sourceElement.addEventListener('touchcancel', function (e) { app.sectionContainer.onTouchCancel(e); }, true);
 	},
 
-	dispose: function () {
-		this.stopUpdates();
-	},
-
 	getSplitPos: function () {
 		var splitPanesContext = this._layer.getSplitPanesContext();
 		return splitPanesContext ?


### PR DESCRIPTION
when closing the COOL I saw unhandled exception:
TypeError: this.stopUpdates is not a function

that function doesn't exist in the current code base:

https://github.com/search?q=repo%3ACollaboraOnline%2Fonline%20stopUpdates&type=code