### PR TITLE
fix: don't crash on null mime-type

### DIFF
--- a/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
+++ b/android/lib/src/main/java/org/libreoffice/androidlib/LOActivity.java
@@ -72,6 +72,7 @@ import java.nio.charset.Charset;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -483,7 +484,7 @@ public class LOActivity extends AppCompatActivity {
                 OutputStream outputStream = null;
                 // CSV files need a .csv suffix to be opened in Calc.
                 String suffix = null;
-                String intentType = mActivity.getIntent().getType();
+                @Nullable String intentType = mActivity.getIntent().getType();
                 if (mActivity.getIntent().getType() == null) {
                     intentType = getMimeType();
                 }
@@ -662,11 +663,11 @@ public class LOActivity extends AppCompatActivity {
         boolean requestCopy = false;
         if (requestCode == REQUEST_COPY) {
             requestCopy = true;
-            if (getMimeType().equals("text/plain")) {
+            if (Objects.equals(getMimeType(), "text/plain")) {
                 requestCode = REQUEST_SAVEAS_ODT;
-            } else if (getMimeType().equals("text/comma-separated-values")) {
+            } else if (Objects.equals(getMimeType(), "text/comma-separated-values")) {
                 requestCode = REQUEST_SAVEAS_ODS;
-            } else if (getMimeType().equals("application/vnd.ms-excel.sheet.binary.macroenabled.12")) {
+            } else if (Objects.equals(getMimeType(), "application/vnd.ms-excel.sheet.binary.macroenabled.12")) {
                 requestCode = REQUEST_SAVEAS_ODS;
             } else {
                 String filename = getFileName(true);
@@ -1162,7 +1163,7 @@ public class LOActivity extends AppCompatActivity {
         return true;
     }
 
-    public static void createNewFileInputDialog(Activity activity, final String defaultFileName, final String mimeType, final int requestCode) {
+    public static void createNewFileInputDialog(Activity activity, final String defaultFileName, final @Nullable String mimeType, final int requestCode) {
         Intent i = new Intent(Intent.ACTION_CREATE_DOCUMENT);
 
         // The mime type and category must be set
@@ -1189,9 +1190,13 @@ public class LOActivity extends AppCompatActivity {
         return builder;
     }
 
-    private String getMimeType() {
+    private @Nullable String getMimeType() {
         ContentResolver cR = getContentResolver();
-        return cR.getType(getIntent().getData());
+
+        Uri data = getIntent().getData();
+        if (data == null) return null;
+
+        return cR.getType(data);
     }
 
     private String getFileName(boolean withExtension) {
@@ -1227,21 +1232,20 @@ public class LOActivity extends AppCompatActivity {
 
     // readonly formats here
     private boolean canDocumentBeExported() {
-        if (getMimeType().equals("application/vnd.ms-excel.sheet.binary.macroenabled.12")) {
+        if (Objects.equals(getMimeType(), "application/vnd.ms-excel.sheet.binary.macroenabled.12")) {
             return false;
         }
         return true;
     }
 
-    private String getOdfExtensionForDocType(String mimeType)
+    private String getOdfExtensionForDocType(@Nullable String mimeType)
     {
         String extTemp = null;
-        if (mimeType.equals("text/plain")) {
+        if (Objects.equals(mimeType, "text/plain")) {
             extTemp = "odt";
-        }
-        else if (mimeType.equals("text/comma-separated-values")) {
+        } else if (Objects.equals(mimeType, "text/comma-separated-values")) {
             extTemp = "ods";
-        } else if (mimeType.equals("application/vnd.ms-excel.sheet.binary.macroenabled.12")) {
+        } else if (Objects.equals(mimeType, "application/vnd.ms-excel.sheet.binary.macroenabled.12")) {
             extTemp = "ods";
         }
         return extTemp;


### PR DESCRIPTION
I found this while digging through Android Vitals crash reports, as well as a few similar reports of NullPointerExceptions on mime types...

Exception java.lang.RuntimeException: Unable to start activity ComponentInfo{com.collabora.libreoffice/org.libreoffice.androidlib.LOActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.equals(java.lang.Object)' on a null object reference ------ 8< snip ------
Caused by java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.equals(java.lang.Object)' on a null object reference
    at org.libreoffice.androidlib.LOActivity.canDocumentBeExported (LOActivity.java:1233)
------ 8< snip ------

...This seems to be because we can sometimes pass an invalid URL to ContentResolver.getType, making getMimeType return null. This would result in us leaking null throughout our code and crashing.

I've annotated a few things that are nullable to make this more obvious, and switched anything using getMimeType() to the (null-safe)

Objects.equals(getMimeType(), ...)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

