### PR TITLE
stylelist: update css classes, ids and icons

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -364,7 +364,7 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 	white-space: break-spaces;
 }
 
-#StyleListPanelPanelExpander .ui-treeview-cell-text {
+.StyleListPanel #TemplatePanel .ui-treeview-cell-text {
 	white-space: break-spaces;
 }
 
@@ -542,26 +542,26 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	background-color: #0056b3;
 }
 /* Styles deck */
-#StyleListPanelPanelExpander [id='2'] button { background: transparent url('images/lc_parastyle.svg') no-repeat center; }
-#StyleListPanelPanelExpander [id='1'] button { background: transparent url('images/lc_charstyle.svg') no-repeat center; }
-#StyleListPanelPanelExpander [id='3'] button { background: transparent url('images/lc_framestyle.svg') no-repeat center; }
-#StyleListPanelPanelExpander [id='4'] button { background: transparent url('images/lc_pagestyle.svg') no-repeat center; }
-#StyleListPanelPanelExpander [id='5'] button { background: transparent url('images/lc_liststyle.svg') no-repeat center; }
-#StyleListPanelPanelExpander [id='6'] button { background: transparent url('images/lc_tablestyle.svg') no-repeat center; }
+.StyleListPanel #TemplatePanel [id='2'] button { background: transparent url('images/lc_parastyle.svg') no-repeat center; }
+.StyleListPanel #TemplatePanel [id='1'] button { background: transparent url('images/lc_charstyle.svg') no-repeat center; }
+.StyleListPanel #TemplatePanel [id='3'] button { background: transparent url('images/lc_framestyle.svg') no-repeat center; }
+.StyleListPanel #TemplatePanel [id='4'] button { background: transparent url('images/lc_pagestyle.svg') no-repeat center; }
+.StyleListPanel #TemplatePanel [id='5'] button { background: transparent url('images/lc_liststyle.svg') no-repeat center; }
+.StyleListPanel #TemplatePanel [id='6'] button { background: transparent url('images/lc_tablestyle.svg') no-repeat center; }
 
 
-[data-theme='dark'] #StyleListPanelPanelExpander [id='1'] button { background: transparent url('images/dark/lc_charstyle.svg') no-repeat center; }
-[data-theme='dark'] #StyleListPanelPanelExpander [id='5'] button { background: transparent url('images/dark/lc_liststyle.svg') no-repeat center; }
-[data-theme='dark'] #StyleListPanelPanelExpander [id='2'] button { background: transparent url('images/dark/lc_parastyle.svg') no-repeat center; }
-[data-theme='dark'] #StyleListPanelPanelExpander [id='4'] button { background: transparent url('images/dark/lc_pagestyle.svg') no-repeat center; }
-[data-theme='dark'] #StyleListPanelPanelExpander [id='3'] button { background: transparent url('images/dark/lc_framestyle.svg') no-repeat center; }
-[data-theme='dark'] #StyleListPanelPanelExpander [id='6'] button { background: transparent url('images/dark/lc_tablestyle.svg') no-repeat center; }
+[data-theme='dark'] .StyleListPanel #TemplatePanel [id='1'] button { background: transparent url('images/dark/lc_charstyle.svg') no-repeat center; }
+[data-theme='dark'] .StyleListPanel #TemplatePanel [id='5'] button { background: transparent url('images/dark/lc_liststyle.svg') no-repeat center; }
+[data-theme='dark'] .StyleListPanel #TemplatePanel [id='2'] button { background: transparent url('images/dark/lc_parastyle.svg') no-repeat center; }
+[data-theme='dark'] .StyleListPanel #TemplatePanel [id='4'] button { background: transparent url('images/dark/lc_pagestyle.svg') no-repeat center; }
+[data-theme='dark'] .StyleListPanel #TemplatePanel [id='3'] button { background: transparent url('images/dark/lc_framestyle.svg') no-repeat center; }
+[data-theme='dark'] .StyleListPanel #TemplatePanel [id='6'] button { background: transparent url('images/dark/lc_tablestyle.svg') no-repeat center; }
 
-#StyleListPanelPanelExpander #left.toolbox button {
+.StyleListPanel #left.toolbox button {
 	background-size: cover;
 }
 
-#StyleListPanelPanelExpander #left.toolbox img {
+.StyleListPanel #left.toolbox img {
 	visibility: hidden;
 }
 
@@ -579,13 +579,15 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 #StyleListDeck,
 #StyleListDeck .root-container.jsdialog.sidebar,
 #StyleListDeck .vertical.jsdialog.sidebar,
-#StyleListPanelPanelExpander,
-#StyleListPanelPanelExpander #content,
-#StyleListPanelPanelExpander #TemplatePanel {
+.StyleListPanel,
+.StyleListPanel #content,
+.StyleListPanel #TemplatePanel {
 	height: 100%;
+	display: flex;
+	flex-direction: column;
 }
 
-#StyleListPanelPanelExpander .ui-expander-content.jsdialog.sidebar.expanded {
+.StyleListPanel .ui-expander-content.jsdialog.sidebar.expanded {
 	height: calc(100% - 45px);
 }
 
@@ -605,6 +607,7 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 #TemplatePanel .sidebar .ui-content.unobutton {
 	width: var(--btn-size-m);
 	height: var(--btn-size-m);
+	background-color: transparent !important;
 }
 
 #TemplatePanel {


### PR DESCRIPTION
Change-Id: Idb7d2a92b8664308df13f0c63fb369ffdf7c7693


* Regression: #https://github.com/CollaboraOnline/online/pull/11083
* Target version: master 

### Summary
- Since the id changed from StyleListPanelPanelExpander, updated the css to the new class StyleListPanel to show the right style list svg icons

- Fixed background-color hover of unobuttons in style list

### PREVIEWS
![Screenshot from 2025-05-14 18-05-51](https://github.com/user-attachments/assets/9017d7b1-2f64-4529-bc92-9b241b67a1ea)
![Screenshot from 2025-05-14 18-00-36](https://github.com/user-attachments/assets/1b9e638c-a17a-4f7f-af46-789b9031e9e6)
![Screenshot from 2025-05-14 18-00-22](https://github.com/user-attachments/assets/f1b35a43-62e3-4709-b725-bc6f31f09e7b)


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

