### PR TITLE
LayoutingService: use taks for update widget

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2814,7 +2814,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 	// replaces widget in-place with new instance with updated data
 	updateWidget: function (container, data) {
-		this._updateWidgetImpl(container, data, this.build);
+		app.layoutingService.appendLayoutingTask(() => {
+			this._updateWidgetImpl(container, data, this.build);
+		});
 	},
 
 	postProcess: function(parent, data) {


### PR DESCRIPTION
- it was removed recently due to fix for popups
- do not do it partially inside updateWidgetImpl
- schedule task in entry point for all components

commit 59432e8bd6eaee0f2c1740992bbdca8ba09affc6
jsdialog: reduce flicker and position changes 3

