### PR TITLE
Mobile: Change checkbox inner input states

### DIFF
--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -865,7 +865,7 @@ div#mobile-wizard-content .spinfieldcontainer .spinfieldimage.disabled {
 	outline: none;
 	box-shadow: 0px 0px 2px 1px var(--color-box-shadow);
 }
-#mobile-wizard input[type='checkbox']:checked {
+#mobile-wizard input[type='checkbox']:checked:not(:disabled) {
 	background: url('images/lc_ok_white.svg') no-repeat center;
 	background-color: var(--color-primary-lighter);
 	border-radius: var(--border-radius);

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2637,6 +2637,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			return;
 		}
 
+		// eg. in mobile wizard input is inside spin button div
+		var innerInput = control.querySelector('input');
+
 		switch (data.action_type) {
 		case 'grab_focus':
 			control.focus();
@@ -2667,11 +2670,19 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		case 'enable':
 			control.disabled = false;
 			control.removeAttribute('disabled');
+			if (innerInput) {
+				innerInput.disabled = false;
+				innerInput.removeAttribute('disabled');
+			}
 			break;
 
 		case 'disable':
-			control.setAttribute('disabled', 'true');
 			control.disabled = true;
+			control.setAttribute('disabled', 'true');
+			if (innerInput) {
+				innerInput.disabled = true;
+				innerInput.setAttribute('disabled');
+			}
 			break;
 
 		case 'setText':
@@ -2680,8 +2691,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				break;
 			}
 
-			// eg. in mobile wizard input is inside spin button div
-			var innerInput = control.querySelector('input');
 			if (innerInput)
 				control = innerInput;
 


### PR DESCRIPTION
Take Text import panel (when opening an CSV file), the parent div
changes disabled attribute but the inner input elements don't which
makes it for bogus status (parent enabled, input child disabled or
vice versa).

Also, make sure we don't wrongly style checkboxes as enabled when they
are disabled.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I3d8d25039baabe97cd723b322cb9895f4dd5502d


## Before 

https://github.com/user-attachments/assets/bbd9773d-db1a-4cd5-8cc8-bedc9d531bbc


## After

https://github.com/user-attachments/assets/862dbd2f-7a89-4c1e-baf5-5ebc613a038d



