### PR TITLE
ScrollToPos: Take split panes into consideration.

### DIFF
--- a/browser/src/docstatefunctions.js
+++ b/browser/src/docstatefunctions.js
@@ -60,6 +60,30 @@ app.isPointVisibleInTheDisplayedArea = function (twipsArray /* x, y */) {
 	}
 };
 
+app.isXVisibleInTheDisplayedArea = function (twipsX) {
+	if (app.map._docLayer._splitPanesContext) {
+		let rectangles = app.map._docLayer._splitPanesContext.getViewRectangles();
+		for (let i = 0; i < rectangles.length; i++) {
+			if (rectangles[i].containsX(twipsX)) return true;
+		}
+		return false;
+	} else {
+		return app.file.viewedRectangle.containsX(twipsX);
+	}
+};
+
+app.isYVisibleInTheDisplayedArea = function (twipsY) {
+	if (app.map._docLayer._splitPanesContext) {
+		let rectangles = app.map._docLayer._splitPanesContext.getViewRectangles();
+		for (let i = 0; i < rectangles.length; i++) {
+			if (rectangles[i].containsY(twipsY)) return true;
+		}
+		return false;
+	} else {
+		return app.file.viewedRectangle.containsY(twipsY);
+	}
+};
+
 app.isRectangleVisibleInTheDisplayedArea = function (
 	twipsArray /* x, y, width, height */,
 ) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2955,9 +2955,10 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		let needsXScroll = false;
 		let needsYScroll = false;
+		const CSSPixelsToTwips = app.dpiScale * app.pixelsToTwips;
 
 		// If x coordinate is already within visible area, we won't scroll to that direction.
-		if (app.file.viewedRectangle.cX1 <= center.x && center.x <= app.file.viewedRectangle.cX2)
+		if (app.isXVisibleInTheDisplayedArea(Math.round(center.x * CSSPixelsToTwips)))
 			center.x = app.file.viewedRectangle.cX1;
 		else {
 			center.x -= this._map.getSize().divideBy(2).x;
@@ -2972,7 +2973,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		const controlYUp = center.y - (app.file.textCursor.visible ? app.file.textCursor.rectangle.cHeight :
 			(app.calc.cellCursorVisible ? app.calc.cellCursorRectangle.cHeight : 0));
 
-		if (app.file.viewedRectangle.cY1 <= controlYUp && controlYDown <= app.file.viewedRectangle.cY2)
+		if (app.isYVisibleInTheDisplayedArea(Math.round(controlYDown * CSSPixelsToTwips)) && app.isYVisibleInTheDisplayedArea(Math.round(controlYUp * CSSPixelsToTwips)))
 			center.y = app.file.viewedRectangle.cY1;
 		else {
 			center.y -= this._map.getSize().divideBy(2).y;


### PR DESCRIPTION
Issue:
* Use split panes.
* Follow a view.
* Scroll down with the first view, say row 100 is behind the frozen area, 101 and below are visible.
* With the second view, type something on line 99. Line 99 seems visible on first view. But there is frozen pane there.
* So the first view won't jump to the second (followed) view's position.

This commit fixes the issue.


Change-Id: I75556a4f9350f2e8d46a3f66b2d8ae87f931ba9f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

