### PR TITLE
Backport: Manage Changes Filter date/time picker needs alignment

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -51,6 +51,14 @@
 	width: max-content;
 	max-width: 1000px;
 }
+#AcceptRejectChangesDialog #RedlineViewPage.jsdialog.ui-grid-cell {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+#AcceptRejectChangesDialog #RedlineFilterPage .ui-timefield {
+	margin: 5px;
+}
 .jsdialog.one-child-popup {
 	border: 0;
 	margin: 0 !important;
@@ -893,6 +901,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	align-items: center;
 	box-sizing: border-box;
 	height: 24px;
+}
+
+.ui-listbox-container{
+	height: 32px;
 }
 
 .ui-listbox {


### PR DESCRIPTION
Backport PR: https://github.com/CollaboraOnline/online/pull/11751

- Fixed alignment issue in the manage dialog for date/time picker.
- Increased ui-listbox-container height for better visibility.
- targeted only gird elements inside AcceptRejectChangesDialog to avoid affecting other dialogs.


Change-Id: I8c36526343593329da45b557e07e9d12636975a5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

