### PR TITLE
Set default values for showNavigator on document load

### DIFF
--- a/browser/src/control/Control.NavigatorPanel.ts
+++ b/browser/src/control/Control.NavigatorPanel.ts
@@ -112,7 +112,7 @@ class NavigatorPanel extends SidebarBase {
 			'click',
 			function () {
 				this.closeNavigation();
-				if (app.map.uiManager.getBooleanDocTypePref('ShowNavigator')) {
+				if (app.showNavigator) {
 					app.map.sendUnoCommand('.uno:Navigator');
 				}
 			}.bind(this),
@@ -216,7 +216,7 @@ class NavigatorPanel extends SidebarBase {
 			// in that case we first show the navigation panel and then switch to tab view
 			this.showNavigationPanel();
 			$('#navigator-dock-wrapper').show(200);
-			app.map.uiManager.setDocTypePref('ShowNavigator', true);
+			app.showNavigator = true;
 			// this will update the indentation marks for elements like ruler
 			app.map.fire('fixruleroffset');
 			if (app.map.isPresentationOrDrawing()) {
@@ -229,7 +229,7 @@ class NavigatorPanel extends SidebarBase {
 
 	closeSidebar() {
 		this.closeNavigation();
-		this.map.uiManager.setDocTypePref('ShowNavigator', false);
+		app.showNavigator = false;
 		super.closeSidebar();
 	}
 
@@ -248,8 +248,7 @@ class NavigatorPanel extends SidebarBase {
 			this.presentationControlsWrapper.style.display = 'block';
 			this.navigatorDockWrapper.style.display = 'none';
 		} else {
-			if (!this.map.uiManager.getBooleanDocTypePref('ShowNavigator'))
-				app.map.sendUnoCommand('.uno:Navigator');
+			if (!app.showNavigator) app.map.sendUnoCommand('.uno:Navigator');
 			this.presentationControlsWrapper.style.display = 'none';
 			this.navigatorDockWrapper.style.display = 'block';
 		}

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -560,11 +560,7 @@ class UIManager extends L.Control {
 					app.socket.sendMessage('uno .uno:SidebarShow');
 					app.socket.sendMessage('uno .uno:MasterSlidesPanel');
 					this.map.sidebar.setupTargetDeck('.uno:MasterSlidesPanel');
-				} else if (this.getBooleanDocTypePref('NavigatorDeck', false)) {
-					app.socket.sendMessage('uno .uno:SidebarShow');
 				}
-			} else if (this.getBooleanDocTypePref('NavigatorDeck', false)) {
-				app.socket.sendMessage('uno .uno:SidebarShow');
 			} else if (this.getBooleanDocTypePref('StyleListDeck', false)) {
 				app.socket.sendMessage('uno .uno:SidebarShow');
 				app.socket.sendMessage('uno .uno:SidebarDeck.StyleListDeck');

--- a/browser/src/control/HRuler.ts
+++ b/browser/src/control/HRuler.ts
@@ -420,9 +420,7 @@ class HRuler extends Ruler {
 		this.options.rightParagraphIndent *= pxPerMm100;
 
 		// Get navigatiosidebar width only when navigation sidebar is visible
-		const navigationsidebarWidth = this._map.uiManager.getBooleanDocTypePref(
-			'ShowNavigator',
-		)
+		const navigationsidebarWidth = app.showNavigator
 			? this._getNavigationSidebarWidth()
 			: 0;
 

--- a/browser/src/docstate.js
+++ b/browser/src/docstate.js
@@ -118,6 +118,8 @@ window.app = {
 	serverAudit: null, // contains list of warnings / errors detected on the server instance
 
 	events: null, // See app/DocEvents.ts for details.
+
+	showNavigator: false, // ShowNavigator class instance is assigned to this.
 };
 
 var activateValidation = false;


### PR DESCRIPTION

- Before this patch in presentation mode because of cache `ShowNavigator` seems to set to true even if navigator is not populated
- we were string this value in local storage which not getting reset on reload
- also we did not need to remember state if session changes
- so better to manage state in app object and not in local storage
- this will remember navigator state only for current session using app object


Change-Id: If5836097cfce6b5a047de2b05aec4b5d7a26fcd0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

