### PR TITLE
these can be const

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -202,7 +202,7 @@ public:
     /// Custom response to a http request.
     virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& /*request*/,
                                    std::istream& /*message*/,
-                                   std::shared_ptr<StreamSocket>& /*socket*/)
+                                   const std::shared_ptr<StreamSocket>& /*socket*/)
     {
         return false;
     }
@@ -210,7 +210,7 @@ public:
     virtual std::map<std::string, std::string>
         parallelizeCheckInfo(const Poco::Net::HTTPRequest& /*request*/,
                              std::istream& /*message*/,
-                             std::shared_ptr<StreamSocket>& /*socket*/)
+                             const std::shared_ptr<StreamSocket>& /*socket*/)
     {
         return {};
     }

--- a/test/UnitInitialLoadFail.cpp
+++ b/test/UnitInitialLoadFail.cpp
@@ -48,7 +48,7 @@ public:
 
     bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
                            std::istream& message,
-                           std::shared_ptr<StreamSocket>& socket) override
+                           const std::shared_ptr<StreamSocket>& socket) override
     {
         return WopiTestServer::handleHttpRequest(request, message, socket);
     }
@@ -56,7 +56,7 @@ public:
     std::map<std::string, std::string>
         parallelizeCheckInfo(const Poco::Net::HTTPRequest& request,
                              std::istream& /*message*/,
-                             std::shared_ptr<StreamSocket>& /*socket*/) override
+                             const std::shared_ptr<StreamSocket>& /*socket*/) override
     {
         std::string uri = Uri::decode(request.getURI());
         LOG_TST("parallelizeCheckInfo requested: " << uri);
@@ -69,7 +69,7 @@ public:
     }
 
     bool handleGetFileRequest(const Poco::Net::HTTPRequest& request,
-                              std::shared_ptr<StreamSocket>& socket) override
+                              const std::shared_ptr<StreamSocket>& socket) override
     {
         if (_getFileCount++ == 0)
         {
@@ -157,7 +157,7 @@ public:
     std::map<std::string, std::string>
         parallelizeCheckInfo(const Poco::Net::HTTPRequest& request,
                              std::istream& /*message*/,
-                             std::shared_ptr<StreamSocket>& socket) override
+                             const std::shared_ptr<StreamSocket>& socket) override
     {
         // We want to test that this socket dtor will get called when this
         // session is Unauthorized. Without the fix the test times out and
@@ -175,7 +175,7 @@ public:
     }
 
     bool handleCheckFileInfoRequest(const Poco::Net::HTTPRequest& /*request*/,
-                                            std::shared_ptr<StreamSocket>& socket) override
+                                    const std::shared_ptr<StreamSocket>& socket) override
     {
         std::unique_ptr<http::Response> httpResponse =
             std::make_unique<http::Response>(http::StatusCode::Unauthorized);

--- a/test/UnitMultiTenant.cpp
+++ b/test/UnitMultiTenant.cpp
@@ -106,7 +106,7 @@ public:
     std::map<std::string, std::string>
         parallelizeCheckInfo(const Poco::Net::HTTPRequest& request,
                              std::istream& /*message*/,
-                             std::shared_ptr<StreamSocket>& /*socket*/) override
+                             const std::shared_ptr<StreamSocket>& /*socket*/) override
     {
         std::string uri = Uri::decode(request.getURI());
         LOG_TST("parallelizeCheckInfo requested: " << uri);

--- a/test/UnitUserPresets.cpp
+++ b/test/UnitUserPresets.cpp
@@ -131,7 +131,7 @@ public:
     std::map<std::string, std::string>
         parallelizeCheckInfo(const Poco::Net::HTTPRequest& request,
                              std::istream& /*message*/,
-                             std::shared_ptr<StreamSocket>& /*socket*/) override
+                             const std::shared_ptr<StreamSocket>& /*socket*/) override
     {
         std::string uri = Uri::decode(request.getURI());
         LOG_TST("parallelizeCheckInfo requested: " << uri);

--- a/test/UnitWOPIFileUrl.cpp
+++ b/test/UnitWOPIFileUrl.cpp
@@ -74,7 +74,7 @@ public:
 
     virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
                                    std::istream& message,
-                                   std::shared_ptr<StreamSocket>& socket) override
+                                   const std::shared_ptr<StreamSocket>& socket) override
     {
         Poco::URI uriReq(request.getURI());
         LOG_TST("FakeWOPIHost: Handling HTTP " << request.getMethod()

--- a/test/UnitWOPIHttpRedirect.cpp
+++ b/test/UnitWOPIHttpRedirect.cpp
@@ -37,7 +37,7 @@ public:
 
     virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
                                    std::istream& message,
-                                   std::shared_ptr<StreamSocket>& socket) override
+                                   const std::shared_ptr<StreamSocket>& socket) override
     {
         Poco::URI uriReq(request.getURI());
         Poco::RegularExpression regInfo("/wopi/files/1");
@@ -172,7 +172,7 @@ public:
 
     virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
                                    std::istream& /*message*/,
-                                   std::shared_ptr<StreamSocket>& socket) override
+                                   const std::shared_ptr<StreamSocket>& socket) override
     {
         Poco::URI uriReq(request.getURI());
         Poco::RegularExpression regInfo("/wopi/files/[0-9]+");

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -39,7 +39,7 @@ public:
 
     virtual bool handleHttpRequest(const Poco::Net::HTTPRequest& request,
                                    std::istream& /*message*/,
-                                   std::shared_ptr<StreamSocket>& socket) override
+                                   const std::shared_ptr<StreamSocket>& socket) override
     {
         const Poco::URI uriReq(request.getURI());
         LOG_TST("FakeWOPIHost: " << request.getMethod() << " request: " << uriReq.toString());

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -283,7 +283,7 @@ protected:
 
     /// Handles WOPI CheckFileInfo requests.
     virtual bool handleCheckFileInfoRequest(const Poco::Net::HTTPRequest& request,
-                                            std::shared_ptr<StreamSocket>& socket)
+                                            const std::shared_ptr<StreamSocket>& socket)
     {
         std::unique_ptr<http::Response> httpResponse = assertCheckFileInfoRequest(request);
         if (!httpResponse)
@@ -323,7 +323,7 @@ protected:
     }
 
     virtual bool handleGetFileRequest(const Poco::Net::HTTPRequest& request,
-                                      std::shared_ptr<StreamSocket>& socket)
+                                      const std::shared_ptr<StreamSocket>& socket)
     {
         std::unique_ptr<http::Response> httpResponse = assertGetFileRequest(request);
         if (!httpResponse)
@@ -351,7 +351,7 @@ protected:
     }
 
     virtual bool handleHttpGetRequest(const Poco::Net::HTTPRequest& request,
-                                      std::shared_ptr<StreamSocket>& socket)
+                                      const std::shared_ptr<StreamSocket>& socket)
     {
         LOG_ASSERT_MSG(request.getMethod() == "GET", "Expect an HTTP GET request");
 
@@ -380,7 +380,7 @@ protected:
 
     virtual bool handleHttpPostRequest(const Poco::Net::HTTPRequest& request,
                                        std::istream& message,
-                                       std::shared_ptr<StreamSocket>& socket)
+                                       const std::shared_ptr<StreamSocket>& socket)
     {
         LOG_ASSERT_MSG(request.getMethod() == "POST", "Expect an HTTP POST request");
 
@@ -463,7 +463,7 @@ protected:
     /// Handles the uploading of a document to wopi.
     virtual bool handleWopiUpload(const Poco::Net::HTTPRequest& request,
                                   std::istream& message,
-                                  std::shared_ptr<StreamSocket>& socket)
+                                  const std::shared_ptr<StreamSocket>& socket)
     {
         const std::string wopiTimestamp = request.get("X-COOL-WOPI-Timestamp", std::string());
         if (!wopiTimestamp.empty())
@@ -540,7 +540,7 @@ protected:
     /// Here we act as a WOPI server, so that we have a server that responds to
     /// the wopi requests without additional expensive setup.
     bool handleHttpRequest(const Poco::Net::HTTPRequest& request, std::istream& message,
-                           std::shared_ptr<StreamSocket>& socket) override
+                           const std::shared_ptr<StreamSocket>& socket) override
     {
         Poco::URI uriReq(Uri::decode(request.getURI()));
 


### PR DESCRIPTION
doing this will allow these to be later called from const methods


Change-Id: I17b8b7c2f92443266c91749381a26913a368ac6e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

