### PR TITLE
setting-iframe: Adjust sectionTitles to sentence case

### DIFF
--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -139,7 +139,7 @@ class SettingIframe {
 				uploadPath: this.PATH.autoTextUpload(),
 			},
 			{
-				sectionTitle: _('Custom Dictionaries'),
+				sectionTitle: _('Custom dictionaries'),
 				sectionDesc: _(
 					'Add or edit words in a spell check dictionary. Words in your wordbook (.dic) will be available for spelling checks.',
 				),
@@ -163,7 +163,7 @@ class SettingIframe {
 				enabledFor: 'userconfig',
 			},
 			{
-				sectionTitle: _('Document Settings'),
+				sectionTitle: _('Document settings'),
 				sectionDesc: _('Adjust how office documents behave.'),
 				listId: 'XcuList',
 				inputId: 'XcuFile',


### PR DESCRIPTION
Title Case can be hard to read and, for example, some
languages (German where capitalization goes for all nouns) even harder
to achieve without problems. Furthermore, this iframe will be seen in
the integrator side and is probably a safer option to make sure
everything is sent out in: Sentence case.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I5183fd5adaf877b557b4636c7b5bfd1ee8dd81c0
