### PR TITLE
sidebar: remember last state

### DIFF
--- a/browser/src/control/Control.SidebarBase.ts
+++ b/browser/src/control/Control.SidebarBase.ts
@@ -85,7 +85,8 @@ abstract class SidebarBase {
 			this.map.focus();
 		}
 
-		this.map.uiManager.setDocTypePref(`Show${this.type}`, false);
+		const upperCaseType = this.type[0].toUpperCase() + this.type.slice(1);
+		this.map.uiManager.setDocTypePref('Show' + upperCaseType, false);
 	}
 
 	onJSUpdate(e: FireEvent) {


### PR DESCRIPTION
This fixes regression from commit b5949f46
Implement NavigatorPanel and create SidebarBase


1. Open Writer
2. Sidebar is opened, close it
3. reopen app

Expected: sidebar is closed (remember last state)
Result: sidebar is always opened


property name is ShowSidebar not Showsidebar