### PR TITLE
Calc hidden rows / columns flickering issue.

### DIFF
--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -769,7 +769,8 @@ export class HeaderInfo {
 
 		this._docVisStart = startPx;
 		let startIdx = this._dimGeom.getIndexFromPos(startPx, 'corepixels');
-		const endIdx = Math.min(this._dimGeom.getIndexFromPos(endPx - 1, 'corepixels'), 1048576 - 1);
+		const maxIndex = this._isColumn ? this._map._docLayer.sheetGeometry.maxVisibleColumnIndex : this._map._docLayer.sheetGeometry.maxVisibleRowIndex;
+		const endIdx = Math.min(this._dimGeom.getIndexFromPos(endPx - 1, 'corepixels'), 1048576 - 1, maxIndex);
 		this._elements = [];
 
 		this._hasSplits = false;


### PR DESCRIPTION
The maxIndex was calculated wrong. This commit fixes the issue.


Change-Id: I12dbb530909262c62e2c269385eb441a5a958078


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

