### PR TITLE
make rendering extra_params more robust

### DIFF
--- a/kubernetes/helm/collabora-online/templates/configmap.yaml
+++ b/kubernetes/helm/collabora-online/templates/configmap.yaml
@@ -8,7 +8,10 @@ metadata:
     {{- include "collabora-online.labels" . | nindent 4 }}
 data:
   {{- if .Values.collabora.extra_params }}
-  extra_params: {{ .Values.collabora.extra_params }}
+  extra_params: |
+  {{- range .Values.collabora.extra_params }}
+    {{ . | quote }}
+  {{- end }}
   {{- end }}
   {{- if .Values.collabora.server_name }}
   server_name: {{ .Values.collabora.server_name }}


### PR DESCRIPTION
I was trying to set a custom CSP with:
```
    extra_params:
      - "--o:ssl.enable=true"
      - "--o:ssl.ssl_verification=false"
      - "--o:ssl.termination=true"
      - "--o:welcome.enable=false"
      - "--o:net.content_security_policy=media-src 'self' blob: https://collabora.opencloud.test; object-src 'self'; style-src 'self'; script-src 'self' 'unsafe-eval'; frame-ancestors collabora.opencloud.test:*; img-src 'self' data: https://www.collaboraoffice.com collabora.opencloud.test:*; connect-src 'self' https://www.zotero.org https://api.zotero.org wss://collabora.opencloud.test https://collabora.opencloud.test; frame-src 'self' https://rating.collaboraonline.com https://rating.collaboraonline.com blob:; font-src 'self'; default-src 'none';"
```
but ran into
```
STDERR:
  Error: Failed to render chart: exit status 1: Error: YAML parse error on opencloud/charts/collabora-online/templates/configmap.yaml: error converting YAML to JSON: yaml: line 13: did not find expected ',' or ']'
  Use --debug flag to render out invalid YAML
  Error: plugin "diff" exited with error
```

This PR allows customizing the `net.content_security_policy`. I will fall back to `net.frame_ancestors` for now.