### PR TITLE
Simplify onDisconnect emission.

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1553,7 +1553,7 @@ bool StreamSocket::checkRemoval(std::chrono::steady_clock::time_point now)
                                                     << ", " << *this);
         if (_socketHandler)
         {
-            _socketHandler->onDisconnect();
+            ensureDisconnected();
             if (!isShutdown())
             {
                 // Note: Ensure proper semantics of onDisconnect()


### PR DESCRIPTION
Hopefully this ensures that we always get at least one onDisconnect, and the logic is easier to read / see / reason about around that.


Change-Id: If0c58c5844f432e0a65ad05681d7759c7e3874d3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

