### PR TITLE
Calc Validity Dropdown: Fix positioning on merged cells.

### DIFF
--- a/browser/src/canvas/sections/CalcValidityDropDownSection.ts
+++ b/browser/src/canvas/sections/CalcValidityDropDownSection.ts
@@ -14,13 +14,6 @@ class CalcValidityDropDown extends HTMLObjectSection {
 	constructor (sectionName: string, documentPosition: cool.SimplePoint, visible: boolean = true) {
 		super(sectionName, 16, 16, documentPosition, 'spreadsheet-drop-down-marker', visible);
 	}
-
-	onClick(point: number[], e: MouseEvent): void {
-		this.stopPropagating();
-		if (app.map._docLayer._validatedCellAddress && app.calc.cellCursorVisible && app.map._docLayer._validatedCellAddress.equals(app.calc.cellAddress.toArray())) {
-			app.map.sendUnoCommand('.uno:DataSelect');
-		}
-	}
 }
 
 app.definitions.calcValidityDropDown = CalcValidityDropDown;

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3481,14 +3481,21 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	_addCellDropDownArrow: function () {
 		if (this._validatedCellAddress && app.calc.cellCursorVisible && this._validatedCellAddress.equals(app.calc.cellAddress.toArray())) {
-			if (!app.sectionContainer.getSectionWithName('DropDownArrow')) {
-				let position = new app.definitions.simplePoint(app.calc.cellCursorRectangle.x2, app.calc.cellCursorRectangle.y2 - 16 * app.pixelsToTwips);
+			let position;
+			if (this.sheetGeometry) {
+				position = this.sheetGeometry.getCellRect(this._validatedCellAddress.x, this._validatedCellAddress.y, this._map.getZoomScale(this._map.getZoom(), this._map.options.defaultZoom));
+				const height = position.max.y - position.min.y;
+				position = new app.definitions.simplePoint(app.calc.cellCursorRectangle.x2, app.calc.cellCursorRectangle.y1 + (height - 16) * app.pixelsToTwips);
+			}
+			else
+				position = new app.definitions.simplePoint(app.calc.cellCursorRectangle.x2, app.calc.cellCursorRectangle.y2 - 16 * app.pixelsToTwips);
 
+			if (!app.sectionContainer.getSectionWithName('DropDownArrow')) {
 				let dropDownSection = new app.definitions.calcValidityDropDown('DropDownArrow', position);
 				app.sectionContainer.addSection(dropDownSection);
 			}
 			else {
-				app.sectionContainer.getSectionWithName('DropDownArrow').setPosition(app.calc.cellCursorRectangle.pX2, app.calc.cellCursorRectangle.pY2 - 16 * app.dpiScale);
+				app.sectionContainer.getSectionWithName('DropDownArrow').setPosition(position.pX, position.pY);
 			}
 		}
 	},


### PR DESCRIPTION
Issue:
* On the core side, position of the validity dropdown is calculated as:
   * The right most position whether the cells are merged or not.
   * The bottom position of the first cell - even if the cells are merged.
* We are sending the click event to the core side to activate the dropdown. So we need to click on the correct position.

This commit also removes unnecessary onClick handler.


Change-Id: I6a5b26b42e4cf77a070452042d5f7a242e874bc0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

