### PR TITLE
jsdialog errors fixes

### DIFF
--- a/browser/src/app/LayoutingService.ts
+++ b/browser/src/app/LayoutingService.ts
@@ -41,7 +41,7 @@ class LayoutingService {
 		if (!task) return false;
 
 		try {
-			task.call(this);
+			task();
 		} catch (ex) {
 			console.error('LayoutingTask exception: ' + ex);
 		}

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -79,15 +79,16 @@ L.Control.JSDialog = L.Control.extend({
 
 	close: function(id, sendCloseEvent) {
 		if (id !== undefined && this.dialogs[id]) {
-			if (!sendCloseEvent && this.dialogs[id].overlay && !this.dialogs[id].isSubmenu) {
+			const dialog = this.dialogs[id];
+			if (!sendCloseEvent && dialog.overlay && !dialog.isSubmenu) {
 				app.layoutingService.appendLayoutingTask(
-					() => { L.DomUtil.remove(this.dialogs[id].overlay); });
+					() => { L.DomUtil.remove(dialog.overlay); });
 			}
 
-			if (this.dialogs[id].timeoutId)
-				clearTimeout(this.dialogs[id].timeoutId);
+			if (dialog.timeoutId)
+				clearTimeout(dialog.timeoutId);
 
-			if (this.dialogs[id].isPopup)
+			if (dialog.isPopup)
 				this.closePopover(id, sendCloseEvent);
 			else
 				this.closeDialog(id, sendCloseEvent);
@@ -225,9 +226,16 @@ L.Control.JSDialog = L.Control.extend({
 
 		app.layoutingService.appendLayoutingTask(() => {
 			L.DomUtil.addClass(container, 'fadeout');
-			container.onanimationend = () => { instance.that.close(instance.id, false); };
+
+			let timeoutId = null;
+			const finallyClose = () => {
+				instance.that.close(instance.id, false);
+				clearTimeout(timeoutId);
+			};
+
+			container.onanimationend = finallyClose;
 			// be sure it will be removed if onanimationend will not be executed
-			setTimeout(() => { instance.that.close(instance.id, false); }, 700);
+			timeoutId = setTimeout(finallyClose, 700);
 		});
 	},
 

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -171,11 +171,18 @@ L.Control.JSDialog = L.Control.extend({
 	},
 
 	focusToLastElement: function(id) {
+		const dialog = this.dialogs[id];
 		app.layoutingService.appendLayoutingTask(() => {
+			if (!dialog.lastFocusedElement) {
+				this.map.focus();
+				return;
+			}
+
 			try {
-				this.dialogs[id].lastFocusedElement.focus();
+				dialog.lastFocusedElement.focus();
 			}
 			catch (error) {
+				console.debug('Cannot focus last element in dialog with id: ' + id);
 				this.map.focus();
 			}
 		});
@@ -243,7 +250,7 @@ L.Control.JSDialog = L.Control.extend({
 			if (instance.cancellable) {
 				// dropdowns are online-only components, don't exist in core
 				var hasToNotifyServer = !instance.isDropdown;
-				overlay.onclick = function () { this.close(instance.id, hasToNotifyServer); }.bind(this);
+				overlay.onclick = () => { this.close(instance.id, hasToNotifyServer); };
 			}
 		}
 		instance.overlay = overlay;
@@ -277,7 +284,7 @@ L.Control.JSDialog = L.Control.extend({
 			L.DomUtil.addClass(instance.container, 'collapsed');
 
 		// prevent from reloading
-		instance.form.addEventListener('submit', function (event) { event.preventDefault(); });
+		instance.form.addEventListener('submit', (event) => { event.preventDefault(); });
 
 		instance.defaultButtonId = this._getDefaultButtonId(instance.children);
 
@@ -356,7 +363,7 @@ L.Control.JSDialog = L.Control.extend({
 	},
 
 	addHandlers: function(instance) {
-		var onInput = function(ev) {
+		var onInput = (ev) => {
 			if (ev.isFirst)
 				instance.that.draggingObject = instance.that.dialogs[instance.id];
 
@@ -372,13 +379,13 @@ L.Control.JSDialog = L.Control.extend({
 		};
 
 		if (instance.haveTitlebar) {
-			instance.titleCloseButton.onclick = function() {
+			instance.titleCloseButton.onclick = () => {
 				instance.that.close(instance.id, true);
 			};
 		}
 
 		if (instance.nonModal && instance.haveTitlebar) {
-			instance.titleCloseButton.onclick = function() {
+			instance.titleCloseButton.onclick = () => {
 				var newestDialog = Math.max.apply(null,
 					Object.keys(instance.that.dialogs).map(function(i) { return parseInt(i);}));
 				if (newestDialog > parseInt(instance.id))
@@ -450,7 +457,7 @@ L.Control.JSDialog = L.Control.extend({
 			console.error('cannot get focus for widget: "' + instance.init_focus_id + '"');
 
 		if (instance.isDropdown && instance.isSubmenu) {
-			instance.container.addEventListener('mouseleave', function () {
+			instance.container.addEventListener('mouseleave', () => {
 				instance.builder.callback('combobox', 'hidedropdown', {id: instance.id}, null, instance.builder);
 			});
 		}
@@ -816,7 +823,7 @@ L.Control.JSDialog = L.Control.extend({
 			this.dialogs[instance.id] = instance;
 
 			if (instance.isSnackbar && instance.snackbarTimeout > 0) {
-				instance.timeoutId = setTimeout(function () { app.map.uiManager.closeSnackbar(); }, instance.snackbarTimeout);
+				instance.timeoutId = setTimeout(() => { app.map.uiManager.closeSnackbar(); }, instance.snackbarTimeout);
 			}
 		}
 	},

--- a/browser/src/control/jsdialog/Util.Dropdown.js
+++ b/browser/src/control/jsdialog/Util.Dropdown.js
@@ -138,6 +138,10 @@ JSDialog.OpenDropdown = function (id, popupParent, entries, innerCallback, popup
 
 					app.layoutingService.appendLayoutingTask(() => {
 						var dropdown = JSDialog.GetDropdown(subMenuId);
+						if (!dropdown) {
+							console.debug('Dropdown: missing :' + subMenuId);
+							return;
+						}
 						var container = dropdown.querySelector('.ui-grid');
 						JSDialog.MakeFocusCycle(container);
 						var focusables = JSDialog.GetFocusableElements(container);

--- a/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
@@ -30,8 +30,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties
 		cy.cGet('#rightpara').click();
 
 		selectText();
-		cy.cGet('#document-container g.Page .TextParagraph .TextPosition')
-			.should('have.attr', 'x', '23584');
+		cy.cGet('#document-container g.Page .TextParagraph .TextPosition[x="23583"], #document-container g.Page .TextParagraph .TextPosition[x="23584"]')
+			.should('exist');
 
 		// Set left alignment
 		cy.cGet('#leftpara').click();
@@ -44,8 +44,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties
 		cy.cGet('#centerpara').click();
 
 		selectText();
-		cy.cGet('#document-container g.Page .TextParagraph .TextPosition')
-			.should('have.attr', 'x', '12492');
+		cy.cGet('#document-container g.Page .TextParagraph .TextPosition[x="12491"], #document-container g.Page .TextParagraph .TextPosition[x="12492"]')
+			.should('exist');
 
 		// Set justified alignment
 		cy.cGet('#justifypara').click();


### PR DESCRIPTION
prevents us from errors when some dynamically created menu is not available
or we used wrong instance in the callback