### PR TITLE
convert-to: allow infilter options for convert to

### DIFF
--- a/common/Session.cpp
+++ b/common/Session.cpp
@@ -249,6 +249,11 @@ void Session::parseDocOptions(const StringVector& tokens, int& part, std::string
             _disableVerifyHost = value == "false";
             ++offset;
         }
+        else if (name == "infilterOptions")
+        {
+            _inFilterOptions = std::move(value);
+            ++offset;
+        }
     }
 
     Anonymizer::mapAnonymized(_userId, _userIdAnonym);

--- a/common/Session.hpp
+++ b/common/Session.hpp
@@ -306,6 +306,8 @@ public:
 
     const std::string& getDocTemplate() const { return _docTemplate; }
 
+    const std::string& getInFilterOption() const { return _inFilterOptions; }
+
 protected:
     Session(const std::shared_ptr<ProtocolHandlerInterface> &handler,
             const std::string& name, const std::string& id, bool readonly);
@@ -450,6 +452,9 @@ private:
     /// Specifies whether certification verification for the wopi server
     /// should be disabled in core
     bool _disableVerifyHost;
+
+    /// Used in convert-to apis to specify loading options
+    std::string _inFilterOptions;
 
 };
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1930,13 +1930,18 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
     const std::string& userTimezone = session->getTimezone();
     const std::string& userPrivateInfo = session->getUserPrivateInfo();
     const std::string& docTemplate = session->getDocTemplate();
+    const std::string& filterOption = session->getInFilterOption();
 
     if constexpr (!Util::isMobileApp())
         consistencyCheckFileExists(uri);
 
     std::string options;
+
+    if (!filterOption.empty())
+        options = filterOption;
+
     if (!lang.empty())
-        options = "Language=" + lang;
+        options += ",Language=" + lang;
 
     if (!deviceFormFactor.empty())
         options += ",DeviceFormFactor=" + deviceFormFactor;

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1914,6 +1914,11 @@ bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
                 options += ",PDFVer=" + pdfVer + "PDFVEREND";
             }
 
+            if (form.has("infilterOptions"))
+            {
+                options += ",infilterOptions=" + form.get("infilterOptions");
+            }
+
             std::string lang = (form.has("lang") ? form.get("lang") : std::string());
             std::string target = (form.has("target") ? form.get("target") : std::string());
             std::string filter = (form.has("filter") ? form.get("filter") : std::string());

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1679,6 +1679,12 @@ bool ClientSession::loadDocument(const char* /*buffer*/, int /*length*/,
         {
             oss << " batch=" << getBatchMode();
         }
+
+        if (!getInFilterOption().empty())
+        {
+            oss << " infilterOptions=" << getInFilterOption();
+        }
+
 #if ENABLE_FEATURE_LOCK
         sendLockedInfo();
 #endif

--- a/wsd/SpecialBrokers.cpp
+++ b/wsd/SpecialBrokers.cpp
@@ -132,6 +132,8 @@ void ConvertToBroker::sendStartMessage(const std::shared_ptr<ClientSession>& cli
     std::string load = "load url=" + encodedFrom + " batch=true";
     if (!getLang().empty())
         load += " lang=" + getLang();
+    if(!_sOptions.empty() && _sOptions.starts_with(",infilterOptions="))
+        load +=  " " + _sOptions.substr(1);
     std::vector<char> loadRequest(load.begin(), load.end());
     clientSession->handleMessage(loadRequest);
 }


### PR DESCRIPTION
i.e:
if using core convert to option to convert csv to ods soffice --headless --convert-to ods:"calc8" --infilter="Text - txt - csv (StarCalc):44,34,UTF8" a.csv

equivalent of that in online would be:
curl -k -F "data=@a.csv" -F "format=ods" -F "infilterOptions=44,34,UTF8" http://localhost:9980/cool/convert-to --output result.ods

fixes #11440

reference to use options: https://wiki.openoffice.org/wiki/Documentation/DevGuide/Spreadsheets/Filter_Options#Filter_Options_for_the_CSV_Filter


Change-Id: Id44018802d7e6a598e39f24e2959e19a51ded427


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

