### PR TITLE
Also copy fonts from /usr/local/share/fonts

### DIFF
--- a/coolwsd-systemplate-setup
+++ b/coolwsd-systemplate-setup
@@ -140,6 +140,16 @@ fi
 find $LOCALBASE/share -name '*.pcf' | xargs rm -f
 find $LOCALBASE/share -name '*.pcf.gz' | xargs rm -f
 
+# Same for /usr/local/share/fonts
+
+if test "$LOCALBASE" != "usr/local/"; then
+    mkdir -p $LOCALBASE/local/share || exit 1
+    ${CP} -r -p -L /${LOCALBASE}/local/share/fonts $LOCALBASE/local/share
+
+    find $LOCALBASE/local/share -name '*.pcf' | xargs rm -f
+    find $LOCALBASE/local/share -name '*.pcf.gz' | xargs rm -f
+fi
+
 # Debugging only hackery to avoid confusion.
 if test "z$ENABLE_DEBUG" != "z" -a "z$HOME" != "z"; then
     echo "$0: Copying development users's fonts into systemplate"


### PR DESCRIPTION
I have a font installed under /usr/local/share/fonts/. Running Online
(debug core build), I immediately see a warning:

warn:vcl.unx.freetype:968539:968522:vcl/unx/generic/glyphs/freetype_glyphcache.cxx:118: open('/usr/local/share/fonts/CAVOLINI.TTF') failed: No such file or directory

But when in a document I try to expand the font list dropdown, Online
crashes on the assertion in FreeTypeTextRenderImpl::GetTextLayout.

The problem is the font that is reported by fontconfig, but is not
available for Online. Handle that path same way as /usr/share/fonts.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I8292194ed6c0410d6720c46e1e3067efb3bf41dc
