### PR TITLE
only std::istream api of Poco::MemoryInputStream needed

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1577,7 +1577,7 @@ bool StreamSocket::checkRemoval(std::chrono::steady_clock::time_point now)
 
 #if !MOBILEAPP
 
-bool StreamSocket::parseHeader(const char* clientName, Poco::MemoryInputStream& message,
+bool StreamSocket::parseHeader(const char* clientName, std::istream& message,
                                Poco::Net::HTTPRequest& request,
                                std::chrono::steady_clock::time_point lastHTTPHeader,
                                MessageMap& map)

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1558,7 +1558,7 @@ public:
 
     /// Detects if we have an HTTP header in the provided message and
     /// populates a request for that.
-    bool parseHeader(const char* clientLoggingName, Poco::MemoryInputStream& message,
+    bool parseHeader(const char* clientLoggingName, std::istream& message,
                      Poco::Net::HTTPRequest& request,
                      std::chrono::steady_clock::time_point lastHTTPHeader, MessageMap& map);
 

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1154,7 +1154,7 @@ void ClientRequestDispatcher::sendResult(const std::shared_ptr<StreamSocket>& so
 }
 
 bool ClientRequestDispatcher::handleWopiAccessCheckRequest(const Poco::Net::HTTPRequest& request,
-                                                           Poco::MemoryInputStream& message,
+                                                           std::istream& message,
                                                            const std::shared_ptr<StreamSocket>& socket)
 {
     assert(socket && "Must have a valid socket");
@@ -1384,7 +1384,7 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(const Poco::Net::HTTP
 }
 
 bool ClientRequestDispatcher::handleClipboardRequest(const Poco::Net::HTTPRequest& request,
-                                                     Poco::MemoryInputStream& message,
+                                                     std::istream& message,
                                                      SocketDisposition& disposition,
                                                      const std::shared_ptr<StreamSocket>& socket)
 {
@@ -1821,7 +1821,7 @@ bool ClientRequestDispatcher::isSpreadsheet(const std::string& fileName)
 
 bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDetails,
                                                 const Poco::Net::HTTPRequest& request,
-                                                Poco::MemoryInputStream& message,
+                                                std::istream& message,
                                                 SocketDisposition& disposition,
                                                 const std::shared_ptr<StreamSocket>& socket)
 {
@@ -2134,7 +2134,7 @@ bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
 
 bool ClientRequestDispatcher::handleClientProxyRequest(const Poco::Net::HTTPRequest& request,
                                                        const RequestDetails& requestDetails,
-                                                       Poco::MemoryInputStream& message,
+                                                       std::istream& message,
                                                        SocketDisposition& disposition)
 {
     //FIXME: The DocumentURI includes the WOPISrc, which makes it potentially invalid URI.

--- a/wsd/ClientRequestDispatcher.hpp
+++ b/wsd/ClientRequestDispatcher.hpp
@@ -80,12 +80,12 @@ private:
                                    const std::shared_ptr<StreamSocket>& socket);
 
     bool handleWopiAccessCheckRequest(const Poco::Net::HTTPRequest& request,
-                                   Poco::MemoryInputStream& message,
+                                   std::istream& message,
                                    const std::shared_ptr<StreamSocket>& socket);
 
     /// @return true if request has been handled synchronously and response sent, otherwise false
     static bool handleClipboardRequest(const Poco::Net::HTTPRequest& request,
-                                       Poco::MemoryInputStream& message,
+                                       std::istream& message,
                                        SocketDisposition& disposition,
                                        const std::shared_ptr<StreamSocket>& socket);
 
@@ -108,13 +108,13 @@ private:
 
     /// @return true if request has been handled synchronously and response sent, otherwise false
     bool handlePostRequest(const RequestDetails& requestDetails,
-                           const Poco::Net::HTTPRequest& request, Poco::MemoryInputStream& message,
+                           const Poco::Net::HTTPRequest& request, std::istream& message,
                            SocketDisposition& disposition,
                            const std::shared_ptr<StreamSocket>& socket);
 
     bool handleClientProxyRequest(const Poco::Net::HTTPRequest& request,
                                   const RequestDetails& requestDetails,
-                                  Poco::MemoryInputStream& message, SocketDisposition& disposition);
+                                  std::istream& message, SocketDisposition& disposition);
 
     void sendResult(const std::shared_ptr<StreamSocket>& socket, CheckStatus result);
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -416,7 +416,7 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
     //handles request starts with /wopi/files
     void handleWopiRequest(const HTTPRequest& request,
                            const RequestDetails &requestDetails,
-                           Poco::MemoryInputStream& message,
+                           std::istream& message,
                            const std::shared_ptr<StreamSocket>& socket)
     {
         Poco::URI requestUri(request.getURI());
@@ -720,7 +720,7 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
     //handles request starts with /wopi/settings
     void handleSettingsRequest(const HTTPRequest& request,
                                const std::string& etagString,
-                               Poco::MemoryInputStream& message,
+                               std::istream& message,
                                const std::shared_ptr<StreamSocket>& socket)
     {
         Poco::URI requestUri(request.getURI());
@@ -886,7 +886,7 @@ static std::string getRequestPath(const HTTPRequest& request)
 
 bool FileServerRequestHandler::handleRequest(const HTTPRequest& request,
                                              const RequestDetails& requestDetails,
-                                             Poco::MemoryInputStream& message,
+                                             std::istream& message,
                                              const std::shared_ptr<StreamSocket>& socket,
                                              ResourceAccessDetails& accessDetails)
 {
@@ -1634,7 +1634,7 @@ std::string boolToString(const bool value)
 
 FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::preprocessFile(
     const HTTPRequest& request, http::Response& httpResponse, const RequestDetails& requestDetails,
-    Poco::MemoryInputStream& message, const std::shared_ptr<StreamSocket>& socket)
+    std::istream& message, const std::shared_ptr<StreamSocket>& socket)
 {
     const ServerURL cnxDetails(requestDetails);
 
@@ -2026,7 +2026,7 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
 void FileServerRequestHandler::preprocessWelcomeFile(const HTTPRequest& request,
                                                      http::Response& httpResponse,
                                                      const RequestDetails& requestDetails,
-                                                     Poco::MemoryInputStream& message,
+                                                     std::istream& message,
                                                      const std::shared_ptr<StreamSocket>& socket)
 {
     const std::string relPath = getRequestPathname(request, requestDetails);
@@ -2073,7 +2073,7 @@ void FilePartHandler::handlePart(const Poco::Net::MessageHeader& header, std::is
 }
 
 void FileServerRequestHandler::fetchWopiSettingConfigs(const Poco::Net::HTTPRequest& request,
-                                                       Poco::MemoryInputStream& message,
+                                                       std::istream& message,
                                                        const std::shared_ptr<StreamSocket>& socket)
 {
     Poco::Net::HTMLForm form(request, message);
@@ -2148,8 +2148,8 @@ void FileServerRequestHandler::fetchWopiSettingConfigs(const Poco::Net::HTTPRequ
 }
 
 void FileServerRequestHandler::fetchSettingFile(const Poco::Net::HTTPRequest& request,
-                                                 Poco::MemoryInputStream& message,
-                                                 const std::shared_ptr<StreamSocket>& socket)
+                                                std::istream& message,
+                                                const std::shared_ptr<StreamSocket>& socket)
 {
     Poco::Net::HTMLForm form(request, message);
 
@@ -2193,7 +2193,7 @@ void FileServerRequestHandler::fetchSettingFile(const Poco::Net::HTTPRequest& re
 }
 
 void FileServerRequestHandler::deleteWopiSettingConfigs(
-    const Poco::Net::HTTPRequest& request, Poco::MemoryInputStream& message,
+    const Poco::Net::HTTPRequest& request, std::istream& message,
     const std::shared_ptr<StreamSocket>& socket)
 {
     Poco::Net::HTMLForm form(request, message);
@@ -2272,7 +2272,7 @@ void FileServerRequestHandler::deleteWopiSettingConfigs(
 }
 
 void FileServerRequestHandler::uploadFileToIntegrator(const Poco::Net::HTTPRequest& request,
-                                                      Poco::MemoryInputStream& message,
+                                                      std::istream& message,
                                                       const std::shared_ptr<StreamSocket>& socket)
 {
     FilePartHandler partHandler;
@@ -2362,7 +2362,7 @@ void FileServerRequestHandler::uploadFileToIntegrator(const Poco::Net::HTTPReque
 void FileServerRequestHandler::preprocessIntegratorAdminFile(const HTTPRequest& request,
                                                             http::Response& response,
                                                             const RequestDetails& requestDetails,
-                                                            Poco::MemoryInputStream& message,
+                                                            std::istream& message,
                                                             const std::shared_ptr<StreamSocket>& socket)
 {
     const ServerURL cnxDetails(requestDetails);

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -125,28 +125,28 @@ private:
     ResourceAccessDetails preprocessFile(const Poco::Net::HTTPRequest& request,
                                          http::Response& httpResponse,
                                          const RequestDetails& requestDetails,
-                                         Poco::MemoryInputStream& message,
+                                         std::istream& message,
                                          const std::shared_ptr<StreamSocket>& socket);
     void preprocessWelcomeFile(const Poco::Net::HTTPRequest& request,
                                http::Response& httpResponse,
                                const RequestDetails& requestDetails,
-                               Poco::MemoryInputStream& message,
+                               std::istream& message,
                                const std::shared_ptr<StreamSocket>& socket);
 
     static void uploadFileToIntegrator(const Poco::Net::HTTPRequest& request,
-                                       Poco::MemoryInputStream& message,
+                                       std::istream& message,
                                        const std::shared_ptr<StreamSocket>& socket);
 
     static void fetchWopiSettingConfigs(const Poco::Net::HTTPRequest& request,
-                                        Poco::MemoryInputStream& message,
+                                        std::istream& message,
                                         const std::shared_ptr<StreamSocket>& socket);
 
     static void fetchSettingFile(const Poco::Net::HTTPRequest& request,
-                                   Poco::MemoryInputStream& message,
+                                   std::istream& message,
                                    const std::shared_ptr<StreamSocket>& socket);
 
     static void deleteWopiSettingConfigs(const Poco::Net::HTTPRequest& request,
-                                         Poco::MemoryInputStream& message,
+                                         std::istream& message,
                                          const std::shared_ptr<StreamSocket>& socket);
 
     void preprocessAdminFile(const Poco::Net::HTTPRequest& request,
@@ -162,7 +162,7 @@ private:
     void preprocessIntegratorAdminFile(const Poco::Net::HTTPRequest& request,
                                        http::Response& httpResponse,
                                        const RequestDetails& requestDetails,
-                                       Poco::MemoryInputStream& message,
+                                       std::istream& message,
                                        const std::shared_ptr<StreamSocket>& socket);
 
     /// Construct a JSON to be accepted by the cool.html from a list like
@@ -192,7 +192,7 @@ public:
 
     bool handleRequest(const Poco::Net::HTTPRequest& request,
                        const RequestDetails& requestDetails,
-                       Poco::MemoryInputStream& message,
+                       std::istream& message,
                        const std::shared_ptr<StreamSocket>& socket,
                        ResourceAccessDetails& accessDetails);
 


### PR DESCRIPTION
only std::istream api of Poco::MemoryInputStream needed in these handlers.