### PR TITLE
Backport: Manage changes dialog alignments

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -48,7 +48,7 @@
 }
 
 #AcceptRejectChangesDialog {
-	width: max-content;
+	width: 100%;
 	max-width: 1000px;
 }
 #AcceptRejectChangesDialog #RedlineViewPage.jsdialog.ui-grid-cell {
@@ -56,9 +56,34 @@
 	flex-direction: column;
 	gap: 8px;
 }
-#AcceptRejectChangesDialog #RedlineFilterPage .ui-timefield {
-	margin: 5px;
+
+#AcceptRejectChangesDialog #grid3.jsdialog.ui-grid {
+	margin-top: 8px;
+	grid-gap: 8px;
 }
+
+#AcceptRejectChangesDialog #writerchanges.jsdialog.ui-treeview {
+	display: grid;
+	grid-template-columns: repeat(2, 1fr) repeat(2, minmax(min-content, auto));
+	column-gap: 8px;
+}
+
+#AcceptRejectChangesDialog .jsdialog.ui-grid .has-img,
+#AcceptRejectChangesDialog .jsdialog.ui-grid .menubutton {
+	margin: 0 !important;
+	width: 100% !important;
+}
+
+#AcceptRejectChangesDialog .ui-treeview-headers,
+#AcceptRejectChangesDialog .jsdialog.ui-treeview-entry { 
+	display: contents;
+}	
+
+#AcceptRejectChangesDialog .jsdialog.ui-treeview-entry > div:nth-child(2),
+#AcceptRejectChangesDialog .ui-treeview-headers .ui-treeview-icon-column {
+	display: none;
+}
+
 .jsdialog.one-child-popup {
 	border: 0;
 	margin: 0 !important;


### PR DESCRIPTION
* Backport PR: #11839 
* Target version: master 

### Summary

Manage changes dialog alignments
- Apply a full width to the AcceptRejectChangesDialog
- Resolved text bleeding between columns when font-size increases
- Removed margins on menubuttons to fix alignments in date/time picker
- Fixed misalignment between ui-treeview-headers and ui-treeview-entries
  by setting consistent grid-template-columns

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

