### PR TITLE
xcu settings affect the document for all users

### DIFF
--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -163,8 +163,8 @@ class SettingIframe {
 				enabledFor: 'userconfig',
 			},
 			{
-				sectionTitle: _('Document View'),
-				sectionDesc: _('Adjust how office documents look.'),
+				sectionTitle: _('Document Settings'),
+				sectionDesc: _('Adjust how office documents behave.'),
 				listId: 'XcuList',
 				inputId: 'XcuFile',
 				buttonId: 'uploadXcuButton',

--- a/browser/admin/src/integrator/Xcu.ts
+++ b/browser/admin/src/integrator/Xcu.ts
@@ -144,7 +144,7 @@ class Xcu {
 					: this.parse(XcuFileContent);
 		} catch (error) {
 			(window as any).SettingIframe.showErrorModal(
-				'Something went wrong while loading Document view settings.',
+				'Something went wrong while loading Document settings.',
 			);
 			console.error('Error parsing XCU file:', error);
 		}
@@ -156,7 +156,7 @@ class Xcu {
 
 		if (xmlDoc.getElementsByTagName('parsererror').length > 0) {
 			(window as any).SettingIframe.showErrorModal(
-				'Something went wrong while loading Document view settings.',
+				'Something went wrong while loading Document settings.',
 			);
 		}
 
@@ -383,11 +383,11 @@ class Xcu {
 
 	public createXcuEditorUI(container: HTMLElement): HTMLElement {
 		const heading = document.createElement('h3');
-		heading.textContent = 'Document View';
+		heading.textContent = 'Document Settings';
 		container.appendChild(heading);
 
 		const descEl = document.createElement('p');
-		descEl.textContent = 'Adjust how office documents look.';
+		descEl.textContent = 'Adjust how office documents behave.';
 		container.appendChild(descEl);
 
 		const editorContainer = document.createElement('div');
@@ -445,7 +445,7 @@ class Xcu {
 		resetButton.type = 'button';
 		resetButton.id = 'xcu-reset-button';
 		resetButton.classList.add('button', 'button--vue-secondary');
-		resetButton.title = 'Reset to default Document View settings';
+		resetButton.title = 'Reset to default Document settings';
 		resetButton.innerHTML = `
 			<span class="button__wrapper">
 				<span class="button__icon xcu-reset-icon">
@@ -459,7 +459,7 @@ class Xcu {
 
 		resetButton.addEventListener('click', async () => {
 			const confirmed = window.confirm(
-				'Are you sure you want to reset Document View settings?',
+				'Are you sure you want to reset Document settings?',
 			);
 			if (!confirmed) {
 				return;
@@ -474,7 +474,7 @@ class Xcu {
 		saveButton.type = 'button';
 		saveButton.id = 'xcu-save-button';
 		saveButton.classList.add('button', 'button-primary');
-		saveButton.title = 'Save Document View settings';
+		saveButton.title = 'Save Document settings';
 		saveButton.innerHTML = `
 			<span class="button__wrapper">
 				<span class="button--text-only">Save</span>


### PR DESCRIPTION
These settings change the document's settings. They are not per-view in the sense that each user has a separate "view" of the document. The settings of the session that opens the document are applied to it and affect the document regardless of the settings of sessions that later join the document. Drop the use of "View" which is somewhat ambiguous here.


Change-Id: I296c2bd738b14a044ebfb170bfddb6aad54d2ec1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

