### PR TITLE
fix(android): add Unit-mobile.cpp

### DIFF
--- a/android/lib/src/main/cpp/CMakeLists.txt.in
+++ b/android/lib/src/main/cpp/CMakeLists.txt.in
@@ -21,6 +21,7 @@ add_library(androidapp SHARED
             ../../../../../common/SigUtil-mobile.cpp
             ../../../../../common/SpookyV2.cpp
             ../../../../../common/Unit.cpp
+            ../../../../../common/Unit-mobile.cpp
             ../../../../../common/Util.cpp
             ../../../../../common/Util-mobile.cpp
             ../../../../../common/Util-unix.cpp


### PR DESCRIPTION
This is a regression from I7a6f906a8b245efb4f9540022c81cbc27099e997 which split up the mobile bits of unit tests...

I suspect something similar to I9c4df8c22c25de72b5ddc231f5cef37ba19f0d04 where Tor didn't notice an identical issue immediately - with the suspicion that it's based on debug mode

> Is it required only when using --enable-debug?


Change-Id: I8005d352e4b0eb61b84d27739d85118656598187


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

