### PR TITLE
Tighter Socket Closed State

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -805,12 +805,9 @@ void SocketPoll::closeAllSockets()
     removeFromWakeupArray();
     for (std::shared_ptr<Socket> &it : _pollSockets)
     {
-        // first close the underlying socket
-#if !MOBILEAPP
+        // first close the underlying socket/fakeSocket
         it->closeFD(*this);
-#else
-        fakeSocketClose(it->getFD());
-#endif
+
         // avoid the socketHandler' getting an onDisconnect
         auto stream = dynamic_cast<StreamSocket *>(it.get());
         if (stream)

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -716,7 +716,7 @@ int SocketPoll::poll(int64_t timeoutMaxMicroS, bool justPoll)
                     rc = -1;
                 }
 
-                if (_pollSockets[i]->isShutdown() || !disposition.isContinue())
+                if (!_pollSockets[i]->isOpen() || !disposition.isContinue())
                 {
                     ++itemsErased;
                     LOGA_TRC(Socket, '#' << _pollFds[i].fd << ": Removing socket (at " << i
@@ -807,6 +807,7 @@ void SocketPoll::closeAllSockets()
     {
         // first close the underlying socket/fakeSocket
         it->closeFD(*this);
+        assert(!it->isOpen() && "Socket is still open after closing");
 
         // avoid the socketHandler' getting an onDisconnect
         auto stream = dynamic_cast<StreamSocket *>(it.get());
@@ -1591,6 +1592,7 @@ bool StreamSocket::checkRemoval(std::chrono::steady_clock::time_point now)
         }
 
         assert(isShutdown() && "Should have issued shutdown");
+        assert(!isOpen() && "Socket is still open after closing");
         return true;
     }
 

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -200,9 +200,9 @@ protected:
             return;
         }
 
-        if (socket->isShutdown())
+        if (!socket->isOpen())
         {
-            LOG_DBG("Socket is shut down. Cannot send Close Frame");
+            LOG_DBG("Socket is not open. Cannot send Close Frame");
             return;
         }
 
@@ -269,7 +269,7 @@ public:
     bool isConnected() const
     {
         std::shared_ptr<StreamSocket> socket = _socket.lock();
-        return socket && !socket->isShutdown();
+        return socket && socket->isOpen();
     }
 
 private:
@@ -841,9 +841,9 @@ protected:
             return -1;
         }
 
-        if (socket->isShutdown())
+        if (!socket->isOpen())
         {
-            LOG_DBG("Socket is shut down. Cannot send WS frame");
+            LOG_DBG("Socket is not open. Cannot send WS frame");
             return 0;
         }
 

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1001,10 +1001,10 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
         socket->ignoreInput();
     }
     else
-        LOG_DBG("Handled request: " << request.getURI()
-                << ", inBuf[sz " << preInBufferSz << " -> " << socket->getInBuffer().size()
-                << ", rm " <<  (preInBufferSz-socket->getInBuffer().size())
-                << "], connection open " << !socket->isShutdown());
+        LOG_DBG("Handled request: " << request.getURI() << ", inBuf[sz " << preInBufferSz << " -> "
+                                    << socket->getInBuffer().size() << ", rm "
+                                    << (preInBufferSz - socket->getInBuffer().size())
+                                    << "], connection open: " << socket->isOpen());
 
 #else // !MOBILEAPP
     Poco::Net::HTTPRequest request;


### PR DESCRIPTION
We centralize `closeFD()` logic to have strong guarantees that we call `close(2)` once, and we always invalidate the FD. In addition, we now treat closed-but-not-shutdown equivalent to `isShutdown()`, where it matters. This is done through the new member `isOpen()`, which we use instead of `isShutdown()` where being closed implies being shut down.

- **wsd: deduplicate Socket::closeFD()**
- **wsd: add Socket::isOpen() and replace isShutdown()**
