### PR TITLE
make run: show large writer document by default

### DIFF
--- a/scripts/build-samples.py
+++ b/scripts/build-samples.py
@@ -256,8 +256,7 @@ if __name__ == "__main__":
         if file.endswith('calc.fods'):
             generateCalc(src, dest, base, extn)
         elif file.endswith('writer-large.fodt'):
-            if 'COOL_WRITER_LARGE' in os.environ:
-                generateWriter(src, dest, base, extn)
+            generateWriter(src, dest, base, extn)
         else:
             copyFile(src, dest, base, extn)
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3787,8 +3787,14 @@ int COOLWSD::innerMain()
     {
         if (i.find("-edit") != std::string::npos)
         {
-            oss   << "    " << i << "\t" << getLaunchURI(std::string("test/samples/") + i) << "\n";
-            ossRO << "    " << i << "\t" << getLaunchURI(std::string("test/samples/") + i, true) << "\n";
+            std::string padded(i);
+            constexpr int width = 22;
+            if (padded.size() < width)
+            {
+                padded.insert(padded.size(), width - padded.size(), ' ');
+            }
+            oss   << "    " << padded << getLaunchURI(std::string("test/samples/") + i) << "\n";
+            ossRO << "    " << padded << getLaunchURI(std::string("test/samples/") + i, true) << "\n";
         }
     }
 


### PR DESCRIPTION
The "-large" suffix is big enough to not work with a simple \t anymore,
so do an explicit padding instead.

The width is just a value that does nothing for the currently longest
string.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I52e698b1e918e382b2c1dae216b8e1b948b3a2b1
