### PR TITLE
iconview: added support for contextmenu

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -514,6 +514,10 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	justify-content: stretch;
 }
 
+.modalpopup .ui-treeview {
+	min-height: min-content;
+}
+
 .ui-treeview * {
 	border-radius: initial;
 }

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -513,11 +513,12 @@ L.Control.JSDialog = L.Control.extend({
 				var childButton = parent.querySelector('[id=\'' + instance.clickToCloseId + '\']');
 				if (childButton)
 					parent = childButton;
-			} else if (instance.clickToCloseText && parent) { // treeview entry for context menu
-				var treeNodes = parent.querySelectorAll('span.ui-treeview-cell-text');
-				if (treeNodes && treeNodes.length) {
-					treeNodes = Array.from(treeNodes);
-					parent = treeNodes.find((value) => { return value.innerText == instance.clickToCloseText; });
+			} else if (instance.clickToCloseText && parent) {
+				var matchingElements;
+				if ((matchingElements = parent.querySelectorAll('span.ui-treeview-cell-text')).length) {// treeview entry for context menu
+					parent = Array.from(matchingElements).find((value) => value.innerText === instance.clickToCloseText);
+				} else if ((matchingElements = parent.querySelectorAll('div.ui-iconview-entry > img')).length) {// iconview entry for context menu
+					parent = Array.from(matchingElements).find((img) => img.title === instance.clickToCloseText);
 				}
 			}
 

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -61,6 +61,7 @@ interface JSBuilder {
 	_getGridColumns: (data: WidgetJSON[]) => number;
 	_getGridRows: (data: WidgetJSON[]) => number;
 	_preventDocumentLosingFocusOnClick: (container: Element) => void;
+	_cleanText: (text: string) => string;
 	_expanderHandler: any; // FIXME: use handlers getter instead
 }
 

--- a/browser/src/control/jsdialog/Widget.IconView.ts
+++ b/browser/src/control/jsdialog/Widget.IconView.ts
@@ -124,7 +124,7 @@ function _iconViewEntry(
 	if (!disabled) {
 		const singleClick = parentData.singleclickactivate === true;
 		$(entryContainer).click(function () {
-			$('#' + parentData.id + ' .ui-treeview-entry').removeClass('selected');
+			$('#' + parentData.id + ' .ui-iconview-entry').removeClass('selected');
 			builder.callback('iconview', 'select', parentData, entry.row, builder);
 			if (singleClick) {
 				builder.callback(
@@ -136,9 +136,24 @@ function _iconViewEntry(
 				);
 			}
 		});
+
+		entryContainer.addEventListener('contextmenu', function (e: Event) {
+			$('#' + parentData.id + ' .ui-iconview-entry').removeClass('selected');
+			builder.callback('iconview', 'select', parentData, entry.row, builder);
+			$(entryContainer).addClass('selected');
+			builder.callback(
+				'iconview',
+				'contextmenu',
+				parentData,
+				entry.row,
+				builder,
+			);
+			e.preventDefault();
+		});
+
 		if (!singleClick) {
 			$(entryContainer).dblclick(function () {
-				$('#' + parentData.id + ' .ui-treeview-entry').removeClass('selected');
+				$('#' + parentData.id + ' .ui-iconview-entry').removeClass('selected');
 				builder.callback(
 					'iconview',
 					'activate',

--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -490,7 +490,9 @@ class TreeViewControl {
 			builder.options.cssClass + ' ui-treeview-cell-text',
 			parent,
 		);
-		cell.innerText = entry.columns[index].text || entry.text;
+		cell.innerText =
+			builder._cleanText(entry.columns[index].text) ||
+			builder._cleanText(entry.text);
 	}
 
 	createLinkCell(


### PR DESCRIPTION
* Resolves: #12113

- adds right-click context menu support for icon view entries
- modifies css to adjust height for context menu
- used `_cleanText` utility to sanitize text

core side changes: https://gerrit.libreoffice.org/c/core/+/185516

Change-Id: I68c73a7664e2e2bbbf5c7fd6250e0af077d0c357

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

