### PR TITLE
fix: show correct page number

### DIFF
--- a/browser/src/canvas/sections/TilesSection.ts
+++ b/browser/src/canvas/sections/TilesSection.ts
@@ -328,7 +328,7 @@ export class TilesSection extends CanvasSectionObject {
 			var partHeightPixels: number = Math.round(this.map._docLayer._partHeightTwips * app.twipsToPixels);
 			var gap: number = Math.round(this.map._docLayer._spaceBetweenParts * app.twipsToPixels);
 			var partWidthPixels: number = Math.round(this.map._docLayer._partWidthTwips * app.twipsToPixels);
-			var startY: number = (partHeightPixels + gap) * (topVisible > 0 ? topVisible -1: 0);
+			var startY: number = (partHeightPixels + gap) * (topVisible > 0 ? topVisible : 0);
 			var rectangle: Array<number>;
 
 			for (var i: number = 0; i <= bottomVisible - topVisible; i++) {


### PR DESCRIPTION
In PDFs, we have some code to render the page numbers based on a fixed page size when tiles haven't yet loaded

Rather than page 1 being the top, the top page is internally considered to be page 0. That means that when subtracting 1, we would shift all the rendered placeholder pages up by one page.

This effect wouldn't show when you were at the top of the document, because then we would be on 'page 0' and would go into the other branch, not subtracting 1 and not rendering the pages incorrectly offset. Scroll down a little, however, and you would find that as soon as the top of page 2 reached the top of your screen the numbers would jump - page "2" becoming page "3". Finally, you wouldn't get a page rendered at all where the last page should be


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

