### PR TITLE
Revert "Disable system dependent primitive renderer in kit"

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -4148,7 +4148,6 @@ bool globalPreinit(const std::string &loTemplate)
 
     // Disable problematic components that may be present from a
     // desktop or developer's install if env. var not set.
-    ::setenv("DISABLE_SYSTEM_DEPENDENT_PRIMITIVE_RENDERER", "1", 1);
     ::setenv("UNODISABLELIBRARY",
              "abp avmediagst avmediavlc cmdmail losessioninstall OGLTrans PresenterScreen "
              "syssh ucpftp1 ucpgio1 ucpimage updatecheckui updatefeed updchk"


### PR DESCRIPTION
This reverts commit 34d958e9790ebe529f642ab23e7622a2c7476730. It does more harm than good: garbled text when chart is activated in other session.. performance drop in rendering

while it only helps with chart activated (edit mode after double click) which is less serious than permament artifacts on the screen