### PR TITLE
Manage changes dialog alignments

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -48,7 +48,7 @@
 }
 
 #AcceptRejectChangesDialog {
-	width: max-content;
+	width: 100%;
 	max-width: 1000px;
 }
 #AcceptRejectChangesDialog #RedlineViewPage.jsdialog.ui-grid-cell {
@@ -56,8 +56,26 @@
 	flex-direction: column;
 	gap: 8px;
 }
-#AcceptRejectChangesDialog #RedlineFilterPage .ui-timefield {
-	margin: 5px;
+
+#AcceptRejectChangesDialog #grid3.jsdialog.ui-grid {
+	margin-top: 8px;
+	grid-gap: 8px;
+}
+
+#AcceptRejectChangesDialog .jsdialog.ui-grid .has-img,
+#AcceptRejectChangesDialog .jsdialog.ui-grid .menubutton {
+	margin: 0 !important;
+	width: 100% !important;
+}
+
+#AcceptRejectChangesDialog .ui-treeview-headers,
+#AcceptRejectChangesDialog .jsdialog.ui-treeview-entry { 
+	grid-template-columns: 60px 60px 120px 130px;
+}
+
+#AcceptRejectChangesDialog .jsdialog.ui-treeview-entry > div:nth-child(2),
+#AcceptRejectChangesDialog .ui-treeview-headers .ui-treeview-icon-column {
+	display: none;
 }
 .jsdialog.one-child-popup {
 	border: 0;


### PR DESCRIPTION
Change-Id: Ib6f96f3a016377ed1d14543c57cf407c1ef36e85


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
 - Apply a full width to the AcceptRejectChangesDialog
 - Removed margins on menubuttons to fix alignments in date/time picker

### BEFORE
![Screenshot from 2025-04-29 09-58-28](https://github.com/user-attachments/assets/3600eca9-b09d-4c37-bc6e-24c7ab95c114)

![Screenshot from 2025-04-29 09-58-36](https://github.com/user-attachments/assets/617459a6-8a2e-4b2a-8b40-cdb14895219d)

### WITH THIS PR
![Screenshot from 2025-04-29 10-10-40](https://github.com/user-attachments/assets/e3459e6c-7602-4810-83e1-1af955f76f43)

![Screenshot from 2025-04-29 02-36-42](https://github.com/user-attachments/assets/31bae093-eb0e-46f3-82d1-def78c4d92d1)


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

