### PR TITLE
Add roles and aria-label for missing div elements for better screen reader

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -228,11 +228,15 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.nodeModify = L.DomUtil.create('div', 'cool-annotation-edit' + ' modify-annotation', this.sectionProperties.wrapper);
 		this.sectionProperties.nodeModifyText = L.DomUtil.create('div', 'cool-annotation-textarea', this.sectionProperties.nodeModify);
 		this.sectionProperties.nodeModifyText.setAttribute('contenteditable', 'true');
+		this.sectionProperties.nodeModifyText.setAttribute('role', 'textbox');
+		this.sectionProperties.nodeModifyText.setAttribute('aria-label', _('Edit comment'));
 		this.sectionProperties.nodeModifyText.id = 'annotation-modify-textarea-' + this.sectionProperties.data.id;
 		this.sectionProperties.contentText = L.DomUtil.create('div', '', this.sectionProperties.contentNode);
 		this.sectionProperties.nodeReply = L.DomUtil.create('div', 'cool-annotation-edit' + ' reply-annotation', this.sectionProperties.wrapper);
 		this.sectionProperties.nodeReplyText = L.DomUtil.create('div', 'cool-annotation-textarea', this.sectionProperties.nodeReply);
 		this.sectionProperties.nodeReplyText.setAttribute('contenteditable', 'true');
+		this.sectionProperties.nodeReplyText.setAttribute('role', 'textbox');
+		this.sectionProperties.nodeReplyText.setAttribute('aria-label', _('Reply comment'));
 		this.sectionProperties.nodeReplyText.id = 'annotation-reply-textarea-' + this.sectionProperties.data.id;
 		this.createChildLinesNode();
 

--- a/browser/src/canvas/sections/URLPopUpSection.ts
+++ b/browser/src/canvas/sections/URLPopUpSection.ts
@@ -66,6 +66,8 @@ class URLPopUpSection extends HTMLObjectSection {
 		const copyBtn = L.DomUtil.createWithId('div', this.copyButtonId, parent);
 		L.DomUtil.addClass(copyBtn, 'hyperlink-popup-btn');
 		copyBtn.setAttribute('title', copyLinkText);
+		copyBtn.setAttribute('role', 'button');
+		copyBtn.setAttribute('aria-label', copyLinkText);
 
         const imgCopyBtn = L.DomUtil.create('img', 'hyperlink-pop-up-copyimg', copyBtn);
 		app.LOUtil.setImage(imgCopyBtn, 'lc_copyhyperlinklocation.svg', app.map);
@@ -78,6 +80,9 @@ class URLPopUpSection extends HTMLObjectSection {
 		const editBtn = L.DomUtil.createWithId('div', this.editButtonId, parent);
 		L.DomUtil.addClass(editBtn, 'hyperlink-popup-btn');
 		editBtn.setAttribute('title', editLinkText);
+		editBtn.setAttribute('role', 'button');
+		editBtn.setAttribute('aria-label', copyLinkText);
+
 
 		const imgEditBtn = L.DomUtil.create('img', 'hyperlink-pop-up-editimg', editBtn);
 		app.LOUtil.setImage(imgEditBtn, 'lc_edithyperlink.svg', app.map);
@@ -90,6 +95,8 @@ class URLPopUpSection extends HTMLObjectSection {
 		const removeBtn = L.DomUtil.createWithId('div', this.removeButtonId, parent);
 		L.DomUtil.addClass(removeBtn, 'hyperlink-popup-btn');
 		removeBtn.setAttribute('title', removeLinkText);
+		removeBtn.setAttribute('role', 'button');
+		removeBtn.setAttribute('aria-label', removeLinkText);
 
 		const imgRemoveBtn = L.DomUtil.create('img', 'hyperlink-pop-up-removeimg', removeBtn);
 		app.LOUtil.setImage(imgRemoveBtn, 'lc_removehyperlink.svg', app.map);

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1698,6 +1698,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		var listbox = L.DomUtil.create('select', builder.options.cssClass + ' ui-listbox ', container);
 		listbox.id = data.id + '-input';
+		if (data.labelledBy)
+			listbox.setAttribute('aria-labelledby', data.labelledBy);
 		var listboxArrow = L.DomUtil.create('span', builder.options.cssClass + ' ui-listbox-arrow', container);
 		listboxArrow.id = 'listbox-arrow-' + data.id;
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -573,6 +573,7 @@ L.Map.include({
 		}
 		var searchInput = document.getElementById('online-help-search-input');
 		searchInput.setAttribute('placeholder',_('Search'));
+		searchInput.setAttribute('aria-label',_('Search'));
 		searchInput.focus(); // auto focus on user input field
 		var helpContentParent = document.getElementsByClassName('ui-dialog-content')[0];
 		var startFilter = false;

--- a/browser/src/control/jsdialog/Widget.ColorPicker.ts
+++ b/browser/src/control/jsdialog/Widget.ColorPicker.ts
@@ -393,7 +393,7 @@ JSDialog.colorPicker = function (
 
 	const recentLabel = L.DomUtil.create('label', '', container);
 	recentLabel.innerText = _('Recent');
-	recentLabel.for = 'ui-color-picker-recent';
+	recentLabel.htmlFor = 'ui-color-picker-recent';
 
 	const recentContainer = L.DomUtil.createWithId(
 		'div',

--- a/browser/src/control/jsdialog/Widget.Edit.ts
+++ b/browser/src/control/jsdialog/Widget.Edit.ts
@@ -89,8 +89,10 @@ class EditWidget {
 
 		if (data.hidden) $(edit).hide();
 
-		if (data.placeholder) $(edit).attr('placeholder', data.placeholder);
-
+		if (data.placeholder) {
+			edit.setAttribute('placeholder', data.placeholder);
+			edit.setAttribute('aria-label', data.placeholder);
+		}
 		return result;
 	}
 


### PR DESCRIPTION

- in few places, added roles and aria-labels to div elements that were missing them
- this will help screen readers to better understand the purpose of these elements


Change-Id: I7a16ae03e73e2cce076e6d5bc84f660a39938211


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

