### PR TITLE
disable exotic file format by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ doc/cpp/**
 **/.cache
 Makefile
 Makefile.in
+coolkitconfig.xcu
 coolwsd.spec
 coolwsd.xml
 aclocal.m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -470,7 +470,7 @@ dist-hook:
 EXTRA_DIST = discovery.xml \
              favicon.ico \
              cool-sbom-template.spdx.json \
-             coolkitconfig.xcu \
+             coolkitconfig.xcu.in \
              coolwsd.spec \
              coolwsd.xml.in \
              coolwsd.service \

--- a/configure.ac
+++ b/configure.ac
@@ -530,10 +530,14 @@ if test -z "$anonym_msg";  then
   anonym_msg="anonymization of user-data is disabled"
 fi
 
+# Disable (0) or Enable (2) exotic file formats
+ENABLE_EXOTIC_FILE_FORMATS="0"
+
 if test "$enable_experimental" = "yes" ; then
   ENABLE_EXPERIMENTAL=true
   experimental_msg="enabled by default"
   SSL_VERIFY="false"
+  ENABLE_EXOTIC_FILE_FORMATS="2"
 fi
 AC_SUBST(ENABLE_EXPERIMENTAL)
 
@@ -541,6 +545,14 @@ AC_MSG_CHECKING([if ssl verification is enabled by default])
 AC_MSG_RESULT([$SSL_VERIFY])
 AC_DEFINE_UNQUOTED([SSL_VERIFY],["$SSL_VERIFY"],[Default SSL Verification mode])
 AC_SUBST(SSL_VERIFY)
+
+AC_MSG_CHECKING([if exotic file formats are enabled by default])
+if test "$ENABLE_EXOTIC_FILE_FORMATS" = "0"; then
+  AC_MSG_RESULT([no])
+else
+  AC_MSG_RESULT([yes])
+fi
+AC_SUBST(ENABLE_EXOTIC_FILE_FORMATS)
 
 AC_SUBST(SERVER_SIGNATURE)
 
@@ -1825,6 +1837,7 @@ AC_CONFIG_FILES([Makefile
                  browser/images/Makefile
                  browser/l10n/Makefile
                  browser/npm-shrinkwrap.json
+                 coolkitconfig.xcu
                  coolwsd.spec
                  coolwsd.xml
                  debian/coolwsd.postinst])

--- a/coolkitconfig.xcu.in
+++ b/coolkitconfig.xcu.in
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <oor:items xmlns:oor="http://openoffice.org/2001/registry" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
+<!-- Disable (0) or Enable (2) exotic file formats like .123, .wks -->
+<item oor:path="/org.openoffice.Office.Common/Security"><prop oor:name="LoadExoticFileFormats" oor:op="fuse"><value>@ENABLE_EXOTIC_FILE_FORMATS@</value></prop></item>
+
 <!-- tdf#106488 - reverse hostname lookup can go badly wrong -->
 <item oor:path="/org.openoffice.Office.Common/Misc"><prop oor:name="UseLocking" oor:op="fuse"><value>false</value></prop></item>
 


### PR DESCRIPTION
Change-Id: I716c9c00b91a481c2f47e0ac4755712e08765b6e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

