### PR TITLE
Show page/slide thumbnails for PDF, drawing or presentation

### DIFF
--- a/browser/src/control/Control.NavigatorPanel.ts
+++ b/browser/src/control/Control.NavigatorPanel.ts
@@ -52,10 +52,10 @@ class NavigatorPanel extends SidebarBase {
 	}
 
 	onDocLayerInit() {
+		const allowedDocTypes = ['presentation', 'drawing'];
 		// for presentation show slide sorter navigation panel by default
 		if (
-			app.map.getDocType() === 'presentation' &&
-			!app.map.isReadOnlyMode() &&
+			allowedDocTypes.includes(app.map.getDocType()) &&
 			!window.mode.isMobile()
 		) {
 			// Navigator panel should be visible and by default we should open slide sorter in case of impress/draw


### PR DESCRIPTION
No matter its permission, these document types should allow the user
to see the page/slide thumbnails. Before this commit, that was not
possible.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I9161c3caeae6d155919fd24de13c273d39edc2a1
