### PR TITLE
Add doc_type parameter to feedback dialog

### DIFF
--- a/browser/css/iframedialog.css
+++ b/browser/css/iframedialog.css
@@ -24,3 +24,7 @@
 	border-radius: var(--border-radius);
 	background: var(--color-background-lighter);
 }
+
+#iframe-feedback {
+	height: 470px;
+}

--- a/browser/src/map/handler/Map.Feedback.js
+++ b/browser/src/map/handler/Map.Feedback.js
@@ -113,7 +113,8 @@ L.Map.Feedback = L.Handler.extend({
 			      { wsdhash : window.app.socket.WSDServer.Hash },
 			      { 'lokit_hash' : lokitHash },
 			      { 'wopi_host_id' : wopiHostId },
-			      { 'proxy_prefix_enabled' : proxyPrefixEnabled }];
+			      { 'proxy_prefix_enabled' : proxyPrefixEnabled },
+			      { 'doc_type': this._map.getDocType()}];
 
 		var options = {
 			prefix: 'iframe-dialog',


### PR DESCRIPTION
Change-Id: I5750b51e9baea6654eb0b76974b72889019ef535


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Added support for capturing the doc_type when users submit feedback. This helps us understand which application (like Writer, Calc, or Impress) the feedback is coming from. This gives us useful context to better analyze and respond to user issues.

![Screenshot from 2025-05-08 09-14-03](https://github.com/user-attachments/assets/7220529e-b534-49fe-a188-dcc00e2b2fd7)


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

