### PR TITLE
cool#11865 &closebutton=false or &closebutton=0 was misinterpreted

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -610,12 +610,30 @@ function getInitializerClass() {
 
 	global.setLogging(global.coolLogging != '');
 
+	function parseBool(val) {
+		if (typeof val !== 'string') return false;
+		switch (val.toLowerCase().trim()) {
+		case '1':
+		case 'true':
+		case 'yes':
+		case 'on':
+			return true;
+		case '0':
+		case 'false':
+		case 'no':
+		case 'off':
+			return false;
+		default:
+			return false;
+		}
+	}
+
 	global.L.Params = {
 		/// Shows close button if non-zero value provided
-		closeButtonEnabled: global.coolParams.get('closebutton'),
+		closeButtonEnabled: parseBool(global.coolParams.get('closebutton')),
 
 		/// Shows revision history file menu option
-		revHistoryEnabled: global.coolParams.get('revisionhistory'),
+		revHistoryEnabled: parseBool(global.coolParams.get('revisionhistory')),
 	};
 
 	global.prefs = {


### PR DESCRIPTION
We were encountering this issue because URLSearchParams.get() returns strings, and in JavaScript, any non-empty string is truthy, including "0" and "false".

I guess it was wrong since a722687c116f81be19423fc92630cb7d7209b65a


Change-Id: Ib6b82ab78939fb00c92552bad8a7a50639db0511


* Resolves: #11865
* Target version: master 
