### PR TITLE
Add styling for active thumbnails in read-only slides

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4186,11 +4186,12 @@ L.CanvasTileLayer = L.Layer.extend({
 	highlightCurrentPart: function (part) {
 		var previews = document.getElementsByClassName('preview-frame');
 		for (var i = 0; i < previews.length; i++) {
+			const img = previews[i].querySelector('img');
 			if (parseInt(previews[i].id.replace('preview-frame-part-', '')) === part) {
-				previews[i].style.border = '2px solid darkgrey';
+				L.DomUtil.addClass(img, 'preview-img-currentpart');
 			}
 			else {
-				previews[i].style.border = 'none';
+				L.DomUtil.removeClass(img, 'preview-img-currentpart');
 			}
 		}
 	},

--- a/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/pdf_page_up_down_spec.js
@@ -13,10 +13,10 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'PDF View Tests', function(
 	it('PDF page down', { env: { 'pdf-view': true } }, function() {
 		cy.cGet('#map').type('{pagedown}');
 		cy.cGet('#map').type('{pagedown}');
-		cy.cGet('#preview-frame-part-1').should('have.attr', 'style', 'border: 2px solid darkgrey;');
+		cy.cGet('#preview-frame-part-1 img').should('have.class', 'preview-img-currentpart');
 		cy.cGet('#map').type('{pageup}');
 		cy.cGet('#map').type('{pageup}');
-		cy.cGet('#preview-frame-part-0').should('have.attr', 'style', 'border: 2px solid darkgrey;');
+		cy.cGet('#preview-frame-part-0 img').should('have.class', 'preview-img-currentpart');
 	});
 
 	it.skip('PDF insert comment', { env: { 'pdf-view': true }, defaultCommandTimeout: 60000 }, function() {


### PR DESCRIPTION
Change-Id: Idbc3945a3ce78532eb56f8a914286e78452094e1

* Resolves: #11919 
* Target version: master 

### Summary
- Removed darkgrey border from selected thumbnails in read-only mode and added  preview-img-currentpart class to the selected thumbnail

### BEFORE

https://github.com/user-attachments/assets/e5710e48-07d4-4464-bf8a-8d5fda511c67



### WITH THIS PR

https://github.com/user-attachments/assets/db8f2498-6949-48f0-ab61-341dbafd7abe




- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

