### PR TITLE
Improve split button structure for accessibility compliance

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -90,7 +90,8 @@ button.jsdialog img {
 }
 
 :not(.main-nav) .button-secondary,
-:not(.main-nav) > div > button:not(.ui-tab):not(.ui-expander):not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.col) {
+:not(.main-nav) .button-secondary:not(.arrowbackground),
+:not(.main-nav) > div > button:not(.ui-tab):not(.ui-expander):not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.col):not(.arrowbackground) {
 	box-sizing: border-box;
 	height: 32px;
 	line-height: normal;

--- a/browser/css/device-desktop.css
+++ b/browser/css/device-desktop.css
@@ -22,7 +22,7 @@
    Rules not intended for touch devices */
 
 .button-secondary:hover,
-button:not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.notebookbar.ui-tab):not(.ui-expander):hover {
+button:not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.notebookbar.ui-tab):not(.ui-expander):not(.arrowbackground):hover {
 	cursor: pointer;
 	color: var(--color-text-darker) !important;
 	background-color: var(--color-background-lighter) !important;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1489,6 +1489,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	background-color: transparent;
 	grid-column: 3;
 	position: relative;
+	border: none;
+	padding: 0px;
 }
 
 .arrowbackground:hover {

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1236,7 +1236,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 					// Determine key direction
 					let key;
 					if (e.key === 'Tab') {
-						e.preventDefault(); // Always prevent default tab behavior
 						key = e.shiftKey ? 'ArrowLeft' : 'ArrowRight'; // Reverse if Shift+Tab
 					} else {
 						key = e.key;
@@ -2244,12 +2243,19 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		if (options && options.hasDropdownArrow) {
 			$(div).addClass('has-dropdown');
-			var arrowbackground = L.DomUtil.create('div', 'arrowbackground', div);
+			if (data.applyCallback) {
+				// Arrow should be a real button (user can interact with it)
+				var arrowbackground = L.DomUtil.create('button', 'arrowbackground', div);
+			} else {
+				// Arrow is just decoration
+				var arrowbackground = L.DomUtil.create('div', 'arrowbackground', div);
+				arrowbackground.setAttribute('aria-hidden', 'true');
+			}			
 			L.DomUtil.create('i', 'unoarrow', arrowbackground);
 			controls['arrow'] = arrowbackground;
 		} else if (data.dropdown === true) {
 			$(div).addClass('has-dropdown');
-			var arrowbackground = L.DomUtil.create('div', 'arrowbackground', div);
+			var arrowbackground = L.DomUtil.create('button', 'arrowbackground', div);
 			L.DomUtil.create('i', 'unoarrow', arrowbackground);
 			controls['arrow'] = arrowbackground;
 
@@ -2273,7 +2279,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		if (arrowbackground) {
 			div.setAttribute('aria-expanded', false);
-			arrowbackground.tabIndex = '0';
+			// if main button element in split button works same as arrowbackground then make sure arrowbackground not focusable due to a11y conflicts 
+			data.applyCallback ? arrowbackground.tabIndex = '0' : arrowbackground.tabIndex = '-1';
 		}
 
 		var openToolBoxMenu = function(event, div) {


### PR DESCRIPTION
- Create a <button> for the dropdown arrow if applycallback is present, allowing user interaction.
- Create a non-focusable <div aria-hidden="true"> if no interaction is needed (purely decorative).
- Solves confusion where screen readers would announce inactive buttons, improving keyboard and screen reader usability.


Change-Id: I1a81857c59ff8faa9fbb6ab341986e1124218af7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

