### PR TITLE
fix(mobile): Recenter pencil icon

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -403,6 +403,8 @@ body {
 }
 
 #mobile-edit-button {
+	justify-content: center;
+	align-items: center;
 	position: absolute;
 	width: 56px;
 	height: 56px;
@@ -422,9 +424,6 @@ body {
 }
 
 #mobile-edit-button-image {
-	position: relative;
-	margin-inline-start: 16px;
-	top: 16px;
 	width: var(--btn-size);
 	height: var(--btn-size);
 	background: url('images/baseline-edit-24px.svg') no-repeat center !important;

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -450,7 +450,7 @@ class UIManager extends L.Control {
 			document.body.setAttribute('data-integratorSidebar', 'true');
 
 		if (window.mode.isMobile()) {
-			$('#mobile-edit-button').show();
+			$('#mobile-edit-button').css('display', 'flex');
 			this.map.mobileBottomBar = JSDialog.MobileBottomBar(this.map);
 			this.map.mobileTopBar = JSDialog.MobileTopBar(this.map);
 			this.map.mobileSearchBar = JSDialog.MobileSearchBar(this.map);

--- a/browser/src/control/Permission.js
+++ b/browser/src/control/Permission.js
@@ -36,7 +36,7 @@ L.Map.include({
 		// we offer save-as to another place where the user can edit the document
 		var isPDF = app.file.fileBasedView && app.file.editComment;
 		if (!isPDF && (this._shouldStartReadOnly() || window.mode.isMobile() || window.mode.isTablet())) {
-			button.show();
+			button.css('display', 'flex');
 		} else {
 			button.hide();
 		}

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -257,7 +257,7 @@ class Dispatcher {
 			if (app.map.isEditMode()) $('#toolbar-down').show();
 			/** show edit button if only we are able to edit but in readonly mode */
 			if (!app.isReadOnly() && app.map.isReadOnlyMode())
-				$('#mobile-edit-button').show();
+				$('#mobile-edit-button').css('display', 'flex');
 		};
 
 		this.actionsMap['prev'] = () => {


### PR DESCRIPTION
On the edit button in the mobile view, the pencil icon has been off-center for a little while. To prevent that from happening again, we can can center it using flex rather than providing a fixed margin and position


Change-Id: Ie080a740ca8927d47be3c3bb444bea79043cb575


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

