### PR TITLE
Use rem units for font sizes to improve accessibility

### DIFF
--- a/browser/admin/src/AdminSocketAnalytics.js
+++ b/browser/admin/src/AdminSocketAnalytics.js
@@ -240,7 +240,7 @@ var AdminSocketAnalytics = AdminSocketBase.extend({
 				.attr('x', this._graphWidth - 70)
 				.attr('y', 50)
 				.attr('y2', 50+legendSpacing)
-				.style('font-size', '17px');
+				.style('font-size', '1.1em');
 
 			var legendData = [
 				{

--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -28,15 +28,15 @@
 	--border-radius: 4px; /* buttons, widgets */
 	--border-radius-large: 10px; /* dialog */
 
-	--tooltip-font-size: 14px;
-	--default-font-size: 12px;
-	--header-font-size: 16px;
+	--tooltip-font-size: 0.875rem;
+	--default-font-size: 0.75rem;
+	--header-font-size: 1rem;
 	/* tab min font-size */
-	--tb-min-fs: 11px;
+	--tb-min-fs: 0.6875rem;
 	/* tab min font-size without units*/
 	--tb-min-fs-u: 11;
 	/* tab max font-size */
-	--tb-max-fs: 16px;
+	--tb-max-fs: 1rem;
 	/* tab max font-size without units*/
 	--tb-max-fs-u: 16;
 	/* tab font-size preferred value or scaler */
@@ -56,6 +56,7 @@
 
 html {
 	height: 100%;
+	font-size: 1rem;
 }
 
 body {
@@ -100,7 +101,7 @@ body {
 .accessibility-info-box {
 	width: 26px;
 	height: 16px;
-	font-size: 12px;
+	font-size: 0.75rem;
 	line-height: 16px;
 	text-align: center;
 	background-color: yellow;
@@ -1035,7 +1036,7 @@ body {
 .hyperlink-popup .leaflet-popup-content {
 	white-space: nowrap;
 	margin: 6px 8px;
-	font-size: 14px;
+	font-size: 0.875rem;
 	line-height: 1;
 	overflow: hidden;
 }

--- a/browser/css/helpdialog.css
+++ b/browser/css/helpdialog.css
@@ -47,7 +47,7 @@
 		/* Smooth transition effect */
 		font-family: Arial, sans-serif;
 		/* Use a common font family */
-		font-size: 16px;
+		font-size: 1rem;
 		/* Font size */
 		color: var(--color-main-text);
 	}
@@ -107,7 +107,7 @@
 		color: -webkit-link;
 		cursor: pointer;
 		text-decoration: underline;
-		font-size: 1em;
+		font-size: 1rem;
 		line-height: 1.5em;
 	}
 

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -964,7 +964,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	appearance: none;
-	height: 24px;
+	height: 1.5rem;
 	line-height: normal;
 	font-size: var(--default-font-size);
 	font-family: var(--jquery-ui-font);

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -360,7 +360,7 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 }
 #NavigatorPanel .ui-treeview-cell-text {
 	/* good to move this into css var*/
-	font-size: 14px;
+	font-size: 0.875rem;
 	white-space: break-spaces;
 }
 
@@ -491,7 +491,7 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	flex: 1;
 	padding: 10px;
 	cursor: pointer;
-	font-size: 14px;
+	font-size: 0.875rem;
 	border-bottom: none;
 	color: var(--color-main-text);
 	transition: background-color 0.3s, border-color 0.3s;

--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -298,14 +298,14 @@
 	text-indent: 1px;
 }
 .leaflet-control-zoom-out {
-	font-size: 20px;
+	font-size: 1.25rem;
 }
 
 .leaflet-touch .leaflet-control-zoom-in {
-	font-size: 22px;
+	font-size: 1.375rem;
 }
 .leaflet-touch .leaflet-control-zoom-out {
-	font-size: 24px;
+	font-size: 1.5rem;
 }
 
 /* View / Edit mode control */
@@ -411,7 +411,7 @@ a.leaflet-control-buttons:hover:first-child {
 /* scale controls */
 
 .leaflet-container .leaflet-control-scale {
-	font-size: 11px;
+	font-size: 0.6875rem;
 }
 .leaflet-left .leaflet-control-scale {
 	margin-left: 5px;
@@ -424,7 +424,7 @@ a.leaflet-control-buttons:hover:first-child {
 	border-top: none;
 	line-height: 1.1;
 	padding: 2px 5px 1px;
-	font-size: 11px;
+	font-size: 0.6875rem;
 	white-space: nowrap;
 	overflow: hidden;
 	-moz-box-sizing: content-box;
@@ -517,7 +517,7 @@ a.leaflet-control-buttons:hover:first-child {
 	text-align: center;
 	width: 32px;
 	height: 32px;
-	font-size: 32px;
+	font-size: 2rem;
 	color: var(--color-main-text);
 	text-decoration: none;
 	background-color: transparent;
@@ -525,7 +525,7 @@ a.leaflet-control-buttons:hover:first-child {
 	border-radius: 50%;
 }
 .leaflet-container a.leaflet-popup-close-button.download-popup {
-	font-size: 20px;
+	font-size: 1.25rem;
 	width: 20px;
 	height: 20px;
 	right: -8px;
@@ -623,7 +623,7 @@ a.leaflet-control-buttons:hover:first-child {
 	margin-top: -10px;
 	pointer-events: none;
 	color: white;
-	font-size: 9px;
+	font-size: 0.5625rem;
 }
 
 div.leaflet-cursor-container:hover > .leaflet-cursor-header {
@@ -770,7 +770,7 @@ input.clipboard {
 
 .leaflet-paste-progress > span > span {
 	padding: 0 4px;
-	font-size: 10px;
+	font-size: 0.625rem;
 	font-weight: bold;
 	color: #fff;
 	text-shadow: 0 1px rgba(0, 0, 0, 0.4);
@@ -805,7 +805,7 @@ input.clipboard {
 
 .leaflet-progress > span > span {
 	padding: 0 8px;
-	font-size: 11px;
+	font-size: 0.6875rem;
 	font-weight: bold;
 	color: #fff;
 	text-shadow: 0 1px rgba(0, 0, 0, 0.4);
@@ -827,7 +827,7 @@ input.clipboard {
 }
 
 .leaflet-progress-label.brand-label {
-	font-size: 14px;
+	font-size: 0.875rem;
 	font-weight: bold;
 }
 
@@ -921,7 +921,7 @@ input.clipboard {
 	border-width: 0px .5px;
 	border-style: solid;
 	border-color: var(--color-border);
-	font-size: 10px;
+	font-size: 0.625rem;
 	text-align: center;
 	color: var(--color-text-lighter);
 	line-height: 7px;

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -376,9 +376,6 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 /* File Tab */
 
 /* Home tab */
-#fontsizecombobox.notebookbar {
-	width: 4.6rem;
-}
 .notebookbar.ui-combobox * {
 	line-height: 22px;
 }

--- a/browser/welcome/welcome.css
+++ b/browser/welcome/welcome.css
@@ -138,21 +138,21 @@ body {
 }
 
 .slides h1 {
-	font-size: 22px;
+	font-size: 1.375rem;
 	font-weight: normal;
 	margin-bottom: 4px;
 	color: var(--welcome-text);
 }
 
 .slides h2 {
-	font-size: 16px;
+	font-size: 1rem;
 	font-weight: normal;
 	margin-top: 0;
 	color: var(--welcome-text);
 }
 
 .slides p {
-	font-size: 14px;
+	font-size: 0.875rem;
 	font-weight: normal;
 	color: var(--welcome-text);
 }
@@ -302,7 +302,7 @@ button:hover .arrow.left.close {
 	width: 48px;
 	height: 48px;
 	line-height: 48px;
-	font-size: 36px;
+	font-size: 2.25rem;
 	position: absolute;
 	content: '\00D7';
 	font-weight: normal;
@@ -351,7 +351,7 @@ button:hover .arrow.left.close {
 		height: 44px;
 		border-radius: 3px;
 		margin: 8px;
-		font-size: 1em;
+		font-size: 1rem;
 	}
 
 	a[id^='slide-'] {
@@ -404,7 +404,7 @@ button:hover .arrow.left.close {
 		height: 44px;
 		border-radius: 3px;
 		margin: 8px;
-		font-size: 1em;
+		font-size: 1rem;
 	}
 
 	a[id^='slide-'] {


### PR DESCRIPTION
- The font in collabora online did not scale well with the change of browser font size change
- now we changes all font sizes to rem units
- this will improve accessibility when change in browser font size change
- improve custom font size changes in jsDialog and in notbookbar


Change-Id: I5c4c180e897333c06b1bde3a87323205253cd3ea


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

