### PR TITLE
cypress: reduce usage of force

### DIFF
--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -10,7 +10,7 @@ function showSidebar() {
 
 	cy.cGet('#sidebar').should('not.have.class', 'selected');
 	cy.cGet('#sidebar-dock-wrapper').should('not.be.visible');
-	cy.cGet('#sidebar').click({force: true});
+	cy.cGet('#sidebar').click();
 	cy.cGet('#sidebar').should('have.class', 'selected');
 	cy.cGet('#sidebar-dock-wrapper').should('be.visible');
 
@@ -24,7 +24,7 @@ function hideSidebar() {
 
 	cy.cGet('#sidebar').should('have.class', 'selected');
 	cy.cGet('#sidebar-dock-wrapper').should('be.visible');
-	cy.cGet('#sidebar').click({force: true});
+	cy.cGet('#sidebar').click();
 	cy.cGet('#sidebar').should('not.have.class', 'selected');
 	cy.cGet('#sidebar-dock-wrapper').should('not.be.visible');
 
@@ -36,7 +36,7 @@ function hideSidebarImpress() {
 
 	cy.cGet('#modifypage').should('have.class', 'selected');
 	cy.cGet('#sidebar-dock-wrapper').should('be.visible');
-	cy.cGet('#modifypage button').click({force: true});
+	cy.cGet('#modifypage button').click('left');
 	cy.cGet('#modifypage').should('not.have.class', 'selected');
 	cy.cGet('#sidebar-dock-wrapper').should('not.be.visible');
 

--- a/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
@@ -9,6 +9,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	beforeEach(function() {
 		helper.setupAndLoadDocument('impress/top_toolbar.odp');
 		desktopHelper.switchUIToCompact();
+		cy.cGet('#toolbar-up .ui-scroll-right').click().click().click().click();
 
 		if (Cypress.env('INTEGRATION') === 'nextcloud') {
 			desktopHelper.hideSidebarIfVisible();

--- a/cypress_test/integration_tests/desktop/writer/notebookbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/notebookbar_spec.js
@@ -49,6 +49,7 @@ describe(['tagdesktop'], 'Notebookbar review operations.', function() {
 
 		// When going to the next redline:
 		cy.cGet('#Review-tab-label').click();
+		cy.cGet('.ui-scroll-right').click();
 		cy.cGet('#review-next-tracked-change-button').click();
 		cy.cGet('#Table-tab-label').should('not.have.class', 'hidden');
 


### PR DESCRIPTION
force parameter allows to ignore some errors, like:
- button is covered by other element

that is what we should avoid if there is any option to do it well