### PR TITLE
trim more aggressively when all sessions declared they are inactive

### DIFF
--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -436,7 +436,7 @@ public:
     void disableBgSave(const std::string &reason);
 
     void bgSaveStarted() { _bgSavesOngoing++; }
-    void bgSaveEnded() { _bgSavesOngoing--; }
+    void bgSaveEnded();
 
     /// Are we currently performing a load ?
     bool isLoadOngoing() const { return _duringLoad > 0; }
@@ -481,6 +481,7 @@ private:
     ModifiedState _modified;
     bool _isBgSaveProcess;
     bool _isBgSaveDisabled;
+    bool _trimIfInactivePostponed;
 
     // Document password provided
     std::string _docPassword;


### PR DESCRIPTION
which will pick up a missed deep trim opportunity if a bg save was still ongoing at the time of declaration of the last active session of entering inactivity


Change-Id: I21ed783f4250cadd1f5c7720b7a32fc745345186


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

