### PR TITLE
restore passing lastHTTPHeader by reference

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1601,7 +1601,7 @@ bool StreamSocket::checkRemoval(std::chrono::steady_clock::time_point now)
 
 bool StreamSocket::parseHeader(const std::string_view clientName, std::istream& message,
                                Poco::Net::HTTPRequest& request,
-                               std::chrono::steady_clock::time_point lastHTTPHeader,
+                               std::chrono::steady_clock::time_point& lastHTTPHeader,
                                MessageMap& map)
 {
     assert(map._headerSize == 0 && map._messageSize == 0);

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1588,7 +1588,7 @@ public:
     /// populates a request for that.
     bool parseHeader(const std::string_view clientName, std::istream& message,
                      Poco::Net::HTTPRequest& request,
-                     std::chrono::steady_clock::time_point lastHTTPHeader, MessageMap& map);
+                     std::chrono::steady_clock::time_point& lastHTTPHeader, MessageMap& map);
 
     Buffer& getInBuffer() { return _inBuffer; }
 


### PR DESCRIPTION
this is an out_value used by
ClientRequestDispatcher::handleIncomingMessage to update its _lastSeenHTTPHeader member

went awry in:

commit bebf8902038d1e6553a5175bc93f07fd8b734d28
CommitDate: Fri Mar 28 11:04:19 2025 +0000

    wsd: time_point is best passed by value


Change-Id: I9c306bc6d28cfd1e6e96c1d3272eda1f2bd392ea


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

