### PR TITLE
Set freeze pane split line color code

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -1107,7 +1107,7 @@ body {
 	border-style: solid; /* required for ie11 */
 	display: none; /* prevent cypress failure */
 
-	color: var(--color-border); /* color */
+	color: #b6b6b6; /* color */
 	opacity: 1; /* opacity */
 	border-top-width: 1px; /* weight */
 }


### PR DESCRIPTION
- before this patch we are using --border-color variable which is causing issues when we are in dark mode or document loaded in dark mode.
- so if user is in dark mode and click freeze pane then the split line color is not visible because the --color-border does not making good contrast with dark theme canavs.
- also it looks good whene we use same color code for both mode as a split line color.
- so now i changed it to a hardcoded color code which is same for both light and dark mode.

Before:

![image](https://github.com/user-attachments/assets/af8f9d2d-1c47-4eb0-8f88-798787d121dc)


After:
![image](https://github.com/user-attachments/assets/dfa80c32-b1d9-49f9-ae14-8b77c4676abe)


Change-Id: I6542b66275fe4d154c18103bd5c2e9b63b2dd64b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

