### PR TITLE
Fix core git hash link

### DIFF
--- a/browser/admin/src/AdminSocketSettings.js
+++ b/browser/admin/src/AdminSocketSettings.js
@@ -106,7 +106,7 @@ var AdminSocketSettings = AdminSocketBase.extend({
 			var lokitVersionObj = JSON.parse(textMsg.substring(textMsg.indexOf('{')));
 			h = lokitVersionObj.BuildId.substring(0, 10);
 			if (parseInt(h,16).toString(16) === h.toLowerCase().replace(/^0+/, '')) {
-				h = '<a target="_blank" href="https://hub.libreoffice.org/git-core/' + h + '">' + h + '</a>';
+				h = '<a target="_blank" href="https://git.libreoffice.org/core/+log/' + lokitVersionObj.BuildId + '/">' + h + '</a>';
 			}
 			$('#lokit-version').html(lokitVersionObj.ProductName + ' ' +
 			                         lokitVersionObj.ProductVersion + lokitVersionObj.ProductExtension +

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -765,7 +765,7 @@ app.definitions.Socket = L.Class.extend({
 			if (parseInt(h,16).toString(16) === h.toLowerCase().replace(/^0+/, '')) {
 				const anchor = document.createElement('a');
 				anchor.setAttribute('target', '_blank');
-				anchor.setAttribute('href', 'https://hub.libreoffice.org/git-core/' + h);
+				anchor.setAttribute('href', 'https://git.libreoffice.org/core/+log/' + lokitVersionObj.BuildId + '/');
 				anchor.textContent = 'git hash: ' + h;
 
 				const span = document.createElement('span');


### PR DESCRIPTION
- Use https://git.libreoffice.org/core/+log/ directly, the hub redirect was bad (links did not work without trailing /, but redirect did not handle it)
- Use full hash in core link, otherwise git.libreoffice.org returns ERR_HTTP2_PROTOCOL_ERROR


Change-Id: I07a13f8b7cecc2f87df864fcc5ad8949e412e86a
