### PR TITLE
chore(iOS): bump version

### DIFF
--- a/ios/Mobile/Info.plist.in
+++ b/ios/Mobile/Info.plist.in
@@ -253,7 +253,7 @@
 	     weird, but at least isn't as bad as being completely misleading.
 	-->
 	<key>CFBundleShortVersionString</key>
-	<string>2404.13.0</string>
+	<string>2504.0.3</string>
 	<key>CFBundleVersion</key>
 	<string>@IOSAPP_BUNDLE_VERSION@</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
The version for the rest of the app was bumped in Ic41770e5918bbb8b7e37615b52b99eb7c370013f, but iOS was ommitted.

To build new testflight versions, we can't be using the same version as was already released on the app store


Change-Id: I404577837423cfcc5b929baa63a924605e4284e5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

