### PR TITLE
Improve keyboard navigation: add Shift+Tab support with cyclic focus behavior

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -323,6 +323,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		spinfield.dir = document.documentElement.dir;
 		spinfield.tabIndex = '0';
 		spinfield.setAttribute('autocomplete', 'off');
+		builder._addAriaLabel(spinfield, data, builder);
+
 		controls['spinfield'] = spinfield;
 
 


### PR DESCRIPTION
Commit 1:
- Ignore disabled elements in focus traversal and move to next enabled element on keydown
- Extended keydown handler to support Shift+Tab for reverse focus traversal
- Implemented cyclic focus: Shift+Tab from first element moves focus to last
- Ensures consistent and accessible navigation across visible tab panels

Commit 2: 
A small improvement in spin field element
 - added Arai-lable for Springfield element

Change-Id: I33e741f0f39c638a94513a8ee4a829febf6af89e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

