### PR TITLE
fix (11810) - Last preview slide in navigation is not fully visible

### DIFF
--- a/browser/css/partsPreviewControl.css
+++ b/browser/css/partsPreviewControl.css
@@ -3,7 +3,7 @@
 	overflow-x: hidden;
 	overflow-y: visible;
 	background: var(--color-background-lighter);
-	max-height: 100%;
+	max-height: 95%;
 	scrollbar-color: var(--color-background-darker) var(--color-background-lighter);
 	scrollbar-width: thin;
 }


### PR DESCRIPTION
* Resolves: # [Last preview slide in navigation is not fully visible #11810](https://github.com/CollaboraOnline/online/issues/11810)
* Target version: master 

### Summary
adjusted the height to make last preview slide visible properly.

### Checklist

- [X] I have run `make prettier-write` and formatted the code. OR **is not required**
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated OR **is not required**

