### PR TITLE
gh#11840 Replace bitmap icon with svg

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -997,22 +997,25 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	display: none;
 }
 
+/* Draw SVG downwards arrow.
+The same as .unoarrow to replace the old .png bitmap arrow*/
 .ui-listbox-arrow {
-	content: '';
-	background: url('images/jquery-ui-lightness/ui-icons_222222_256x240.png') no-repeat transparent;
-	background-position: -67px -17px !important;
-	display: inline-block;
-	position: relative;
-	width: 11px;
-	height: 11px;
-	cursor: pointer;
-	pointer-events: none;
+	width: auto !important;
+	height: 0px;
+	font-size: 0;
+	line-height: 0;
+	border: 4px solid transparent;
+	border-top: 5px solid var(--color-main-text);
+	display: inline-block !important;
 	margin-inline-start: -16px;
 	margin-inline-end: 4px;
+	margin-top: 4px;
+	cursor: pointer;
+	pointer-events: none;
 }
 
 [data-theme='dark'] .ui-listbox-arrow {
-	background: url('images/jquery-ui-lightness/ui-icons_ffffff_256x240.png') no-repeat transparent;
+	border-top-color: var(--color-text-dark);
 }
 
 .ui-listbox[disabled='disabled'] ~ .ui-listbox-arrow,
@@ -1039,9 +1042,16 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	padding-inline: 5px;
 }
 
+/* Similar to .arrowbackground, centers the vector dropdown arrow. */
 .ui-combobox-button {
-	padding-left: 20px;
+	box-sizing: border-box;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	border-left: 1px solid var(--color-border);
+	background-color: transparent;
+	padding-left: 20px;
 }
 
 .ui-combobox-button:hover {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1522,7 +1522,7 @@ The same as .unoarrow to replace the old .png bitmap arrow*/
 	grid-column: 3;
 	position: relative;
 	border: none;
-	padding: 0px;
+	padding: 1px;
 }
 
 .arrowbackground:hover {


### PR DESCRIPTION
https://github.com/CollaboraOnline/online/issues/11840

### Summary
Changed `.ui-listbox-arrow` to draw a vector arrow instead of using JQuerry UI Lightness theme icon.

Updated `.ui-combobox-button` to center new `.ui-listbox-arrow` logic.

Updated `.arrowbackground` for better centering of `.unoarrow`.

`.ui-listbox-arrow` before: 
![image](https://github.com/user-attachments/assets/231dc4c1-a963-4624-91da-3f3545f2adb4)

`.ui-listbox-arrow` after:
![image](https://github.com/user-attachments/assets/7fdc6138-9090-4826-beb0-de9639bb257e)


`.arrowbackground` and `.unoarrow` before:
![image](https://github.com/user-attachments/assets/912e537a-c608-4aab-a508-006f7e1b91ca)

`.arrowbackground` and `.unoarrow` after:
![image](https://github.com/user-attachments/assets/9faf6c53-0955-4cd9-b1cc-8cf31352660c)


Change-Id: Ifd5f9b68a8897a20a3e4fad74830f8469c850e45


* Resolves: # <!-- related github issue -->
* Target version: master 


### TODO

- [ ] Find and update other cases of the issue. 

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

