### PR TITLE
Navigator: Add padding to placeholder (empty list text)

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -445,6 +445,10 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	box-sizing: border-box;
 }
 
+.navigator-container .ui-treeview-placeholder {
+	padding: 16px;
+}
+
 .navigation-title {
 	font-weight: bold;
 }

--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -1130,7 +1130,7 @@ class TreeViewControl {
 		if (data.id === 'contenttree') {
 			var tr = L.DomUtil.create(
 				'div',
-				builder.options.cssClass + ' ui-treview-entry',
+				builder.options.cssClass + ' ui-treview-entry ui-treeview-placeholder',
 				this._container,
 			);
 			tr.innerText = _(


### PR DESCRIPTION
So, it shares the some alignment as navigation-header

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I075a1c43b69b7f22b0e7cc4faf49035cd2677385
