### PR TITLE
add Util::trimMalloc

### DIFF
--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1327,6 +1327,9 @@ int main(int argc, char**argv)
     /// Returns the result of malloc_info, which is an XML string with all the arenas.
     std::string getMallocInfo();
 
+    /// Call malloc_trim or alternative allocator equivalent
+    void trimMalloc();
+
     // std::size isn't available on our android baseline so use this
     // solution as a workaround
     template <typename T, size_t S> char (&n_array_size( T(&)[S] ))[S];

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -11,9 +11,6 @@
 
 #include <config.h>
 #include <config_version.h>
-#ifdef __linux__
-#include <malloc.h>
-#endif
 
 #include "COOLWSD.hpp"
 
@@ -3825,11 +3822,9 @@ int COOLWSD::innerMain()
         mainWait->insertNewSocket(inotifySocket);
     }
 #endif
-#endif
 
-#if defined(M_TRIM_THRESHOLD)
     LOG_DBG("trimming memory post startup");
-    malloc_trim(0);
+    Util::trimMalloc();
     time_t prevTrimTrigger = 0;
 #endif
 
@@ -3881,7 +3876,6 @@ int COOLWSD::innerMain()
             stampFetch = timeNow;
         }
 
-#if defined(M_TRIM_THRESHOLD)
         // if Admin hasn't seen any document activity for over 10 mins them malloc_trim
         constexpr time_t idleTrimCheck(10 * 60);
 
@@ -3892,13 +3886,11 @@ int COOLWSD::innerMain()
             if (adminIdle > idleTrimCheck)
             {
                 LOG_DBG("trimming memory on idle");
-                malloc_trim(0);
+                Util::trimMalloc();
                 // Don't bother repeating until LastActivityTime changes.
                 prevTrimTrigger = lastAdminActivity;
             }
         }
-#endif
-
 #endif
 
 #if ENABLE_DEBUG && !MOBILEAPP


### PR DESCRIPTION
which typically calls malloc_trim but will call tcmalloc's MallocExtension_ReleaseFreeMemory if tcmalloc is in use instead.

log which allocator is in use.


Change-Id: I95a777bdcdc9cbec12ccba3b95f73d555d87d7fe


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

