### PR TITLE
cypress: make scrolling tests more stable

### DIFF
--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -239,8 +239,8 @@ function selectZoomLevel(zoomLevel, makeZoomVisible = true) {
 	// Force because sometimes the icons are scrolled off the screen to the right
 	if (makeZoomVisible)
 		makeZoomItemsVisible();
-	cy.cGet('#toolbar-down #zoom .arrowbackground').click({force: true});
-	cy.cGet('#zoom-dropdown').contains('.ui-combobox-entry', zoomLevel).click({force: true});
+	cy.cGet('#toolbar-down #zoom .arrowbackground').click();
+	cy.cGet('#zoom-dropdown').contains('.ui-combobox-entry', zoomLevel).click();
 	shouldHaveZoomLevel(zoomLevel);
 
 	cy.log('<< selectZoomLevel - end');

--- a/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/scrolling_spec.js
@@ -50,7 +50,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 		}
 
 		// Document should scroll
-		desktopHelper.assertScrollbarPosition('vertical', 230, 250);
+		desktopHelper.assertScrollbarPosition('vertical', 230, 300);
 		// Document should not scroll horizontally
 		desktopHelper.assertScrollbarPosition('horizontal', 48, 50);
 	});

--- a/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
@@ -7,10 +7,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 
 	beforeEach(function() {
 		helper.setupAndLoadDocument('writer/scrolling.odt');
-		desktopHelper.switchUIToCompact();
-
-		cy.cGet('#toolbar-up .ui-scroll-right').click();
-		cy.cGet('#sidebar').click({force: true});
 	});
 
 	it('Check if we jump the view on new page insertion', function() {
@@ -25,11 +21,12 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 	});
 
 	it('Scrolling to bottom/top', function() {
-		desktopHelper.selectZoomLevel('40', false);
+		desktopHelper.selectZoomLevel('40');
+
 		helper.typeIntoDocument('{ctrl}{home}');
 		//scroll to bottom
 		desktopHelper.assertVisiblePage(1, 1, 4);
-		desktopHelper.pressKey(1, 'pagedown');
+		desktopHelper.pressKey(2, 'pagedown');
 		desktopHelper.assertVisiblePage(2, 2, 4);
 		desktopHelper.pressKey(1, 'pagedown');
 		desktopHelper.assertVisiblePage(3, 3, 4);
@@ -45,22 +42,25 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 	});
 
 	it('Scrolling to left/right', function() {
-		cy.cGet('#toolbar-down').click();
-		desktopHelper.selectZoomLevel('200', false);
+		desktopHelper.selectZoomLevel('200');
 		//show horizontal scrollbar
 		cy.cGet('.leaflet-layer').click('bottom');
 		cy.wait(1000);
+		desktopHelper.assertScrollbarPosition('horizontal', 0, 270)
+;
 		helper.typeIntoDocument('{home}{end}{home}');
 		cy.wait(1000);
-		cy.cGet('#test-div-horizontal-scrollbar').should('have.text', '0');
+		desktopHelper.assertScrollbarPosition('horizontal', 0, 270);
+
 		helper.typeIntoDocument('{end}{home}{end}');
+		cy.wait(1000);
 		desktopHelper.assertScrollbarPosition('horizontal', 430, 653);
 	});
 
 	it('Check if we jump the view on change of formatting mark', function() {
 		desktopHelper.switchUIToNotebookbar();
+		desktopHelper.selectZoomLevel('40');
 
-		desktopHelper.selectZoomLevel('40', false);
 		helper.typeIntoDocument('{ctrl}{home}');
 		desktopHelper.pressKey(2, 'pagedown');
 		desktopHelper.pressKey(1, 'pagedown');


### PR DESCRIPTION
- avoid using force so we know we already have the elements initialized and visible
- avoid switching the view mode on start which is not necessary for the testing feature itself