### PR TITLE
flag async shutdown via _shutdownSignalled

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -2185,8 +2185,7 @@ private:
 
                     close(_fd);
                     _fd = -1;
-                    socket->flush();
-                    onDisconnect();
+                    socket->shutdown(); // Trigger async shutdown.
                     break;
                 }
 


### PR DESCRIPTION
When there is no more data left to send from a ServerSession use StreamSocket::shutdown to set _shutdownSignalled to flag async shutdown and let handlePoll write the queued outBuffer until it is empty (or no more writes are possible). handlePoll will trigger onDisconnect at that point instead of explicitly calling it early here.

i.e. with this, onDisconnect is called as:

```
 #0  http::ServerSession::onDisconnect (this=0x7fffc00041c0) at ./net/HttpRequest.hpp:2210
 #1  0x00000000007d63c9 in StreamSocket::ensureDisconnected (this=0x7fffcc003230) at net/Socket.hpp:1258
 #2  0x0000000000aa3901 in StreamSocket::handlePoll (this=0x7fffcc003230, disposition=..., now=std::chrono::_V2::steady_clock time_point = { 611539841270573ns }, events=4)
     at net/Socket.hpp:1779
 #3  0x0000000000a9001f in SocketPoll::poll (this=0x7fffd0001070, timeoutMaxMicroS=17684522, justPoll=false) at net/Socket.cpp:709
 #4  0x00000000007215fc in SocketPoll::poll (this=0x7fffd0001070, timeoutMax=std::chrono::duration = { 64000000us }, justPoll=false) at net/Socket.hpp:883
 #5  0x00000000008c0108 in DocumentBroker::pollThread (this=0x7fffd0002a00) at wsd/DocumentBroker.cpp:379
 #6  0x000000000091861c in DocumentBroker::DocumentBrokerPoll::pollingThread (this=0x7fffd0001070) at wsd/DocumentBroker.cpp:172
 #7  0x0000000000a8e269 in SocketPoll::pollingThreadEntry (this=0x7fffd0001070) at net/Socket.cpp:479
```

Change-Id: Ib1ccb298bdfca2d5c4863880324c4e2e2638eae0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

