### PR TITLE
fix(integrator-settings): init l10n for translations

### DIFF
--- a/browser/admin/adminIntegratorSettings.html
+++ b/browser/admin/adminIntegratorSettings.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="%UI_LANG%" data-theme="%UI_THEME%">
+<html data-theme="%UI_THEME%">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -12,6 +12,7 @@
     />
     <link rel="stylesheet" href="%SERVICE_ROOT%/browser/%VERSION%/color-palette.css" />
     <link rel="stylesheet" href="%SERVICE_ROOT%/browser/%VERSION%/color-palette-dark.css" />
+    <script src="%SERVICE_ROOT%/browser/%VERSION%/l10n.js" defer></script>
     <link
       rel="stylesheet"
       href="%SERVICE_ROOT%/browser/%VERSION%/admin/css/adminIntegratorSettings.css"
@@ -36,6 +37,7 @@
         data-wopi-setting-base-url="%WOPI_SETTING_BASE_URL%"
         data-iframe-type="%IFRAME_TYPE%"
         data-css-vars="<!--%CSS_VARIABLES%-->"
+        data-lang="%UI_LANG%"
       />
     </div>
   </body>

--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -12,7 +12,12 @@
 
 /* global _ */
 
-declare var _: any;
+interface StringConstructor {
+	defaultLocale: string;
+	locale: string;
+}
+var _: any = (s) => s.toLocaleString();
+
 interface Window {
 	accessToken?: string;
 	accessTokenTTL?: string;
@@ -47,6 +52,16 @@ interface SectionConfig {
 	enabledFor?: string;
 	debugOnly?: boolean;
 }
+
+const initTranslationStr = () => {
+	const element = document.getElementById('initial-variables');
+	document.documentElement.lang =
+		(element as HTMLInputElement).dataset.lang || 'en-US';
+
+	String.defaultLocale = 'en-US';
+	String.locale =
+		document.documentElement.getAttribute('lang') || String.defaultLocale;
+};
 
 class SettingIframe {
 	private wordbook;
@@ -664,6 +679,7 @@ class SettingIframe {
 document.addEventListener('DOMContentLoaded', () => {
 	const adminContainer = document.getElementById('allConfigSection');
 	if (adminContainer) {
+		initTranslationStr();
 		(window as any).settingIframe = new SettingIframe();
 		(window as any).settingIframe.init();
 	}


### PR DESCRIPTION
Change-Id: I898a624b7ba12b20929148b71e7e5574c141631d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Test translations by appending ?lang=<locale> to the URL, for example: `https://<BASE_URL>/admin/adminIntegratorSettings.html?lang=hu`
- If a matching translation bundle is available, the page will render in that locale, otherwise, it will fall back to English (en-US).

Hungarian Preview 
![192 168 1 37_9980_browser_5aec54016c_admin_adminIntegratorSettings html_lang=hu](https://github.com/user-attachments/assets/44dd20e5-56d3-4109-be59-ddde9681ec14)


