### PR TITLE
gh#11840 Support RTL centering, minor cleanup

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -973,8 +973,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	display: none;
 }
 
-/* Draw SVG downwards arrow.
-The same as .unoarrow to replace the old .png bitmap arrow*/
+/* Draw vector border as downwards arrow. */
 .ui-listbox-arrow {
 	width: auto !important;
 	height: 0px;
@@ -988,10 +987,6 @@ The same as .unoarrow to replace the old .png bitmap arrow*/
 	margin-top: 4px;
 	cursor: pointer;
 	pointer-events: none;
-}
-
-[data-theme='dark'] .ui-listbox-arrow {
-	border-top-color: var(--color-text-dark);
 }
 
 .ui-listbox[disabled='disabled'] ~ .ui-listbox-arrow,

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1478,7 +1478,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	border: 4px solid transparent;
 	border-top: 5px solid var(--color-main-text);
 	display: inline-block !important;
-	margin-left: 3px;
+	margin-inline-start: 3px;
 	margin-top: 4px;
 }
 

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -989,6 +989,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	pointer-events: none;
 }
 
+:dir(rtl) .ui-listbox-arrow {
+	margin-inline-start: 4px;
+	margin-inline-end: -16px;
+}
 .ui-listbox[disabled='disabled'] ~ .ui-listbox-arrow,
 .ui-combobox[disabled='disabled'] ~ .ui-listbox-arrow {
 	opacity: 0.5;
@@ -1020,7 +1024,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	border-left: 1px solid var(--color-border);
+	border-inline-start: 1px solid var(--color-border);
 	background-color: transparent;
 	padding-left: 20px;
 }


### PR DESCRIPTION
https://github.com/CollaboraOnline/online/issues/11840


### Summary
- Updated `.ui-listbox-arrow` comment for clarity.
- Removed the redundant dark mode color scheme for `.ui-listbox-arrow` class.
- Check for RTL direction and update `margin-inline-start` and `margin-inline-end` using `:dir(rtl)` under `.ui-listbox-arrow` for proper centering based on text direction.
- Use `border-inline-start` logical CSS  property instead of `border-left` in `.ui-combobox-button` to automatically detect text direction and the border properly.

#### Before RTL compatibility changes:
![image](https://github.com/user-attachments/assets/3fd5594b-dbb4-4f3d-87a0-b31d7cf088d3)
The arrow's position is completely off, but the button itself is still functional. This is because the button's margins are statically given, and text direction is not checked for to account for this.
![image](https://github.com/user-attachments/assets/d9273ceb-c79d-42a4-bd47-f3d85b0dd56d)
Also, the small border separating the grey button area (left side in picture above) from the text next to it (right side) is in the wrong position, because we are drawing it using `border-left`.
#### After RTL compatibility changes:
![image](https://github.com/user-attachments/assets/449a892e-7a0d-4062-9523-2c889e96faaa)
Using `:dir(rtl)` under `.ui-listbox-arrow` and reversing the `margin-inline-start` and `margin-inline-end` fixes the placement issue for RTL text, and keeps the original margins for LTR text. 
For `.ui-combobox-button`, we simply need to modify the border position line from `border-left:` to `border-inline-start:`, which will create the border's position based on text direction.
Since `.ui-listbox-arrow` already used `inline` for it's margin positions, simply adding the pseudo-class and updating the logic fixes the positioning issue.

Also, there was a similar issue for `.unoarrow` and `.arrowbackground`:
![image](https://github.com/user-attachments/assets/05a5a2fd-3c80-4c1a-b356-9a53f9d60405)
By replacing `margin-left` and with `margin-inline-start`, we fix this issue.
![image](https://github.com/user-attachments/assets/d7891b78-8b3b-437d-96b1-30be978310c1)



### TODO

- [x] Look into RTL centering issue for `.unoarrow` and `.arrowbackground`.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

