### PR TITLE
fix: Don't run requestAnimationFrames instantly

### DIFF
--- a/browser/src/app/Util.ts
+++ b/browser/src/app/Util.ts
@@ -276,13 +276,7 @@ class Util {
 		fn: () => void,
 		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 		context: any,
-		immediate?: boolean,
 	): number {
-		if (immediate) {
-			fn.call(context);
-			return 0;
-		}
-
 		return window.requestAnimationFrame(fn.bind(context));
 	}
 

--- a/browser/src/app/Util.ts
+++ b/browser/src/app/Util.ts
@@ -286,8 +286,8 @@ class Util {
 		}
 	}
 
-	public static MAX_SAFE_INTEGER = Math.pow(2, 3) - 1;
-	public static MIN_SAFE_INTEGER = Util.MAX_SAFE_INTEGER;
+	public static MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
+	public static MIN_SAFE_INTEGER = -Util.MAX_SAFE_INTEGER;
 }
 
 app.util = Util;

--- a/browser/src/dom/Draggable.js
+++ b/browser/src/dom/Draggable.js
@@ -176,7 +176,7 @@ L.Draggable = L.Evented.extend({
 		app.util.cancelAnimFrame(this._animRequest);
 		this._lastEvent = e;
 
-		this._animRequest = app.util.requestAnimFrame(this._updatePosition, this, true, this._dragStartTarget);
+		this._animRequest = app.util.requestAnimFrame(this._updatePosition, this);
 	},
 
 	_updatePosition: function () {

--- a/browser/src/map/handler/Map.TouchGesture.js
+++ b/browser/src/map/handler/Map.TouchGesture.js
@@ -645,7 +645,7 @@ L.Map.TouchGesture = L.Handler.extend({
 		this._map.dragging._draggable._onDown(evt);
 		this._timeStamp = Date.now();
 		this._inSwipeAction = true;
-		this.autoscrollAnimReq = app.util.requestAnimFrame(this._autoscroll, this, true);
+		this.autoscrollAnimReq = app.util.requestAnimFrame(this._autoscroll, this);
 	},
 
 	_cancelAutoscrollRAF: function () {
@@ -705,7 +705,7 @@ L.Map.TouchGesture = L.Handler.extend({
 			TileManager.preFetchTiles(true /* forceBorderCalc */);
 
 			if (!horizontalEnd || !verticalEnd) {
-				this.autoscrollAnimReq = app.util.requestAnimFrame(this._autoscroll, this, true);
+				this.autoscrollAnimReq = app.util.requestAnimFrame(this._autoscroll, this);
 			} else {
 				this._inSwipeAction = false;
 				if (app.file.fileBasedView)


### PR DESCRIPTION
Previously, in Ifdf885452135346e1df5f3196d49f76b8d1f983a, we would have
fallbacks for if requestAnimationFrame didn't exist

	var requestFn = window.requestAnimationFrame || getPrefixed('RequestAnimationFrame') || timeoutDefer,

We would sometimes run a function immediately: in the case that the
function couldn't be deferred into a timeout and timeoutDefer was the
selected requestAnimationFrame fallback

	L.Util.requestAnimFrame = function (fn, context, immediate) {
		if (immediate && requestFn === timeoutDefer) {
			fn.call(context);
		} else {
			return requestFn.call(window, L.bind(fn, context));
		}
	};

Unfortunately, when we removed the fallbacks we changed the code like so

	export function requestAnimFrame(
		fn: () => void,
		// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
		context: any,
		immediate?: boolean,
	): number {
		if (immediate) {
			fn.call(context);
			return 0;
		}

		return window.requestAnimationFrame(fn.bind(context));
	}

Which incorrectly runs the function immediately *all the time* if that
is provided. Instead, we should be running the function immediately
*none of the time*, as we will never be running this in a setTimeout
task.

All of this causes some major issues with touch movement: when panning
if we execute the callback immediately we will jump much further than we
are meant to. Stopping this fixes a lot of the touch movement problems
we've been having recently.

We should remove that, and we can clean up the parameters from any
callers.

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: I3de3582807439d9115af43feccfcd3293e68d0d4

---

Additionally,

In Ifdf885452135346e1df5f3196d49f76b8d1f983a and If77f50074b002c8a7566daf61cac3b14474aa838
MIN_SAFE_INTEGER and MAX_SAFE_INTEGER were changed in ways that I can
only presume are typos.

For the max value `Math.pow(2, 53)-1` became `Math.pow(2, 3)-1`
For the min value`-MAX_SAFE_INTEGER` became `MAX_SAFE_INTEGER`

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: Iba4ea718338d703701340a538c157fdbbb9296b1