### PR TITLE
feat(android): send large messages through http

### DIFF
--- a/android/lib/src/main/cpp/androidapp.cpp
+++ b/android/lib/src/main/cpp/androidapp.cpp
@@ -101,6 +101,25 @@ static void send2JS(const JNIThreadContext &jctx, const std::vector<char>& buffe
 {
     LOG_DBG("Send to JS: " << COOLProtocol::getAbbreviatedMessage(buffer.data(), buffer.size()));
 
+    const char *newline = (const char *)memchr(buffer.data(), '\n', buffer.size());
+    JNIEnv *env = jctx.getEnv();
+
+    if (buffer.size() > 1024) {
+        jbyteArray jmessage = env->NewByteArray(buffer.size());
+        env->SetByteArrayRegion(jmessage, 0, buffer.size(),
+                                reinterpret_cast<const jbyte *>(buffer.data()));
+
+        jboolean jisbinary = newline != nullptr;
+        jmethodID callFakeWebsocket = env->GetMethodID(g_loActivityClz, "rawCallFakeWebsocketOnLargeMessage", "([BZ)V");
+        env->CallVoidMethod(g_loActivityObj, callFakeWebsocket, jmessage, jisbinary);
+        env->DeleteLocalRef(jmessage);
+
+        if (env->ExceptionCheck())
+            env->ExceptionDescribe();
+
+        return;
+    }
+
     std::string js;
 
     // Check if the message is binary. We say that any message that isn't just a single line is
@@ -109,7 +128,6 @@ static void send2JS(const JNIThreadContext &jctx, const std::vector<char>& buffe
     // handles it fine even if such a message, too, comes in as an ArrayBuffer. (Look for the
     // "textMsg = String.fromCharCode.apply(null, imgBytes);".)
 
-    const char *newline = (const char *)memchr(buffer.data(), '\n', buffer.size());
     if (newline != nullptr)
     {
         // The data needs to be an ArrayBuffer
@@ -147,7 +165,6 @@ static void send2JS(const JNIThreadContext &jctx, const std::vector<char>& buffe
 
     LOG_DBG("Sending to JavaScript: " << subjs);
 
-    JNIEnv *env = jctx.getEnv();
     jstring jstr = env->NewStringUTF(js.c_str());
     jmethodID callFakeWebsocket = env->GetMethodID(g_loActivityClz, "rawCallFakeWebsocketOnMessage", "(Ljava/lang/String;)V");
     env->CallVoidMethod(g_loActivityObj, callFakeWebsocket, jstr);

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1122,6 +1122,12 @@ function getInitializerClass() {
 		};
 		this.close = function() {
 		};
+		if (global.ThisIsAMobileApp) {
+			this.onremotebinarymessage = function() {
+			};
+			this.onremotemessage = function() {
+			};
+		}
 	};
 	global.FakeWebSocket.prototype.send = function(data) {
 		global.postMobileMessage(data);

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -82,6 +82,11 @@ app.definitions.Socket = L.Class.extend({
 			                                            parseInt(map.options.docParams.access_token_ttl) - Date.now() - tokenExpiryWarning);
 		}
 
+		if (window.ThisIsAMobileApp) {
+			this.socket.onremotebinarymessage = L.bind(this._onRemoteBinaryMessage, this);
+			this.socket.onremotemessage = L.bind(this._onRemoteMessage, this);
+		}
+
 		// process messages for early socket connection
 		this._emptyQueue();
 	},
@@ -483,6 +488,29 @@ app.definitions.Socket = L.Class.extend({
 				completeCallback();
 			}
 		}
+	},
+
+	_onRemoteBinaryMessage: function(messageId) {
+		const request = new XMLHttpRequest();
+		request.open("GET", `cool:/cool/message?id=${messageId}`);
+		request.responseType = "arraybuffer";
+		request.onload = () => {
+			console.log({ binaryMessage: request.response, request });
+			if (!request.response) return;
+			this._slurpMessage({ data: request.response });
+		};
+		request.send();
+	},
+
+	_onRemoteMessage: function(messageId) {
+		const request = new XMLHttpRequest();
+		request.open("GET", `cool:/cool/message?id=${messageId}`);
+		request.onload = () => {
+			console.log({ textualMessage: request.response, request });
+			if (!request.response) return;
+			this._slurpMessage({ data: request.response });
+		};
+		request.send();
 	},
 
 	// The problem: if we process one websocket message at a time, the


### PR DESCRIPTION
We've had some major performance problems in android, and lots of them seem to have been caused by sending large messages over the fakewebsocket - which turns out to be a very slow operation.

This patch will send any messages over 1024 bytes through a http request, which seem to be much faster than putting such long messages through the previous route. I chose 1024 because it's a nice number, I have no particular evidence that it's the absolute best value for this.

To let mobile know that there's a message waiting, we still do inject some javascript into the webview, however as it's a much shorter message it's very quick.

It's not perfect - there's still some jitteriness - but it's so much closer to where we want that I think it's worth merging it now anyway. I have some further ideas for cleaning this up more - such as running a long http request through the cool protocol in a similar way to a websocket - but I'd prefer to get something rather than iterate forever.


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

