### PR TITLE
use Socket for log context

### DIFF
--- a/wsd/RequestVettingStation.cpp
+++ b/wsd/RequestVettingStation.cpp
@@ -234,7 +234,6 @@ void RequestVettingStation::handleRequest(const std::string& id,
     _requestDetails = requestDetails;
     _ws = ws;
     _socket = socket;
-    _logContextFD = socket->getFD();
     _mobileAppDocId = mobileAppDocId;
 
     std::string url = _requestDetails.getDocumentURI();

--- a/wsd/RequestVettingStation.hpp
+++ b/wsd/RequestVettingStation.hpp
@@ -48,16 +48,14 @@ public:
         : _requestDetails(requestDetails)
         , _poll(poll)
         , _mobileAppDocId(0)
-        , _logContextFD(-1)
     {
     }
 
     inline void logPrefix(std::ostream& os) const
     {
-        if (_logContextFD > -1)
-        {
-            os << '#' << _logContextFD << ": ";
-        }
+        auto socket = _socket.lock();
+        int logContextFD = socket ? socket->getFD() : -1;
+        os << '#' << logContextFD << ": ";
     }
 
     /// Called when cool.html is served, to start the vetting as early as possible.
@@ -118,7 +116,6 @@ private:
     std::weak_ptr<StreamSocket> _socket;
     Util::Stopwatch _birthday;
     unsigned _mobileAppDocId;
-    int _logContextFD;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
lock the weak_ptr and use -1 if it no longer exists instead of stashing the original fd value for use as log context


Change-Id: I6c6ffccded2c6baac55aafa0940b436329ef309a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

