### PR TITLE
cool#11779 - thread slide layer compression.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -435,6 +435,7 @@ kit_headers = kit/ChildSession.hpp \
               kit/KitHelper.hpp \
               kit/KitWebSocket.hpp \
               kit/SetupKitEnvironment.hpp \
+	      kit/SlideCompressor.hpp \
               kit/StateRecorder.hpp \
               kit/Watermark.hpp
 

--- a/common/ThreadPool.hpp
+++ b/common/ThreadPool.hpp
@@ -58,6 +58,8 @@ public:
 
     ~ThreadPool() { stop(); }
 
+    int getThreadCount() { return _maxConcurrency; }
+
     void start()
     {
         {

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -65,6 +65,8 @@ enum class LokEventTargetEnum
     Window
 };
 
+class SlideCompressor;
+
 /// Represents a session to the WSD process, in a Kit process. Note that this is not a singleton.
 class ChildSession final : public Session
 {
@@ -194,8 +196,9 @@ private:
     bool unoSignatureCommand(const std::string& commandName);
     bool selectText(const StringVector& tokens, LokEventTargetEnum target);
     bool selectGraphic(const StringVector& tokens);
-    bool renderNextSlideLayer(unsigned width, unsigned height, double dDevicePixelRatio,
-                              bool& done);
+    bool renderNextSlideLayer(SlideCompressor &scomp,
+                              unsigned width, unsigned height,
+                              double dDevicePixelRatio, bool& done);
     bool renderSlide(const StringVector& tokens);
     bool renderWindow(const StringVector& tokens);
     bool resizeWindow(const StringVector& tokens);

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -440,6 +440,11 @@ public:
 
     LogUiCmd& getLogUiCmd() { return logUiCmd; }
 
+    /// Get a thread-pool to perform an operation in
+    /// all operations must complete by the time we
+    /// return to the poll
+    ThreadPool& getSyncPool() { return _deltaPool; }
+
 private:
     void postForceModifiedCommand(bool modified);
 

--- a/kit/SlideCompressor.hpp
+++ b/kit/SlideCompressor.hpp
@@ -1,0 +1,58 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <vector>
+#include <memory>
+#include <functional>
+
+#include "ThreadPool.hpp"
+
+/// Do slide compression work in a thread pool
+class SlideCompressor {
+    ThreadPool &_pool;
+
+    struct SlideItem {
+        std::vector<char> _output;
+    };
+    std::vector<std::shared_ptr<SlideItem>> _items;
+public:
+    SlideCompressor(ThreadPool &pool) :
+        _pool(pool)
+    {
+    }
+
+    /// workFn generates is passed a buffer to generate its output into
+    void pushWork(std::function<void(std::vector<char>&)> workFn)
+    {
+        auto item = std::make_shared<SlideItem>();
+        _items.push_back(item);
+                _pool.pushWork([=]{ workFn(item->_output); });
+    }
+
+    /// sendFunc is called in the same order after all items are compressed
+    void compress(std::function<void(std::vector<char>&)> sendFunc)
+    {
+        LOG_TRC("Compressing " << _items.size() << " layers with " << _pool.getThreadCount() << " threads");
+
+        if (_items.size() > 0)
+            _pool.run();
+
+        for (auto &it : _items)
+        {
+            if (it->_output.size() > 0)
+                sendFunc(it->_output);
+        }
+    }
+};
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Current PNG compression is as expected unfeasibly slow - so parallelize this with a ThreadPool where possible.


Change-Id: Ifd0e33c5da42b0c1b7722a2b45b9fe101733cd66


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

