### PR TITLE
indirection: allow ws request with cross origin

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -359,6 +359,9 @@
       <geolocation_setup>
         <enable desc="Enable geolocation_setup when using indirection server with geolocation configuration" type="bool" default="false">false</enable>
         <timezone desc="IANA timezone of server. For example: Europe/Berlin" type="string"></timezone>
+        <allowed_websocket_origins desc="Origin header to get accepted during websocket upgrade">
+          <!-- <origin></origin> -->
+        </allowed_websocket_origins>
       </geolocation_setup>
       <server_name desc="server name to show in cluster overview admin panel" type="string" default=""></server_name>
     </indirection_endpoint>

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -2251,7 +2251,16 @@ bool ClientRequestDispatcher::handleClientWsUpgrade(const Poco::Net::HTTPRequest
 
     // First Upgrade.
     const ServerURL cnxDetails(requestDetails);
-    auto ws = std::make_shared<WebSocketHandler>(socket, request, cnxDetails.getWebServerUrl());
+    bool allowedOrigin = false;
+#if !MOBILEAPP
+    if (COOLWSD::IndirectionServerEnabled && COOLWSD::GeolocationSetup)
+    {
+        const std::string actualOrigin = request.get("Origin");
+        allowedOrigin = HostUtil::allowedWSOrigin(actualOrigin);
+    }
+#endif
+
+    auto ws = std::make_shared<WebSocketHandler>(socket, request, cnxDetails.getWebServerUrl(), allowedOrigin);
 
     // Response to clients beyond this point is done via WebSocket.
     try

--- a/wsd/HostUtil.cpp
+++ b/wsd/HostUtil.cpp
@@ -30,6 +30,7 @@ std::map<std::string, std::string> HostUtil::AliasHosts;
 std::set<std::string> HostUtil::hostList;
 std::string HostUtil::FirstHost;
 bool HostUtil::WopiEnabled;
+std::set<std::string> HostUtil::AllowedWSOriginList;
 
 void HostUtil::parseWopiHost(const Poco::Util::LayeredConfiguration& conf)
 {
@@ -244,6 +245,31 @@ void HostUtil::setFirstHost(const Poco::URI& uri)
                 << FirstHost
                 << ", To use multiple host/aliases check alias_groups tag in configuration");
     }
+}
+
+void HostUtil::parseAllowedWSOrigins(Poco::Util::LayeredConfiguration& conf)
+{
+    for (size_t i = 0;; i++)
+    {
+        const std::string path =
+            "indirection_endpoint.geolocation_setup.allowed_websocket_origins.origin[" +
+            std::to_string(i) + ']';
+        if (!conf.has(path))
+        {
+            break;
+        }
+        const std::string origin = conf.getString(path, "");
+        if (!origin.empty())
+        {
+            LOG_INF("Adding Origin[" << origin << "] to allowed websocket origin list");
+            HostUtil::AllowedWSOriginList.insert(origin);
+        }
+    }
+}
+
+bool HostUtil::allowedWSOrigin(const std::string& origin)
+{
+    return AllowedWSOriginList.find(origin) != AllowedWSOriginList.end();
 }
 
 bool HostUtil::isWopiHostsEmpty()

--- a/wsd/HostUtil.hpp
+++ b/wsd/HostUtil.hpp
@@ -34,6 +34,8 @@ private:
     static std::string FirstHost;
     /// list of host (not aliases) in alias_groups
     static std::set<std::string> hostList;
+    /// list of allowed websocket origin, used only when indirection_endpoint.geolocation is enabled
+    static std::set<std::string> AllowedWSOriginList;
 
     static bool WopiEnabled;
 
@@ -43,6 +45,9 @@ public:
 
     /// parse wopi.storage.alias_groups.group
     static void parseAliases(Poco::Util::LayeredConfiguration& conf);
+
+    /// parse indirection_endpoint.geolocation_setup.allowed_websocket_origins
+    static void parseAllowedWSOrigins(Poco::Util::LayeredConfiguration& conf);
 
     /// if request uri is an alias, replace request uri host and port with
     /// original hostname and port defined by group tag from coolwsd.xml
@@ -60,6 +65,8 @@ public:
     static void setFirstHost(const Poco::URI& uri);
 
     static bool isWopiHostsEmpty();
+
+    static bool allowedWSOrigin(const std::string& origin);
 
 private:
     /// add host to WopiHosts

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -113,6 +113,9 @@ void StorageBase::initialize()
 
     HostUtil::parseAliases(app.config());
 
+    if (COOLWSD::IndirectionServerEnabled && COOLWSD::GeolocationSetup)
+        HostUtil::parseAllowedWSOrigins(app.config());
+
 #else // MOBILEAPP
     FilesystemEnabled = true;
 #endif // MOBILEAPP


### PR DESCRIPTION
- only if `allowed_websocket_origins.origin` matches
- particularly useful when using geolocation setup where websocket uri
and value at "Origin" header can be different because uri can be altered
by indirection server

Change-Id: I9f3e8a389248080ba44ebafc03ac2ad6373b7756

* Target version: master 

## 3 test cases:

1. normal case it should accept the request if origin matches

```sh
websocat --insecure "wss://localhost:9980/cool/https%3A%2F%2Flocalhost%3A9980%2Fwopi%2Ffiles%2Fhome%2Frashesh%2Fwork%2Fcollabora%2Fonline%2Fmaster%2Ftest%2Fsamples%2Fcalc-edit.ods%3Faccess_token%3Dtest%26access_token_ttl%3D0/ws?WOPISrc=https%3A%2F%2Flocalhost%3A9980%2Fwopi%2Ffiles%2Fhome%2Frashesh%2Fwork%2Fcollabora%2Fonline%2Fmaster%2Ftest%2Fsamples%2Fcalc-edit.ods&compat=/ws" -H "Origin: https://localhost:9980"
```

- Works as expected

1. normal case it should deny if origin doesn't match

```sh
websocat --insecure "wss://localhost:9980/cool/https%3A%2F%2Flocalhost%3A9980%2Fwopi%2Ffiles%2Fhome%2Frashesh%2Fwork%2Fcollabora%2Fonline%2Fmaster%2Ftest%2Fsamples%2Fcalc-edit.ods%3Faccess_token%3Dtest%26access_token_ttl%3D0/ws?WOPISrc=https%3A%2F%2Flocalhost%3A9980%2Fwopi%2Ffiles%2Fhome%2Frashesh%2Fwork%2Fcollabora%2Fonline%2Fmaster%2Ftest%2Fsamples%2Fcalc-edit.ods&compat=/ws" -H "Origin: https://demo.ja.collaboraonline.com"
```

- Fails as expected

3. Enabling geolocation and indirection_endpoint settings with value:

```xml
        <allowed_websocket_origins desc="Origin header to get accepted during websocket upgrade">
          <origin>https://demo.eu.collaboraonline.com</origin>
          <origin>https://demo.ja.collaboraonline.com</origin>
          <origin>https://demo.us.collaboraonline.com</origin>
          <origin>https://demo.sa.collaboraonline.com</origin>
        </allowed_websocket_origins>
```

```sh
websocat --insecure "wss://localhost:9980/cool/https%3A%2F%2Flocalhost%3A9980%2Fwopi%2Ffiles%2Fhome%2Frashesh%2Fwork%2Fcollabora%2Fonline%2Fmaster%2Ftest%2Fsamples%2Fcalc-edit.ods%3Faccess_token%3Dtest%26access_token_ttl%3D0/ws?WOPISrc=https%3A%2F%2Flocalhost%3A9980%2Fwopi%2Ffiles%2Fhome%2Frashesh%2Fwork%2Fcollabora%2Fonline%2Fmaster%2Ftest%2Fsamples%2Fcalc-edit.ods&compat=/ws" -H "Origin: https://demo.ja.collaboraonline.com"
```

- Works as expected

4. Enabling geolocation_setup but providing wrong `Origin` header which doesn't match to provided regex

```sh
websocat --insecure "wss://localhost:9980/cool/https%3A%2F%2Flocalhost%3A9980%2Fwopi%2Ffiles%2Fhome%2Frashesh%2Fwork%2Fcollabora%2Fonline%2Fmaster%2Ftest%2Fsamples%2Fcalc-edit.ods%3Faccess_token%3Dtest%26access_token_ttl%3D0/ws?WOPISrc=https%3A%2F%2Flocalhost%3A9980%2Fwopi%2Ffiles%2Fhome%2Frashesh%2Fwork%2Fcollabora%2Fonline%2Fmaster%2Ftest%2Fsamples%2Fcalc-edit.ods&compat=/ws" -H "Origin: https://demo.in.collaboraonline.com"

```

- Fails as expected
