### PR TITLE
ServerSession may shutdownConnection on socket before all data gets sent

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -2181,6 +2181,7 @@ private:
 
                     close(_fd);
                     _fd = -1;
+                    socket->flush();
                     onDisconnect();
                     break;
                 }


### PR DESCRIPTION
So any remaining data in the buffer from an earlier socket::send doesn't really get sent over the wire. Explicitly flush before shutdownConnection.


Change-Id: I7979223cb289adfd970b1678eaa9c5a0f097aa53


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

