### PR TITLE
Reset CheckFileInfo on Failure

### DIFF
--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -863,22 +863,16 @@ int main(int argc, char**argv)
         return std::string(message, size);
     }
 
-    /// Eliminates the prefix from str(if present) and returns a copy of the modified string
-    inline
-    std::string eliminatePrefix(const std::string& str, const std::string& prefix)
+    /// Eliminates the prefix from str (if present) and returns a string view.
+    inline std::string_view eliminatePrefix(const std::string_view str,
+                                            const std::string_view prefix)
     {
-        std::string::const_iterator prefix_pos;
-        std::string::const_iterator str_pos;
-
-        std::tie(prefix_pos,str_pos) = std::mismatch(prefix.begin(), prefix.end(), str.begin());
-
-        if (prefix_pos == prefix.end())
+        if (str.starts_with(prefix))
         {
-            // Non-Prefix part
-            return std::string(str_pos, str.end());
+            return str.substr(prefix.size());
         }
 
-        // Return the original string as it is
+        // Return the original string as-is.
         return str;
     }
 

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1326,7 +1326,8 @@ public:
     /// Note: when reusing this Session, it is assumed that the socket
     /// is already added to the SocketPoll on a previous call (do not
     /// use multiple SocketPoll instances on the same Session).
-    void asyncRequest(const Request& req, const std::weak_ptr<SocketPoll>& poll)
+    /// Returns false when it fails to start the async request.
+    bool asyncRequest(const Request& req, const std::weak_ptr<SocketPoll>& poll)
     {
         std::shared_ptr<SocketPoll> socketPoll(poll.lock());
         if (!socketPoll)
@@ -1341,7 +1342,7 @@ public:
                 _onConnectFail(shared_from_this());
             }
 
-            return;
+            return false;
         }
 
         LOG_TRC("New asyncRequest on [" << socketPoll->name() << "]: " << req.getVerb() << ' '
@@ -1363,6 +1364,7 @@ public:
 
         LOG_DBG("Starting asyncRequest on [" << socketPoll->name() << "]: " << req.getVerb() << ' '
                                              << host() << ':' << port() << ' ' << req.getUrl());
+        return true;
     }
 
     void asyncShutdown()

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -13,6 +13,21 @@
 
 #include <HttpTestServer.hpp>
 
+#if ENABLE_SSL
+#include <net/SslSocket.hpp>
+#endif // ENABLE_SSL
+#include <common/FileUtil.hpp>
+#include <common/Util.hpp>
+#include <net/AsyncDNS.hpp>
+#include <net/DelaySocket.hpp>
+#include <net/HttpRequest.hpp>
+#include <net/ServerSocket.hpp>
+#include <net/Socket.hpp>
+#include <test/helpers.hpp>
+#include <test/lokassert.hpp>
+
+#include <cppunit/extensions/HelperMacros.h>
+
 #include <Poco/URI.h>
 #include <Poco/Net/AcceptCertificateHandler.h>
 #include <Poco/Net/InvalidCertificateHandler.h>
@@ -23,23 +38,9 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <string>
-#include <test/lokassert.hpp>
-
-#if ENABLE_SSL
-#include "Ssl.hpp"
-#include <net/SslSocket.hpp>
-#endif
-#include <net/AsyncDNS.hpp>
-#include <net/ServerSocket.hpp>
-#include <net/DelaySocket.hpp>
-#include <net/HttpRequest.hpp>
-#include <FileUtil.hpp>
-#include <Util.hpp>
-#include <helpers.hpp>
-
-#include <cppunit/extensions/HelperMacros.h>
 
 /// When enabled, in addition to the loopback
 /// server, an external server will be used

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -339,8 +339,7 @@ void HttpRequestTests::testSimpleGetSync()
 {
     constexpr std::string_view testname = "simpleGetSync";
 
-    const auto data = Util::rng::getHexString(Util::rng::getNext() % 1024);
-    const auto body = std::string(data.data(), data.size());
+    const std::string body = Util::rng::getHexString(Util::rng::getNext() % 1024);
     std::string URL = "/echo/" + body;
     TST_LOG("Requesting URI: [" << URL << ']');
 
@@ -376,8 +375,7 @@ void HttpRequestTests::testChunkedGetSync()
 {
     constexpr std::string_view testname = "chunkedGetSync";
 
-    const auto data = Util::rng::getHexString(Util::rng::getNext() % 1024);
-    const auto body = std::string(data.data(), data.size());
+    const std::string body = Util::rng::getHexString(Util::rng::getNext() % 1024);
     std::string URL = "/echo/chunked/" + body;
     TST_LOG("Requesting URI: [" << URL << ']');
 

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -542,7 +542,13 @@ void HttpRequestTests::test500GetStatuses()
 #ifdef ENABLE_EXTERNAL_REGRESSION_CHECK
         std::pair<std::shared_ptr<Poco::Net::HTTPResponse>, std::string> pocoResponseExt;
         if (statusCode > 100)
-            pocoResponseExt = helpers::pocoGet(false, "httpbin.org", 80, url);
+        {
+#if ENABLE_SSL
+            pocoResponseExt = helpers::pocoGet(/*secure=*/true, "httpbin.org", 443, url);
+#else
+            pocoResponseExt = helpers::pocoGet(/*secure=*/false, "httpbin.org", 80, url);
+#endif // ENABLE_SSL
+        }
 #endif
 
         const std::shared_ptr<const http::Response> httpResponse = httpSession->response();
@@ -607,7 +613,12 @@ void HttpRequestTests::testSimplePost_External()
 
     httpRequest.setBodyFile(path);
 
+#if ENABLE_SSL
     auto httpSession = http::Session::createHttpSsl("httpbin.org");
+#else
+    auto httpSession = http::Session::createHttp("httpbin.org");
+#endif // ENABLE_SSL
+
     httpSession->setTimeout(DefTimeoutSeconds);
 
     std::condition_variable cv;

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -159,7 +159,10 @@ public:
         {
             // First attempt, timeout.
             LOG_TST("PutFile: sleeping");
-            sleep(ConnectionTimeoutSeconds + 1);
+            sleep(ConnectionTimeoutSeconds); // Connection timeout.
+            usleep(300'000); // Go over, to be certain we timed-out the upload.
+            // Don't sleep for 2 x ConnectionTimeoutSeconds, as the
+            // CheckFileInfo request may timeout, since we're stuck here.
         }
 
         // Success.

--- a/test/UtilTests.cpp
+++ b/test/UtilTests.cpp
@@ -36,6 +36,7 @@ class UtilTests : public CPPUNIT_NS::TestFixture
 #if ENABLE_DEBUG
     CPPUNIT_TEST(testUtf8);
 #endif
+    CPPUNIT_TEST(testEliminatePrefix);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -45,6 +46,7 @@ class UtilTests : public CPPUNIT_NS::TestFixture
     void testNumberToHex();
     void testCharacterConverter();
     void testUtf8();
+    void testEliminatePrefix();
 };
 
 void UtilTests::testStringifyHexLine()
@@ -201,6 +203,21 @@ void UtilTests::testUtf8()
     LOK_ASSERT(Util::isValidUtf8("🏃 is not 🏊."));
     LOK_ASSERT(!Util::isValidUtf8("\xff\x03"));
 #endif
+}
+
+void UtilTests::testEliminatePrefix()
+{
+    constexpr auto testname = __func__;
+
+    LOK_ASSERT_EQUAL_STR(std::string(), Util::eliminatePrefix(std::string(), std::string()));
+    LOK_ASSERT_EQUAL_STR("test", Util::eliminatePrefix("test", std::string()));
+    LOK_ASSERT_EQUAL_STR("", Util::eliminatePrefix(std::string(), "test"));
+    LOK_ASSERT_EQUAL_STR("what", Util::eliminatePrefix(std::string("testwhat"), "test"));
+    LOK_ASSERT_EQUAL_STR("Command", Util::eliminatePrefix(std::string(".uno:Command"), ".uno:"));
+    LOK_ASSERT_EQUAL_STR("", Util::eliminatePrefix(std::string(".uno:Command"), ".uno:Command"));
+    LOK_ASSERT_EQUAL_STR(".uno:Command", Util::eliminatePrefix(std::string(".uno:Command"), ".uno:Commander"));
+    LOK_ASSERT_EQUAL_STR("uno:Command", Util::eliminatePrefix(std::string(".uno:Command"), "."));
+    LOK_ASSERT_EQUAL_STR(".uno:Command", Util::eliminatePrefix(std::string(".uno:Command"), ""));
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(UtilTests);

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -594,7 +594,7 @@ Admin::Admin()
         LOG_WRN("Low memory condition detected: only " << _totalAvailMemKb / 1024
                                                        << " MB of RAM available");
 
-    LOG_INF("hardware threads: " << std::thread::hardware_concurrency());
+    LOG_INF("Hardware threads: " << std::thread::hardware_concurrency());
 }
 
 Admin::~Admin()

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -5215,7 +5215,11 @@ void DocumentBroker::checkFileInfo(const std::shared_ptr<ClientSession>& session
     assert(!_checkFileInfo && "Unexpected CheckFileInfo in progress");
     _checkFileInfo =
         std::make_shared<CheckFileInfo>(_poll, session->getPublicUri(), std::move(cfiContinuation));
-    _checkFileInfo->checkFileInfo(redirectLimit);
+    if (!_checkFileInfo->checkFileInfo(redirectLimit))
+    {
+        LOG_INF("Resetting async CheckFileInfo as it failed to start");
+        _checkFileInfo.reset();
+    }
 }
 #endif // !MOBILEAPP
 

--- a/wsd/wopi/CheckFileInfo.cpp
+++ b/wsd/wopi/CheckFileInfo.cpp
@@ -24,7 +24,7 @@
 #include <common/JsonUtil.hpp>
 #include <Util.hpp>
 
-void CheckFileInfo::checkFileInfo(int redirectLimit)
+bool CheckFileInfo::checkFileInfo(int redirectLimit)
 {
     std::string uriAnonym = COOLWSD::anonymizeUrl(_url.toString());
 
@@ -169,7 +169,7 @@ void CheckFileInfo::checkFileInfo(int redirectLimit)
     _state = State::Active;
 
     // Run the CheckFileInfo request on the WebServer Poll.
-    _httpSession->asyncRequest(httpRequest, _poll);
+    return _httpSession->asyncRequest(httpRequest, _poll);
 }
 
 void CheckFileInfo::checkFileInfoSync(int redirectionLimit)

--- a/wsd/wopi/CheckFileInfo.hpp
+++ b/wsd/wopi/CheckFileInfo.hpp
@@ -67,7 +67,8 @@ public:
     std::unique_ptr<WopiStorage::WOPIFileInfo> wopiFileInfo(const Poco::URI& uriPublic) const;
 
     /// Start the actual request.
-    void checkFileInfo(int redirectionLimit);
+    /// Return false if we couldn't start it.
+    bool checkFileInfo(int redirectionLimit);
 
     /// Start the request and wait for the response.
     /// In some scenarios we can't proceed without CheckFileInfo results.

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -715,7 +715,7 @@ std::size_t WopiStorage::uploadLocalFileToStorageAsync(
     const std::shared_ptr<SocketPoll>& socketPoll, const AsyncUploadCallback& asyncUploadCallback)
 {
     auto profileZone =
-        std::make_shared<ProfileZone>(std::string("WopiStorage::uploadLocalFileToStorage"),
+        std::make_shared<ProfileZone>(std::string("WopiStorage::uploadLocalFileToStorageAsync"),
                                       std::map<std::string, std::string>({ { "url", _fileUrl } }));
 
     // TODO: Check if this URI has write permission (canWrite = true)

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -732,7 +732,7 @@ std::size_t WopiStorage::uploadLocalFileToStorageAsync(
 
     const bool isSaveAs = !saveAsPath.empty() && !saveAsFilename.empty();
     const std::string filePath(isSaveAs ? saveAsPath : getRootFilePathUploading());
-    const std::string filePathAnonym = COOLWSD::anonymizeUrl(filePath);
+    std::string filePathAnonym = COOLWSD::anonymizeUrl(filePath);
 
     const FileUtil::Stat fileStat(filePath);
     if (!fileStat.good())
@@ -751,7 +751,7 @@ std::size_t WopiStorage::uploadLocalFileToStorageAsync(
                                            : uriObject.getPath() + "/contents");
     auth.authorizeURI(uriObject);
 
-    const std::string uriAnonym = COOLWSD::anonymizeUrl(uriObject.toString());
+    std::string uriAnonym = COOLWSD::anonymizeUrl(uriObject.toString());
 
     const std::string wopiLog(isSaveAs ? "WOPI::PutRelativeFile"
                                        : (isRename ? "WOPI::RenameFile" : "WOPI::PutFile"));
@@ -867,7 +867,7 @@ std::size_t WopiStorage::uploadLocalFileToStorageAsync(
                                           isRename };
 
             // Handle the response.
-            const StorageBase::UploadResult res =
+            StorageBase::UploadResult res =
                 handleUploadToStorageResponse(details, httpResponse->getBody());
 
             // Fire the callback to our client (DocBroker, typically).


### PR DESCRIPTION
- **wsd: log and ProfileZone name**
- **wsd: remove const to allow moving**
- **wsd: test: fix stability of UnitConflictAfterTimeoutSuccess**
- **wsd: simplify Util::eliminatePrefix and add tests**
- **wsd: test: include cleanup in HttpRequestTests**
- **wsd: test: remove redundant variables**
- **wsd: test: support ssl and non-ssl external http tests**
- **wsd: asyncRequest checks for valid SocketPoll**
- **wsd: test: add invalid poll test to HttpRequestTests**
- **wsd: reset the checkfileinfo when we fail**
