### PR TITLE
Fix copy server log

### DIFF
--- a/browser/src/control/Control.ServerAuditDialog.ts
+++ b/browser/src/control/Control.ServerAuditDialog.ts
@@ -35,7 +35,6 @@ class ClientAuditor {
 	}
 }
 
-
 class ServerAuditDialog {
 	map: any;
 	id: string = 'ServerAuditDialog';

--- a/browser/src/control/Control.ServerAuditDialog.ts
+++ b/browser/src/control/Control.ServerAuditDialog.ts
@@ -35,10 +35,6 @@ class ClientAuditor {
 	}
 }
 
-// // 🔹 Utility function
-// export function isClipboardAvailable(): boolean {
-// 	return !!navigator.clipboard && window.isSecureContext;
-// }
 
 class ServerAuditDialog {
 	map: any;

--- a/browser/src/control/Control.ServerAuditDialog.ts
+++ b/browser/src/control/Control.ServerAuditDialog.ts
@@ -35,6 +35,11 @@ class ClientAuditor {
 	}
 }
 
+// // 🔹 Utility function
+// export function isClipboardAvailable(): boolean {
+// 	return !!navigator.clipboard && window.isSecureContext;
+// }
+
 class ServerAuditDialog {
 	map: any;
 	id: string = 'ServerAuditDialog';
@@ -105,9 +110,56 @@ class ServerAuditDialog {
 		};
 	}
 
+	public isClipboardAvailable(
+		clipboard = navigator.clipboard,
+		isSecure = window.isSecureContext,
+	): boolean {
+		return !!clipboard && isSecure;
+	}
+
 	public open() {
 		const serverEntries = this.getEntries(app.serverAudit);
 		const clientEntries = this.getEntries(ClientAuditor.performClientAudit());
+
+		// allEntries = serveEntries + clientEntries
+		const allEntries = serverEntries.concat(clientEntries);
+
+		// ✅ Combine all audit entries into a single string for clipboard copying
+		function dedent(str: string) {
+			return str.replace(/^[ \t]+/gm, ''); // removes leading spaces/tabs on each line
+		}
+
+		const auditText =
+			allEntries
+				.map((entry) => {
+					const statusIcon = entry.columns[0]?.collapsed;
+					const statusText = entry.columns[1]?.text;
+					const helpText = entry.columns[2]?.text;
+					const helpLink = entry.columns[2]?.link;
+
+					const statusLabel =
+						statusIcon === 'serverauditok.svg'
+							? 'ok'
+							: statusIcon === 'serverauditerror.svg'
+								? 'error'
+								: 'unknown';
+
+					return dedent(`
+			======================================
+		
+			Status (${statusLabel}):
+			${statusText}
+		
+			Help (SDK: ${helpText}):
+			${helpLink}
+		`);
+				})
+				.join('') + '\n======================================\n';
+
+		const finalAuditText = `Summary of Server Audit Dialog:\n${auditText}`;
+
+		// ✅ Attempt to copy to clipboard
+		this.copyAuditToClipboard(finalAuditText);
 
 		const dialogBuildEvent = {
 			data: this.getJSON(serverEntries.concat(clientEntries)),
@@ -118,6 +170,66 @@ class ServerAuditDialog {
 			window.mode.isMobile() ? 'mobilewizard' : 'jsdialog',
 			dialogBuildEvent,
 		);
+	}
+
+	private showClipboardSnackbar(message: string, color: string): void {
+		const snackbar = document.createElement('div');
+		snackbar.textContent = '';
+		snackbar.textContent = message;
+		snackbar.style.position = 'fixed';
+		snackbar.style.bottom = '20px';
+		snackbar.style.left = '50%';
+		snackbar.style.transform = 'translateX(-50%)';
+		snackbar.style.backgroundColor = '#4CAF50';
+		snackbar.style.color = 'white';
+		snackbar.style.padding = '12px 24px';
+		snackbar.style.borderRadius = '4px';
+		snackbar.style.boxShadow = '0 2px 6px rgba(0, 0, 0, 0.3)';
+		snackbar.style.zIndex = '9999';
+
+		document.body.appendChild(snackbar);
+
+		setTimeout(() => {
+			snackbar.remove();
+		}, 3000); // hide after 3 seconds
+	}
+
+	private additionalWarnings: any[] = [];
+
+	private copyAuditToClipboard(text: string): void {
+		if (this.isClipboardAvailable()) {
+			navigator.clipboard
+				.writeText(text)
+				.then(() => {
+					const msg = '✅ Server audit log copied!!';
+					console.warn(msg);
+
+					// ✅ Show a small confirmation popup/snackbar
+					this.showClipboardSnackbar(msg, '#4CAF50');
+				})
+				.catch((err) => {
+					const msg = `❌ Failed to copy server audit log: ${err}`;
+					console.warn(msg);
+
+					// ❌ Show a small confirmation popup/snackbar
+					this.showClipboardSnackbar(msg, '#FF4933');
+				});
+		} else {
+			console.warn(
+				'⚠️ Clipboard unsupported. Could not copy server audit log.',
+			);
+
+			const warning = {
+				id: this.id + '-clipboardwarning',
+				type: 'fixedtext',
+				text: '⚠️ Clipboard unsupported. You may not be able to copy the audit results.',
+				style:
+					'background-color: yellow; color: black; padding: 6px; margin-top: 8px; border: 1px solid red; font-weight: bold;',
+			};
+
+			// Push this to the dialog only if needed (see next step)
+			this.additionalWarnings = [warning];
+		}
 	}
 
 	private getEntries(source: any): Array<TreeEntryJSON> {
@@ -189,6 +301,75 @@ class ServerAuditDialog {
 		const hasErrors = this.hasErrors();
 		const countErrors = this.countErrors();
 
+		// '✅' Clipboard availability check function
+		// function isClipboardBroken(): boolean {
+		// 	const broken =
+		// 		!navigator.clipboard ||
+		// 		typeof navigator.clipboard.write !== 'function' ||
+		// 		typeof navigator.clipboard.read !== 'function' ||
+		// 		window.location.protocol !== 'https:';
+
+		// 	// Optional: detailed logging
+		// 	console.log('🧪 [Clipboard Check]');
+		// 	console.log('navigator.clipboard:', navigator.clipboard);
+		// 	console.log('navigator.clipboard.write:', navigator.clipboard?.write);
+		// 	console.log('navigator.clipboard.read:', navigator.clipboard?.read);
+		// 	console.log('window.location.protocol:', window.location.protocol);
+		// 	console.log('🧪 Clipboard broken?', broken);
+
+		// 	return broken;
+		// }
+
+		// '✅' Conditionally render a clipboard warning if API is unavailable or insecure
+		// const clipboardWarning =
+		// 	isClipboardBroken()
+		// 		? {
+		// 				id: this.id + '-clipboardwarning',
+		// 				type: 'fixedtext',
+		// 				text: 'Clipboard unsupported. You may not be able to copy the audit results.',
+		// 				style:
+		// 					'background-color: yellow; color: black; padding: 6px; margin-top: 8px; border: 1px solid red; font-weight: bold;',
+		// 		  }
+		// 		: null;
+
+		// ✅ Construct children array with clipboardWarning included
+		const childrenArray = [
+			...this.additionalWarnings, // <-- insert warning block here
+			{
+				id: 'auditlist',
+				type: 'treelistbox',
+				headers: [
+					{ text: _('Status'), sortable: false },
+					{ text: _('Help'), sortable: false },
+				],
+				entries: entries,
+				enabled: entries.length > 0,
+			},
+			!hasErrors
+				? {
+						id: 'auditsuccess',
+						type: 'fixedtext',
+						text: _('No issues found'),
+					}
+				: {
+						id: 'auditerror',
+						type: 'fixedtext',
+						text: _('Alerts:') + ' ' + countErrors,
+					},
+			{
+				id: this.id + '-buttonbox',
+				type: 'buttonbox',
+				children: [
+					{
+						id: 'ok',
+						type: 'pushbutton',
+						text: _('OK'),
+					} as PushButtonWidget,
+				],
+				layoutstyle: 'end',
+			} as ButtonBoxWidget,
+		].filter(Boolean); // Remove nulls if clipboardWarning is null
+
 		return {
 			id: this.id,
 			dialogid: this.id,
@@ -207,41 +388,7 @@ class ServerAuditDialog {
 					id: this.id + '-mainbox',
 					type: 'container',
 					vertical: true,
-					children: [
-						{
-							id: 'auditlist',
-							type: 'treelistbox',
-							headers: [
-								/* icon */ { text: _('Status'), sortable: false },
-								{ text: _('Help'), sortable: false },
-							],
-							entries: entries,
-							enabled: entries.length > 0,
-						},
-						!hasErrors
-							? {
-									id: 'auditsuccess',
-									type: 'fixedtext',
-									text: _('No issues found'),
-								}
-							: {
-									id: 'auditerror',
-									type: 'fixedtext',
-									text: _('Alerts:') + ' ' + countErrors,
-								},
-						{
-							id: this.id + '-buttonbox',
-							type: 'buttonbox',
-							children: [
-								{
-									id: 'ok',
-									type: 'pushbutton',
-									text: _('OK'),
-								} as PushButtonWidget,
-							],
-							layoutstyle: 'end',
-						} as ButtonBoxWidget,
-					],
+					children: childrenArray,
 				} as ContainerWidgetJSON,
 			],
 		} as JSDialogJSON;


### PR DESCRIPTION
Modified
browser/src/control/Control.ServerAuditDialog.ts

Major added/changed:

1. public open() - changed:
   To pop-up the success window when copying to clipboard was successful.

2. private showClipboardSnackbar(...) - added
    To create custom pop up window.

3. private copyAuditToClipboard(...) - chamged
    Making sure to add warning message inside server log when needed.

To Replicate
Follow [this](https://collaboraonline.github.io/post/build-code/#build-code-on-gitpod) official instruction 


 

