### PR TITLE
lockStateUpdateRequest holds ClientSession by weak_ptr

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2186,6 +2186,12 @@ bool DocumentBroker::updateStorageLockStateAsync(const std::shared_ptr<ClientSes
         const std::shared_ptr<ClientSession> requestingSession = _lockStateUpdateRequest->session();
         _lockStateUpdateRequest.reset(); // No longer needed.
 
+        if (!requestingSession)
+        {
+            LOG_DBG("RequestingSession no longer exists");
+            return;
+        }
+
         // We have some result, look at the result status.
         handleLockResult(*requestingSession, asyncLock.result());
     };


### PR DESCRIPTION
and the comment mentions this explicitly, but it is unconditionally dereferenced here:

```
 #1  0x00007fb91dd367f1 in __GI_abort () at abort.c:79
 #2  0x0000000000c22a7e in std::__glibcxx_assert_fail(char const*, int, char const*, char const*) ()
 #3  0x00000000006fec1e in std::__shared_ptr_access<ClientSession, (__gnu_cxx::_Lock_policy)2, false, false>::operator* (this=<synthetic pointer>)
     at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/shared_ptr_base.h:1347
 #4  std::__shared_ptr_access<ClientSession, (__gnu_cxx::_Lock_policy)2, false, false>::operator* (this=<optimized out>)
     at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/shared_ptr_base.h:1347
 #5  DocumentBroker::updateStorageLockStateAsync(std::shared_ptr<ClientSession> const&, StorageBase::LockState, std::string&)::{lambda(StorageBase::AsyncRequest<StorageBase::LockUpdateResult> const&)#1}::operator()(StorageBase::AsyncRequest<StorageBase::LockUpdateResult> const&) const () at wsd/DocumentBroker.cpp:2182
 #6  0x00000000007c7eda in std::function<void (StorageBase::AsyncRequest<StorageBase::LockUpdateResult> const&)>::operator()(StorageBase::AsyncRequest<StorageBase::LockUpdateResult> const&) const (__args#0=..., this=0x7fb8a0004660) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:587
 #7  WopiStorage::updateLockStateAsync(Authorization const&, LockContext&, StorageBase::LockState, StorageBase::Attributes const&, std::shared_ptr<SocketPoll> const&, std::function<void (StorageBase::AsyncRequest<StorageBase::LockUpdateResult> const&)> const&)::{lambda(std::shared_ptr<http::Session> const&)#1}::operator()(std::shared_ptr<http::Session> const&) const () at wsd/wopi/WopiStorage.cpp:446
 #8  0x0000000000668e52 in std::function<void (std::shared_ptr<http::Session> const&)>::operator()(std::shared_ptr<http::Session> const&) const (__args#0=
     std::shared_ptr<http::Session> (use count 3, weak count 1) = {...}, this=0x7fb90839cd48) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:587
 #9  http::Session::callOnFinished (this=0x7fb90839cc70) at ./net/HttpRequest.hpp:1480
 #10 0x0000000000669233 in http::Session::newRequest(http::Request const&)::{lambda()#1}::operator()() const (__closure=0x7fb9140151e8) at ./net/HttpRequest.hpp:1513
 #11 0x000000000083cc48 in http::Response::readData(char const*, long) () at net/HttpRequest.cpp:640
 #12 0x0000000000841176 in http::Session::handleIncomingMessage (this=0x7fb90839cc70, disposition=...) at ./net/Buffer.hpp:132
 #13 0x0000000000863994 in StreamSocket::handlePoll (this=0x7fb914066fe0, disposition=..., now=..., events=1)
     at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/shared_ptr_base.h:1665
 #14 0x000000000085b1b6 in SocketPoll::poll(long, bool) () at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/stl_vector.h:1123
 #15 0x00000000007132b0 in SocketPoll::poll (justPoll=false, timeoutMax=..., this=<optimized out>) at ./net/Socket.hpp:875
 #16 DocumentBroker::pollThread() () at wsd/DocumentBroker.cpp:785
 #17 0x000000000073fbdb in DocumentBroker::DocumentBrokerPoll::pollingThread (this=<optimized out>) at wsd/DocumentBroker.cpp:171
 #18 0x000000000085c535 in SocketPoll::pollingThreadEntry() () at net/Socket.cpp:469
 #19 0x0000000000c26fb3 in execute_native_thread_routine ()
 #20 0x00007fb91e0ee6db in start_thread (arg=0x7fb895ffb700) at pthread_create.c:463
 #21 0x00007fb91de1774f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

Change-Id: I99c6b3980774712b94ca2ff7e27a8c4c1a9b24dd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

