### PR TITLE
Backport 11463: Enable tooltip for style list

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2118,7 +2118,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				}
 			}
 
-			div.setAttribute('data-cooltip', builder._cleanText(data.text));
+			const tooltip = builder._cleanText(data.tooltip) || builder._cleanText(data.text);
+			div.setAttribute('data-cooltip', tooltip);
 
 			if (builder.options.useInLineLabelsForUnoButtons === true) {
 				$(div).addClass('inline');

--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -539,6 +539,8 @@ class TreeViewControl {
 		// regular columns
 		for (const index in entry.columns) {
 			td = L.DomUtil.create('div', '', tr);
+			td.setAttribute('data-cooltip', entry.text);
+			L.control.attachTooltipEventListener(td, builder.map);
 			rowElements.push(td);
 
 			span = L.DomUtil.create(

--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -539,7 +539,7 @@ class TreeViewControl {
 		// regular columns
 		for (const index in entry.columns) {
 			td = L.DomUtil.create('div', '', tr);
-			td.setAttribute('data-cooltip', entry.text);
+			if (entry.text) td.setAttribute('data-cooltip', entry.text);
 			L.control.attachTooltipEventListener(td, builder.map);
 			rowElements.push(td);
 


### PR DESCRIPTION
Change-Id: Ib89dd448bf583bff4fb385e10c0eae51eed0ce96

Enable tooltip for style list in 24.04.


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

