### PR TITLE
audit dialog: add attributes to SDK entries

### DIFF
--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -507,6 +507,8 @@ class TreeViewControl {
 		const link = L.DomUtil.create('a', '', cell);
 		link.href = entry.columns[index].link || entry.columns[index].text;
 		link.innerText = entry.columns[index].text || entry.text;
+		link.target = '_blank';
+		link.rel = 'noopener';
 	}
 
 	fillCells(


### PR DESCRIPTION
we were not able to open SDK due to CSP in the same page