### PR TITLE
RequestDetails::_documentURI is unused

### DIFF
--- a/wsd/RequestDetails.hpp
+++ b/wsd/RequestDetails.hpp
@@ -119,7 +119,6 @@ private:
     std::string _uriString;
     std::string _proxyPrefix;
     std::string _hostUntrusted;
-    std::string _documentURI;
     bool _isGet : 1;
     bool _isHead : 1;
     bool _isProxy : 1;


### PR DESCRIPTION
Change-Id: I551febbc29a5d6aed7049c2af22f6e866d365d91


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

