### PR TITLE
feat(helm): Add deployment annotations and labels configuration

### DIFF
--- a/kubernetes/helm/collabora-online/templates/deployment.yaml
+++ b/kubernetes/helm/collabora-online/templates/deployment.yaml
@@ -6,6 +6,13 @@ metadata:
   name: {{ include "collabora-online.fullname" . }}
   labels:
     {{- include "collabora-online.labels" . | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   minReadySeconds: {{ .Values.deployment.minReadySeconds }}
   {{- if not .Values.autoscaling.enabled }}

--- a/kubernetes/helm/collabora-online/templates/statefulset.yaml
+++ b/kubernetes/helm/collabora-online/templates/statefulset.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ include "collabora-online.fullname" . }}
   labels:
     {{- include "collabora-online.labels" . | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   serviceName: {{ include "collabora-online.fullname" . }}
   minReadySeconds: {{ .Values.deployment.minReadySeconds }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -147,6 +147,8 @@ service:
 deployment:
   # Use StatefulSet or Deployment
   kind: Deployment
+  annotations: {}
+  labels: {}
   containerPort: 9980
   type: RollingUpdate
   minReadySeconds: 0


### PR DESCRIPTION
* Resolves: #11984 
* Target version: master 

### Summary

Add annotations and labels configuration to the Kubernetes Helm chart `values.yaml` and Deployment/StatefulSet resource templates.
