### PR TITLE
build: fix failure on relative-path core

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -640,7 +640,13 @@ if test \( "$enable_iosapp" = "yes" -a `uname -s` = "Darwin" \) -o \( "$enable_a
       if test -z "$LOBUILDDIR_X86_64" ; then
          LOBUILDDIR_X86_64="$LOBUILDDIR"
       fi
+
+      LOBUILDDIR_ARM64_V8A=`readlink -f "$LOBUILDDIR_ARM64_V8A"`
+      LOBUILDDIR_X86=`readlink -f "$LOBUILDDIR_X86"`
+      LOBUILDDIR_X86_64=`readlink -f "$LOBUILDDIR_X86_64"`
    fi
+
+   LOBUILDDIR=`readlink -f "$LOBUILDDIR"`
 
    # Get the git hash of the core build
    CORE_VERSION_HASH=`cd $LOBUILDDIR && grep buildid instdir/program/setuprc | sed -e 's/buildid=//' -e 's/............................$//'`


### PR DESCRIPTION
This is pretty similar to #7081, but works for --with-lo-builddir which is used in the Android app


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

