### PR TITLE
browser: add initial empty function "_stubMessage"

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -232,7 +232,8 @@ class InitializerBase {
 			} // else jsdom
 		}
 
-		const element = document.getElementById("initial-variables");
+		const element = window.L.initial = document.getElementById("initial-variables");
+		window.L.initial._stubMessage = function () {};
 
 		window.host = "";
 		window.serviceRoot = "";

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -659,6 +659,10 @@ app.definitions.Socket = L.Class.extend({
 		textMsg = e.textMsg;
 		imgBytes = e.imgBytes;
 
+		if (window.L.Browser.cypressTest) {
+			window.L.initial._stubMessage(textMsg);
+		}
+
 		this._logSocket('INCOMING', textMsg);
 
 		var command = this.parseServerCmd(textMsg);

--- a/cypress_test/cypress.config.ts
+++ b/cypress_test/cypress.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
 	chromeWebSecurity: false,
 	screenshotOnRunFailure: true,
 	screenshotsFolder: './integration_tests/snapshots/actual',
+	logServerResponse: false,
 	env: {
 		USER_INTERFACE: process.env.USER_INTERFACE,
 		visualRegressionType: 'regression',

--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -183,6 +183,18 @@ function loadDocumentNoIntegration(filePath, isMultiUser) {
 				}
 			});
 		}
+	}).then(function(win) {
+		if (Cypress.config('logServerResponse')) {
+			cy.getFrameWindow()
+				.its('L', {log: false})
+				.then(function(L) {
+					cy.stub(L.initial, '_stubMessage')
+						.log(false)
+						.callsFake(function(e){
+							Cypress.log({name: 'server response =>', message: e});
+						});
+				});
+		}
 	});
 
 	cy.log('<< loadDocumentNoIntegration - end');


### PR DESCRIPTION
The purpose is to create a function to be stubbed by a
third-party application, such as Cypress, to log server responses.

Change-Id: I76781cc6b90954d471dd5777379bcea136d96b42
Signed-off-by: Henry Castro <hcastro@collabora.com>
