### PR TITLE
Fix: Auto-adjust iframe height using postMessage

### DIFF
--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -682,6 +682,32 @@ document.addEventListener('DOMContentLoaded', () => {
 		initTranslationStr();
 		(window as any).settingIframe = new SettingIframe();
 		(window as any).settingIframe.init();
+		const postHeight = () => {
+			window.parent.postMessage(
+				{
+					MessageId: 'Iframe_Height',
+					SendTime: Date.now(),
+					Values: {
+						ContentHeight: document.documentElement.offsetHeight + 'px',
+					},
+				},
+				'*',
+			);
+		};
+
+		let timeout: any;
+		const debouncePostHeight = () => {
+			clearTimeout(timeout);
+			timeout = setTimeout(postHeight, 100);
+		};
+
+		const mutationObserver = new MutationObserver(debouncePostHeight);
+		mutationObserver.observe(document.body, {
+			childList: true,
+			subtree: true,
+			attributes: true,
+			characterData: true,
+		});
 	}
 });
 


### PR DESCRIPTION
Fix: Auto-adjust iframe height using postMessage

Previously, the iframe height was hardcoded, which could result in excessive whitespace at the bottom. Now, we send a postMessage with the type  and the height (in pixels) as the payload. This allows the integrator to dynamically adjust the iframe height based on actual content.

Follow UP: Once this get in, a change in the SDK is needed.


Change-Id: I509c7ffb9fdaccb65146a52371d8b08d1b0c0301


* Resolves: # <!-- related github issue -->
* Target version: master 
