### PR TITLE
Added Stylelint rule to enforce space before block-opening brace and fix CSS files

### DIFF
--- a/browser/.stylelintrc.json
+++ b/browser/.stylelintrc.json
@@ -24,6 +24,7 @@
 		"no-invalid-double-slash-comments": true,
 		"shorthand-property-no-redundant-values": true,
 		"declaration-bang-space-before": "always",
-		"declaration-colon-space-after": "always"
+		"declaration-colon-space-after": "always",
+		"block-opening-brace-space-before": "always"
 	}
 }

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -787,7 +787,7 @@ $(INTERMEDIATE_DIR)/cool-src.js: tscompile.done $(call prereq_cool) $(COOL_JS_DS
 $(DIST_FOLDER)/bundle.css: $(call prereq_css)
 	@mkdir -p $(dir $@)
 	@echo "Checking for CSS errors..."
-	@$(NODE) node_modules/stylelint/bin/stylelint.js --config $(srcdir)/.stylelintrc.json $(srcdir)/css/*.css
+	@$(NODE) node_modules/stylelint/bin/stylelint.js --config $(srcdir)/.stylelintrc.json $(srcdir)/css/*.css --fix
 	$(call bundle_css)
 
 $(DIST_FOLDER)/bundle.js: $(INTERMEDIATE_DIR)/cool-src.js $(call prereq_all)

--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -10,7 +10,7 @@
 }
 
 #toolbar-down .unotoolbutton[disabled],
-#toolbar-down .unotoolbutton[disabled] *[disabled]{
+#toolbar-down .unotoolbutton[disabled] *[disabled] {
 	opacity: 0.5;
 	background-color: transparent;
 }

--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -207,8 +207,7 @@ body {
 	margin: 0;
 }
 
-.leaflet-progress-layer
-{
+.leaflet-progress-layer {
 	position: absolute;
 	top: 50%;
 	left: 50%;
@@ -351,7 +350,7 @@ body {
 	}
 }
 
-.sidebar-panel{
+.sidebar-panel {
 	padding: 0px;
 	margin: 0px;
 	position: relative;
@@ -419,7 +418,7 @@ body {
 	display: none;
 }
 
-#mobile-edit-button.impress.portrait{
+#mobile-edit-button.impress.portrait {
 	bottom: 70px;
 }
 
@@ -430,7 +429,7 @@ body {
 	transform: rotate(0deg);
 	transition: transform 0.5s;
 }
-#mobile-edit-button:active{
+#mobile-edit-button:active {
 	transform: scale(1.2);
 }
 #mobile-edit-button:active > #mobile-edit-button-image {
@@ -737,10 +736,10 @@ body {
 	box-shadow: 0px 4px 10px var(--color-box-shadow);
 }
 
-.cool-annotation-img .avatar-img{
+.cool-annotation-img .avatar-img {
 	border: none;
 }
-.cool-annotation-img > .avatar-img{
+.cool-annotation-img > .avatar-img {
 	display: block;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;

--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -29,7 +29,7 @@ html[dir='rtl'] .sub-menu-arrow {
 #toolbar-logo {
 	width: 0px !important;
 }
-#document-header{
+#document-header {
 	display: none !important;
 }
 
@@ -122,7 +122,7 @@ html[dir='rtl'] .sub-menu-arrow {
 	display: none;
 }
 
-.spreadsheet-tab-selected{
+.spreadsheet-tab-selected {
 	color: #0b87e7 !important;
 	border-color: #0b87e7;
 }
@@ -135,10 +135,10 @@ html[dir='rtl'] .sub-menu-arrow {
 	margin: 0;
 }
 
-.spreadsheet-tabs-container, #spreadsheet-toolbar{
+.spreadsheet-tabs-container, #spreadsheet-toolbar {
 	background-color: var(--color-main-background);
 }
-#spreadsheet-toolbar{
+#spreadsheet-toolbar {
 	background-color: var(--color-main-background);
 	border-top: 1px solid var(--color-border);
 	grid-template-columns: 40px auto;
@@ -159,7 +159,7 @@ textarea.cool-annotation-textarea {
 
 /* Related to toolbar.css */
 @-moz-document url-prefix() {
-	#toolbar-up{
+	#toolbar-up {
 		top: -1px;
 	}
 }
@@ -169,7 +169,7 @@ textarea.cool-annotation-textarea {
 #toolbar-up #redo.disabled, #toolbar-up #undo.disabled, #toolbar-up #mobile_wizard.disabled, #toolbar-up #insertion_mobile_wizard.disabled {
 	display: none;
 }
-#toolbar-wrapper.mobile{
+#toolbar-wrapper.mobile {
 	border-top: none;
 	z-index: auto !important;
 	flex-direction: column;
@@ -189,7 +189,7 @@ textarea.cool-annotation-textarea {
 	height: 100%;
 	overflow-y: scroll;
 }
-#toolbar-up.w2ui-toolbar{
+#toolbar-up.w2ui-toolbar {
 	padding-top: 0px;
 	padding-bottom: 0px;
 	background: transparent;
@@ -215,7 +215,7 @@ textarea.cool-annotation-textarea {
 	height: 39px !important;
 	display: none;
 }
-#toolbar-up #fullscreen{display: none;}
+#toolbar-up #fullscreen {display: none;}
 #toolbar-down {
 	border-top: 1px solid var(--color-border) !important;
 	display: none;
@@ -246,22 +246,22 @@ textarea.cool-annotation-textarea {
 	-o-transform: rotate(180deg);
 	transform: rotate(180deg);
 }
-.w2ui-icon.equal, .w2ui-icon.autosum{width: 38px !important;}
+.w2ui-icon.equal, .w2ui-icon.autosum {width: 38px !important;}
 
-#toolbar-up .checked{
+#toolbar-up .checked {
 	border-color: transparent !important;
 	background: none !important;
 	box-shadow: none;
 }
-#toolbar-up .checked .w2ui-tb-image, #toolbar-up .w2ui-tb-image:hover, #toolbar-up .w2ui-tb-image:focus, #toolbar-up .w2ui-tb-image:active, #toolbar-hamburger.menuwizard-closed:active{
+#toolbar-up .checked .w2ui-tb-image, #toolbar-up .w2ui-tb-image:hover, #toolbar-up .w2ui-tb-image:focus, #toolbar-up .w2ui-tb-image:active, #toolbar-hamburger.menuwizard-closed:active {
 	-webkit-filter: drop-shadow(0px 0px 4px var(--color-primary-darker));
 	filter: drop-shadow(0px 0px 4px var(--color-primary-darker));
 }
-#toolbar-up .over{
+#toolbar-up .over {
 	border-color: transparent !important;
 	box-shadow: none !important;
 }
-#toolbar-up .over:hover .w2ui-tb-image, #toolbar-up .over:active .w2ui-tb-image{
+#toolbar-up .over:hover .w2ui-tb-image, #toolbar-up .over:active .w2ui-tb-image {
 	-webkit-filter: drop-shadow(0px 0px 4px var(--color-primary-darker));
 	filter: drop-shadow(0px 0px 4px var(--color-primary-darker));
 	border-color: transparent;
@@ -285,14 +285,14 @@ textarea.cool-annotation-textarea {
 	border-radius: 7px;
 	outline: 1px solid var(--color-background-lighter);
 }
-.w2ui-toolbar .w2ui-break{
+.w2ui-toolbar .w2ui-break {
 	background-image: none;
 	background-color: #dae6f3;
 }
 #formulabar .w2ui-break {
 	visibility: hidden;
 }
-#setgamma input.spinfield, #linewidth input.spinfield, #nolines input.spinfield{
+#setgamma input.spinfield, #linewidth input.spinfield, #nolines input.spinfield {
 	width: 140px !important;
 }
 #toolbar-down table.w2ui-button:not(.checked) td.w2ui-tb-down > div {
@@ -305,19 +305,19 @@ textarea.cool-annotation-textarea {
 	border-top: 5px solid #8D99A7;
 	margin-bottom: 5px !important;
 }
-#toolbar-search #search *{
+#toolbar-search #search * {
 	width: 100% !important;
 }
-#toolbar-search input#search-input{
+#toolbar-search input#search-input {
 	font-size: 16px;
 }
-#toolbar-search #hidesearchbar{
+#toolbar-search #hidesearchbar {
 	padding: 1px 8px !important;
 }
-#toolbar-search #search{
+#toolbar-search #search {
 	width: 80%;
 }
-.context-menu-link{
+.context-menu-link {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
@@ -614,7 +614,7 @@ textarea.cool-annotation-textarea {
 	.iframe-dialog-content {
 		height: 100%;
 	}
-	.iframe-dialog-modal{
+	.iframe-dialog-modal {
 		position: static;
 		height: 100%;
 	}
@@ -686,7 +686,7 @@ div#fontstyletoolbox + div#style.mobile-wizard {
 	background-color: var(--color-primary) !important;
 }
 
-.mobile-wizard-titlebar-btn-container{
+.mobile-wizard-titlebar-btn-container {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;

--- a/browser/css/device-tablet.css
+++ b/browser/css/device-tablet.css
@@ -42,7 +42,7 @@
 	-webkit-align-items: center;
 	align-items: center;
 }
-.hasnotebookbar{
+.hasnotebookbar {
 	overflow: auto hidden;
 	scrollbar-width: none;
 	-ms-overflow-style: none;

--- a/browser/css/impress-mobile.css
+++ b/browser/css/impress-mobile.css
@@ -1,4 +1,4 @@
-.slide-master-mode > .leaflet-container{
+.slide-master-mode > .leaflet-container {
 	background-color: var(--color-primary-lighter);
 	box-shadow: inset 0px 0px 5px 0px var(--color-primary);
 }

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -440,7 +440,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 
 .ui-expander-label.expanded::before,
 .ui-treeview-expandable:not(.collapsed) > div > .ui-treeview-expander::before,
-.ui-treeview div[aria-expanded='true'] > div > .ui-treeview-expander::before  {
+.ui-treeview div[aria-expanded='true'] > div > .ui-treeview-expander::before {
 	content: 'V';
 	color: transparent;
 	margin-inline-end: 7px;
@@ -451,7 +451,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 
 [data-theme='dark'] .ui-expander-label::before,
 [data-theme='dark'] .ui-treeview-expandable > div > .ui-treeview-expander::before,
-[data-theme='dark'] .ui-treeview div[aria-expanded] > div > .ui-treeview-expander::before  {
+[data-theme='dark'] .ui-treeview div[aria-expanded] > div > .ui-treeview-expander::before {
 	filter: brightness(1);
 }
 
@@ -729,7 +729,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 .ui-treeview.droptarget {
 	border: 1px solid #888;
 }
-.ui-treeview.droptarget:hover{
+.ui-treeview.droptarget:hover {
 	border: 1px solid #888;
 	box-shadow: 0 0 2px 0 #777;
 }
@@ -948,7 +948,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	height: 24px;
 }
 
-.ui-listbox-container{
+.ui-listbox-container {
 	height: 32px;
 }
 
@@ -959,7 +959,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 .ui-listbox,
 .ui-combobox,
-.ui-timefield  {
+.ui-timefield {
 	box-sizing: border-box;
 	-webkit-appearance: none;
 	-moz-appearance: none;
@@ -1382,8 +1382,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 #mobile-wizard #inclspaceslabel2,
 #mobile-wizard #exclspaceslabel2,
 #mobile-wizard #cjkcharsft2,
-#mobile-wizard #commentslabel
-{
+#mobile-wizard #commentslabel {
 	float: left !important;
 	clear: left !important;
 	width: 70% !important;
@@ -1398,8 +1397,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 #mobile-wizard #docchars,
 #mobile-wizard #doccharsnospaces,
 #mobile-wizard #doccjkchars,
-#mobile-wizard #docComments
-{
+#mobile-wizard #docComments {
 	float: right !important;
 	clear: right !important;
 	width: 20% !important;
@@ -1677,17 +1675,17 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	-webkit-animation-timing-function: ease-in-out;
 	animation-timing-function: ease-in-out;
 }
-@keyframes spinner-saving-anim{
-	0%{transform: translateY(-20px) translateX(0px); opacity: 0;}
-	20%{transform: translateY(5px) translateX(15px); opacity: 1;}
-	45%{transform: translateY(22px) translateX(-10px); opacity: 1;}
-	100%{transform: translateY(60px) translateX(15px); opacity: 0;}
+@keyframes spinner-saving-anim {
+	0% {transform: translateY(-20px) translateX(0px); opacity: 0;}
+	20% {transform: translateY(5px) translateX(15px); opacity: 1;}
+	45% {transform: translateY(22px) translateX(-10px); opacity: 1;}
+	100% {transform: translateY(60px) translateX(15px); opacity: 0;}
 }
-@-webkit-keyframes spinner-saving-anim{
-	0%{transform: translateY(-20px) translateX(0px); opacity: 0;}
-	20%{transform: translateY(5px) translateX(15px); opacity: 1;}
-	45%{transform: translateY(22px) translateX(-10px); opacity: 1;}
-	100%{transform: translateY(60px) translateX(15px); opacity: 0;}
+@-webkit-keyframes spinner-saving-anim {
+	0% {transform: translateY(-20px) translateX(0px); opacity: 0;}
+	20% {transform: translateY(5px) translateX(15px); opacity: 1;}
+	45% {transform: translateY(22px) translateX(-10px); opacity: 1;}
+	100% {transform: translateY(60px) translateX(15px); opacity: 0;}
 }
 
 .spinner-img #spinner-box-f-right {
@@ -2086,7 +2084,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	border-color: transparent;
 }
 
-#toolbar-down  .jsdialog .ui-edit-container{
+#toolbar-down  .jsdialog .ui-edit-container {
 	place-content: center;
 }
 

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -567,7 +567,7 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 /* required to dynamically resize treeviews or lists inside sidebar */
 .sidebar-container, .navigator-container
 .sidebar-container > .root-container.jsdialog.sidebar,.navigator-container > .root-container.jsdialog.sidebar > .root-container.jsdialog.sidebar
-.sidebar-container > .root-container.jsdialog.sidebar > .vertical.jsdialog.sidebar , .navigator-container > .root-container.jsdialog.sidebar > .vertical.jsdialog.sidebar{
+.sidebar-container > .root-container.jsdialog.sidebar > .vertical.jsdialog.sidebar , .navigator-container > .root-container.jsdialog.sidebar > .vertical.jsdialog.sidebar {
 	height: 100%;
 }
 

--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -87,12 +87,12 @@
 }
 
 .leaflet-overlay-pane { z-index: 4; }
-.leaflet-shadow-pane  { z-index: 5; }
-.leaflet-marker-pane  { z-index: 6; }
-.leaflet-popup-pane   { z-index: 7; }
+.leaflet-shadow-pane { z-index: 5; }
+.leaflet-marker-pane { z-index: 6; }
+.leaflet-popup-pane { z-index: 7; }
 
 .leaflet-map-pane canvas { z-index: 1; }
-.leaflet-map-pane svg    { z-index: 2; }
+.leaflet-map-pane svg { z-index: 2; }
 
 .leaflet-vml-shape {
 	width: 1px;
@@ -349,7 +349,7 @@ a.leaflet-control-buttons:hover:first-child {
 	border: thin solid;
 }
 
-.leaflet-control-buttons-disabled{
+.leaflet-control-buttons-disabled {
 	opacity: 0.5;
 }
 
@@ -885,8 +885,7 @@ input.clipboard {
 }
 
 .cool-ruler-indentation-marker-center,
-.cool-ruler-horizontal-indentation-marker-center
-{
+.cool-ruler-horizontal-indentation-marker-center {
 	position: fixed;
 	display: none;
 	top: 0;

--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -490,15 +490,15 @@ nav.hasnotebookbar #save.saved::after {
 	-webkit-animation-timing-function: ease-in-out;
 	animation-timing-function: ease-in-out;
 }
-@keyframes up-n-down-anim{
-	0%{margin-top: 0;}
-	50%{margin-top: -20px;}
-	100%{margin-top: 0;}
+@keyframes up-n-down-anim {
+	0% {margin-top: 0;}
+	50% {margin-top: -20px;}
+	100% {margin-top: 0;}
 }
-@-webkit-keyframes up-n-down-anim{
-	0%{margin-top: 0;}
-	50%{margin-top: -20px;}
-	100%{margin-top: 0;}
+@-webkit-keyframes up-n-down-anim {
+	0% {margin-top: 0;}
+	50% {margin-top: -20px;}
+	100% {margin-top: 0;}
 }
 
 .sidebar .locking-overlay {

--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -3,7 +3,7 @@ label.mobile-wizard {
 	float: left;
 }
 
-.menuwizard .menu-entry-icon{
+.menuwizard .menu-entry-icon {
 	padding-left: 4%;
 }
 #mobile-wizard:not(.menuwizard) .menu-entry-with-icon {
@@ -19,11 +19,11 @@ span.menu-entry-icon {
 	padding-left: 2%;
 }
 
-#mobile-wizard.menuwizard .mobile-wizard-back.close-button{
+#mobile-wizard.menuwizard .mobile-wizard-back.close-button {
 	visibility: hidden !important;
 }
 
-#toolbar-hamburger.menuwizard-opened{
+#toolbar-hamburger.menuwizard-opened {
 	z-index: 1501 !important;
 	position: relative !important;
 	background-color: var(--color-primary-lighter) !important;
@@ -31,7 +31,7 @@ span.menu-entry-icon {
 	border-radius: 0 0 0 15px !important;
 }
 
-#mobile-wizard.menuwizard .mobile-wizard-titlebar{
+#mobile-wizard.menuwizard .mobile-wizard-titlebar {
 	border: none !important;
 }
 span#main-menu-btn-icon {
@@ -49,7 +49,7 @@ span#main-menu-btn-icon {
 	width: 100%;
 }
 
-.ui-header.level-1.mobile-wizard.ui-widget img[src='images/lc_exportpdf.svg']{
+.ui-header.level-1.mobile-wizard.ui-widget img[src='images/lc_exportpdf.svg'] {
 	visibility: visible;
 }
 
@@ -90,7 +90,7 @@ span#main-menu-btn-icon {
 	background-color: #fff !important;
 }
 
-.colors-container-selected-basic-color{
+.colors-container-selected-basic-color {
 	box-shadow: 0 2px 3px -2px var(--color-primary);
 	border-radius: var(--border-radius);
 	border: 2px solid var(--color-primary) !important;
@@ -122,7 +122,7 @@ span#main-menu-btn-icon {
 	padding: 0 4%;
 }
 
-.colors-container-no-color-row, .colors-container-auto-color-row{
+.colors-container-no-color-row, .colors-container-auto-color-row {
 	display: flex;
 	justify-content: flex-start;
 	align-items: center;
@@ -192,7 +192,7 @@ p.mobile-wizard.ui-combobox-text {
 .menuwizard #mobile-wizard-content > div .ui-widget {
 	padding-left: 0px !important;
 }
-#mobile-wizard:not(.menuwizard) #mobile-wizard-content > .ui-header.level-0.mobile-wizard.ui-widget{
+#mobile-wizard:not(.menuwizard) #mobile-wizard-content > .ui-header.level-0.mobile-wizard.ui-widget {
 	padding-left: 2% !important;
 	width: 100%;
 }
@@ -223,12 +223,12 @@ p.mobile-wizard.ui-combobox-text.selected {
 	background: url('images/lc_helpindex_secondary.svg') no-repeat right 16px bottom 88px / 124px !important;
 }
 
-#ParaPropertyPanel + .ui-content{
+#ParaPropertyPanel + .ui-content {
 	display: flex;
 	flex-wrap: wrap !important;
 	justify-content: space-around;
 }
-.ui-tabs-content > div[title='Layouts']{
+.ui-tabs-content > div[title='Layouts'] {
 	justify-content: center;
 	-ms-box-orient: horizontal !important;
 	display: -webkit-box;
@@ -243,13 +243,13 @@ p.mobile-wizard.ui-combobox-text.selected {
 	flex-wrap: wrap !important;
 	margin-top: 25px;
 }
-#mobile-wizard #rotationlabel, #cellbackgroundlabel, #NumberFormatCurrency > .unolabel, #NumberFormatPercent > .unolabel, #NumberFormatDecimal > .unolabel{
+#mobile-wizard #rotationlabel, #cellbackgroundlabel, #NumberFormatCurrency > .unolabel, #NumberFormatPercent > .unolabel, #NumberFormatDecimal > .unolabel {
 	display: none;
 }
 #rotationlabel:not(#mobile-wizard) {
 	visibility: hidden;
 }
-#mobile-wizard #NumberFormatDecimal, #mobile-wizard #NumberFormatPercent{
+#mobile-wizard #NumberFormatDecimal, #mobile-wizard #NumberFormatPercent {
 	margin-left: 20%;
 }
 #mobile-wizard #NumberFormatCurrency {
@@ -293,7 +293,7 @@ p.mobile-wizard.ui-combobox-text.selected {
 	background-color: var(--color-background-lighter);
 }
 
-#mobile-wizard-content *{
+#mobile-wizard-content * {
 	font-family: var(--mobile-font);
 	color: var(--color-main-text);
 }
@@ -313,7 +313,7 @@ p.mobile-wizard.ui-combobox-text.selected {
 	border: none !important;
 	padding: 0px 0px 16px;
 }
-#mobile-wizard-content > #ScCellAppearancePropertyPanel + .ui-content.level-0.mobile-wizard{
+#mobile-wizard-content > #ScCellAppearancePropertyPanel + .ui-content.level-0.mobile-wizard {
 	display: flex;
 	justify-content: center;
 	align-items: start;
@@ -392,7 +392,7 @@ p.mobile-wizard.ui-combobox-text.selected {
 	display: none;
 }
 
-#mobile-wizard-content .ui-content > table > tr > td > table > table > tr:first-child > td > img{
+#mobile-wizard-content .ui-content > table > tr > td > table > table > tr:first-child > td > img {
 	margin-top: 0px !important;
 }
 
@@ -543,7 +543,7 @@ p.mobile-wizard.ui-combobox-text.selected {
 	display: table-cell;
 	vertical-align: middle;
 }
-.spinfieldcontainer .plus:active, .spinfieldcontainer .minus:active{
+.spinfieldcontainer .plus:active, .spinfieldcontainer .minus:active {
 	background-color: var(--color-primary-lighter);
 	font-weight: bold
 }
@@ -596,7 +596,7 @@ input.ui-edit.mobile-wizard,
 }
 
 /*insert table special layout*/
-.inserttablecontrols label.ui-text{
+.inserttablecontrols label.ui-text {
 	margin-left: 14%;
 	width: 50%;
 	border: none;
@@ -604,27 +604,27 @@ input.ui-edit.mobile-wizard,
 	color: #555 !important;
 }
 
-.inserttablecontrols #rows, .inserttablecontrols #cols{
+.inserttablecontrols #rows, .inserttablecontrols #cols {
 	background: url('images/lc_inserttable_row_mono.svg') no-repeat left;
 	border-bottom: 1px solid var(--color-border-lighter) !important;
 	width: 90%;
 	border-radius: none;
 }
-.inserttablecontrols #cols{
+.inserttablecontrols #cols {
 	background: url('images/lc_inserttable_col_mono.svg') no-repeat left;
 }
-.inserttablecontrols .spinfield{
+.inserttablecontrols .spinfield {
 	width: 35% !important;
 	margin-left: 10% !important;
 	text-align: center;
 }
-.inserttablecontrols .plus, .inserttablecontrols .minus{
+.inserttablecontrols .plus, .inserttablecontrols .minus {
 	border: none;
 	font-weight: bold;
 }
 /*END insert table special layout*/
 
-.leaflet-control-zoom.leaflet-bar{
+.leaflet-control-zoom.leaflet-bar {
 	border: none !important;
 }
 a.leaflet-control-zoom-in {
@@ -635,14 +635,14 @@ a.leaflet-control-zoom-in {
 	box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.2), 0 4px 6px 0 rgba(0, 0, 0, 0.19) !important;
 	border: none !important;
 }
-#slide-sorter .preview-img{
+#slide-sorter .preview-img {
 	border-radius: var(--border-radius);
 	border-color: var(--color-border);
 }
-#slide-sorter .preview-img:hover{
+#slide-sorter .preview-img:hover {
 	border-color: var(--color-primary-darker);
 }
-#slide-sorter .preview-img-currentpart{
+#slide-sorter .preview-img-currentpart {
 	border-color: var(--color-primary-dark);
 	border-style: solid;
 	border-radius: var(--border-radius);
@@ -656,18 +656,18 @@ a.leaflet-control-zoom-in {
 	color: var(--color-primary-dark) !important;
 }
 
-.w2ui-icon.users{
+.w2ui-icon.users {
 	background-size: 20px !important;
 }
-.ui-content label{
+.ui-content label {
 	line-height: 25px;
 	vertical-align: top;
 	padding-left: 4%;
 }
-#buttonnone + label, #buttonbefore + label, #buttonafter + label, #buttonoptimal + label, #buttonparallel + label, #buttonthrough + label{
+#buttonnone + label, #buttonbefore + label, #buttonafter + label, #buttonoptimal + label, #buttonparallel + label, #buttonthrough + label {
 	padding-left: 0;
 }
-#mobile-wizard #Color > img{
+#mobile-wizard #Color > img {
 	border-radius: 100px;
 	background-color: var(--color-background);
 }
@@ -694,13 +694,13 @@ a.leaflet-control-zoom-in {
 #aligntoolbar span, #aligntoolbar2 span {
 	visibility: hidden;
 }
-#MergeCells > span{
+#MergeCells > span {
 	color: rgb(var(--doc-type));
 	text-align: end;
 	vertical-align: bottom;
 }
 
-#DeleteTable > span{
+#DeleteTable > span {
 	font-weight: bold;
 	color: var(--color-error);
 	text-align: end;
@@ -758,8 +758,8 @@ a.leaflet-control-zoom-in {
 	width: 100%;
 }
 
-#DecrementIndent + input:disabled{display: none;}
-div#mobile-wizard-content input[type='number']{
+#DecrementIndent + input:disabled {display: none;}
+div#mobile-wizard-content input[type='number'] {
 	color: var(--color-text-dark);
 	height: 46px;
 	width: 37%;
@@ -769,7 +769,7 @@ div#mobile-wizard-content input[type='number']{
 	-webkit-appearance: textfield;
 	background-color: var(--color-background-dark);
 }
-div#mobile-wizard-content .spinfieldcontainer{
+div#mobile-wizard-content .spinfieldcontainer {
 	height: 48px;
 	width: -moz-available;
 	width: -webkit-fill-available;
@@ -790,7 +790,7 @@ div#mobile-wizard-content .spinfieldcontainer:active .spinfieldimage, div#mobile
 div#mobile-wizard-content .spinfieldcontainer .spinfieldimage.disabled {
 	opacity: 0.5 !important;
 }
-#mobile-wizard #Bold, #mobile-wizard #Italic, #mobile-wizard #Underline, #mobile-wizard #Strikeout{
+#mobile-wizard #Bold, #mobile-wizard #Italic, #mobile-wizard #Underline, #mobile-wizard #Strikeout {
 	margin: 0;
 	-webkit-appearance: none;
 	-moz-appearance: none;
@@ -809,23 +809,23 @@ div#mobile-wizard-content .spinfieldcontainer .spinfieldimage.disabled {
 	float: left;
 	background-size: 24px !important;
 }
-#mobile-wizard-content > .unobutton:focus, #mobile-wizard-content .unobutton:active{
+#mobile-wizard-content > .unobutton:focus, #mobile-wizard-content .unobutton:active {
 	outline: none;
 	background-color: var(--color-primary-lighter) !important;
 	box-shadow: 0 0 0px 8px var(--color-primary-lighter);
 	border-radius: 0.1px;
 }
-#mobile-wizard #buttonbefore{background: url('images/sc_wrapleft.svg') no-repeat center;}
-#mobile-wizard #buttonafter{background: url('images/sc_wrapright.svg') no-repeat center;}
-#mobile-wizard #buttonoptimal{background: url('images/sc_wrapideal.svg') no-repeat center;}
-#mobile-wizard #buttonparallel{background: url('images/sc_wrapmenu.svg') no-repeat center;}
-#mobile-wizard #buttonnone{background: url('images/sc_wrapoff.svg') no-repeat center;}
-#mobile-wizard #buttonthrough{background: url('images/sc_wrapthrough.svg') no-repeat center;}
-#mobile-wizard #top{background: url('images/sc_aligntop.svg') no-repeat center;}
-#mobile-wizard #bottom{background: url('images/sc_alignbottom.svg') no-repeat center;}
-#mobile-wizard #standard{background: url('images/sc_alignverticalcenter.svg') no-repeat center;}
+#mobile-wizard #buttonbefore {background: url('images/sc_wrapleft.svg') no-repeat center;}
+#mobile-wizard #buttonafter {background: url('images/sc_wrapright.svg') no-repeat center;}
+#mobile-wizard #buttonoptimal {background: url('images/sc_wrapideal.svg') no-repeat center;}
+#mobile-wizard #buttonparallel {background: url('images/sc_wrapmenu.svg') no-repeat center;}
+#mobile-wizard #buttonnone {background: url('images/sc_wrapoff.svg') no-repeat center;}
+#mobile-wizard #buttonthrough {background: url('images/sc_wrapthrough.svg') no-repeat center;}
+#mobile-wizard #top {background: url('images/sc_aligntop.svg') no-repeat center;}
+#mobile-wizard #bottom {background: url('images/sc_alignbottom.svg') no-repeat center;}
+#mobile-wizard #standard {background: url('images/sc_alignverticalcenter.svg') no-repeat center;}
 #mobile-wizard .checkbutton,
-#mobile-wizard .radiobutton{
+#mobile-wizard .radiobutton {
 	clear: both;
 	width: 92%;
 	margin: 0 4%;
@@ -847,11 +847,11 @@ div#mobile-wizard-content .spinfieldcontainer .spinfieldimage.disabled {
 	line-height: normal;
 	padding: 10px 2px 10px 15px;
 }
-#mobile-wizard input[type='checkbox']:disabled{
+#mobile-wizard input[type='checkbox']:disabled {
 	border: 2px solid var(--color-border-lighter);
 	box-shadow: 0px 0px 2px 1px var(--color-border-lighter);
 }
-#mobile-wizard input[type='checkbox']{
+#mobile-wizard input[type='checkbox'] {
 	width: var(--btn-size);
 	height: var(--btn-size);
 	margin: 10px 10px 10px auto !important;
@@ -865,7 +865,7 @@ div#mobile-wizard-content .spinfieldcontainer .spinfieldimage.disabled {
 	outline: none;
 	box-shadow: 0px 0px 2px 1px var(--color-box-shadow);
 }
-#mobile-wizard input[type='checkbox']:checked{
+#mobile-wizard input[type='checkbox']:checked {
 	background: url('images/lc_ok_white.svg') no-repeat center;
 	background-color: var(--color-primary-lighter);
 	border-radius: var(--border-radius);
@@ -873,20 +873,20 @@ div#mobile-wizard-content .spinfieldcontainer .spinfieldimage.disabled {
 	outline: none;
 	box-shadow: none;
 }
-#mobile-wizard input[type='checkbox']:before{
+#mobile-wizard input[type='checkbox']:before {
 	width: 20px;
 	height: 20px;
 }
-#mobile-wizard input[type='checkbox']:after{
+#mobile-wizard input[type='checkbox']:after {
 	top: -20px;
 	width: 16px;
 }
 
-#mobile-wizard input[type='radio']:disabled{
+#mobile-wizard input[type='radio']:disabled {
 	border: 2px solid var(--color-border-lighter);
 	box-shadow: none;
 }
-#mobile-wizard input[type='radio']{
+#mobile-wizard input[type='radio'] {
 	border-radius: 50%;
 	width: var(--btn-size);
 	height: var(--btn-size);
@@ -899,36 +899,36 @@ div#mobile-wizard-content .spinfieldcontainer .spinfieldimage.disabled {
 	outline: none;
 	box-shadow: #00000015 0px 0px 2px 1px;
 }
-#mobile-wizard input[type='radio']:checked{
+#mobile-wizard input[type='radio']:checked {
 	background: url('images/lc_ok_white.svg') no-repeat center;
 	background-color: var(--color-primary-lighter);
 	border: 2px solid var(--color-primary);
 	outline: none;
 	box-shadow: none;
 }
-#mobile-wizard input[type='radio']:checked:disabled{
+#mobile-wizard input[type='radio']:checked:disabled {
 	background-color: var(--color-border-lighter) !important;
 	border: 2px solid var(--color-border-lighter) !important;
 }
-#mobile-wizard input[type='radio']:before{
+#mobile-wizard input[type='radio']:before {
 	width: 20px;
 	height: 20px;
 }
-#mobile-wizard input[type='radio']:after{
+#mobile-wizard input[type='radio']:after {
 	top: -20px;
 	width: 16px;
 }
 
-#enablecontour + label{
+#enablecontour + label {
 	line-height: 44px;
 	vertical-align: baseline;
 	padding-left: 24px;
 }
-#SdTableDesignPanel + .ui-content div[id^='Use']{
+#SdTableDesignPanel + .ui-content div[id^='Use'] {
 	width: 92%;
 	padding-right: 4% !important;
 }
-input[type='checkbox']#UseBandingColumnStyle, input[type='checkbox']#UseLastColumnStyle, input[type='checkbox']#UseFirstColumnStyle, input[type='checkbox']#UseBandingRowStyle, input[type='checkbox']#UseLastRowStyle, input[type='checkbox']#UseFirstRowStyle{
+input[type='checkbox']#UseBandingColumnStyle, input[type='checkbox']#UseLastColumnStyle, input[type='checkbox']#UseFirstColumnStyle, input[type='checkbox']#UseBandingRowStyle, input[type='checkbox']#UseLastRowStyle, input[type='checkbox']#UseFirstRowStyle {
 	margin-right: 0px !important;
 }
 #mobile-wizard #FontworkSameLetterHeights {
@@ -959,15 +959,15 @@ input[type='checkbox']#UseBandingColumnStyle, input[type='checkbox']#UseLastColu
 	margin: 5px 4%;
 	font-size: var(--default-font-size);
 }
-#mobile-wizard button:focus{
+#mobile-wizard button:focus {
 	outline: none;
 }
-#mobile-wizard button:active{
+#mobile-wizard button:active {
 	outline: none;
 	border: none;
 	background-color: var(--color-primary-lighter);
 }
-#mobile-wizard button:disabled{
+#mobile-wizard button:disabled {
 	background-color: var(--color-background-lighter);
 	border-color: var(--color-background-lighter);
 	color: var(--color-text-lighter) !important;
@@ -1145,7 +1145,7 @@ label.disabled {
 	padding-bottom: 32px;
 }
 
-#mobile-wizard .empty-comment-wizard-link{
+#mobile-wizard .empty-comment-wizard-link {
 	color: var(--color-primary);
 	display: flex;
 	justify-content: center;
@@ -1182,8 +1182,7 @@ label.disabled {
 	flex-wrap: wrap;
 }
 
-#mobile-wizard #FontworkShapeType-fontwork-plain-text, #mobile-wizard #FontworkShapeType-fontwork-wave, #mobile-wizard #FontworkShapeType-fontwork-inflate, #mobile-wizard #FontworkShapeType-fontwork-stop, #mobile-wizard #FontworkShapeType-fontwork-curve-up, #mobile-wizard #FontworkShapeType-fontwork-curve-down, #mobile-wizard #FontworkShapeType-fontwork-triangle-up, #mobile-wizard #FontworkShapeType-fontwork-triangle-down, #mobile-wizard #FontworkShapeType-fontwork-fade-right, #mobile-wizard #FontworkShapeType-fontwork-fade-left, #mobile-wizard #FontworkShapeType-fontwork-fade-up, #mobile-wizard #FontworkShapeType-fontwork-fade-down, #mobile-wizard #FontworkShapeType-fontwork-slant-up, #mobile-wizard #FontworkShapeType-fontwork-slant-down, #mobile-wizard #FontworkShapeType-fontwork-fade-up-and-right, #mobile-wizard #FontworkShapeType-fontwork-fade-up-and-left, #mobile-wizard #FontworkShapeType-fontwork-chevron-up, #mobile-wizard #FontworkShapeType-fontwork-chevron-down, #mobile-wizard #FontworkShapeType-fontwork-arch-up-curve, #mobile-wizard #FontworkShapeType-fontwork-arch-down-curve, #mobile-wizard #FontworkShapeType-fontwork-arch-left-curve, #mobile-wizard #FontworkShapeType-fontwork-arch-right-curve, #mobile-wizard #FontworkShapeType-fontwork-circle-curve, #mobile-wizard #FontworkShapeType-fontwork-open-circle-curve, #mobile-wizard #FontworkShapeType-fontwork-arch-up-pour, #mobile-wizard #FontworkShapeType-fontwork-arch-down-pour, #mobile-wizard #FontworkShapeType-fontwork-arch-right-pour, #mobile-wizard #FontworkShapeType-fontwork-circle-pour, #mobile-wizard #FontworkShapeType-fontwork-open-circle-pour
-{
+#mobile-wizard #FontworkShapeType-fontwork-plain-text, #mobile-wizard #FontworkShapeType-fontwork-wave, #mobile-wizard #FontworkShapeType-fontwork-inflate, #mobile-wizard #FontworkShapeType-fontwork-stop, #mobile-wizard #FontworkShapeType-fontwork-curve-up, #mobile-wizard #FontworkShapeType-fontwork-curve-down, #mobile-wizard #FontworkShapeType-fontwork-triangle-up, #mobile-wizard #FontworkShapeType-fontwork-triangle-down, #mobile-wizard #FontworkShapeType-fontwork-fade-right, #mobile-wizard #FontworkShapeType-fontwork-fade-left, #mobile-wizard #FontworkShapeType-fontwork-fade-up, #mobile-wizard #FontworkShapeType-fontwork-fade-down, #mobile-wizard #FontworkShapeType-fontwork-slant-up, #mobile-wizard #FontworkShapeType-fontwork-slant-down, #mobile-wizard #FontworkShapeType-fontwork-fade-up-and-right, #mobile-wizard #FontworkShapeType-fontwork-fade-up-and-left, #mobile-wizard #FontworkShapeType-fontwork-chevron-up, #mobile-wizard #FontworkShapeType-fontwork-chevron-down, #mobile-wizard #FontworkShapeType-fontwork-arch-up-curve, #mobile-wizard #FontworkShapeType-fontwork-arch-down-curve, #mobile-wizard #FontworkShapeType-fontwork-arch-left-curve, #mobile-wizard #FontworkShapeType-fontwork-arch-right-curve, #mobile-wizard #FontworkShapeType-fontwork-circle-curve, #mobile-wizard #FontworkShapeType-fontwork-open-circle-curve, #mobile-wizard #FontworkShapeType-fontwork-arch-up-pour, #mobile-wizard #FontworkShapeType-fontwork-arch-down-pour, #mobile-wizard #FontworkShapeType-fontwork-arch-right-pour, #mobile-wizard #FontworkShapeType-fontwork-circle-pour, #mobile-wizard #FontworkShapeType-fontwork-open-circle-pour {
 	padding: 4% !important;
 	margin: 0px !important;
 	float: left;
@@ -1266,7 +1265,7 @@ label.disabled {
 	border: 1px solid var(--color-border);
 }
 
-.unotoolbutton.mobile-wizard .unobutton img{
+.unotoolbutton.mobile-wizard .unobutton img {
 	width: 24px;
 	height: 24px;
 }

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -211,11 +211,11 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 #table-Home-Section-Insert #table-GroupB20 #InsertTable.notebookbar {
 	width: 50px;
 }
-#table-Home-Section-Insert #table-LineB9 #InsertGraphic.notebookbar{
+#table-Home-Section-Insert #table-LineB9 #InsertGraphic.notebookbar {
 	width: auto;
 	margin-left: -2px;
 }
-#buttonbefore.notebookbar, #buttonafter.notebookbar, #buttonoptimal.notebookbar, #buttonparallel.notebookbar, #buttonnone.notebookbar, #buttonthrough.notebookbar, #bottom.notebookbar, #top.notebookbar, #standard.notebookbar, #Bold.notebookbar, #Italic.notebookbar, #Underline.notebookbar, #Strikeout.notebookbar{
+#buttonbefore.notebookbar, #buttonafter.notebookbar, #buttonoptimal.notebookbar, #buttonparallel.notebookbar, #buttonnone.notebookbar, #buttonthrough.notebookbar, #bottom.notebookbar, #top.notebookbar, #standard.notebookbar, #Bold.notebookbar, #Italic.notebookbar, #Underline.notebookbar, #Strikeout.notebookbar {
 	margin: 0px !important;
 	padding: 0px !important;
 }
@@ -285,10 +285,10 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	border-top-right-radius: 12px;
 	border-bottom-right-radius: 12px;
 }
-#table-HomeTab .unospan-uptoolbar:not(.disabled):hover{
+#table-HomeTab .unospan-uptoolbar:not(.disabled):hover {
 	box-shadow: -2px 0 2px 2px #e6e6e6b0;
 }
-#table-HomeTab .unospan-downtoolbar:not(.disabled):hover{
+#table-HomeTab .unospan-downtoolbar:not(.disabled):hover {
 	box-shadow: 2px 0 2px 2px #e6e6e6b0;
 }
 #table-HomeTab .unospan-uptoolbar img, #table-HomeTab .unospan-downtoolbar img {
@@ -347,7 +347,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	margin: auto !important;
 	display: block;
 }
-.has-label.has-dropdown:not(.inline) .unolabel{
+.has-label.has-dropdown:not(.inline) .unolabel {
 	display: inline-block;
 	clear: both;
 }
@@ -367,8 +367,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	align-items: center;
 }
 
-#FormatPaintbrush span
-{
+#FormatPaintbrush span {
 	display: none;
 }
 
@@ -420,7 +419,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	gap: 0;
 }
 
-#stylesview-btn div{
+#stylesview-btn div {
 	border: none;
 }
 
@@ -533,13 +532,11 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 
 /* other */
 
-.ui-drawing-area-container
-{
+.ui-drawing-area-container {
 	position: relative;
 }
 
-.ui-drawing-area-loader
-{
+.ui-drawing-area-loader {
 	border: 5px solid var(--color-border-lighter);
 	border-top: 5px solid var(--color-border);
 	border-radius: 50%;
@@ -552,8 +549,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	top: 25%;
 }
 
-.ui-drawing-area-loader-container
-{
+.ui-drawing-area-loader-container {
 	position: absolute;
 	left: 0;
 	top: 0;
@@ -566,8 +562,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	100% { transform: rotate(360deg); }
 }
 
-.ui-drawing-area-placeholder-container
-{
+.ui-drawing-area-placeholder-container {
 	position: absolute;
 	overflow: hidden;
 	left: 0;
@@ -576,8 +571,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	height: 100%;
 }
 
-.ui-drawing-area-placeholder
-{
+.ui-drawing-area-placeholder {
 	margin: 0;
 	position: absolute;
 	top: 50%;

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -366,7 +366,7 @@
 	width: 95%;
 }
 
-.w2ui-button{
+.w2ui-button {
 	margin: 0 !important;
 }
 
@@ -508,7 +508,7 @@ button.leaflet-control-search-next
 #styles-input {
 	width: 150px !important;
 }
-#toolbar-up #fontnamecombobox .select2-container{
+#toolbar-up #fontnamecombobox .select2-container {
 	margin-left: 5px;
 	margin-right: 5px;
 	width: 150px !important;
@@ -519,7 +519,7 @@ button.leaflet-control-search-next
 	line-height: 24px;
 	padding-right: 8px;
 }
-#toolbar-up #fontsizecombobox .select2-container{
+#toolbar-up #fontsizecombobox .select2-container {
 	min-width: 55px !important;
 }
 #fontsizecombobox-input {
@@ -952,127 +952,127 @@ button.leaflet-control-search-next
 	width: 32px !important;
 	height: 32px !important; }
 
-.w2ui-icon.print{ background: url('images/lc_print.svg') no-repeat center; }
-.w2ui-icon.undo{ background: url('images/lc_undo.svg') no-repeat center; }
-.w2ui-icon.redo{ background: url('images/lc_redo.svg') no-repeat center; }
-.w2ui-icon.copyformat{ background: url('images/lc_formatpaintbrush.svg') no-repeat center; }
-.w2ui-icon.deleteformat{ background: url('images/lc_setdefault.svg') no-repeat center; }
-.w2ui-icon.bold{ background: url('images/lc_bold.svg') no-repeat center; }
-.w2ui-icon.italic{ background: url('images/lc_italic.svg') no-repeat center; }
-.w2ui-icon.underline{ background: url('images/lc_underline.svg') no-repeat center; }
-.w2ui-icon.strikeout{ background: url('images/lc_strikeout.svg') no-repeat center; }
-.w2ui-icon.textcolor{ background: url('images/lc_fontcolor.svg') no-repeat center; }
-.w2ui-icon.backcolor{ background: url('images/lc_backcolor.svg') no-repeat center; }
-.w2ui-icon.backgroundcolor{ background: url('images/lc_fillcolor.svg') no-repeat center; }
-.w2ui-icon.alignleft{ background: url('images/lc_leftpara.svg') no-repeat center; }
-.w2ui-icon.alignhorizontal{ background: url('images/lc_centerpara.svg') no-repeat center; }
-.w2ui-icon.alignright{ background: url('images/lc_rightpara.svg') no-repeat center; }
-.w2ui-icon.alignblock{ background: url('images/lc_justifypara.svg') no-repeat center; }
-.w2ui-icon.aligntop{ background: url('images/lc_aligntop.svg') no-repeat center; }
-.w2ui-icon.alignvcenter{ background: url('images/lc_alignvcenter.svg') no-repeat center; }
-.w2ui-icon.alignbottom{ background: url('images/lc_alignbottom.svg') no-repeat center; }
-.w2ui-icon.cellverttop{ background: url('images/lc_cellverttop.svg') no-repeat center; }
-.w2ui-icon.cellvertcenter{ background: url('images/lc_cellvertcenter.svg') no-repeat center; }
-.w2ui-icon.cellvertbottom{ background: url('images/lc_cellvertbottom.svg') no-repeat center; }
-.w2ui-icon.linespacing, .w2ui-icon.spacepara1, .w2ui-icon.spacepara15{ background: url('images/lc_linespacing.svg') no-repeat center; }
-.w2ui-icon.spacepara2{ background: url('images/lc_spacepara2.svg') no-repeat center; }
-.w2ui-icon.paraspaceincrease{ background: url('images/lc_paraspaceincrease.svg') no-repeat center; }
-.w2ui-icon.paraspacedecrease{ background: url('images/lc_paraspacedecrease.svg') no-repeat center; }
-.w2ui-icon.numbering{ background: url('images/lc_defaultnumbering.svg') no-repeat center; }
-.w2ui-icon.bullet{ background: url('images/lc_defaultbullet.svg') no-repeat center; }
-.w2ui-icon.incrementindent{ background: url('images/lc_leftindent.svg') no-repeat center; }
-.w2ui-icon.decrementindent{ background: url('images/lc_decrementindent.svg') no-repeat center; }
-.w2ui-icon.outlineleft{ background: url('images/lc_outlineleft.svg') no-repeat center; }
-.w2ui-icon.outlineright{ background: url('images/lc_outlineright.svg') no-repeat center; }
-.w2ui-icon.text{ background: url('images/lc_text.svg') no-repeat center; }
-.w2ui-icon.annotation{ background: url('images/lc_shownote.svg') no-repeat center; }
-.w2ui-icon.inserttable{ background: url('images/lc_inserttable.svg') no-repeat center; }
-.w2ui-icon.insertgraphic{ background: url('images/lc_gallery.svg') no-repeat center; }
-.w2ui-icon.link{ background: url('images/lc_inserthyperlink.svg') no-repeat center; }
-.w2ui-icon.insertsymbol{ background: url('images/lc_insertsymbol.svg') no-repeat center; }
-.w2ui-icon.edit{ background: url('images/lc_editdoc.svg') no-repeat center; }
-.w2ui-icon.fold{ background: url('images/lc_fold.svg') no-repeat center center / 19px; opacity: 0.8; filter: alpha(opacity=80);}
-.w2ui-icon.unfold{ background: url('images/unfold.svg') no-repeat center center/ 19px; opacity: 0.8; filter: alpha(opacity=80);}
-.w2ui-icon.hamburger{ background: url('images/hamburger.svg') no-repeat center; }
-.w2ui-icon.setborderstyle{ background: url('images/lc_setborderstyle.svg') no-repeat center; }
-.w2ui-icon.togglemergecells{ background: url('images/lc_togglemergecells.svg') no-repeat center; }
-.w2ui-icon.wraptext{ background: url('images/lc_wraptext.svg') no-repeat center; }
-.w2ui-icon.numberformatstandard{ background: url('images/lc_numberformatstandard.svg') no-repeat center; }
-.w2ui-icon.numberformatcurrency{ background: url('images/lc_numberformatcurrency.svg') no-repeat center; }
-.w2ui-icon.numberformatpercent{ background: url('images/lc_numberformatpercent.svg') no-repeat center; }
-.w2ui-icon.numberformatdecimal{ background: url('images/lc_numberformatdecimal.svg') no-repeat center; }
-.w2ui-icon.numberformatdate{ background: url('images/lc_numberformatdate.svg') no-repeat center; }
-.w2ui-icon.numberformattime{ background: url('images/lc_numberformattime.svg') no-repeat center; }
-.w2ui-icon.numberformatscientific{ background: url('images/lc_numberformatscientific.svg') no-repeat center; }
-.w2ui-icon.numberformatthousands{ background: url('images/lc_numberformatthousands.svg') no-repeat center; }
-.w2ui-icon.numberformatincdecimals{ background: url('images/lc_numberformatincdecimals.svg') no-repeat center; }
-.w2ui-icon.numberformatdecdecimals{ background: url('images/lc_numberformatdecdecimals.svg') no-repeat center; }
-.w2ui-icon.insertobjectchart{ background: url('images/lc_drawchart.svg') no-repeat center; }
-.w2ui-icon.insertrowsafter{ background: url('images/lc_insertrowsafter.svg') no-repeat center; }
-.w2ui-icon.insertcolumnsafter{ background: url('images/lc_insertcolumnsafter.svg') no-repeat center; }
-.w2ui-icon.insertcolumnsbefore{ background: url('images/lc_insertcolumnsbefore.svg') no-repeat center; }
-.w2ui-icon.insertrowsbefore{ background: url('images/lc_insertrowsbefore.svg') no-repeat center; }
-.w2ui-icon.autosum{ background: url('images/lc_autosum.svg') no-repeat center; }
-.w2ui-icon.orientation{ background: url('images/lc_orientation.svg') no-repeat center; }
-.w2ui-icon.deleterows{ background: url('images/lc_deleterows.svg') no-repeat center; }
-.w2ui-icon.hiderow{ background: url('images/lc_hiderow.svg') no-repeat center; }
-.w2ui-icon.showrow{ background: url('images/lc_showrow.svg') no-repeat center; }
-.w2ui-icon.deletecolumns{ background: url('images/lc_deletecolumns.svg') no-repeat center; }
-.w2ui-icon.hidecolumn{ background: url('images/lc_hidecolumn.svg') no-repeat center; }
-.w2ui-icon.showcolumn{ background: url('images/lc_showcolumn.svg') no-repeat center; }
-.w2ui-icon.entirerow{ background: url('images/lc_entirerow.svg') no-repeat center; }
-.w2ui-icon.setoptimalrowheight{ background: url('images/lc_setoptimalrowheight.svg') no-repeat center; }
-.w2ui-icon.setoptimalcolumnwidth{ background: url('images/lc_setoptimalcolumnwidth.svg') no-repeat center; }
-.w2ui-icon.entirecell{ background: url('images/lc_entirecell.svg') no-repeat center; }
-.w2ui-icon.entirecolumn{ background: url('images/lc_entirecolumn.svg') no-repeat center; }
-.w2ui-icon.selecttable{ background: url('images/lc_selecttable.svg') no-repeat center; }
+.w2ui-icon.print { background: url('images/lc_print.svg') no-repeat center; }
+.w2ui-icon.undo { background: url('images/lc_undo.svg') no-repeat center; }
+.w2ui-icon.redo { background: url('images/lc_redo.svg') no-repeat center; }
+.w2ui-icon.copyformat { background: url('images/lc_formatpaintbrush.svg') no-repeat center; }
+.w2ui-icon.deleteformat { background: url('images/lc_setdefault.svg') no-repeat center; }
+.w2ui-icon.bold { background: url('images/lc_bold.svg') no-repeat center; }
+.w2ui-icon.italic { background: url('images/lc_italic.svg') no-repeat center; }
+.w2ui-icon.underline { background: url('images/lc_underline.svg') no-repeat center; }
+.w2ui-icon.strikeout { background: url('images/lc_strikeout.svg') no-repeat center; }
+.w2ui-icon.textcolor { background: url('images/lc_fontcolor.svg') no-repeat center; }
+.w2ui-icon.backcolor { background: url('images/lc_backcolor.svg') no-repeat center; }
+.w2ui-icon.backgroundcolor { background: url('images/lc_fillcolor.svg') no-repeat center; }
+.w2ui-icon.alignleft { background: url('images/lc_leftpara.svg') no-repeat center; }
+.w2ui-icon.alignhorizontal { background: url('images/lc_centerpara.svg') no-repeat center; }
+.w2ui-icon.alignright { background: url('images/lc_rightpara.svg') no-repeat center; }
+.w2ui-icon.alignblock { background: url('images/lc_justifypara.svg') no-repeat center; }
+.w2ui-icon.aligntop { background: url('images/lc_aligntop.svg') no-repeat center; }
+.w2ui-icon.alignvcenter { background: url('images/lc_alignvcenter.svg') no-repeat center; }
+.w2ui-icon.alignbottom { background: url('images/lc_alignbottom.svg') no-repeat center; }
+.w2ui-icon.cellverttop { background: url('images/lc_cellverttop.svg') no-repeat center; }
+.w2ui-icon.cellvertcenter { background: url('images/lc_cellvertcenter.svg') no-repeat center; }
+.w2ui-icon.cellvertbottom { background: url('images/lc_cellvertbottom.svg') no-repeat center; }
+.w2ui-icon.linespacing, .w2ui-icon.spacepara1, .w2ui-icon.spacepara15 { background: url('images/lc_linespacing.svg') no-repeat center; }
+.w2ui-icon.spacepara2 { background: url('images/lc_spacepara2.svg') no-repeat center; }
+.w2ui-icon.paraspaceincrease { background: url('images/lc_paraspaceincrease.svg') no-repeat center; }
+.w2ui-icon.paraspacedecrease { background: url('images/lc_paraspacedecrease.svg') no-repeat center; }
+.w2ui-icon.numbering { background: url('images/lc_defaultnumbering.svg') no-repeat center; }
+.w2ui-icon.bullet { background: url('images/lc_defaultbullet.svg') no-repeat center; }
+.w2ui-icon.incrementindent { background: url('images/lc_leftindent.svg') no-repeat center; }
+.w2ui-icon.decrementindent { background: url('images/lc_decrementindent.svg') no-repeat center; }
+.w2ui-icon.outlineleft { background: url('images/lc_outlineleft.svg') no-repeat center; }
+.w2ui-icon.outlineright { background: url('images/lc_outlineright.svg') no-repeat center; }
+.w2ui-icon.text { background: url('images/lc_text.svg') no-repeat center; }
+.w2ui-icon.annotation { background: url('images/lc_shownote.svg') no-repeat center; }
+.w2ui-icon.inserttable { background: url('images/lc_inserttable.svg') no-repeat center; }
+.w2ui-icon.insertgraphic { background: url('images/lc_gallery.svg') no-repeat center; }
+.w2ui-icon.link { background: url('images/lc_inserthyperlink.svg') no-repeat center; }
+.w2ui-icon.insertsymbol { background: url('images/lc_insertsymbol.svg') no-repeat center; }
+.w2ui-icon.edit { background: url('images/lc_editdoc.svg') no-repeat center; }
+.w2ui-icon.fold { background: url('images/lc_fold.svg') no-repeat center center / 19px; opacity: 0.8; filter: alpha(opacity=80);}
+.w2ui-icon.unfold { background: url('images/unfold.svg') no-repeat center center/ 19px; opacity: 0.8; filter: alpha(opacity=80);}
+.w2ui-icon.hamburger { background: url('images/hamburger.svg') no-repeat center; }
+.w2ui-icon.setborderstyle { background: url('images/lc_setborderstyle.svg') no-repeat center; }
+.w2ui-icon.togglemergecells { background: url('images/lc_togglemergecells.svg') no-repeat center; }
+.w2ui-icon.wraptext { background: url('images/lc_wraptext.svg') no-repeat center; }
+.w2ui-icon.numberformatstandard { background: url('images/lc_numberformatstandard.svg') no-repeat center; }
+.w2ui-icon.numberformatcurrency { background: url('images/lc_numberformatcurrency.svg') no-repeat center; }
+.w2ui-icon.numberformatpercent { background: url('images/lc_numberformatpercent.svg') no-repeat center; }
+.w2ui-icon.numberformatdecimal { background: url('images/lc_numberformatdecimal.svg') no-repeat center; }
+.w2ui-icon.numberformatdate { background: url('images/lc_numberformatdate.svg') no-repeat center; }
+.w2ui-icon.numberformattime { background: url('images/lc_numberformattime.svg') no-repeat center; }
+.w2ui-icon.numberformatscientific { background: url('images/lc_numberformatscientific.svg') no-repeat center; }
+.w2ui-icon.numberformatthousands { background: url('images/lc_numberformatthousands.svg') no-repeat center; }
+.w2ui-icon.numberformatincdecimals { background: url('images/lc_numberformatincdecimals.svg') no-repeat center; }
+.w2ui-icon.numberformatdecdecimals { background: url('images/lc_numberformatdecdecimals.svg') no-repeat center; }
+.w2ui-icon.insertobjectchart { background: url('images/lc_drawchart.svg') no-repeat center; }
+.w2ui-icon.insertrowsafter { background: url('images/lc_insertrowsafter.svg') no-repeat center; }
+.w2ui-icon.insertcolumnsafter { background: url('images/lc_insertcolumnsafter.svg') no-repeat center; }
+.w2ui-icon.insertcolumnsbefore { background: url('images/lc_insertcolumnsbefore.svg') no-repeat center; }
+.w2ui-icon.insertrowsbefore { background: url('images/lc_insertrowsbefore.svg') no-repeat center; }
+.w2ui-icon.autosum { background: url('images/lc_autosum.svg') no-repeat center; }
+.w2ui-icon.orientation { background: url('images/lc_orientation.svg') no-repeat center; }
+.w2ui-icon.deleterows { background: url('images/lc_deleterows.svg') no-repeat center; }
+.w2ui-icon.hiderow { background: url('images/lc_hiderow.svg') no-repeat center; }
+.w2ui-icon.showrow { background: url('images/lc_showrow.svg') no-repeat center; }
+.w2ui-icon.deletecolumns { background: url('images/lc_deletecolumns.svg') no-repeat center; }
+.w2ui-icon.hidecolumn { background: url('images/lc_hidecolumn.svg') no-repeat center; }
+.w2ui-icon.showcolumn { background: url('images/lc_showcolumn.svg') no-repeat center; }
+.w2ui-icon.entirerow { background: url('images/lc_entirerow.svg') no-repeat center; }
+.w2ui-icon.setoptimalrowheight { background: url('images/lc_setoptimalrowheight.svg') no-repeat center; }
+.w2ui-icon.setoptimalcolumnwidth { background: url('images/lc_setoptimalcolumnwidth.svg') no-repeat center; }
+.w2ui-icon.entirecell { background: url('images/lc_entirecell.svg') no-repeat center; }
+.w2ui-icon.entirecolumn { background: url('images/lc_entirecolumn.svg') no-repeat center; }
+.w2ui-icon.selecttable { background: url('images/lc_selecttable.svg') no-repeat center; }
 
-.w2ui-icon.accepttrackedchanges{ background: url('images/lc_acceptchanges.svg') no-repeat center; }
-.w2ui-icon.ok{ background: url('images/lc_ok.svg') no-repeat center; }
-.w2ui-icon.cancel{ background: url('images/lc_cancel.svg') no-repeat center; }
-.w2ui-icon.color{ background: url('images/lc_color.svg') no-repeat center; }
-.w2ui-icon.deletepage{ background: url('images/lc_deletepage.svg') no-repeat center; }
-.w2ui-icon.duplicatepage{ background: url('images/lc_duplicatepage.svg') no-repeat center; }
-.w2ui-icon.showslide{ background: url('images/lc_showslide.svg') no-repeat center; }
-.w2ui-icon.hideslide{ background: url('images/lc_hideslide.svg') no-repeat center; }
-.w2ui-icon.equal{ background: url('images/lc26049.svg') no-repeat center; }
-.w2ui-icon.help{ background: url('images/lc_helpindex.svg') no-repeat center; }
-.w2ui-icon.insertpage{ background: url('images/lc_insertpage.svg') no-repeat center; }
-.w2ui-icon.conditionalformatdialog{ background: url('images/lc_conditionalformatmenu.svg') no-repeat center; }
-.w2ui-icon.search{ background: url('images/sc_recsearch.svg') no-repeat center; }
-.w2ui-icon.presentation{ background: url('images/lc_dia.svg') no-repeat center; }
-.w2ui-icon.sign_ok{ background: url('images/sign_ok.svg') no-repeat center; }
-.w2ui-icon.sign_not_ok{ background: url('images/sign_not_ok.svg') no-repeat center; }
-.w2ui-icon.zoomin{ background: url('images/plus.svg') no-repeat center; }
-.w2ui-icon.zoomout{ background: url('images/minus.svg') no-repeat center; }
-.w2ui-icon.zoomreset{ background: url('images/lc_view100.svg') no-repeat center; }
-.w2ui-icon.more{ background: url('images/lc_downsearch.svg') no-repeat center; }
-.w2ui-icon.firstrecord{ background: url('images/lc_firstrecord.svg') no-repeat center; }
-.w2ui-icon.nextrecord{ background: url('images/lc_nextrecord.svg') no-repeat center; }
-.w2ui-icon.prevrecord{ background: url('images/lc_prevrecord.svg') no-repeat center; }
-.w2ui-icon.lastrecord{ background: url('images/lc_lastrecord.svg') no-repeat center; }
-.w2ui-icon.sortascending{ background: url('images/lc_sortascending.svg') no-repeat center; }
-.w2ui-icon.sortdescending{ background: url('images/lc_sortdescending.svg') no-repeat center; }
-.w2ui-icon.selected{ background: url('images/lc_ok.svg') no-repeat center; }
-.w2ui-icon.users{ background: url('images/contacts-dark.svg') no-repeat center; }
-.w2ui-icon.fullscreen{ background: url('images/lc_fullscreen.svg') no-repeat center; }
+.w2ui-icon.accepttrackedchanges { background: url('images/lc_acceptchanges.svg') no-repeat center; }
+.w2ui-icon.ok { background: url('images/lc_ok.svg') no-repeat center; }
+.w2ui-icon.cancel { background: url('images/lc_cancel.svg') no-repeat center; }
+.w2ui-icon.color { background: url('images/lc_color.svg') no-repeat center; }
+.w2ui-icon.deletepage { background: url('images/lc_deletepage.svg') no-repeat center; }
+.w2ui-icon.duplicatepage { background: url('images/lc_duplicatepage.svg') no-repeat center; }
+.w2ui-icon.showslide { background: url('images/lc_showslide.svg') no-repeat center; }
+.w2ui-icon.hideslide { background: url('images/lc_hideslide.svg') no-repeat center; }
+.w2ui-icon.equal { background: url('images/lc26049.svg') no-repeat center; }
+.w2ui-icon.help { background: url('images/lc_helpindex.svg') no-repeat center; }
+.w2ui-icon.insertpage { background: url('images/lc_insertpage.svg') no-repeat center; }
+.w2ui-icon.conditionalformatdialog { background: url('images/lc_conditionalformatmenu.svg') no-repeat center; }
+.w2ui-icon.search { background: url('images/sc_recsearch.svg') no-repeat center; }
+.w2ui-icon.presentation { background: url('images/lc_dia.svg') no-repeat center; }
+.w2ui-icon.sign_ok { background: url('images/sign_ok.svg') no-repeat center; }
+.w2ui-icon.sign_not_ok { background: url('images/sign_not_ok.svg') no-repeat center; }
+.w2ui-icon.zoomin { background: url('images/plus.svg') no-repeat center; }
+.w2ui-icon.zoomout { background: url('images/minus.svg') no-repeat center; }
+.w2ui-icon.zoomreset { background: url('images/lc_view100.svg') no-repeat center; }
+.w2ui-icon.more { background: url('images/lc_downsearch.svg') no-repeat center; }
+.w2ui-icon.firstrecord { background: url('images/lc_firstrecord.svg') no-repeat center; }
+.w2ui-icon.nextrecord { background: url('images/lc_nextrecord.svg') no-repeat center; }
+.w2ui-icon.prevrecord { background: url('images/lc_prevrecord.svg') no-repeat center; }
+.w2ui-icon.lastrecord { background: url('images/lc_lastrecord.svg') no-repeat center; }
+.w2ui-icon.sortascending { background: url('images/lc_sortascending.svg') no-repeat center; }
+.w2ui-icon.sortdescending { background: url('images/lc_sortdescending.svg') no-repeat center; }
+.w2ui-icon.selected { background: url('images/lc_ok.svg') no-repeat center; }
+.w2ui-icon.users { background: url('images/contacts-dark.svg') no-repeat center; }
+.w2ui-icon.fullscreen { background: url('images/lc_fullscreen.svg') no-repeat center; }
 .w2ui-icon.editmode { background: url('images/lc_listitem-selected.svg') no-repeat center / 28px; }
-.w2ui-icon.sidebar_modify_page{ background: url('images/lc_sidebar.svg') no-repeat center; }
-.w2ui-icon.sidebar_slide_change{ background: url('images/lc_slidechangewindow.svg') no-repeat center; }
-.w2ui-icon.sidebar_custom_animation{ background: url('images/lc_customanimation.svg') no-repeat center; }
-.w2ui-icon.sidebar_master_slides{ background: url('images/lc_masterslide.svg') no-repeat center; }
-.w2ui-icon.mobile_wizard{ background: url('images/lc_mobile_wizard.svg') no-repeat center; }
-.w2ui-icon.fullscreen-presentation{ background: url('images/lc_fullscreen-presentation-toolbar-mobile.svg') no-repeat center;}
-.w2ui-icon.mobile_comment_wizard{ background: url('images/lc_mobile_comment_wizard.svg') no-repeat center; }
-.w2ui-icon.insertion_mobile_wizard{ background: url('images/lc_insertion_mobile_wizard.svg') no-repeat center; }
-.w2ui-icon.viewcomments{ background: url('images/lc_mobile_comment_wizard.svg') no-repeat center; }
-.w2ui-icon.insertcomment{ background: url('images/lc_insertcomment.svg') no-repeat center; }
-.w2ui-icon.freezepanes{ background: url('images/lc_freezepanes.svg') no-repeat center; }
-.w2ui-icon.freezepanescolumn{ background: url('images/lc_freezepanescolumn.svg') no-repeat center; }
-.w2ui-icon.freezepanesrow{ background: url('images/lc_freezepanesrow.svg') no-repeat center; }
-.w2ui-icon.navigator{ background: url('images/lc_navigator.svg') no-repeat center; }
-.w2ui-icon.gridvisible{ background: url('images/lc_gridvisible.svg') no-repeat center; }
-.w2ui-icon.griduse{ background: url('images/lc_griduse.svg') no-repeat center; }
+.w2ui-icon.sidebar_modify_page { background: url('images/lc_sidebar.svg') no-repeat center; }
+.w2ui-icon.sidebar_slide_change { background: url('images/lc_slidechangewindow.svg') no-repeat center; }
+.w2ui-icon.sidebar_custom_animation { background: url('images/lc_customanimation.svg') no-repeat center; }
+.w2ui-icon.sidebar_master_slides { background: url('images/lc_masterslide.svg') no-repeat center; }
+.w2ui-icon.mobile_wizard { background: url('images/lc_mobile_wizard.svg') no-repeat center; }
+.w2ui-icon.fullscreen-presentation { background: url('images/lc_fullscreen-presentation-toolbar-mobile.svg') no-repeat center;}
+.w2ui-icon.mobile_comment_wizard { background: url('images/lc_mobile_comment_wizard.svg') no-repeat center; }
+.w2ui-icon.insertion_mobile_wizard { background: url('images/lc_insertion_mobile_wizard.svg') no-repeat center; }
+.w2ui-icon.viewcomments { background: url('images/lc_mobile_comment_wizard.svg') no-repeat center; }
+.w2ui-icon.insertcomment { background: url('images/lc_insertcomment.svg') no-repeat center; }
+.w2ui-icon.freezepanes { background: url('images/lc_freezepanes.svg') no-repeat center; }
+.w2ui-icon.freezepanescolumn { background: url('images/lc_freezepanescolumn.svg') no-repeat center; }
+.w2ui-icon.freezepanesrow { background: url('images/lc_freezepanesrow.svg') no-repeat center; }
+.w2ui-icon.navigator { background: url('images/lc_navigator.svg') no-repeat center; }
+.w2ui-icon.gridvisible { background: url('images/lc_gridvisible.svg') no-repeat center; }
+.w2ui-icon.griduse { background: url('images/lc_griduse.svg') no-repeat center; }
 
 .w2ui-icon.flipvertical { background: url('images/lc_flipvertical.svg') no-repeat center; }
 .w2ui-icon.fliphorizontal { background: url('images/lc_fliphorizontal.svg') no-repeat center; }
@@ -1243,123 +1243,123 @@ button.leaflet-control-search-next
 [data-theme='dark'] .w2ui-icon.connectors_connectorlines { background: url('images/dark/lc_connectorlines.svg') no-repeat center; }
 [data-theme='dark'] .w2ui-icon.connectors_connectorlinearrows { background: url('images/dark/lc_connectorlinearrows.svg') no-repeat center; }
 [data-theme='dark'] .w2ui-icon.connectors_connectorcurvearrows { background: url('images/dark/lc_connectorcurvearrows.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.print{ background: url('images/dark/lc_print.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.undo{ background: url('images/dark/lc_undo.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.redo{ background: url('images/dark/lc_redo.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.copyformat{ background: url('images/dark/lc_formatpaintbrush.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.deleteformat{ background: url('images/dark/lc_setdefault.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.bold{ background: url('images/dark/lc_bold.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.italic{ background: url('images/dark/lc_italic.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.underline{ background: url('images/dark/lc_underline.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.strikeout{ background: url('images/dark/lc_strikeout.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.textcolor{ background: url('images/dark/lc_fontcolor.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.backcolor{ background: url('images/dark/lc_backcolor.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.backgroundcolor{ background: url('images/dark/lc_fillcolor.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.alignleft{ background: url('images/dark/lc_leftpara.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.alignhorizontal{ background: url('images/dark/lc_centerpara.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.alignright{ background: url('images/dark/lc_rightpara.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.alignblock{ background: url('images/dark/lc_justifypara.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.aligntop{ background: url('images/dark/lc_aligntop.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.alignvcenter{ background: url('images/dark/lc_alignvcenter.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.alignbottom{ background: url('images/dark/lc_alignbottom.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.cellverttop{ background: url('images/dark/lc_cellverttop.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.cellvertcenter{ background: url('images/dark/lc_cellvertcenter.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.cellvertbottom{ background: url('images/dark/lc_cellvertbottom.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.linespacing, .w2ui-icon.spacepara1, .w2ui-icon.spacepara15{ background: url('images/dark/lc_linespacing.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.spacepara2{ background: url('images/dark/lc_spacepara2.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.paraspaceincrease{ background: url('images/dark/lc_paraspaceincrease.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.paraspacedecrease{ background: url('images/dark/lc_paraspacedecrease.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.numbering{ background: url('images/dark/lc_defaultnumbering.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.bullet{ background: url('images/dark/lc_defaultbullet.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.incrementindent{ background: url('images/dark/lc_leftindent.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.decrementindent{ background: url('images/dark/lc_decrementindent.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.outlineleft{ background: url('images/dark/lc_outlineleft.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.outlineright{ background: url('images/dark/lc_outlineright.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.text{ background: url('images/dark/lc_text.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.annotation{ background: url('images/dark/lc_shownote.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.inserttable{ background: url('images/dark/lc_inserttable.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.insertgraphic{ background: url('images/dark/lc_gallery.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.link{ background: url('images/dark/lc_inserthyperlink.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.insertsymbol{ background: url('images/dark/lc_insertsymbol.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.edit{ background: url('images/dark/lc_editdoc.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.fold{ background: url('images/dark/lc_fold.svg') no-repeat center center / 19px; opacity: 0.8; filter: alpha(opacity=80);}
-[data-theme='dark'] .w2ui-icon.unfold{ background: url('images/dark/unfold.svg') no-repeat center center/ 19px; opacity: 0.8; filter: alpha(opacity=80);}
-[data-theme='dark'] .w2ui-icon.hamburger{ background: url('images/dark/hamburger.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.setborderstyle{ background: url('images/dark/lc_setborderstyle.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.togglemergecells{ background: url('images/dark/lc_togglemergecells.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.wraptext{ background: url('images/dark/lc_wraptext.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.numberformatstandard{ background: url('images/dark/lc_numberformatstandard.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.numberformatcurrency{ background: url('images/dark/lc_numberformatcurrency.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.numberformatpercent{ background: url('images/dark/lc_numberformatpercent.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.numberformatdecimal{ background: url('images/dark/lc_numberformatdecimal.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.numberformatdate{ background: url('images/dark/lc_numberformatdate.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.numberformattime{ background: url('images/dark/lc_numberformattime.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.numberformatscientific{ background: url('images/dark/lc_numberformatscientific.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.numberformatthousands{ background: url('images/dark/lc_numberformatthousands.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.numberformatincdecimals{ background: url('images/dark/lc_numberformatincdecimals.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.numberformatdecdecimals{ background: url('images/dark/lc_numberformatdecdecimals.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.insertobjectchart{ background: url('images/dark/lc_drawchart.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.insertrowsafter{ background: url('images/dark/lc_insertrowsafter.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.insertcolumnsafter{ background: url('images/dark/lc_insertcolumnsafter.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.insertcolumnsbefore{ background: url('images/dark/lc_insertcolumnsbefore.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.insertrowsbefore{ background: url('images/dark/lc_insertrowsbefore.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.autosum{ background: url('images/dark/lc_autosum.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.orientation{ background: url('images/dark/lc_orientation.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.deleterows{ background: url('images/dark/lc_deleterows.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.hiderow{ background: url('images/dark/lc_hiderow.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.showrow{ background: url('images/dark/lc_showrow.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.deletecolumns{ background: url('images/dark/lc_deletecolumns.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.hidecolumn{ background: url('images/dark/lc_hidecolumn.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.showcolumn{ background: url('images/dark/lc_showcolumn.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.entirerow{ background: url('images/dark/lc_entirerow.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.setoptimalrowheight{ background: url('images/dark/lc_setoptimalrowheight.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.setoptimalcolumnwidth{ background: url('images/dark/lc_setoptimalcolumnwidth.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.entirecell{ background: url('images/dark/lc_entirecell.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.entirecolumn{ background: url('images/dark/lc_entirecolumn.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.selecttable{ background: url('images/dark/lc_selecttable.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.print { background: url('images/dark/lc_print.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.undo { background: url('images/dark/lc_undo.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.redo { background: url('images/dark/lc_redo.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.copyformat { background: url('images/dark/lc_formatpaintbrush.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.deleteformat { background: url('images/dark/lc_setdefault.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.bold { background: url('images/dark/lc_bold.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.italic { background: url('images/dark/lc_italic.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.underline { background: url('images/dark/lc_underline.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.strikeout { background: url('images/dark/lc_strikeout.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.textcolor { background: url('images/dark/lc_fontcolor.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.backcolor { background: url('images/dark/lc_backcolor.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.backgroundcolor { background: url('images/dark/lc_fillcolor.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignleft { background: url('images/dark/lc_leftpara.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignhorizontal { background: url('images/dark/lc_centerpara.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignright { background: url('images/dark/lc_rightpara.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignblock { background: url('images/dark/lc_justifypara.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.aligntop { background: url('images/dark/lc_aligntop.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignvcenter { background: url('images/dark/lc_alignvcenter.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.alignbottom { background: url('images/dark/lc_alignbottom.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.cellverttop { background: url('images/dark/lc_cellverttop.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.cellvertcenter { background: url('images/dark/lc_cellvertcenter.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.cellvertbottom { background: url('images/dark/lc_cellvertbottom.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.linespacing, .w2ui-icon.spacepara1, .w2ui-icon.spacepara15 { background: url('images/dark/lc_linespacing.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.spacepara2 { background: url('images/dark/lc_spacepara2.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.paraspaceincrease { background: url('images/dark/lc_paraspaceincrease.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.paraspacedecrease { background: url('images/dark/lc_paraspacedecrease.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numbering { background: url('images/dark/lc_defaultnumbering.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.bullet { background: url('images/dark/lc_defaultbullet.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.incrementindent { background: url('images/dark/lc_leftindent.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.decrementindent { background: url('images/dark/lc_decrementindent.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.outlineleft { background: url('images/dark/lc_outlineleft.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.outlineright { background: url('images/dark/lc_outlineright.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.text { background: url('images/dark/lc_text.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.annotation { background: url('images/dark/lc_shownote.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.inserttable { background: url('images/dark/lc_inserttable.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertgraphic { background: url('images/dark/lc_gallery.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.link { background: url('images/dark/lc_inserthyperlink.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertsymbol { background: url('images/dark/lc_insertsymbol.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.edit { background: url('images/dark/lc_editdoc.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.fold { background: url('images/dark/lc_fold.svg') no-repeat center center / 19px; opacity: 0.8; filter: alpha(opacity=80);}
+[data-theme='dark'] .w2ui-icon.unfold { background: url('images/dark/unfold.svg') no-repeat center center/ 19px; opacity: 0.8; filter: alpha(opacity=80);}
+[data-theme='dark'] .w2ui-icon.hamburger { background: url('images/dark/hamburger.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.setborderstyle { background: url('images/dark/lc_setborderstyle.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.togglemergecells { background: url('images/dark/lc_togglemergecells.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.wraptext { background: url('images/dark/lc_wraptext.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatstandard { background: url('images/dark/lc_numberformatstandard.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatcurrency { background: url('images/dark/lc_numberformatcurrency.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatpercent { background: url('images/dark/lc_numberformatpercent.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatdecimal { background: url('images/dark/lc_numberformatdecimal.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatdate { background: url('images/dark/lc_numberformatdate.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformattime { background: url('images/dark/lc_numberformattime.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatscientific { background: url('images/dark/lc_numberformatscientific.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatthousands { background: url('images/dark/lc_numberformatthousands.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatincdecimals { background: url('images/dark/lc_numberformatincdecimals.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.numberformatdecdecimals { background: url('images/dark/lc_numberformatdecdecimals.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertobjectchart { background: url('images/dark/lc_drawchart.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertrowsafter { background: url('images/dark/lc_insertrowsafter.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertcolumnsafter { background: url('images/dark/lc_insertcolumnsafter.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertcolumnsbefore { background: url('images/dark/lc_insertcolumnsbefore.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertrowsbefore { background: url('images/dark/lc_insertrowsbefore.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.autosum { background: url('images/dark/lc_autosum.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.orientation { background: url('images/dark/lc_orientation.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.deleterows { background: url('images/dark/lc_deleterows.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.hiderow { background: url('images/dark/lc_hiderow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.showrow { background: url('images/dark/lc_showrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.deletecolumns { background: url('images/dark/lc_deletecolumns.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.hidecolumn { background: url('images/dark/lc_hidecolumn.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.showcolumn { background: url('images/dark/lc_showcolumn.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.entirerow { background: url('images/dark/lc_entirerow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.setoptimalrowheight { background: url('images/dark/lc_setoptimalrowheight.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.setoptimalcolumnwidth { background: url('images/dark/lc_setoptimalcolumnwidth.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.entirecell { background: url('images/dark/lc_entirecell.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.entirecolumn { background: url('images/dark/lc_entirecolumn.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.selecttable { background: url('images/dark/lc_selecttable.svg') no-repeat center; }
 
-[data-theme='dark'] .w2ui-icon.accepttrackedchanges{ background: url('images/dark/lc_acceptchanges.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.ok{ background: url('images/dark/lc_ok.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.cancel{ background: url('images/dark/lc_cancel.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.color{ background: url('images/dark/lc_color.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.deletepage{ background: url('images/dark/lc_deletepage.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.duplicatepage{ background: url('images/dark/lc_duplicatepage.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.equal{ background: url('images/dark/lc26049.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.help{ background: url('images/dark/lc_helpindex.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.insertpage{ background: url('images/dark/lc_insertpage.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.insertsheet{ background: url('images/dark/plus.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.conditionalformatdialog{ background: url('images/dark/lc_conditionalformatmenu.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.search{ background: url('images/dark/sc_recsearch.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.presentation{ background: url('images/dark/lc_dia.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.sign_ok{ background: url('images/dark/sign_ok.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.sign_not_ok{ background: url('images/dark/sign_not_ok.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.zoomin{ background: url('images/dark/plus.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.zoomout{ background: url('images/dark/minus.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.zoomreset{ background: url('images/dark/lc_view100.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.more{ background: url('images/dark/lc_downsearch.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.firstrecord{ background: url('images/dark/lc_firstrecord.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.nextrecord{ background: url('images/dark/lc_nextrecord.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.prevrecord{ background: url('images/dark/lc_prevrecord.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.lastrecord{ background: url('images/dark/lc_lastrecord.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.sortascending{ background: url('images/dark/lc_sortascending.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.sortdescending{ background: url('images/dark/lc_sortdescending.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.selected{ background: url('images/dark/lc_ok.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.users{ background: url('images/dark/contacts-dark.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.fullscreen{ background: url('images/dark/lc_fullscreen.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.accepttrackedchanges { background: url('images/dark/lc_acceptchanges.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.ok { background: url('images/dark/lc_ok.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.cancel { background: url('images/dark/lc_cancel.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.color { background: url('images/dark/lc_color.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.deletepage { background: url('images/dark/lc_deletepage.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.duplicatepage { background: url('images/dark/lc_duplicatepage.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.equal { background: url('images/dark/lc26049.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.help { background: url('images/dark/lc_helpindex.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertpage { background: url('images/dark/lc_insertpage.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertsheet { background: url('images/dark/plus.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.conditionalformatdialog { background: url('images/dark/lc_conditionalformatmenu.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.search { background: url('images/dark/sc_recsearch.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.presentation { background: url('images/dark/lc_dia.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sign_ok { background: url('images/dark/sign_ok.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sign_not_ok { background: url('images/dark/sign_not_ok.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.zoomin { background: url('images/dark/plus.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.zoomout { background: url('images/dark/minus.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.zoomreset { background: url('images/dark/lc_view100.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.more { background: url('images/dark/lc_downsearch.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.firstrecord { background: url('images/dark/lc_firstrecord.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.nextrecord { background: url('images/dark/lc_nextrecord.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.prevrecord { background: url('images/dark/lc_prevrecord.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.lastrecord { background: url('images/dark/lc_lastrecord.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sortascending { background: url('images/dark/lc_sortascending.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sortdescending { background: url('images/dark/lc_sortdescending.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.selected { background: url('images/dark/lc_ok.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.users { background: url('images/dark/contacts-dark.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.fullscreen { background: url('images/dark/lc_fullscreen.svg') no-repeat center; }
 [data-theme='dark'] .w2ui-icon.editmode { background: url('images/dark/lc_listitem-selected.svg') no-repeat center / 28px; }
-[data-theme='dark'] .w2ui-icon.sidebar_modify_page{ background: url('images/dark/lc_sidebar.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.sidebar_slide_change{ background: url('images/dark/lc_slidechangewindow.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.sidebar_custom_animation{ background: url('images/dark/lc_customanimation.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.sidebar_master_slides{ background: url('images/dark/lc_masterslide.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.mobile_wizard{ background: url('images/dark/lc_mobile_wizard.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.fullscreen-presentation{ background: url('images/dark/lc_fullscreen-presentation-toolbar-mobile.svg') no-repeat center;}
-[data-theme='dark'] .w2ui-icon.mobile_comment_wizard{ background: url('images/dark/lc_mobile_comment_wizard.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.insertion_mobile_wizard{ background: url('images/dark/lc_insertion_mobile_wizard.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.viewcomments{ background: url('images/dark/lc_mobile_comment_wizard.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.insertcomment{ background: url('images/dark/lc_insertcomment.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.freezepanes{ background: url('images/dark/lc_freezepanes.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.freezepanescolumn{ background: url('images/dark/lc_freezepanescolumn.svg') no-repeat center; }
-[data-theme='dark'] .w2ui-icon.freezepanesrow{ background: url('images/dark/lc_freezepanesrow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sidebar_modify_page { background: url('images/dark/lc_sidebar.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sidebar_slide_change { background: url('images/dark/lc_slidechangewindow.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sidebar_custom_animation { background: url('images/dark/lc_customanimation.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.sidebar_master_slides { background: url('images/dark/lc_masterslide.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.mobile_wizard { background: url('images/dark/lc_mobile_wizard.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.fullscreen-presentation { background: url('images/dark/lc_fullscreen-presentation-toolbar-mobile.svg') no-repeat center;}
+[data-theme='dark'] .w2ui-icon.mobile_comment_wizard { background: url('images/dark/lc_mobile_comment_wizard.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertion_mobile_wizard { background: url('images/dark/lc_insertion_mobile_wizard.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.viewcomments { background: url('images/dark/lc_mobile_comment_wizard.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.insertcomment { background: url('images/dark/lc_insertcomment.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.freezepanes { background: url('images/dark/lc_freezepanes.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.freezepanescolumn { background: url('images/dark/lc_freezepanescolumn.svg') no-repeat center; }
+[data-theme='dark'] .w2ui-icon.freezepanesrow { background: url('images/dark/lc_freezepanesrow.svg') no-repeat center; }
 
 [data-theme='dark'] .w2ui-icon.flipvertical { background: url('images/dark/lc_flipvertical.svg') no-repeat center; }
 [data-theme='dark'] .w2ui-icon.fliphorizontal { background: url('images/dark/lc_fliphorizontal.svg') no-repeat center; }
@@ -1777,8 +1777,7 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 
 @media only screen and (max-width: 600px) {
 	#userListSummary,
-	#userListHeader
-	{
+	#userListHeader {
 		display: none;
 	}
 }


### PR DESCRIPTION

Change-Id: Ie74b9a730d13dadf8c66bc7e5676f05930925800


* Resolves: #11824 
* Target version: master 

### Summary

- Added Stylelint rule to enforce space before block-opening brace and fix CSS files

### TODO

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

