### PR TITLE
cid#463621 silence Variable copied when it could be moved

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -113,7 +113,7 @@
 #undef WASMAPP
 
 /* Makes config variables conditionally static, only in non-debug builds, to allow for overriding them in unit-tests. */
-#undef CONFIG_STATIC
+#undef CONFIG_STATIC_TYPE
 
 /* Controls whether or not we allow loading documents from the local filesystem. */
 #ifndef ENABLE_LOCAL_FILESYSTEM
@@ -122,4 +122,10 @@
 #else
 #define ENABLE_LOCAL_FILESYSTEM 0
 #endif
+#endif
+
+#if defined(__COVERITY__)
+#define CONFIG_STATIC static
+#else
+#define CONFIG_STATIC CONFIG_STATIC_TYPE
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -437,7 +437,7 @@ AC_MSG_CHECKING([whether to enable debug build])
 if test "$enable_debug" = "yes"; then
    AC_MSG_RESULT([yes])
    AC_DEFINE([ENABLE_DEBUG],1,[Whether to compile in some extra debugging support code and disable some security pieces])
-   AC_DEFINE([CONFIG_STATIC],,[Static config values are disabled in debug builds to allow for overriding in tests])
+   AC_DEFINE([CONFIG_STATIC_TYPE],,[Static config values are disabled in debug builds to allow for overriding in tests])
    ENABLE_DEBUG=true
    ENABLE_DEBUG_PROTOCOL=true
    COOLWSD_LOGLEVEL="trace"
@@ -475,7 +475,7 @@ if test "$enable_debug" = "yes"; then
 else
     AC_MSG_RESULT([no (Release build)])
     AC_DEFINE([ENABLE_DEBUG],0,[Whether to compile in some extra debugging support code and disable some security pieces])
-    AC_DEFINE([CONFIG_STATIC],static,[Static config values are enabled in release builds for performance])
+    AC_DEFINE([CONFIG_STATIC_TYPE],static,[Static config values are enabled in release builds for performance])
 fi
 AC_SUBST(ENABLE_DEBUG)
 AC_SUBST(ENABLE_BUNDLE)


### PR DESCRIPTION
tweak config.h to always have CONFIG_STATIC as static for coverity, with or without --enable-debug used.


Change-Id: I0dddf0235a4c5b18af1b2d7c1f92d7741a9224d3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

