### PR TITLE
calc: light and dark mode sync in document-canvas

### DIFF
--- a/browser/src/control/Control.ColumnGroup.ts
+++ b/browser/src/control/Control.ColumnGroup.ts
@@ -88,6 +88,7 @@ export class ColumnGroup extends GroupBase {
 	drawGroupControl (group: GroupEntry): void {
 		let startX = this.getRelativeX(group.startPos);
 		let startY = this._levelSpacing + (this._groupHeadSize + this._levelSpacing) * group.level;
+		const strokeColor = GroupBase.getColors().strokeColor;
 		const endX = this.getEndPosition(group.endPos);
 
 		if (this.isGroupHeaderVisible(startX, group.startPos)) {
@@ -95,7 +96,7 @@ export class ColumnGroup extends GroupBase {
 			this.context.beginPath();
 			this.context.fillStyle = this.backgroundColor;
 			this.context.fillRect(this.transformRectX(startX, this._groupHeadSize), startY, this._groupHeadSize, this._groupHeadSize);
-			this.context.strokeStyle = 'black';
+			this.context.strokeStyle = strokeColor;
 			this.context.lineWidth = 1.0;
 			this.context.strokeRect(this.transformRectX(startX + 0.5, this._groupHeadSize), startY + 0.5, this._groupHeadSize, this._groupHeadSize);
 
@@ -129,7 +130,7 @@ export class ColumnGroup extends GroupBase {
 			startY += this._groupHeadSize * 0.5;
 			startX = Math.round(startX) + 1;
 			startY = Math.round(startY);
-			this.context.strokeStyle = 'black';
+			this.context.strokeStyle = strokeColor;
 			this.context.lineWidth = 2.0;
 			this.context.moveTo(this.transformX(startX), startY);
 			this.context.lineTo(this.transformX(endX - app.roundedDpiScale), startY);
@@ -146,7 +147,7 @@ export class ColumnGroup extends GroupBase {
 		const startX = Math.round((this._cornerHeaderWidth - ctrlHeadSize) * 0.5);
 		const startY = levelSpacing + (ctrlHeadSize + levelSpacing) * level;
 
-		ctx.strokeStyle = 'black';
+		ctx.strokeStyle = GroupBase.getColors().strokeColor;
 		ctx.lineWidth = 1.0;
 		ctx.strokeRect(this.transformRectX(startX + 0.5, ctrlHeadSize), startY + 0.5, ctrlHeadSize, ctrlHeadSize);
 		// draw level number

--- a/browser/src/control/Control.CornerGroup.ts
+++ b/browser/src/control/Control.CornerGroup.ts
@@ -37,13 +37,15 @@ export class CornerGroup extends app.definitions.canvasSectionObject {
 		this._map = L.Map.THIS;
 		this._map.on('sheetgeometrychanged', this.update, this);
 		this._map.on('viewrowcolumnheaders', this.update, this);
+		this._map.on('darkmodechanged', this._cornerGroupColors, this);
 
-		// Style.
-		const baseElem = document.getElementsByTagName('body')[0];
-		const elem = L.DomUtil.create('div', 'spreadsheet-header-row', baseElem);
-		this.backgroundColor = L.DomUtil.getStyle(elem, 'background-color'); // This is a section property.
-		this.borderColor = this.backgroundColor; // This is a section property.
-		L.DomUtil.remove(elem);
+		this._cornerGroupColors();
+	}
+
+	private _cornerGroupColors(): void {
+		const colors = GroupBase.getColors();
+		this.backgroundColor = colors.backgroundColor;
+		this.borderColor = colors.borderColor;
 	}
 
 	update(): void {

--- a/browser/src/control/Control.GroupBase.ts
+++ b/browser/src/control/Control.GroupBase.ts
@@ -60,7 +60,9 @@ export abstract class GroupBase extends app.definitions.canvasSectionObject {
 
 		this._map.on('sheetgeometrychanged', this.update, this);
 		this._map.on('viewrowcolumnheaders', this.update, this);
+		this._map.on('darkmodechanged', this._groupBaseColors, this);
 		this._createFont();
+		this._groupBaseColors();
 		this.update();
 		this.isRemoved = false;
 	}
@@ -72,15 +74,38 @@ export abstract class GroupBase extends app.definitions.canvasSectionObject {
 	_createFont(): void {
 		const baseElem = document.getElementsByTagName('body')[0];
 		const elem = L.DomUtil.create('div', 'spreadsheet-header-row', baseElem);
-		this.backgroundColor = L.DomUtil.getStyle(elem, 'background-color'); // This is a section property.
-		this.borderColor = this.backgroundColor;
-		this._textColor = L.DomUtil.getStyle(elem, 'color');
+
 		const fontFamily = L.DomUtil.getStyle(elem, 'font-family');
 		const fontSize = parseInt(L.DomUtil.getStyle(elem, 'font-size'));
 		this._getFont = function() {
 			return Math.round(fontSize * app.dpiScale) + 'px ' + fontFamily;
 		};
 		L.DomUtil.remove(elem);
+	}
+
+	public static getColors(): { backgroundColor: string, borderColor: string, textColor?: string, strokeColor?: string } {	
+		const baseElem = document.getElementsByTagName('body')[0];
+		const elem = L.DomUtil.create('div', 'spreadsheet-header-row', baseElem);
+		const isDark = window.prefs.getBoolean('darkTheme');
+
+		this.backgroundColor = L.DomUtil.getStyle(elem, 'background-color');
+		this.borderColor = this.backgroundColor;
+
+		this._textColor = L.DomUtil.getStyle(elem, 'color');
+		L.DomUtil.remove(elem);
+		return {
+			backgroundColor: this.backgroundColor,
+			borderColor: this.borderColor,
+			textColor: this._textColor,
+			strokeColor: isDark ? 'white' : 'black'
+		};
+	}
+
+	private _groupBaseColors(): void {
+		const colors = GroupBase.getColors();
+		this.backgroundColor = colors.backgroundColor;
+		this.borderColor = colors.borderColor;
+		this._textColor = colors.textColor;
 	}
 
 	// This returns the required width for the section.

--- a/browser/src/control/Control.RowGroup.ts
+++ b/browser/src/control/Control.RowGroup.ts
@@ -88,13 +88,14 @@ export class RowGroup extends GroupBase {
 		let startX = this._levelSpacing + (this._groupHeadSize + this._levelSpacing) * group.level;
 		let startY = this.getRelativeY(group.startPos);
 		const endY = this.getEndPosition(group.endPos);
+		const strokeColor = GroupBase.getColors().strokeColor;
 
 		if (this.isGroupHeaderVisible(startY, group.startPos)) {
 			// draw head
 			this.context.beginPath();
 			this.context.fillStyle = this.backgroundColor;
 			this.context.fillRect(this.transformRectX(startX, this._groupHeadSize), startY, this._groupHeadSize, this._groupHeadSize);
-			this.context.strokeStyle = 'black';
+			this.context.strokeStyle = strokeColor;
 			this.context.lineWidth = 1.0;
 			this.context.strokeRect(this.transformRectX(startX + 0.5, this._groupHeadSize), startY + 0.5, this._groupHeadSize, this._groupHeadSize);
 
@@ -128,7 +129,7 @@ export class RowGroup extends GroupBase {
 			startX += this._groupHeadSize * 0.5;
 			startX = Math.round(startX);
 			startY = Math.round(startY) + 1;
-			this.context.strokeStyle = 'black';
+			this.context.strokeStyle = strokeColor;
 			this.context.lineWidth = 2.0;
 			this.context.moveTo(this.transformX(startX), startY);
 			this.context.lineTo(this.transformX(startX), endY - app.roundedDpiScale);
@@ -147,7 +148,7 @@ export class RowGroup extends GroupBase {
 		const startX = levelSpacing + (ctrlHeadSize + levelSpacing) * level;
 		const startY = Math.round((this._cornerHeaderHeight - ctrlHeadSize) * 0.5);
 
-		ctx.strokeStyle = 'black';
+		ctx.strokeStyle = GroupBase.getColors().strokeColor;
 		ctx.lineWidth = 1.0;
 		ctx.strokeRect(this.transformRectX(startX + 0.5, ctrlHeadSize), startY + 0.5, ctrlHeadSize, ctrlHeadSize);
 		// draw level number


### PR DESCRIPTION
Change-Id: I0e53c2cc5a61b64e786757a4443c73f9021c9993

* Resolves: #11372 
* Target version: master 

### Summary
When switching between light and dark mode in Calc, the row, column, and corner of the document canvas did not immediately apply the correct background color. The background color only updated after refreshing the page, regardless of whether dark mode or light mode was active.

### PREVIEWS
[Screencast from 23-04-25 20:10:19.webm](https://github.com/user-attachments/assets/ffc18d37-4967-4426-8377-1983573ce10c)


