### PR TITLE
CanvasSectionContainer: Take split-panes into account while checking …

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -493,7 +493,14 @@ class CanvasSectionContainer {
 	}
 
 	public isDocumentObjectVisible (section: CanvasSectionObject): boolean {
-		return app.LOUtil._doRectanglesIntersect(app.file.viewedRectangle.pToArray(), [section.position[0], section.position[1], section.size[0], section.size[1]]);
+		return app.isRectangleVisibleInTheDisplayedArea(
+			[
+				section.position[0] * app.pixelsToTwips,
+				section.position[1] * app.pixelsToTwips,
+				section.size[0] * app.pixelsToTwips,
+				section.size[1] * app.pixelsToTwips
+			]
+		);
 	}
 
 	// For window sections, there is a "targetSection" property in CanvasSectionContainer.

--- a/browser/src/canvas/sections/OtherViewCellCursorSection.ts
+++ b/browser/src/canvas/sections/OtherViewCellCursorSection.ts
@@ -116,7 +116,7 @@ class OtherViewCellCursorSection extends CanvasSectionObject {
         if (app.sectionContainer.doesSectionExist(textCursorSectionName))
             return; // Don't show the popup if the cursor header is shown.
 
-        if (this.sectionProperties.popUpContainer) {
+        if (this.sectionProperties.popUpContainer && this.isVisible) {
             this.adjustPopUpPosition();
 
             this.sectionProperties.popUpShown = true;
@@ -137,6 +137,11 @@ class OtherViewCellCursorSection extends CanvasSectionObject {
                 this.sectionProperties.popUpContainer.style.display = 'none';
         }
         this.clearPopUpTimer();
+    }
+
+    onDocumentObjectVisibilityChange(): void {
+        if (this.sectionProperties.popUpShown && !this.isVisible)
+            this.hideUsernamePopUp();
     }
 
     public static addOrUpdateOtherViewCellCursor(viewId: number, username: string, rectangleData: Array<string>, part: number) {
@@ -217,7 +222,6 @@ class OtherViewCellCursorSection extends CanvasSectionObject {
     public static showPopUpForView(viewId: number) {
         if (OtherViewCellCursorSection.doesViewCursorExist(viewId)) {
             const section = OtherViewCellCursorSection.getViewCursorSection(viewId);
-
             section.showUsernamePopUp();
         }
     }

--- a/browser/src/canvas/sections/OtherViewCursorSection.ts
+++ b/browser/src/canvas/sections/OtherViewCursorSection.ts
@@ -91,7 +91,7 @@ class OtherViewCursorSection extends HTMLObjectSection {
         section.adjustHTMLObjectPosition();
         const documentPosition = new cool.SimplePoint(section.position[0] * app.pixelsToTwips, (section.position[1] - 20) * app.pixelsToTwips);
 
-        if (section.showSection)
+        if (section.showSection && section.isVisible)
             app.definitions.cursorHeaderSection.showCursorHeader(viewId, username, documentPosition, color);
 
         app.sectionContainer.requestReDraw();


### PR DESCRIPTION
…a section's visibility.

Don't show username popups if the section is not visible.

Issue:
* Calc: CellCursorSection and CursorHeaderSection didn't hide the popups and drawing when other cell cursor is somewhere on the frozen panes. To reproduce:
* Add split panes.
* Scroll down.
* With a second view, go to the same scrolled position.
* With the second view, scroll up a bit and put the cellcursor somewhere that overlaps with the split view of the first view.
* Second cell cursor sholdn't be visible on the frozen panes of the first view.


Change-Id: If1c3c41218dfb28f9af219794b26ce6f25aa000a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

