### PR TITLE
impress: document position reset on scroll or thumbnail click in readonly

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -415,6 +415,7 @@ L.Control.PartsPreview = L.Control.extend({
 		var partHeightPixels = Math.round((this._map._docLayer._partHeightTwips + this._map._docLayer._spaceBetweenParts) * app.twipsToPixels);
 		var scrollTop = partHeightPixels * partNumber;
 		var viewHeight = app.sectionContainer.getViewSize()[1];
+		var currentScrollX = (app.sectionContainer.getSectionWithName(L.CSections.Scroll.name).containerObject.getDocumentTopLeft()[0] / app.dpiScale);
 
 		if (viewHeight > partHeightPixels && partNumber > 0)
 			scrollTop -= Math.round((viewHeight - partHeightPixels) * 0.5);
@@ -423,7 +424,7 @@ L.Control.PartsPreview = L.Control.extend({
 		if (fromBottom)
 			scrollTop += partHeightPixels - viewHeight;
 		scrollTop = Math.round(scrollTop / app.dpiScale);
-		app.sectionContainer.getSectionWithName(L.CSections.Scroll.name).onScrollTo({x: 0, y: scrollTop});
+		app.sectionContainer.getSectionWithName(L.CSections.Scroll.name).onScrollTo({x: currentScrollX, y: scrollTop});
 	},
 
 	_scrollViewByDirection: function(buttonType) {
@@ -436,6 +437,8 @@ L.Control.PartsPreview = L.Control.extend({
 		var viewHeightScaled = Math.round(Math.floor(viewHeight) / app.dpiScale);
 		var scrollBySize = Math.floor(viewHeightScaled * 0.75);
 		var topPx = (app.sectionContainer.getSectionWithName(L.CSections.Scroll.name).containerObject.getDocumentTopLeft()[1] / app.dpiScale);
+		var currentScrollX = app.sectionContainer.getSectionWithName(L.CSections.Scroll.name).containerObject.getDocumentTopLeft()[0] / app.dpiScale;
+
 		if (buttonType === 'prev') {
 			if (this._map.getCurrentPartNumber() == 0) {
 				if (topPx - scrollBySize <= 0) {
@@ -453,7 +456,7 @@ L.Control.PartsPreview = L.Control.extend({
 				}
 			}
 		}
-		app.sectionContainer.getSectionWithName(L.CSections.Scroll.name).onScrollBy({x: 0, y: buttonType === 'prev' ? -scrollBySize : scrollBySize});
+		app.sectionContainer.getSectionWithName(L.CSections.Scroll.name).onScrollBy({x: currentScrollX, y: buttonType === 'prev' ? -scrollBySize : scrollBySize});
 	},
 
 	_setPart: function (e) {


### PR DESCRIPTION
Change-Id: I347beade8642dc5e280f9002d20d219e4feab097


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- In the document viewer, prior to this change, vertical scrolling whether to a specific part of the document or by clicking on a thumbnail caused the horizontal position to reset to 0 and pushing the previews to the left

- To fix the above, we now use the current scroll value on X and not default to 0

### BEFORE
[Screencast from 23-05-25 14:32:54.webm](https://github.com/user-attachments/assets/3d563a5c-11c8-47da-9eb7-f091353454ac)


### WITH THIS PR
[Screencast from 23-05-25 14:23:53.webm](https://github.com/user-attachments/assets/16dd91df-02ba-4659-bbf0-3c316329214e)
- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required


