### PR TITLE
Seccomp: disable setns for child processes

### DIFF
--- a/common/Seccomp.cpp
+++ b/common/Seccomp.cpp
@@ -195,6 +195,7 @@ bool lockdown([[maybe_unused]] Type type)
         KILL_SYSCALL(sync),   // I/O perf.
         KILL_SYSCALL(mount),
         KILL_SYSCALL(umount2),
+        KILL_SYSCALL(setns),
         KILL_SYSCALL(swapon),
         KILL_SYSCALL(swapoff),
         KILL_SYSCALL(reboot), // !


### PR DESCRIPTION
This can be allowed for the container, the child process does not need it.


Change-Id: I3d91dee111394c347ed2e583005834ccfa3adcab


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Just for completion 

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

