### PR TITLE
Stat::path is unused

### DIFF
--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -201,8 +201,6 @@ namespace FileUtil
         bool bad() const { return !good(); }
         const struct ::stat& sb() const { return _sb; }
 
-        const std::string& path() const { return _path; }
-
         bool isDirectory() const { return S_ISDIR(_sb.st_mode); }
         bool isFile() const { return S_ISREG(_sb.st_mode); }
         bool isLink() const { return S_ISLNK(_sb.st_mode); }

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -909,7 +909,6 @@ void WhiteBoxTests::testStat()
     LOK_ASSERT(!st.isDirectory());
     LOK_ASSERT(st.isFile());
     LOK_ASSERT(!st.isLink());
-    LOK_ASSERT(st.path() == tmpFile);
 
     // Modified-time tests.
     // Some test might fail when the system has a different resolution for file timestamps


### PR DESCRIPTION
Change-Id: I412626adb0566fac77eca2c12fecf058cf26a4d6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

