### PR TITLE
Only enable input processing on jsdialog message if it is disabled.

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1131,9 +1131,11 @@ void Document::trimAfterInactivity()
             if (session && !session->isCloseFrame())
             {
                 session->loKitCallback(type, payload);
-                if (self->isLoadOngoing())
+                if (self->isLoadOngoing() && !self->processInputEnabled())
+                {
                     LOG_DBG("Enable processing input due to event of " << type << " during load");
-                session->getProtocol()->enableProcessInput(true);
+                    session->getProtocol()->enableProcessInput(true);
+                }
                 return;
             }
         }


### PR DESCRIPTION
Profiling suggests the un-necessary wakeup on every message is unfeasibly expensive, 40% of a long-running profile.


Change-Id: Icc51ae917c2ceddfc648a05b7f0332adf5238309


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

