### PR TITLE
zotero: fixed citation style not being saved (cherry-pick)

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -667,8 +667,10 @@ bool ChildSession::_handleInput(const char *buffer, int length)
                 assert(false);
                 return false;
             }
-            else if (tokens[1].find(".uno:SetDocumentProperties") != std::string::npos)
+            else if (tokens[1].find(".uno:SetDocumentProperties") != std::string::npos && tokens.size() == 2)
             {
+                // Don't append anything if command has any parameters
+                // It maybe json and appending plain string makes everything broken
                 std::string PossibleFileExtensions[3] = {"", TO_UPLOAD_SUFFIX + std::string(UPLOADING_SUFFIX), TO_UPLOAD_SUFFIX};
                 for (size_t i = 0; i < 3; i++)
                 {


### PR DESCRIPTION
appending string to json argument caused json to become invalid and entire command was not executed


Change-Id: I7e22b89022ef91fbe1db3eda52f210e7e65852e2

* Target version: distro/collabora/co-24.04 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

