### PR TITLE
Toolbar-down: fix search buttons when disabled

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -9,6 +9,12 @@
 	border: 1px solid var(--color-border-lighter);
 }
 
+#toolbar-down .unotoolbutton[disabled],
+#toolbar-down .unotoolbutton[disabled] *[disabled]{
+	opacity: 0.5;
+	background-color: transparent;
+}
+
 /* toolbuttons */
 .unotoolbutton .unobutton.selected + .ui-content.unolabel {
 	color: var(--color-text-dark);


### PR DESCRIPTION
Before this commit, the disabled button in the toolbar-down where
being set with a background color from the following declaration:
"jsdialog:not(.sidebar) *[disabled]" in the same btns.css file.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I86f433bf2f9219fd8e799ab290f128dd1b4fb1ad
