### PR TITLE
fix: Stop touch movement from freezing

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3678,6 +3678,10 @@ L.CanvasTileLayer = L.Layer.extend({
 	},
 
 	_syncTilePanePos: function () {
+		if (this._container) {
+			var mapPanePos = this._map._getMapPanePos();
+			L.DomUtil.setPosition(this._container, new L.Point(-mapPanePos.x , -mapPanePos.y));
+		}
 		var documentBounds = this._map.getPixelBoundsCore();
 		var documentPos = documentBounds.min;
 		var documentEndPos = documentBounds.max;


### PR DESCRIPTION
In I10e1ae5781c170c0d8a85b8638daa8f61e3eaa6e, we removed the unused tile pane. Unfortunately, it wasn't quite unused.

In CanvasTileLayer, we used it as a parent to our container. When we synchronized the position, that also moved around the container. Touch control, it seems, needed that movement: while we could start moving we would very often end up unable to move afterwards.


Change-Id: Ib9859b3faa71edee4826ed41c976f5f9fde9f83d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

