### PR TITLE
Avoid error on close

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3963,8 +3963,6 @@ L.CanvasTileLayer = L.Layer.extend({
 	},
 
 	onRemove: function (map) {
-		this._painter.dispose();
-
 		L.DomUtil.remove(this._container);
 		map._removeZoomLimit(this);
 		this._container = null;


### PR DESCRIPTION
browser/a510bb2f78/src/layer/tile/CanvasTileLayer.js:3360 Uncaught TypeError: this._painter.dispose is not a function
    at NewClass.onRemove (/browser/a510bb2f78/src/layer/tile/CanvasTileLayer.js:3360:23)

dispose doesn't exist
