### PR TITLE
use std::vector::data instead of &foo[0]

### DIFF
--- a/net/HttpHelper.cpp
+++ b/net/HttpHelper.cpp
@@ -34,10 +34,10 @@ void sendUncompressedFileContent(const std::shared_ptr<StreamSocket>& socket,
     std::unique_ptr<char[]> buf = std::make_unique<char[]>(bufferSize);
     do
     {
-        file.read(&buf[0], bufferSize);
+        file.read(buf.get(), bufferSize);
         const int size = file.gcount();
         if (size > 0)
-            socket->send(&buf[0], size, true);
+            socket->send(buf.get(), size, true);
         else
             break;
     } while (file);
@@ -54,20 +54,20 @@ void sendDeflatedFileContent(const std::shared_ptr<StreamSocket>& socket, const 
     {
         std::ifstream file(path, std::ios::binary);
         std::unique_ptr<char[]> buf = std::make_unique<char[]>(fileSize);
-        file.read(&buf[0], fileSize);
+        file.read(buf.get(), fileSize);
 
         static const unsigned int Level = 1;
         const long unsigned int size = file.gcount();
         long unsigned int compSize = compressBound(size);
         std::unique_ptr<char[]> cbuf = std::make_unique<char[]>(compSize);
-        int result = compress2((Bytef*)&cbuf[0], &compSize, (Bytef*)&buf[0], size, Level);
+        int result = compress2((Bytef*)cbuf.get(), &compSize, (Bytef*)buf.get(), size, Level);
         if (result != Z_OK)
         {
              LOG_ERR("failed compress of: " << path << " result: " << result);
              return;
         }
         if (size > 0)
-            socket->send(&cbuf[0], compSize, true);
+            socket->send(cbuf.get(), compSize, true);
     }
 }
 

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -511,16 +511,16 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS, bool justPoll)
         struct timespec timeout;
         timeout.tv_sec = timeoutMaxMicroS / (1000 * 1000);
         timeout.tv_nsec = (timeoutMaxMicroS % (1000 * 1000)) * 1000;
-        rc = ::ppoll(&_pollFds[0], size + 1, &timeout, nullptr);
+        rc = ::ppoll(_pollFds.data(), size + 1, &timeout, nullptr);
 #  else
         int timeoutMaxMs = (timeoutMaxMicroS + 999) / 1000;
         LOG_TRC("Legacy Poll start, timeoutMs: " << timeoutMaxMs);
-        rc = ::poll(&_pollFds[0], size + 1, std::max(timeoutMaxMs,0));
+        rc = ::poll(_pollFds.data(), size + 1, std::max(timeoutMaxMs,0));
 #  endif
 #else
         LOG_TRC("SocketPoll Poll");
         int timeoutMaxMs = (timeoutMaxMicroS + 999) / 1000;
-        rc = fakeSocketPoll(&_pollFds[0], size + 1, std::max(timeoutMaxMs,0));
+        rc = fakeSocketPoll(_pollFds.data(), size + 1, std::max(timeoutMaxMs,0));
 #endif
     }
     while (rc < 0 && errno == EINTR);

--- a/tools/map.cpp
+++ b/tools/map.cpp
@@ -325,7 +325,7 @@ public:
             std::vector<unsigned char> data;
             data.resize (map.size());
             if (lseek(mem_fd, map.getStart(), SEEK_SET) < 0 ||
-                read(mem_fd, &data[0], map.size()) != (int)map.size())
+                read(mem_fd, data.data(), map.size()) != (int)map.size())
                 error(EXIT_FAILURE, errno, "Failed to seek in /proc/%d/mem to %lld",
                       _proc_id, map.getStart());
 

--- a/wsd/ProxyProtocol.cpp
+++ b/wsd/ProxyProtocol.cpp
@@ -141,7 +141,7 @@ bool ProxyProtocolHandler::parseEmitIncoming(
         it = in.begin();
         for (; it != in.end() && *it != '\n'; ++it);
         *it = '\0';
-        uint64_t len = strtoll( &in[0], nullptr, 16 );
+        uint64_t len = strtoll( in.data(), nullptr, 16 );
         in.erase(in.begin(), it + 1);
         if (len > in.size())
         {


### PR DESCRIPTION
&foo[0] is caught by the hardening compiler flags for the empty case. Which isn't the case here, but tidier to be consistent on this.

Similarly use std::unique_ptr<>.get() instead of &foo[0].


Change-Id: I898a0320e6d4f0eafb6d2a80cebf14ed460a9f3c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

