### PR TITLE
Admin Improvements

### DIFF
--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -87,7 +87,8 @@ extern "C" { void dump_forkit_state(void); /* easy for gdb */ }
 
 void dump_forkit_state()
 {
-    std::ostringstream oss;
+    std::ostringstream oss(Util::makeDumpStateStream());
+    oss << "Start ForKit " << getpid() << " Dump State:\n";
 
     oss << "Forkit: " << ForkCounter << " forks\n"
         << "  LogLevel: " << LogLevel << "\n"
@@ -105,10 +106,11 @@ void dump_forkit_state()
 
     oss << "\nMalloc info [" << getpid() << "]: \n\t"
         << Util::replace(Util::getMallocInfo(), "\n", "\n\t") << '\n';
+    oss << "\nEnd ForKit " << getpid() << " Dump State.\n";
 
     const std::string msg = oss.str();
     fprintf(stderr, "%s", msg.c_str());
-    LOG_TRC(msg);
+    LOG_WRN(msg);
 }
 
 class ServerWSHandler;

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -4163,14 +4163,17 @@ std::string anonymizeUsername(const std::string& username)
 void dump_kit_state()
 {
     std::ostringstream oss(Util::makeDumpStateStream());
+    oss << "Start Kit " << getpid() << " Dump State:\n";
+
     KitSocketPoll::dumpGlobalState(oss);
 
     oss << "\nMalloc info [" << getpid() << "]: \n\t"
         << Util::replace(Util::getMallocInfo(), "\n", "\n\t") << '\n';
+    oss << "\nEnd Kit " << getpid() << " Dump State.\n";
 
     const std::string msg = oss.str();
-    fprintf(stderr, "%s\n", msg.c_str()); // Log in the journal.
-    LOG_INF(msg);
+    fprintf(stderr, "%s", msg.c_str()); // Log in the journal.
+    LOG_WRN(msg);
 }
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -1223,7 +1223,7 @@ void Admin::scheduleMonitorConnect(const std::string &uri, std::chrono::steady_c
     _pendingConnects.push_back(std::move(todo));
 }
 
-void Admin::getMetrics(std::ostringstream& metrics) const
+void Admin::getMetrics(std::ostream& metrics) const
 {
     const size_t memAvail = getTotalAvailableMemory();
     const size_t memUsed = getTotalMemoryUsage();

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -822,7 +822,7 @@ void Admin::rescheduleCpuTimer(unsigned interval)
     wakeup();
 }
 
-size_t Admin::getTotalMemoryUsage()
+size_t Admin::getTotalMemoryUsage() const
 {
     // To simplify and clarify this; since load, link and pre-init all
     // inside the forkit - we should account all of our fixed cost of
@@ -836,11 +836,10 @@ size_t Admin::getTotalMemoryUsage()
     return totalMem;
 }
 
-size_t Admin::getTotalCpuUsage()
+size_t Admin::getTotalCpuUsage() const
 {
     const size_t forkitJ = Util::getCpuUsage(_forKitPid);
     const size_t wsdJ = Util::getCpuUsage(getpid());
-    const size_t kitsJ = _model.getKitsJiffies();
 
     if (_lastJiffies == 0)
     {
@@ -848,31 +847,32 @@ size_t Admin::getTotalCpuUsage()
         return 0;
     }
 
+    const size_t kitsJ = _model.getKitsJiffies();
     const size_t totalJ = ((forkitJ + wsdJ) - _lastJiffies) + kitsJ;
     _lastJiffies = forkitJ + wsdJ;
 
     return totalJ;
 }
 
-unsigned Admin::getMemStatsInterval()
+unsigned Admin::getMemStatsInterval() const
 {
     ASSERT_CORRECT_THREAD();
     return _memStatsTaskIntervalMs;
 }
 
-unsigned Admin::getCpuStatsInterval()
+unsigned Admin::getCpuStatsInterval() const
 {
     ASSERT_CORRECT_THREAD();
     return _cpuStatsTaskIntervalMs;
 }
 
-unsigned Admin::getNetStatsInterval()
+unsigned Admin::getNetStatsInterval() const
 {
     ASSERT_CORRECT_THREAD();
     return _netStatsTaskIntervalMs;
 }
 
-std::string Admin::getChannelLogLevels()
+std::string Admin::getChannelLogLevels() const
 {
     std::string result = "wsd=" + Log::getLogLevelName("wsd");
 
@@ -896,7 +896,7 @@ void Admin::setChannelLogLevel(const std::string& channelName, std::string level
     }
 }
 
-std::string Admin::getLogLines()
+std::string Admin::getLogLines() const
 {
     ASSERT_CORRECT_THREAD();
 
@@ -1223,10 +1223,10 @@ void Admin::scheduleMonitorConnect(const std::string &uri, std::chrono::steady_c
     _pendingConnects.push_back(std::move(todo));
 }
 
-void Admin::getMetrics(std::ostringstream &metrics)
+void Admin::getMetrics(std::ostringstream& metrics) const
 {
-    size_t memAvail =  getTotalAvailableMemory();
-    size_t memUsed = getTotalMemoryUsage();
+    const size_t memAvail = getTotalAvailableMemory();
+    const size_t memUsed = getTotalMemoryUsage();
 
     metrics << "global_host_system_memory_bytes " << _totalSysMemKb * 1024 << std::endl;
     metrics << "global_host_tcp_connections " << net::Defaults.maxExtConnections << std::endl;
@@ -1266,7 +1266,7 @@ void Admin::start()
     startThread();
 }
 
-std::vector<std::pair<std::string, int>> Admin::getMonitorList()
+std::vector<std::pair<std::string, int>> Admin::getMonitorList() const
 {
     const auto& config = Application::instance().config();
     std::vector<std::pair<std::string, int>> monitorList;

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -48,9 +48,6 @@ using namespace COOLProtocol;
 
 using Poco::Util::Application;
 
-const int Admin::MinStatsIntervalMs = 50;
-const int Admin::DefStatsIntervalMs = 1000;
-
 /// Process incoming websocket messages
 void AdminSocketHandler::handleMessage(const std::vector<char> &payload)
 {

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -710,9 +710,11 @@ void Admin::pollingThread()
         if (_dumpMetrics.compare_exchange_strong(dumpMetrics, false))
         {
             std::ostringstream oss(Util::makeDumpStateStream());
-            oss << "Admin Metrics:\n";
-            getMetrics(oss);
-            oss << '\n';
+            oss << "Start Admin " << getpid() << " Dump State:\n";
+
+            dumpState(oss);
+
+            oss << "End Admin " << getpid() << " Dump State.\n";
 
             const std::string str = oss.str();
             fprintf(stderr, "%s", str.c_str());
@@ -1137,10 +1139,22 @@ void Admin::cleanupLostKits()
 
 void Admin::dumpState(std::ostream& os) const
 {
-    // FIXME: be more helpful ...
     SocketPoll::dumpState(os);
-}
 
+    os << "Monitor sockets: " << _monitorSockets.size() << ":\n";
+    if (!_monitorSockets.empty())
+    {
+        for (const auto& socket : _monitorSockets)
+        {
+            os << socket.first << ": " << (socket.second->isConnected() ? "" : "dis")
+               << "connected\n";
+        }
+    }
+
+    os << "Admin Metrics:\n";
+    getMetrics(os);
+    os << '\n';
+}
 
 MonitorSocketHandler::MonitorSocketHandler(Admin *admin, const std::string &uri)
     : AdminSocketHandler(admin)

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -709,12 +709,14 @@ void Admin::pollingThread()
         bool dumpMetrics = true;
         if (_dumpMetrics.compare_exchange_strong(dumpMetrics, false))
         {
-            std::ostringstream oss;
+            std::ostringstream oss(Util::makeDumpStateStream());
             oss << "Admin Metrics:\n";
             getMetrics(oss);
+            oss << '\n';
+
             const std::string str = oss.str();
-            fprintf(stderr, "%s\n", str.c_str());
-            LOG_TRC(str);
+            fprintf(stderr, "%s", str.c_str());
+            LOG_WRN(str);
         }
 
         // Handle websockets & other work.

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -264,8 +264,8 @@ private:
     std::atomic<bool> _closeMonitor = false;
 
     // Don't update any more frequently than this since it's excessive.
-    static const int MinStatsIntervalMs;
-    static const int DefStatsIntervalMs;
+    static constexpr int MinStatsIntervalMs = 50;
+    static constexpr int DefStatsIntervalMs = 1000;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -176,7 +176,7 @@ public:
                               unsigned oomKilledCount);
     void addLostKitsTerminated(unsigned lostKitsTerminated);
 
-    void getMetrics(std::ostringstream& metrics) const;
+    void getMetrics(std::ostream& metrics) const;
 
     /// Will dump the metrics in the log and stderr from the Admin SocketPoll.
     static void dumpMetrics() { instance()._dumpMetrics = true; }

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -94,16 +94,16 @@ public:
 
     void updateMonitors(std::vector<std::pair<std::string, int>>& oldMonitors);
 
-    std::vector<std::pair<std::string, int>> getMonitorList();
+    std::vector<std::pair<std::string, int>> getMonitorList() const;
 
     /// Custom poll thread function
     void pollingThread() override;
 
-    size_t getTotalMemoryUsage();
+    size_t getTotalMemoryUsage() const;
     /// Takes into account the 'memproportion' property in config file to find the amount of memory
     /// available to us.
-    size_t getTotalAvailableMemory() { return _totalAvailMemKb; }
-    size_t getTotalCpuUsage();
+    size_t getTotalAvailableMemory() const { return _totalAvailMemKb; }
+    size_t getTotalCpuUsage() const;
 
     void modificationAlert(const std::string& dockey, pid_t pid, bool value);
 
@@ -129,19 +129,19 @@ public:
     /// Callers must ensure that modelMutex is acquired
     AdminModel& getModel();
 
-    unsigned getMemStatsInterval();
+    unsigned getMemStatsInterval() const;
 
-    unsigned getCpuStatsInterval();
+    unsigned getCpuStatsInterval() const;
 
-    unsigned getNetStatsInterval();
+    unsigned getNetStatsInterval() const;
 
     /// Returns the log levels of wsd and forkit & kits.
-    std::string getChannelLogLevels();
+    std::string getChannelLogLevels() const;
 
     /// Sets the specified channel's log level (wsd or forkit and kits).
     void setChannelLogLevel(const std::string& channelName, std::string level);
 
-    std::string getLogLines();
+    std::string getLogLines() const;
 
     void rescheduleMemTimer(unsigned interval);
 
@@ -176,7 +176,7 @@ public:
                               unsigned oomKilledCount);
     void addLostKitsTerminated(unsigned lostKitsTerminated);
 
-    void getMetrics(std::ostringstream &metrics);
+    void getMetrics(std::ostringstream& metrics) const;
 
     /// Will dump the metrics in the log and stderr from the Admin SocketPoll.
     static void dumpMetrics() { instance()._dumpMetrics = true; }
@@ -232,7 +232,7 @@ private:
     size_t _totalAvailMemKb;
 
     size_t _lastTotalMemory;
-    size_t _lastJiffies;
+    mutable size_t _lastJiffies;
     size_t _cleanupIntervalMs;
     uint64_t _lastSentCount;
     uint64_t _lastRecvCount;

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -306,7 +306,7 @@ std::string AdminModel::query(const std::string& command)
 }
 
 /// Returns memory consumed by all active coolkit processes
-unsigned AdminModel::getKitsMemoryUsage()
+unsigned AdminModel::getKitsMemoryUsage() const
 {
     ASSERT_CORRECT_THREAD_OWNER(_owner);
 
@@ -334,7 +334,7 @@ unsigned AdminModel::getKitsMemoryUsage()
     return totalMem;
 }
 
-size_t AdminModel::getKitsJiffies()
+size_t AdminModel::getKitsJiffies() const
 {
     ASSERT_CORRECT_THREAD_OWNER(_owner);
 
@@ -681,7 +681,7 @@ void AdminModel::removeDocument(const std::string& docKey)
     }
 }
 
-std::string AdminModel::getMemStats()
+std::string AdminModel::getMemStats() const
 {
     ASSERT_CORRECT_THREAD_OWNER(_owner);
 
@@ -694,7 +694,7 @@ std::string AdminModel::getMemStats()
     return oss.str();
 }
 
-std::string AdminModel::getCpuStats()
+std::string AdminModel::getCpuStats() const
 {
     ASSERT_CORRECT_THREAD_OWNER(_owner);
 
@@ -707,7 +707,7 @@ std::string AdminModel::getCpuStats()
     return oss.str();
 }
 
-std::string AdminModel::getSentActivity()
+std::string AdminModel::getSentActivity() const
 {
     ASSERT_CORRECT_THREAD_OWNER(_owner);
 
@@ -720,7 +720,7 @@ std::string AdminModel::getSentActivity()
     return oss.str();
 }
 
-std::string AdminModel::getRecvActivity()
+std::string AdminModel::getRecvActivity() const
 {
     ASSERT_CORRECT_THREAD_OWNER(_owner);
 
@@ -733,7 +733,7 @@ std::string AdminModel::getRecvActivity()
     return oss.str();
 }
 
-std::string AdminModel::getConnectionActivity()
+std::string AdminModel::getConnectionActivity() const
 {
     ASSERT_CORRECT_THREAD_OWNER(_owner);
 
@@ -746,7 +746,7 @@ std::string AdminModel::getConnectionActivity()
     return oss.str();
 }
 
-unsigned AdminModel::getTotalActiveViews()
+unsigned AdminModel::getTotalActiveViews() const
 {
     ASSERT_CORRECT_THREAD_OWNER(_owner);
 
@@ -1144,7 +1144,7 @@ struct KitProcStats
     AggregateStats _cpuTime;
 };
 
-void AdminModel::CalcDocAggregateStats(DocumentAggregateStats& stats)
+void AdminModel::CalcDocAggregateStats(DocumentAggregateStats& stats) const
 {
     for (auto& d : _documents)
         stats.Update(*d.second, true);
@@ -1175,7 +1175,7 @@ void PrintKitAggregateMetrics(std::ostringstream &oss, const char* name, const c
     values.Print(oss, prefix, unit);
 }
 
-void AdminModel::getMetrics(std::ostringstream &oss)
+void AdminModel::getMetrics(std::ostringstream& oss) const
 {
     ASSERT_CORRECT_THREAD_OWNER(_owner);
 
@@ -1356,7 +1356,7 @@ void AdminModel::sendMigrateMsgAfterSave(bool lastSaveSuccessful, const std::str
     COOLWSD::alertUserInternal(docKey, oss.str());
 }
 
-std::string AdminModel::getWopiSrcMap()
+std::string AdminModel::getWopiSrcMap() const
 {
     std::ostringstream oss;
     oss << "wopiSrcMap: {";
@@ -1393,9 +1393,9 @@ void AdminModel::resetMigratingInfo()
     _targetMigServerId = std::string();
 }
 
-std::string AdminModel::getFilename(int pid)
+std::string AdminModel::getFilename(int pid) const
 {
-    for (auto& it : _documents)
+    for (const auto& it : _documents)
     {
         if (it.second->getPid() == pid)
         {

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -1051,7 +1051,7 @@ private:
     uint64_t _count; ///< The number of samples. We are 8-byte aligned, so make this 64-bits.
 };
 
-struct ActiveExpiredStats
+class ActiveExpiredStats final
 {
 public:
     const AggregateStats& active() const { return _active; }

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -38,8 +38,8 @@
 
 namespace
 {
-std::ostringstream& print(std::ostringstream& oss, const std::string_view prefix,
-                          const std::string_view name, const std::string_view suffix)
+std::ostream& print(std::ostream& oss, const std::string_view prefix, const std::string_view name,
+                    const std::string_view suffix)
 {
     oss << prefix << (prefix.empty() ? "" : "_") << name << (suffix.empty() ? "" : "_") << suffix;
     return oss;
@@ -1035,8 +1035,7 @@ public:
     uint64_t getTotal() const { return _total; }
     uint64_t getCount() const { return _count; }
 
-    void Print(std::ostringstream& oss, const std::string_view prefix,
-               const std::string_view unit) const
+    void Print(std::ostream& oss, const std::string_view prefix, const std::string_view unit) const
     {
         print(oss, prefix, "total", unit) << _total << '\n';
         print(oss, prefix, "average", unit) << getIntAverage() << '\n';
@@ -1065,7 +1064,7 @@ public:
             _expired.Update(value);
     }
 
-    void Print(std::ostringstream &oss, const char *prefix, const char* name, const char* unit) const
+    void Print(std::ostream& oss, const char* prefix, const char* name, const char* unit) const
     {
         _all.Print(print(oss, prefix, "all", name), std::string_view(), unit);
         _active.Print(print(oss, prefix, "active", name), std::string_view(), unit);
@@ -1164,18 +1163,20 @@ void CalcKitStats(KitProcStats& stats)
     }
 }
 
-void PrintDocActExpMetrics(std::ostringstream &oss, const char* name, const char* unit, const ActiveExpiredStats &values)
+void PrintDocActExpMetrics(std::ostream& oss, const char* name, const char* unit,
+                           const ActiveExpiredStats& values)
 {
     values.Print(oss, "document", name, unit);
 }
 
-void PrintKitAggregateMetrics(std::ostringstream &oss, const char* name, const char* unit, const AggregateStats &values)
+void PrintKitAggregateMetrics(std::ostream& oss, const char* name, const char* unit,
+                              const AggregateStats& values)
 {
     const std::string prefix = std::string("kit_") + name;
     values.Print(oss, prefix, unit);
 }
 
-void AdminModel::getMetrics(std::ostringstream& oss) const
+void AdminModel::getMetrics(std::ostream& oss) const
 {
     ASSERT_CORRECT_THREAD_OWNER(_owner);
 

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -584,14 +584,14 @@ void AdminModel::addDocument(const std::string& docKey, pid_t pid,
     const std::string& wopiHost = wopiSrc.getHost();
     oss << memoryAllocated << ' ' << wopiHost << ' ' << isViewReadOnly << ' ' << wopiSrc.toString()
         << ' ' << Uri::decode(docKey);
-    if (ConfigUtil::getConfigValue<bool>("logging.docstats", false))
-    {
-        std::string docstats = "docstats : adding a document : " + filename
-                            + ", created by : " + COOLWSD::anonymizeUsername(userName)
-                            + ", using WopiHost : " + COOLWSD::anonymizeUrl(wopiHost)
-                            + ", allocating memory of : " + memoryAllocated;
 
-        LOG_ANY(docstats);
+    CONFIG_STATIC const bool log = ConfigUtil::getConfigValue<bool>("logging.docstats", false);
+    if (log)
+    {
+        LOG_ANY("docstats : adding a document : "
+                << filename << ", created by : " << COOLWSD::anonymizeUsername(userName)
+                << ", using WopiHost : " << COOLWSD::anonymizeUrl(wopiHost)
+                << ", allocating memory of : " << memoryAllocated);
     }
     notify(oss.str());
 }

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -583,7 +583,7 @@ void AdminModel::addDocument(const std::string& docKey, pid_t pid,
 
     const std::string& wopiHost = wopiSrc.getHost();
     oss << memoryAllocated << ' ' << wopiHost << ' ' << isViewReadOnly << ' ' << wopiSrc.toString()
-        << ' ' << Uri::decode(docKey);
+        << ' ' << docKey;
 
     CONFIG_STATIC const bool log = ConfigUtil::getConfigValue<bool>("logging.docstats", false);
     if (log)

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -1291,13 +1291,14 @@ void AdminModel::UpdateMemoryDirty()
 
 void AdminModel::notifyDocsMemDirtyChanged()
 {
-    for (const auto& it: _documents)
+    for (const auto& [name, doc] : _documents)
     {
-        int memoryDirty = it.second->getMemoryDirty();
-        if (it.second->hasMemDirtyChanged())
+        if (doc->hasMemDirtyChanged())
         {
-            notify("propchange " + std::to_string(it.second->getPid()) + " mem " + std::to_string(memoryDirty));
-            it.second->setMemDirtyChanged(false);
+            std::ostringstream msg;
+            msg << "propchange " << doc->getPid() << " mem " << doc->getMemoryDirty();
+            notify(msg.str());
+            doc->setMemDirtyChanged(false);
         }
     }
 }

--- a/wsd/AdminModel.cpp
+++ b/wsd/AdminModel.cpp
@@ -1041,6 +1041,7 @@ private:
 struct ActiveExpiredStats
 {
 public:
+    const AggregateStats& active() const { return _active; }
 
     void Update(uint64_t value, bool active)
     {
@@ -1067,6 +1068,7 @@ public:
         _expired.Print(oss, ossTmp.str().c_str(), unit);
     }
 
+private:
     AggregateStats _all;
     AggregateStats _active;
     AggregateStats _expired;
@@ -1200,7 +1202,7 @@ void AdminModel::getMetrics(std::ostringstream &oss)
     oss << "kit_killed_count " << _killedCount << std::endl;
     oss << "kit_killed_oom_count " << _oomKilledCount << std::endl;
     PrintKitAggregateMetrics(oss, "thread_count", "", kitStats._threadCount);
-    PrintKitAggregateMetrics(oss, "memory_used", "bytes", docStats._kitUsedMemory._active);
+    PrintKitAggregateMetrics(oss, "memory_used", "bytes", docStats._kitUsedMemory.active());
     PrintKitAggregateMetrics(oss, "cpu_time", "seconds", kitStats._cpuTime);
     oss << std::endl;
 
@@ -1210,8 +1212,8 @@ void AdminModel::getMetrics(std::ostringstream &oss)
     oss << std::endl;
 
     PrintDocActExpMetrics(oss, "views_all_count", "", docStats._viewsCount);
-    docStats._activeViewsCount._active.Print(oss, "document_active_views_active_count", "");
-    docStats._expiredViewsCount._active.Print(oss, "document_active_views_expired_count", "");
+    docStats._activeViewsCount.active().Print(oss, "document_active_views_active_count", "");
+    docStats._expiredViewsCount.active().Print(oss, "document_active_views_expired_count", "");
     oss << std::endl;
 
     PrintDocActExpMetrics(oss, "opened_time", "seconds", docStats._openedTime);

--- a/wsd/AdminModel.hpp
+++ b/wsd/AdminModel.hpp
@@ -78,13 +78,13 @@ struct DocCleanupSettings
     void setBadBehaviorPeriod(size_t badBehaviorPeriod) { _badBehaviorPeriod = badBehaviorPeriod; }
     size_t getBadBehaviorPeriod() const { return _badBehaviorPeriod; }
     void setIdleTime(size_t idleTime) { _idleTime = idleTime; }
-    size_t getIdleTime() { return _idleTime; }
+    size_t getIdleTime() const { return _idleTime; }
     void setLimitDirtyMem(size_t limitDirtyMem) { _limitDirtyMem = limitDirtyMem; }
     size_t getLimitDirtyMem() const { return _limitDirtyMem; }
     void setLimitCpu(size_t limitCpu) { _limitCpu = limitCpu; }
     size_t getLimitCpu() const { return _limitCpu; }
     void setLostKitGracePeriod(size_t lostKitGracePeriod) { _lostKitGracePeriod = lostKitGracePeriod; }
-    size_t getLostKitGracePeriod() { return _lostKitGracePeriod; }
+    size_t getLostKitGracePeriod() const { return _lostKitGracePeriod; }
 
 private:
     size_t _cleanupInterval;
@@ -216,7 +216,7 @@ public:
 
     size_t getLastJiffies() const { return _lastJiffy; }
     void setLastJiffies(size_t newJ);
-    unsigned getLastCpuPercentage(){ return _lastCpuPercentage; }
+    unsigned getLastCpuPercentage() const { return _lastCpuPercentage; }
 
     const std::map<std::string, View>& getViews() const { return _views; }
 
@@ -367,8 +367,8 @@ public:
     std::string getAllHistory() const;
 
     /// Returns memory consumed by all active coolkit processes
-    unsigned getKitsMemoryUsage();
-    size_t getKitsJiffies();
+    unsigned getKitsMemoryUsage() const;
+    size_t getKitsJiffies() const;
 
     void subscribe(int sessionId, const std::weak_ptr<WebSocketHandler>& ws);
     void subscribe(int sessionId, const std::string& command);
@@ -411,8 +411,8 @@ public:
 
     void addBytes(const std::string& docKey, uint64_t sent, uint64_t recv);
 
-    uint64_t getSentBytesTotal() { return _sentBytesTotal; }
-    uint64_t getRecvBytesTotal() { return _recvBytesTotal; }
+    uint64_t getSentBytesTotal() const { return _sentBytesTotal; }
+    uint64_t getRecvBytesTotal() const { return _recvBytesTotal; }
 
     static double getServerUptimeSecs();
 
@@ -429,7 +429,7 @@ public:
     void setForKitPid(pid_t pid) { _forKitPid = pid; }
     void addLostKitsTerminated(unsigned lostKitsTerminated);
 
-    void getMetrics(std::ostringstream &oss);
+    void getMetrics(std::ostringstream& oss) const;
 
     std::set<pid_t> getDocumentPids() const;
     void UpdateMemoryDirty();
@@ -446,33 +446,33 @@ public:
     bool isDocReadOnly(const std::string&);
     void setMigratingInfo(const std::string& docKey, const std::string& routeToken, const std::string& serverId);
     void resetMigratingInfo();
-    std::string getCurrentMigDoc() { return _currentMigDoc; }
-    std::string getCurrentMigToken() { return _currentMigToken; }
-    std::string getTargetMigServerId() { return _targetMigServerId; }
+    std::string getCurrentMigDoc() const { return _currentMigDoc; }
+    std::string getCurrentMigToken() const { return _currentMigToken; }
+    std::string getTargetMigServerId() const { return _targetMigServerId; }
     void sendMigrateMsgAfterSave(bool lastSaveSuccessful, const std::string& docKey);
-    std::string getWopiSrcMap();
-    std::string getFilename(int pid);
+    std::string getWopiSrcMap() const;
+    std::string getFilename(int pid) const;
     void routeTokenSanityCheck();
     void sendShutdownReceivedMsg();
 
 private:
     void doRemove(std::map<std::string, std::unique_ptr<Document>>::iterator &docIt);
 
-    std::string getMemStats();
+    std::string getMemStats() const;
 
-    std::string getSentActivity();
+    std::string getSentActivity() const;
 
-    std::string getRecvActivity();
+    std::string getRecvActivity() const;
 
-    std::string getConnectionActivity();
+    std::string getConnectionActivity() const;
 
-    std::string getCpuStats();
+    std::string getCpuStats() const;
 
-    unsigned getTotalActiveViews();
+    unsigned getTotalActiveViews() const;
 
     std::string getDocuments() const;
 
-    void CalcDocAggregateStats(DocumentAggregateStats& stats);
+    void CalcDocAggregateStats(DocumentAggregateStats& stats) const;
 
 private:
     DocProcSettings _defDocProcSettings;

--- a/wsd/AdminModel.hpp
+++ b/wsd/AdminModel.hpp
@@ -479,7 +479,9 @@ private:
 
     std::map<int, Subscriber> _subscribers;
     std::map<std::string, std::unique_ptr<Document>> _documents;
-    std::map<std::string, std::unique_ptr<Document>> _expiredDocuments;
+
+    /// The serialized histories of all expired documents.
+    std::vector<std::string> _expiredDocumentsHistories;
 
     /// The last N total memory Dirty size.
     std::list<unsigned> _memStats;

--- a/wsd/AdminModel.hpp
+++ b/wsd/AdminModel.hpp
@@ -26,7 +26,7 @@
 struct DocumentAggregateStats;
 
 /// A client view in Admin controller.
-class View
+class View final
 {
 public:
     View(std::string sessionId, std::string userName, std::string userId, bool readOnly)
@@ -127,7 +127,7 @@ private:
 };
 
 /// Containing basic information about document
-class DocBasicInfo
+class DocBasicInfo final
 {
     std::string _docKey;
     std::time_t _idleTime;
@@ -153,7 +153,7 @@ public:
 };
 
 /// A document in Admin controller.
-class Document
+class Document final
 {
     // cf. FILE* member.
     Document(const Document &) = delete;
@@ -310,7 +310,7 @@ private:
 };
 
 /// An Admin session subscriber.
-class Subscriber
+class Subscriber final
 {
 public:
     explicit Subscriber(std::weak_ptr<WebSocketHandler> ws)
@@ -346,7 +346,7 @@ private:
 };
 
 /// The Admin controller implementation.
-class AdminModel
+class AdminModel final
 {
     AdminModel(const AdminModel &) = delete;
     AdminModel& operator = (const AdminModel &) = delete;
@@ -499,11 +499,11 @@ private:
     /// We check the owner even in the release builds, needs to be always correct.
     std::thread::id _owner;
 
-    std::string _currentMigDoc = std::string();
+    std::string _currentMigDoc;
 
-    std::string _currentMigToken = std::string();
+    std::string _currentMigToken;
 
-    std::string _targetMigServerId = std::string();
+    std::string _targetMigServerId;
 
     unsigned _memStatsSize = 100;
     unsigned _cpuStatsSize = 100;

--- a/wsd/AdminModel.hpp
+++ b/wsd/AdminModel.hpp
@@ -429,7 +429,7 @@ public:
     void setForKitPid(pid_t pid) { _forKitPid = pid; }
     void addLostKitsTerminated(unsigned lostKitsTerminated);
 
-    void getMetrics(std::ostringstream& oss) const;
+    void getMetrics(std::ostream& oss) const;
 
     std::set<pid_t> getDocumentPids() const;
     void UpdateMemoryDirty();

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4239,17 +4239,18 @@ void forwardSignal(const int signum);
 void dump_state()
 {
     std::ostringstream oss(Util::makeDumpStateStream());
+    oss << "Start WSD " << getpid() << " Dump State:\n";
 
     if (Server)
         Server->dumpState(oss);
 
     oss << "\nMalloc info [" << getpid() << "]: \n\t"
         << Util::replace(Util::getMallocInfo(), "\n", "\n\t") << '\n';
+    oss << "\nEnd WSD " << getpid() << " Dump State.\n";
 
     const std::string msg = oss.str();
-    fprintf(stderr, "%s\n", msg.c_str()); // Log in the journal.
-
-    LOG_INF(msg);
+    fprintf(stderr, "%s", msg.c_str()); // Log in the journal.
+    LOG_WRN(msg);
 
 #if !MOBILEAPP
     Admin::dumpMetrics();

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3363,8 +3363,7 @@ public:
         PrisonerPoll->dumpState(os);
 
 #if !MOBILEAPP
-        os << "\nAdmin poll:\n";
-        _admin.dumpState(os);
+        _admin.dumpMetrics(); // Dump the state from the Admin poll thread.
 
         // If we have any delaying work going on.
         os << '\n';


### PR DESCRIPTION
- **wsd: admin: stream logs instead of concatenating strings**
- **wsd: admin: docKey is an opaque ID and shouldn't be decoded**
- **wsd: admin: privatize ActiveExpiredStats members**
- **wsd: admin: clean up AggregateStats**
- **wsd: admin: cleanup AdminModel**
- **wsd: admin: constexpr**
- **wsd: normalize state dumping**
- **wsd: admin: const correctness in Admin**
- **wsd: admin: printers take ostream**
- **wsd: dump Admin metrics through dumpState**
- **wsd: admin: clean up AdminModel::notifyDocsMemDirtyChanged()**
- **wsd: admin: move AdminModel::doRemove() to re-work it**
- **wsd: admin: no need to keep expired documents around**
