### PR TITLE
Fix table alignments in manage changes dialog

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -62,6 +62,12 @@
 	grid-gap: 8px;
 }
 
+#AcceptRejectChangesDialog #writerchanges.jsdialog.ui-treeview {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr) repeat(2, minmax(min-content, auto));
+	column-gap: 8px;
+}
+
 #AcceptRejectChangesDialog .jsdialog.ui-grid .has-img,
 #AcceptRejectChangesDialog .jsdialog.ui-grid .menubutton {
 	margin: 0 !important;
@@ -70,7 +76,7 @@
 
 #AcceptRejectChangesDialog .ui-treeview-headers,
 #AcceptRejectChangesDialog .jsdialog.ui-treeview-entry { 
-	grid-template-columns: 60px 60px 120px 130px;
+	display: contents;
 }
 
 #AcceptRejectChangesDialog .jsdialog.ui-treeview-entry > div:nth-child(2),


### PR DESCRIPTION
Change-Id: If5d39bb689da38f812fd32ced170405f078c94dc


* Regression: #11783 
* Target version: master 

### Summary
When font size increases, text was previously overflowing into adjacent columns, creating readability issues. This new grid alignment implementation resolves this problem by using responsive column sizing.

### PREVIEWS

CURRENT IF THE FONT SIZE IS "15PX"
![Screenshot from 2025-05-05 14-08-11](https://github.com/user-attachments/assets/8f226276-102b-4c28-92ed-4fe4d8188055)

WITH THIS PR
![Screenshot from 2025-05-05 14-10-37](https://github.com/user-attachments/assets/346a238b-0f88-4b73-bcc6-e68e50945186)


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

