### PR TITLE
cid#427990 Dereference after null check

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2128,6 +2128,12 @@ bool DocumentBroker::updateStorageLockState(ClientSession& session, StorageBase:
         return false;
     }
 
+    if (!_storage)
+    {
+        error = "Missing storage";
+        return false;
+    }
+
     const StorageBase::LockUpdateResult result = _storage->updateLockState(
         session.getAuthorization(), *_lockCtx, lock, _currentStorageAttrs);
 


### PR DESCRIPTION
DocumentBroker::pollThread check for _storage at:

if (_storage && !_lockStateUpdateRequest && _lockCtx->needsRefresh(now)) {
    refreshLock();
}

but not when calling updateStorageLockState later


Change-Id: I55b72be06e3000983fd7887c5158ed768003de98


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

