### PR TITLE
fuzz: just return the default in getConfigValue()

### DIFF
--- a/common/ConfigUtil.hpp
+++ b/common/ConfigUtil.hpp
@@ -325,6 +325,11 @@ template <typename T>
 inline T getConfigValue(const std::string& name, const typename T::rep def,
                         const typename T::rep min = 0)
 {
+    if (Util::isFuzzing())
+    {
+        return T(def);
+    }
+
     return getConfigValue<T>(Poco::Util::Application::instance().config(), name, def, min);
 }
 


### PR DESCRIPTION
Similar to the other getConfigValue() (taking an
Poco::Util::AbstractConfiguration) does, to prevent:

terminate called after throwing an instance of 'Poco::NullPointerException'
  what():  Null pointer

Since the fuzzer has no configuration, similar to the core.git fuzzers.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ib12e6fa0931a0259ad4432ab97c5d9705bd1d235
