### PR TITLE
Disable system dependent primitive renderer in kit

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -4148,6 +4148,7 @@ bool globalPreinit(const std::string &loTemplate)
 
     // Disable problematic components that may be present from a
     // desktop or developer's install if env. var not set.
+    ::setenv("DISABLE_SYSTEM_DEPENDENT_PRIMITIVE_RENDERER", "1", 1);
     ::setenv("UNODISABLELIBRARY",
              "abp avmediagst avmediavlc cmdmail losessioninstall OGLTrans PresenterScreen "
              "syssh ucpftp1 ucpgio1 ucpimage updatecheckui updatefeed updchk"


### PR DESCRIPTION
This fixes regression caused by commit	1acd37a671b9d3633a7d31a0b60478815fbc685f author	Armin Le Grand (Collabora) <Armin.Le.Grand@me.com>	Fri Sep 13 11:42:27 2024 +0200 committer	Armin Le Grand <Armin.Le.Grand@me.com>	Mon Sep 23 14:12:04 2024 +0200 CairoSDPR: Activate globally to check builds/tests

This is to check all builds/tests with activated CairoSDPR to evtl. make needed additional changes as preparation to activate this in the future.

----------------------

The bug was in rendering tiles while chart becomes activated (double click on chart) - surrounding tiles become blank. So selecting some data range was not possible without visual aid where to look for them.

This patch uses embedded feature flag to disable it without core change.
