### PR TITLE
browser, docstate: document that twips<->pixel multipliers are zoom-dependent

### DIFF
--- a/browser/src/docstate.js
+++ b/browser/src/docstate.js
@@ -44,8 +44,8 @@ window.app = {
 	DebugManager: null, // Attach DebugManager class.
 	dispatcher: null, // A Dispatcher class instance is assigned to this.
 	layoutingService: null, // instance of a service processing squashed DOM updates
-	twipsToPixels: 0, // Twips to pixels multiplier.
-	pixelsToTwips: 0, // Pixels to twips multiplier.
+	twipsToPixels: 0, // Twips to pixels multiplier, according to the current zoom level.
+	pixelsToTwips: 0, // Pixels to twips multiplier, according to the current zoom level.
 	accessibilityState: false, // If accessibility was enabled by user
 	UI: {
 		language: {


### PR DESCRIPTION
See CanvasTileLayer.js _updateTileTwips(). A wrong guess would be that
these are CSS pixels, which are not zoom dependent.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I2c1afe8f012dcd75e4f2d46bf2a063b0823fd451
