### PR TITLE
avoid need for tokenize_outside_quotes by using trailing substr

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -192,8 +192,7 @@ bool ChildSession::_handleInput(const char *buffer, int length)
 {
     LOG_TRC("handling [" << getAbbreviatedMessage(buffer, length) << ']');
     const std::string firstLine = getFirstLine(buffer, length);
-    const StringVector tokens =
-        StringVector::tokenize_outside_quotes(firstLine.data(), firstLine.size());
+    const StringVector tokens = StringVector::tokenize(firstLine.data(), firstLine.size());
 
     // if _clientVisibleArea.getWidth() == 0, then it is probably not a real user.. probably is a convert-to or similar
     LogUiCommands logUndoRelatedcommandAtfunctionEnd(this, &tokens);
@@ -2089,11 +2088,11 @@ bool ChildSession::dialogEvent(const StringVector& tokens)
     {
         getLOKitDocument()->setView(_viewId);
         getLOKitDocument()->sendDialogEvent(lokWindowId,
-                                            tokens.cat(' ', 2).c_str());
+                                            tokens.substrFromToken(2).c_str());
     }
     else
     {
-        getLOKit()->sendDialogEvent(lokWindowId, tokens.cat(' ', 2).c_str());
+        getLOKit()->sendDialogEvent(lokWindowId, tokens.substrFromToken(2).c_str());
     }
 
     return true;
@@ -2305,7 +2304,7 @@ bool ChildSession::unoCommand(const StringVector& tokens)
                           tokens.equals(1, ".uno:OpenHyperlink") ||
                           tokens.startsWith(1, "vnd.sun.star.script:"));
 
-    const std::string saveArgs = tokens.cat(' ', 2);
+    const std::string saveArgs = tokens.substrFromToken(2);
     LOG_TRC("uno command " << tokens[1] << " " << saveArgs << " notify: " << bNotify);
 
     // check that internal UNO commands don't make it to the core

--- a/test/StringVectorTests.cpp
+++ b/test/StringVectorTests.cpp
@@ -94,38 +94,8 @@ void StringVectorTests::testTokenizer()
     LOK_ASSERT_EQUAL(std::string("tileheight=3840"), tokens[8]);
     LOK_ASSERT_EQUAL(std::string("ver=-1"), tokens[9]);
 
-    // tokenize_outside_quotes
-    tokens = StringVector::tokenize_outside_quotes(std::string("A='X Y'"));
-    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
-    LOK_ASSERT_EQUAL(std::string("A='X Y'"), tokens[0]);
-
-    tokens = StringVector::tokenize_outside_quotes(std::string("A=\"X Y\""));
-    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), tokens.size());
-    LOK_ASSERT_EQUAL(std::string("A=\"X Y\""), tokens[0]);
-
-    tokens = StringVector::tokenize_outside_quotes(std::string(" A=\"X Y\" B=\"Z\" C "));
-    LOK_ASSERT_EQUAL(static_cast<std::size_t>(3), tokens.size());
-    LOK_ASSERT_EQUAL(std::string("A=\"X Y\""), tokens[0]);
-    LOK_ASSERT_EQUAL(std::string("B=\"Z\""), tokens[1]);
-    LOK_ASSERT_EQUAL(std::string("C"), tokens[2]);
-
-    tokens =
-        StringVector::tokenize_outside_quotes(std::string("\"don't tokenize this\" tokenize this"));
-    LOK_ASSERT_EQUAL(static_cast<std::size_t>(3), tokens.size());
-    LOK_ASSERT_EQUAL(std::string("\"don't tokenize this\""), tokens[0]);
-    LOK_ASSERT_EQUAL(std::string("tokenize"), tokens[1]);
-    LOK_ASSERT_EQUAL(std::string("this"), tokens[2]);
-
-    tokens = StringVector::tokenize_outside_quotes(std::string("apost\\'phe don\\'t"));
-    LOK_ASSERT_EQUAL(std::string("apost\\'phe"), tokens[0]);
-    LOK_ASSERT_EQUAL(std::string("don\\'t"), tokens[1]);
-
     // With custom delimiters
     tokens = StringVector::tokenize(std::string("ABC:DEF"), ':');
-    LOK_ASSERT_EQUAL(std::string("ABC"), tokens[0]);
-    LOK_ASSERT_EQUAL(std::string("DEF"), tokens[1]);
-
-    tokens = StringVector::tokenize_outside_quotes(std::string("ABC'DEF"), '\'');
     LOK_ASSERT_EQUAL(std::string("ABC"), tokens[0]);
     LOK_ASSERT_EQUAL(std::string("DEF"), tokens[1]);
 
@@ -149,31 +119,6 @@ void StringVectorTests::testTokenizer()
     tokens = StringVector::tokenize(URI, '/');
     LOK_ASSERT_EQUAL(static_cast<std::size_t>(7), tokens.size());
     LOK_ASSERT_EQUAL(std::string("31"), tokens[6]);
-
-    // tokenize_outside_quotes with string delimiters
-    tokens = StringVector::tokenize_outside_quotes(std::string("ABC<delim>DEF"), "<delim>");
-    LOK_ASSERT_EQUAL(std::string("ABC"), tokens[0]);
-    LOK_ASSERT_EQUAL(std::string("DEF"), tokens[1]);
-
-    tokens =
-        StringVector::tokenize_outside_quotes(std::string("ABC\"<delim>\"DE<delim>F"), "<delim>");
-    LOK_ASSERT_EQUAL(std::string("ABC\"<delim>\"DE"), tokens[0]);
-    LOK_ASSERT_EQUAL(std::string("F"), tokens[1]);
-
-    tokens = StringVector::tokenize_outside_quotes(std::string("ABC'F"), "<delim>");
-    LOK_ASSERT_EQUAL(std::string("ABC'F"), tokens[0]);
-
-    tokens = StringVector::tokenize_outside_quotes(std::string("\"'<delim>'\""), "<delim>");
-    LOK_ASSERT_EQUAL(std::string("\"'<delim>'\""), tokens[0]);
-
-    tokens = StringVector::tokenize_outside_quotes(std::string("\"\"<delim>\"\"A"), "<delim>");
-    LOK_ASSERT_EQUAL(std::string("\"\""), tokens[0]);
-    LOK_ASSERT_EQUAL(std::string("\"\"A"), tokens[1]);
-
-    tokens =
-        StringVector::tokenize_outside_quotes(std::string("apost\\'phe<delim>don\\'t"), "<delim>");
-    LOK_ASSERT_EQUAL(std::string("apost\\'phe"), tokens[0]);
-    LOK_ASSERT_EQUAL(std::string("don\\'t"), tokens[1]);
 }
 
 void StringVectorTests::testTokenizerTokenizeAnyOf()


### PR DESCRIPTION
of the original string.


Change-Id: I64926ac9dca7d7f0ece343afeb0eef1615d67777


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

