### PR TITLE
use std::istream baseclass instead of Poco::MemoryInputStream

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -37,8 +37,6 @@ class Message;
 // Forward declaration to avoid pulling the world here.
 namespace Poco
 {
-    class MemoryInputStream;
-
     namespace Net
     {
         class HTTPServerRequest;
@@ -203,7 +201,7 @@ public:
 
     /// Custom response to a http request.
     virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& /*request*/,
-                                   Poco::MemoryInputStream& /*message*/,
+                                   std::istream& /*message*/,
                                    std::shared_ptr<StreamSocket>& /*socket*/)
     {
         return false;
@@ -211,7 +209,7 @@ public:
 
     virtual std::map<std::string, std::string>
         parallelizeCheckInfo(const Poco::Net::HTTPRequest& /*request*/,
-                             Poco::MemoryInputStream& /*message*/,
+                             std::istream& /*message*/,
                              std::shared_ptr<StreamSocket>& /*socket*/)
     {
         return {};

--- a/test/UnitInitialLoadFail.cpp
+++ b/test/UnitInitialLoadFail.cpp
@@ -47,7 +47,7 @@ public:
     }
 
     bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
-                           Poco::MemoryInputStream& message,
+                           std::istream& message,
                            std::shared_ptr<StreamSocket>& socket) override
     {
         return WopiTestServer::handleHttpRequest(request, message, socket);
@@ -55,7 +55,7 @@ public:
 
     std::map<std::string, std::string>
         parallelizeCheckInfo(const Poco::Net::HTTPRequest& request,
-                             Poco::MemoryInputStream& /*message*/,
+                             std::istream& /*message*/,
                              std::shared_ptr<StreamSocket>& /*socket*/) override
     {
         std::string uri = Uri::decode(request.getURI());
@@ -156,7 +156,7 @@ public:
     // enables parallel checkFileInfo connection
     std::map<std::string, std::string>
         parallelizeCheckInfo(const Poco::Net::HTTPRequest& request,
-                             Poco::MemoryInputStream& /*message*/,
+                             std::istream& /*message*/,
                              std::shared_ptr<StreamSocket>& socket) override
     {
         // We want to test that this socket dtor will get called when this

--- a/test/UnitMultiTenant.cpp
+++ b/test/UnitMultiTenant.cpp
@@ -105,7 +105,7 @@ public:
 
     std::map<std::string, std::string>
         parallelizeCheckInfo(const Poco::Net::HTTPRequest& request,
-                             Poco::MemoryInputStream& /*message*/,
+                             std::istream& /*message*/,
                              std::shared_ptr<StreamSocket>& /*socket*/) override
     {
         std::string uri = Uri::decode(request.getURI());

--- a/test/UnitUserPresets.cpp
+++ b/test/UnitUserPresets.cpp
@@ -130,7 +130,7 @@ public:
 
     std::map<std::string, std::string>
         parallelizeCheckInfo(const Poco::Net::HTTPRequest& request,
-                             Poco::MemoryInputStream& /*message*/,
+                             std::istream& /*message*/,
                              std::shared_ptr<StreamSocket>& /*socket*/) override
     {
         std::string uri = Uri::decode(request.getURI());

--- a/test/UnitWOPIFileUrl.cpp
+++ b/test/UnitWOPIFileUrl.cpp
@@ -73,7 +73,7 @@ public:
     }
 
     virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
-                                   Poco::MemoryInputStream& message,
+                                   std::istream& message,
                                    std::shared_ptr<StreamSocket>& socket) override
     {
         Poco::URI uriReq(request.getURI());

--- a/test/UnitWOPIHttpRedirect.cpp
+++ b/test/UnitWOPIHttpRedirect.cpp
@@ -36,7 +36,7 @@ public:
     }
 
     virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
-                                   Poco::MemoryInputStream& message,
+                                   std::istream& message,
                                    std::shared_ptr<StreamSocket>& socket) override
     {
         Poco::URI uriReq(request.getURI());
@@ -171,7 +171,7 @@ public:
     }
 
     virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
-                                   Poco::MemoryInputStream& /*message*/,
+                                   std::istream& /*message*/,
                                    std::shared_ptr<StreamSocket>& socket) override
     {
         Poco::URI uriReq(request.getURI());

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -38,7 +38,7 @@ public:
     }
 
     virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
-                                   Poco::MemoryInputStream& /*message*/,
+                                   std::istream& /*message*/,
                                    std::shared_ptr<StreamSocket>& socket) override
     {
         const Poco::URI uriReq(request.getURI());

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -379,7 +379,7 @@ protected:
     }
 
     virtual bool handleHttpPostRequest(const Poco::Net::HTTPRequest& request,
-                                       Poco::MemoryInputStream& message,
+                                       std::istream& message,
                                        std::shared_ptr<StreamSocket>& socket)
     {
         LOG_ASSERT_MSG(request.getMethod() == "POST", "Expect an HTTP POST request");
@@ -462,7 +462,7 @@ protected:
 
     /// Handles the uploading of a document to wopi.
     virtual bool handleWopiUpload(const Poco::Net::HTTPRequest& request,
-                                  Poco::MemoryInputStream& message,
+                                  std::istream& message,
                                   std::shared_ptr<StreamSocket>& socket)
     {
         const std::string wopiTimestamp = request.get("X-COOL-WOPI-Timestamp", std::string());
@@ -539,7 +539,7 @@ protected:
 
     /// Here we act as a WOPI server, so that we have a server that responds to
     /// the wopi requests without additional expensive setup.
-    bool handleHttpRequest(const Poco::Net::HTTPRequest& request, Poco::MemoryInputStream& message,
+    bool handleHttpRequest(const Poco::Net::HTTPRequest& request, std::istream& message,
                            std::shared_ptr<StreamSocket>& socket) override
     {
         Poco::URI uriReq(Uri::decode(request.getURI()));


### PR DESCRIPTION
Change-Id: I1697726144bde3730d8a9f0303bdd38022f0edd7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

