### PR TITLE
helm: add nginx-deny service

### DIFF
--- a/kubernetes/helm/collabora-online/templates/nginx-deny/configmap.yaml
+++ b/kubernetes/helm/collabora-online/templates/nginx-deny/configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.nginxDeny.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "collabora-online.fullname" . }}-nginxdeny
+  labels:
+    {{- include "collabora-online.labels" . | nindent 4 }}
+data:
+  nginx.conf: |
+    events { }
+    http {
+        server {
+            listen 80 default_server;
+            location / {
+                return 403;
+            }
+        }
+    }
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/nginx-deny/deployment.yaml
+++ b/kubernetes/helm/collabora-online/templates/nginx-deny/deployment.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.nginxDeny.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "collabora-online.fullname" . }}-nginxdeny
+  labels:
+    {{- include "collabora-online.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.nginxDeny.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "collabora-online.selectorLabels" . | nindent 6 }}
+      type: nginxdeny
+  template:
+    metadata:
+      labels:
+        {{- include "collabora-online.selectorLabels" . | nindent 8 }}
+        type: nginxdeny
+    spec:
+      serviceAccountName: {{ include "collabora-online.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.nginxDeny.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-nginxdeny
+          securityContext:
+            {{- toYaml .Values.nginxDeny.securityContext | nindent 12 }}
+          image: "{{ .Values.nginxDeny.image.repository }}:{{ .Values.nginxDeny.image.tag }}"
+          imagePullPolicy: {{ .Values.nginxDeny.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.nginxDeny.containerPort }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.nginxDeny.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+      {{- with .Values.nginxDeny.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nginxDeny.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nginxDeny.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "collabora-online.fullname" . }}-nginxdeny
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/nginx-deny/ingress.yaml
+++ b/kubernetes/helm/collabora-online/templates/nginx-deny/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.nginxDeny.enabled -}}
+{{- $fullName := include "collabora-online.fullname" . -}}
+{{- $svcPort := .Values.nginxDeny.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-nginxdeny
+  labels:
+    {{- include "collabora-online.labels" . | nindent 4 }}
+  {{- with .Values.nginxDeny.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.nginxDeny.ingress.className }}
+  ingressClassName: {{ .Values.nginxDeny.ingress.className }}
+  {{- end }}
+  {{- if .Values.nginxDeny.ingress.tls }}
+  tls:
+    {{- range .Values.nginxDeny.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.nginxDeny.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}-nginxdeny
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/nginx-deny/service.yaml
+++ b/kubernetes/helm/collabora-online/templates/nginx-deny/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.nginxDeny.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "collabora-online.fullname" . }}-nginxdeny
+  labels:
+    {{- include "collabora-online.labels" . | nindent 4 }}
+    type: nginxdeny
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.nginxDeny.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "collabora-online.selectorLabels" . | nindent 4 }}
+    type: nginxdeny
+{{- end }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -279,6 +279,74 @@ podDisruptionBudget:
   # minAvailable: 1
   # maxUnavailable: 1
 
+# Ingress-Nginx has changed their default security settings in release <https://github.com/kubernetes/ingress-nginx/blob/main/changelog/controller-1.12.0.md>. `annotations-risk-level` default settings has changed from `critical` -> `high`. So annotation like `nginx.ingress.kubernetes.io/server-snippet` is not allowed.
+#
+# so something like following is not allowed unless you change the annotation-risk-level to critical.
+#
+# ```yaml
+# nginx.ingress.kubernetes.io/server-snippet: |
+#   location /cool/getMetrics { deny all; return 403; }
+#   location /cool/adminws/ { deny all; return 403; }
+#   location /browser/dist/admin/admin.html { deny all; return 403; }
+# ```
+#
+# This a workaround in our helm chart where we will deploying a dummy deny-service which can enabled or disabled based on yaml value.
+# Then admins can configure ingress block such that specific requests which they want to be denied goes to this deny service
+# For example
+# nginxDeny:
+#   enabled: true
+#
+#   ingress:
+#     enabled: true
+#     className: "nginx"
+#     hosts:
+#       - host: test.collabora.online
+#         paths:
+#         - path: "/browser/dist/admin/admin.html"
+#           pathType: ImplementationSpecific
+#         - path: "/cool/getMetrics"
+#           pathType: Exact
+#         - path: "/cool/adminws/"
+#           pathType: Exact
+
+nginxDeny:
+  enabled: false
+
+  image:
+    repository: nginx
+    tag: stable-alpine
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+  podAnnotations: []
+  podSecurityContext: {}
+  securityContext: {}
+
+  containerPort: 80
+
+  env: []
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  service:
+    port: 8080
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
 dynamicConfig:
   enabled: false
   logging:


### PR DESCRIPTION
- Ingress-Nginx has changed their default security settings in release <https://github.com/kubernetes/ingress-nginx/blob/main/changelog/controller-1.12.0.md>. `annotations-risk-level` default settings has changed from `critical` -> `high`. So annotation like `nginx.ingress.kubernetes.io/server-snippet` is not allowed.

- so something like following is not allowed unless you change the annotation-risk-level to critical and sometimes admins don't want to change the risk level:

```yml
nginx.ingress.kubernetes.io/server-snippet: |
  location /cool/getMetrics { deny all; return 403; }
  location /cool/adminws/ { deny all; return 403; }
  location /browser/dist/admin/admin.html { deny all; return 403; }
```

- this patch introduce workaround in our helm chart where we will deploying a dummy deny-service called nginx deny which can enabled or disabled based on yaml value.
- Then admins can configure ingress block such that specific requests which they want to be denied goes to this deny service

- For example

```yml
 nginxDeny:
  enabled: true

  ingress:
    enabled: true
    className: "nginx"
    hosts:
      - host: test.collabora.online
        paths:
        - path: "/browser/dist/admin/admin.html"
          pathType: ImplementationSpecific
        - path: "/cool/getMetrics"
          pathType: Exact
        - path: "/cool/adminws/"
          pathType: Exact
```

Change-Id: If040a529a4c5497c27261a98fe8ac30acec8a37a

* Target version: master 

