### PR TITLE
move _socket in SocketDisposition::execute

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1073,13 +1073,16 @@ void SocketDisposition::execute()
             // Ensure the thread is running before adding callback.
             _toPoll->startThread();
         }
-        _toPoll->addCallback([pollCopy = _toPoll, socket = _socket, socketMoveFn = std::move(_socketMove)]()
+        _toPoll->addCallback(
+            [pollCopy = _toPoll, socket = std::move(_socket),
+             socketMoveFn = std::move(_socketMove)]()
             {
                 pollCopy->insertNewSocket(socket);
                 socketMoveFn(socket);
             });
 
         _socketMove = nullptr;
+        _socket = nullptr;
         _toPoll = nullptr;
     }
 }


### PR DESCRIPTION
 coolwsd(Util::assertCorrectThread(std::thread::id, char const*, int)+0x300)[0xa35e2a]
 coolwsd(Socket::assertCorrectThread(char const*, int) const+0x42)[0x71cc86]
 coolwsd(StreamSocket::ensureDisconnected()+0x3f)[0x7d21fd]
 coolwsd(StreamSocket::~StreamSocket()+0x1d8)[0x7d2072]
 coolwsd(void std::destroy_at<StreamSocket>(StreamSocket*)+0x23)[0x81bb33]
 coolwsd(void std::_Destroy<StreamSocket>(StreamSocket*)+0x1c)[0x81b88b]
 coolwsd(std::_Sp_counted_ptr_inplace<StreamSocket, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose()+0x44)[0x81975e]
 coolwsd(std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use()+0x27)[0x7349f9]
 coolwsd(std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use_cold()+0x1c)[0x72c9d6]
 coolwsd(std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release()+0x12d)[0x7186f1]
 coolwsd(std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count()+0x2b)[0x72ca35]
 coolwsd(std::__shared_ptr<Socket, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr()+0x20)[0x7cf208]
 coolwsd(std::shared_ptr<Socket>::~shared_ptr()+0x1c)[0x7cf252]
 coolwsd(SocketDisposition::~SocketDisposition()+0x4c)[0x7cf2f0]
 coolwsd(http::Session::asyncConnect(std::weak_ptr<SocketPoll> const&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}::operator()(std::shared_ptr<StreamSocket>, net::AsyncConnectResult) const+0x406)[0x7d9ce6]

SocketDisposition should forget about it as soon as its handed off to the destination poll.


Change-Id: If2d54da5ef30fbb78c80cdf67753d9732ddf61cb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

