### PR TITLE
zotero: send field parameter to avoid citation field expansion

### DIFF
--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -1665,6 +1665,10 @@ L.Control.Zotero = L.Control.extend({
 				'Fields': {
 					'type': '[][]com.sun.star.beans.PropertyValue',
 					'value': newValueArray
+				},
+				'NeverExpand': {
+					'type': 'boolean',
+					'value': true
 				}
 			};
 			this.map.sendUnoCommand('.uno:UpdateFields', updatedCitations, true);
@@ -1700,6 +1704,7 @@ L.Control.Zotero = L.Control.extend({
 			field['TypeName'] = {type: 'string', value: 'SetRef'};
 			field['Name'] = {type: 'string', value: 'ZOTERO_ITEM CSL_CITATION ' + cslJSON + ' RND' + app.util.randomString(10)};
 			field['Content'] = {type: 'string', value: citationString};
+			field['NeverExpand'] = {type: 'boolean', value: true};
 		} else if (this.getFieldType() == 'Bookmark') {
 			field['Bookmark'] = {type: 'string', value: 'ZOTERO_BREF_' + app.util.randomString(12)};
 			field['BookmarkText'] = {type: 'string', value: citationString};


### PR DESCRIPTION
problem:
in online when a reference mark field is inserted(as ref mark)  and you start typing after it, field always expanded.


Change-Id: I10dc7ce28db5d212f91e6cf26abaefb11938d652

* Target version: distro/collabora/co-24.04 

requires: https://gerrit.libreoffice.org/c/core/+/185350