### PR TITLE
Revert "Skip decompressing keyframes that become not-current"

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -2180,28 +2180,20 @@ class TileManager {
 					}
 
 					let keyframeImage = null;
-					if (x.isKeyframe) {
-						if (x.keyframeBuffer)
-							keyframeImage = new ImageData(
-								x.keyframeBuffer,
-								e.data.tileSize,
-								e.data.tileSize,
-							);
-						else {
-							tile.imgDataCache = null;
-							tile.rawDeltas = x.rawDelta;
-						}
-					}
-
-					if (!x.isKeyframe || keyframeImage)
-						this.applyDelta(
-							tile,
-							x.rawDelta,
-							x.deltas,
-							x.keyframeDeltaSize,
-							keyframeImage,
-							x.wireMessage,
+					if (x.isKeyframe)
+						keyframeImage = new ImageData(
+							x.keyframeBuffer,
+							e.data.tileSize,
+							e.data.tileSize,
 						);
+					this.applyDelta(
+						tile,
+						x.rawDelta,
+						x.deltas,
+						x.keyframeDeltaSize,
+						keyframeImage,
+						x.wireMessage,
+					);
 
 					this.createTileBitmap(tile, x, pendingDeltas, bitmaps);
 				}

--- a/browser/src/layer/tile/CanvasTileWorkerSrc.js
+++ b/browser/src/layer/tile/CanvasTileWorkerSrc.js
@@ -18,7 +18,6 @@ const PROCESS_TIME = 10;
 
 let transactionHandlerId = null;
 const transactions = [];
-let currentKeys = new Set();
 
 function transactionCallback(start_time = null) {
 	if (start_time === null) start_time = performance.now();
@@ -36,9 +35,6 @@ function transactionCallback(start_time = null) {
 
 		transaction.decompressed.push(tile);
 		transaction.buffers.push(tile.rawDelta.buffer);
-
-		// Skip keyframe tiles that are no longer current
-		if (tile.isKeyframe && !currentKeys.has(tile.key)) continue;
 
 		const deltas = self.fzstd.decompress(tile.rawDelta);
 		tile.keyframeDeltaSize = 0;
@@ -108,7 +104,6 @@ if ('undefined' === typeof window) {
 	function onMessage(e) {
 		switch (e.data.message) {
 			case 'endTransaction':
-				currentKeys = new Set(e.data.current);
 				transactions.push({
 					data: e.data,
 					decompressed: [],


### PR DESCRIPTION
This reverts commit 46cbac82ed1ee1071da66f107ee87928043ea0bd.

It was causing artifacts shown on a screen.
Mostly visible when working with charts or formatting marks