### PR TITLE
Don't access rating.collaboraonline.com during tests to avoid timeouts

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -217,6 +217,13 @@ public:
         return {};
     }
 
+    virtual std::string getProxyRatingServer() const
+    {
+        // return a blank proxy rating server by default so there is no
+        // external network traffic during tests.
+        return std::string();
+    }
+
     /// Called when the document has been loaded,
     /// based on the "loaded:" message, in the context of filterSendWebSocketMessage.
     /// Return true to stop further handling of messages.

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -767,8 +767,11 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
             {
                 if (uri.ends_with("lokit-extra-img.svg"))
                 {
+                    std::string proxyRatingServer =
+                        !isUnitTesting ? ProxyRequestHandler::getProxyRatingServer()
+                                       : UnitWSD::get().getProxyRatingServer();
                     ProxyRequestHandler::handleRequest(uri.substr(pos + ProxyRemoteLen), socket,
-                                                       ProxyRequestHandler::getProxyRatingServer());
+                                                       proxyRatingServer);
                     servedSync = true;
                 }
 #if ENABLE_FEATURE_LOCK


### PR DESCRIPTION
Only explicitly used in UnitProxy.


Change-Id: Iac9c787458dbd257ed3ef0552a4a6c39049fe0e9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

