### PR TITLE
don't trim memory in parent while bgsave child exists

### DIFF
--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -435,6 +435,9 @@ public:
     /// Permanently disable background save for this process
     void disableBgSave(const std::string &reason);
 
+    void bgSaveStarted() { _bgSavesOngoing++; }
+    void bgSaveEnded() { _bgSavesOngoing--; }
+
     /// Are we currently performing a load ?
     bool isLoadOngoing() const { return _duringLoad > 0; }
 
@@ -512,6 +515,7 @@ private:
 
     const unsigned _mobileAppDocId;
     int _duringLoad;
+    int _bgSavesOngoing;
 
     LogUiCmd logUiCmd;
 };

--- a/kit/KitWebSocket.hpp
+++ b/kit/KitWebSocket.hpp
@@ -99,11 +99,12 @@ public:
         , _document(std::move(document))
         , _session(session)
     {
+        _document->bgSaveStarted();
     }
 
     ~BgSaveParentWebSocketHandler()
     {
-        // Just to make it easier to set a breakpoint
+        _document->bgSaveEnded();
     }
 
 protected:


### PR DESCRIPTION
Change-Id: Ia97b9e762e3e28e0ff82b91c19dcf946e753a361


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

