### PR TITLE
from capability query don't log a WRN if convert-to is not available

### DIFF
--- a/wsd/ClientRequestDispatcher.hpp
+++ b/wsd/ClientRequestDispatcher.hpp
@@ -61,7 +61,8 @@ private:
     /// Does this address feature in the allowed hosts list.
     static bool allowPostFrom(const std::string& address);
 
-    static bool allowConvertTo(const std::string& address, const Poco::Net::HTTPRequest& request, AsyncFn asyncCb);
+    static bool allowConvertTo(const std::string& address, const Poco::Net::HTTPRequest& request,
+                               bool capabilityQuery, AsyncFn asyncCb);
 
     /// @return true if request has been handled synchronously and response sent, otherwise false
     bool handleRootRequest(const RequestDetails& requestDetails,


### PR DESCRIPTION
Continue to do that if convert-to is used and it was denied, but don't do that when we self-query if convert-to is allowed in order to fill out if convert-to is available in capabilities


Change-Id: I17afe6a733a59ba7d3480362d116f1f54956cfa3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

