### PR TITLE
close Admin::Document smaps file when document is expired

### DIFF
--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -789,10 +789,10 @@ void Admin::uploadedAlert(const std::string& docKey, pid_t pid, bool value)
 
 void Admin::addDoc(const std::string& docKey, pid_t pid, const std::string& filename,
                    const std::string& sessionId, const std::string& userName, const std::string& userId,
-                   const int smapsFD, const std::string& wopiSrc, bool readOnly)
+                   const std::weak_ptr<FILE>& smapsFp, const std::string& wopiSrc, bool readOnly)
 {
-    addCallback([this, docKey, pid, filename, sessionId, userName, userId, smapsFD, wopiSrc, readOnly] {
-        _model.addDocument(docKey, pid, filename, sessionId, userName, userId, smapsFD, Poco::URI(wopiSrc), readOnly);
+    addCallback([this, docKey, pid, filename, sessionId, userName, userId, smapsFp, wopiSrc, readOnly] {
+        _model.addDocument(docKey, pid, filename, sessionId, userName, userId, smapsFp, Poco::URI(wopiSrc), readOnly);
     });
 }
 

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -115,7 +115,8 @@ public:
     /// Calls with same pid will increment view count, if pid already exists
     void addDoc(const std::string& docKey, pid_t pid, const std::string& filename,
                 const std::string& sessionId, const std::string& userName,
-                const std::string& userId, int smapsFD, const std::string& wopiSrc, bool readOnly);
+                const std::string& userId, const std::weak_ptr<FILE>& smapsFD,
+                const std::string& wopiSrc, bool readOnly);
 
     /// Decrement view count till becomes zero after which doc is removed
     void rmDoc(const std::string& docKey, const std::string& sessionId);

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -147,7 +147,8 @@ void Document::updateMemoryDirty()
     if (now - _lastTimeSMapsRead >= 5)
     {
         size_t lastMemDirty = _memoryDirty;
-        _memoryDirty = _procSMaps  ? Util::getPssAndDirtyFromSMaps(_procSMaps).second : 0;
+        auto procSMaps = _procSMaps.lock();
+        _memoryDirty = procSMaps ? Util::getPssAndDirtyFromSMaps(procSMaps.get()).second : 0;
         _lastTimeSMapsRead = now;
         if (lastMemDirty != _memoryDirty)
             _hasMemDirtyChanged = true;
@@ -533,12 +534,12 @@ void AdminModel::uploadedAlert(const std::string& docKey, pid_t pid, bool value)
 void AdminModel::addDocument(const std::string& docKey, pid_t pid,
                              const std::string& filename, const std::string& sessionId,
                              const std::string& userName, const std::string& userId,
-                             const int smapsFD, const Poco::URI& wopiSrc, bool isViewReadOnly)
+                             const std::weak_ptr<FILE>& smapsFp, const Poco::URI& wopiSrc, bool isViewReadOnly)
 {
     ASSERT_CORRECT_THREAD_OWNER(_owner);
     const auto ret =
         _documents.emplace(docKey, std::make_unique<Document>(docKey, pid, filename, wopiSrc));
-    ret.first->second->setProcSMapsFD(smapsFD);
+    ret.first->second->setProcSMapsFp(smapsFp);
     ret.first->second->takeSnapshot();
     ret.first->second->addView(sessionId, userName, userId, isViewReadOnly);
     LOG_DBG("Added admin document [" << docKey << "].");
@@ -614,6 +615,7 @@ void AdminModel::doRemove(std::map<std::string, std::unique_ptr<Document>>::iter
     std::unique_ptr<Document> doc;
     std::swap(doc, docIt->second);
     _documents.erase(docIt);
+    doc->setExpired();
     _expiredDocuments.emplace(docItKey + std::to_string(std::chrono::duration_cast<std::chrono::nanoseconds>(
                                                             std::chrono::steady_clock::now().time_since_epoch()).count()),
                               std::move(doc));

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -3721,7 +3721,7 @@ DocumentBroker::addSessionInternal(const std::shared_ptr<ClientSession>& session
     // Create uri without query parameters
     const std::string wopiSrc(uri.getScheme() + "://" + uri.getAuthority() + uri.getPath());
     _admin.addDoc(_docKey, getPid(), getFilename(), id, session->getUserName(),
-                  session->getUserId(), _childProcess->getSMapsFD(), wopiSrc, session->isReadOnly());
+                  session->getUserId(), _childProcess->getSMapsFp(), wopiSrc, session->isReadOnly());
     _admin.setDocWopiDownloadDuration(_docKey, _wopiDownloadDuration);
 #endif
 


### PR DESCRIPTION
Admin::Documents are moved to _expiredDocuments when the matching real document is closed. At which point _memoryDirty won't be updated anymore so we can close the open FILE* to the removed process smaps file to release a fd, and drop the FILE buffer.


Change-Id: Ied919f6e0fe614be7ad42cc15ddca60f0a4adab2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

