### PR TITLE
killpoco: replace Poco::format

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1207,12 +1207,13 @@ bool ChildSession::getCommandValues(const StringVector& tokens)
     if (command == ".uno:DocumentRepair")
     {
         char* undo;
-        const std::string jsonTemplate("{\"commandName\":\".uno:DocumentRepair\",\"Redo\":%s,\"Undo\":%s}");
         values = getLOKitDocument()->getCommandValues(".uno:Redo");
         undo = getLOKitDocument()->getCommandValues(".uno:Undo");
-        std::string json = Poco::format(jsonTemplate,
-                                        std::string(values == nullptr ? "" : values),
-                                        std::string(undo == nullptr ? "" : undo));
+        std::ostringstream jsonTemplate;
+        jsonTemplate << "{\"commandName\":\".uno:DocumentRepair\",\"Redo\":"
+                     << (values == nullptr ? "" : values)
+                     << ",\"Undo\":" << (undo == nullptr ? "" : undo) << "}";
+        std::string json = jsonTemplate.str();
         // json only contains view IDs, insert matching user names.
         std::map<int, UserInfo> viewInfo = _docManager->getViewInfo();
         insertUserNames(viewInfo, json);

--- a/test/TileCacheTests.cpp
+++ b/test/TileCacheTests.cpp
@@ -1280,8 +1280,9 @@ void TileCacheTests::checkTiles(std::shared_ptr<http::WebSocketSession>& socket,
         if (currentPart != it)
         {
             // change part
-            const std::string text = Poco::format("setclientpart part=%d", it);
-            sendTextFrame(socket, text, testname);
+            std::ostringstream oss;
+            oss << "setclientpart part=" << it;
+            sendTextFrame(socket, oss.str(), testname);
             // Wait for the change to take effect otherwise we get invalidatetile
             // which removes our next tile request subscription (expecting us to
             // issue a new tile request as a response, which a real client would do).
@@ -1344,10 +1345,11 @@ void TileCacheTests::requestTiles(std::shared_ptr<http::WebSocketSession>& socke
             tileHeight = tileSize;
             tileX = tileSize * itCol;
             tileY = tileSize * itRow;
-            text
-                = Poco::format("tile nviewid=0 part=%d width=%d height=%d tileposx=%d tileposy=%d "
-                               "tilewidth=%d tileheight=%d",
-                               part, pixTileSize, pixTileSize, tileX, tileY, tileWidth, tileHeight);
+            std::ostringstream oss;
+            oss << "tile nviewid=0 part=" << part << " width=" << pixTileSize
+                << " height=" << pixTileSize << " tileposx=" << tileX << " tileposy=" << tileY
+                << " tilewidth=" << tileWidth << " tileheight=" << tileHeight;
+            text = oss.str();
 
             sendTextFrame(socket, text, testname);
             tile = assertResponseString(socket, "tile:", testname);

--- a/test/UnitCursor.cpp
+++ b/test/UnitCursor.cpp
@@ -12,6 +12,7 @@
 #include <config.h>
 
 #include <memory>
+#include <sstream>
 #include <string>
 
 #include <Poco/Exception.h>
@@ -86,13 +87,11 @@ void limitCursor(
     // Send an arrow key to initialize the CellCursor, otherwise we get "EMPTY".
     helpers::sendTextFrame(socket, "key type=input char=0 key=1027", testname);
 
-    std::string text;
-    Poco::format(text,
-                 "commandvalues "
-                 "command=.uno:CellCursor?outputHeight=%d&outputWidth=%d&tileHeight=%d&tileWidth=%"
-                 "d",
-                 256, 256, 3840, 3840);
-    helpers::sendTextFrame(socket, text, testname);
+    std::ostringstream text;
+    text << "commandvalues "
+         << "command=.uno:CellCursor?outputHeight=" << 256 << "&outputWidth=" << 256
+         << "&tileHeight=" << 3840 << "&tileWidth=" << 3840;
+    helpers::sendTextFrame(socket, text.str(), testname);
     const auto cursor = helpers::getResponseString(socket, "commandvalues:", testname);
     getCursor(cursor.substr(14), cursorX, cursorY, cursorWidth, cursorHeight, testname);
 

--- a/test/UnitEachView.cpp
+++ b/test/UnitEachView.cpp
@@ -26,9 +26,6 @@ namespace
 void testEachView(const std::string& doc, const std::string& type, const std::string& protocol,
                   const std::string& protocolView, const std::string& testname)
 {
-    const std::string view = testname + "view %d -> ";
-    const std::string error = testname + "view %d, did not receive a %s message as expected";
-
     TST_LOG("testEachView for " << testname);
 
     std::shared_ptr<SocketPoll> socketPoll = std::make_shared<SocketPoll>("UnitEachView");
@@ -42,6 +39,7 @@ void testEachView(const std::string& doc, const std::string& type, const std::st
 
         TST_LOG("Loading " << documentURL);
         int itView = 0;
+        const std::string view = testname + "view %d -> ";
         std::shared_ptr<http::WebSocketSession> socket =
             helpers::loadDocAndGetSession(socketPoll, Poco::URI(helpers::getTestServerURI()),
                                           documentURL, Poco::format(view, itView));
@@ -71,6 +69,8 @@ void testEachView(const std::string& doc, const std::string& type, const std::st
         // Double of the default.
         constexpr std::chrono::milliseconds timeoutMs{ 20000 };
         response = helpers::getResponseString(socket, protocol, Poco::format(view, itView), timeoutMs);
+
+        const std::string error = testname + "view %d, did not receive a %s message as expected";
         LOK_ASSERT_MESSAGE(Poco::format(error, itView, protocol), !response.empty());
 
         // Connect and load 0..N Views, where N<=limit

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -397,7 +397,10 @@ void COOLWSD::checkSessionLimitsAndWarnClients()
     if (COOLWSD::MaxDocuments < 10000 &&
         (docBrokerCount > static_cast<ssize_t>(COOLWSD::MaxDocuments) || COOLWSD::NumConnections >= COOLWSD::MaxConnections))
     {
-        const std::string info = Poco::format(PAYLOAD_INFO_LIMIT_REACHED, COOLWSD::MaxDocuments, COOLWSD::MaxConnections);
+        std::ostringstream oss;
+        oss << "info: cmd=socket kind=limitreached params=" << COOLWSD::MaxDocuments << ","
+            << COOLWSD::MaxConnections;
+        const std::string info = oss.str();
         LOG_INF("Sending client 'limitreached' message: " << info);
 
         try

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -86,8 +86,10 @@ inline void shutdownLimitReached(const std::shared_ptr<ProtocolHandlerInterface>
     if (!proto)
         return;
 
-    const std::string error = Poco::format(PAYLOAD_UNAVAILABLE_LIMIT_REACHED, COOLWSD::MaxDocuments,
-                                           COOLWSD::MaxConnections);
+    std::ostringstream oss;
+    oss << "error: cmd=socket kind=hardlimitreached params=" << COOLWSD::MaxDocuments << ","
+        << COOLWSD::MaxConnections;
+    const std::string error = oss.str();
     LOG_INF("Sending client 'hardlimitreached' message: " << error);
 
     try
@@ -180,9 +182,10 @@ findOrCreateDocBroker(DocumentBroker::ChildType type, const std::string& uri,
                     << "] for docKey [" << docKey << ']');
             if constexpr (ConfigUtil::isSupportKeyEnabled())
             {
-                const std::string error = Poco::format(PAYLOAD_UNAVAILABLE_LIMIT_REACHED,
-                                                       COOLWSD::MaxDocuments, COOLWSD::MaxConnections);
-                return std::make_pair(nullptr, error);
+                std::ostringstream oss;
+                oss << "error: cmd=socket kind=hardlimitreached params=" << COOLWSD::MaxDocuments
+                    << "," << COOLWSD::MaxConnections;
+                return std::make_pair(nullptr, oss.str());
             }
         }
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -2490,9 +2490,10 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
                              adminFile); // Now template has the main content..
     }
 
-    static const std::string scriptJS("<script src=\"%s/browser/" COOLWSD_VERSION_HASH
-                                      "/%s.js\"></script>");
-    std::string brandJS(Poco::format(scriptJS, responseRoot, std::string(BRANDING)));
+    std::ostringstream ossBrandJS;
+    ossBrandJS << "<script src=\"" << responseRoot << "/browser/" COOLWSD_VERSION_HASH "/"
+               << BRANDING << ".js\"></script>";
+    std::string brandJS = ossBrandJS.str();
     std::string brandFooter;
 
     if constexpr (ConfigUtil::isSupportKeyEnabled())
@@ -2503,11 +2504,18 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
 
         if (!key.verify() || key.validDaysRemaining() <= 0)
         {
-            static const std::string footerPage(
-                "<footer class=\"footer has-text-centered\"><strong>Key:</strong> %s "
-                "&nbsp;&nbsp;<strong>Expiry Date:</strong> %s</footer>");
-            brandJS = Poco::format(scriptJS, std::string(SUPPORT_KEY_BRANDING_UNSUPPORTED));
-            brandFooter = Poco::format(footerPage, key.data(), Poco::DateTimeFormatter::format(key.expiry(), Poco::DateTimeFormat::RFC822_FORMAT));
+            std::ostringstream oss;
+            oss << "<script src=\"" << SUPPORT_KEY_BRANDING_UNSUPPORTED
+                << "/browser/" COOLWSD_VERSION_HASH ".js\"></script>";
+            brandJS = oss.str();
+
+            std::ostringstream ossBrandFooter;
+            ossBrandFooter << "<footer class=\"footer has-text-centered\"><strong>Key:</strong> "
+                           << key.data() << " &nbsp;&nbsp;<strong>Expiry Date:</strong> "
+                           << Poco::DateTimeFormatter::format(key.expiry(),
+                                                              Poco::DateTimeFormat::RFC822_FORMAT)
+                           << "</footer>";
+            brandFooter = ossBrandFooter.str();
         }
     }
 
@@ -2564,31 +2572,34 @@ void FileServerRequestHandler::updateThemeResources(std::string& fileContent,
         SupportKey key(keyString);
         if (!key.verify() || key.validDaysRemaining() <= 0)
         {
-            const std::string linkCSS = "<link rel=\"stylesheet\" href=\"" + responseRoot +
-                                        "/browser/" + COOLWSD_VERSION_HASH + "/" + themePrefix +
-                                        "%s.css\">";
-            const std::string themeScriptJS = "<script src=\"" + responseRoot + "/browser/" +
-                                              COOLWSD_VERSION_HASH + "/" + themePrefix +
-                                              "%s.js\"></script>";
-            brandCSS = Poco::format(linkCSS, std::string(SUPPORT_KEY_BRANDING_UNSUPPORTED));
-            brandJS = Poco::format(themeScriptJS, std::string(SUPPORT_KEY_BRANDING_UNSUPPORTED));
+            std::ostringstream ossBrandCSS;
+            ossBrandCSS << "<link rel=\"stylesheet\" href=\"" << responseRoot << "/browser/"
+                        << COOLWSD_VERSION_HASH << "/" << themePrefix
+                        << SUPPORT_KEY_BRANDING_UNSUPPORTED << ".css\">";
+            brandCSS = ossBrandCSS.str();
+
+            std::ostringstream ossBrandJS;
+            ossBrandJS << "<script src=\"" << responseRoot << "/browser/" << COOLWSD_VERSION_HASH
+                       << "/" << themePrefix << SUPPORT_KEY_BRANDING_UNSUPPORTED
+                       << ".js\"></script>";
+            brandJS = ossBrandJS.str();
         }
     }
 
     if (brandCSS.empty())
     {
-        const std::string linkCSS = "<link rel=\"stylesheet\" href=\"" + responseRoot +
-                                    "/browser/" + COOLWSD_VERSION_HASH + "/" + themePrefix +
-                                    "%s.css\">";
-        brandCSS = Poco::format(linkCSS, std::string(BRANDING));
+        std::ostringstream ossBrandCSS;
+        ossBrandCSS << "<link rel=\"stylesheet\" href=\"" << responseRoot << "/browser/"
+                    << COOLWSD_VERSION_HASH << "/" << themePrefix << BRANDING << ".css\">";
+        brandCSS = ossBrandCSS.str();
     }
 
     if (brandJS.empty())
     {
-        const std::string themeScriptJS = "<script src=\"" + responseRoot + "/browser/" +
-                                          COOLWSD_VERSION_HASH + "/" + themePrefix +
-                                          "%s.js\"></script>";
-        brandJS = Poco::format(themeScriptJS, std::string(BRANDING));
+        std::ostringstream ossBrandJS;
+        ossBrandJS << "<script src=\"" << responseRoot << "/browser/" << COOLWSD_VERSION_HASH << "/"
+                   << themePrefix << BRANDING << ".js\"></script>";
+        brandJS = ossBrandJS.str();
     }
 
     Poco::replaceInPlace(fileContent, std::string("<!--%BRANDING_CSS%-->"), brandCSS);

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -2463,9 +2463,6 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
     const ServerURL cnxDetails(requestDetails);
     const std::string responseRoot = cnxDetails.getResponseRoot();
 
-    static const std::string scriptJS("<script src=\"%s/browser/" COOLWSD_VERSION_HASH "/%s.js\"></script>");
-    static const std::string footerPage("<footer class=\"footer has-text-centered\"><strong>Key:</strong> %s &nbsp;&nbsp;<strong>Expiry Date:</strong> %s</footer>");
-
     const std::string relPath = getRequestPathname(request, requestDetails);
     LOG_DBG("Preprocessing file: " << relPath);
     std::string adminFile = *getUncompressedFile(relPath);
@@ -2493,6 +2490,8 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
                              adminFile); // Now template has the main content..
     }
 
+    static const std::string scriptJS("<script src=\"%s/browser/" COOLWSD_VERSION_HASH
+                                      "/%s.js\"></script>");
     std::string brandJS(Poco::format(scriptJS, responseRoot, std::string(BRANDING)));
     std::string brandFooter;
 
@@ -2504,6 +2503,9 @@ void FileServerRequestHandler::preprocessAdminFile(const HTTPRequest& request,
 
         if (!key.verify() || key.validDaysRemaining() <= 0)
         {
+            static const std::string footerPage(
+                "<footer class=\"footer has-text-centered\"><strong>Key:</strong> %s "
+                "&nbsp;&nbsp;<strong>Expiry Date:</strong> %s</footer>");
             brandJS = Poco::format(scriptJS, std::string(SUPPORT_KEY_BRANDING_UNSUPPORTED));
             brandFooter = Poco::format(footerPage, key.data(), Poco::DateTimeFormatter::format(key.expiry(), Poco::DateTimeFormat::RFC822_FORMAT));
         }
@@ -2550,15 +2552,11 @@ void FileServerRequestHandler::updateThemeResources(std::string& fileContent,
         !safeThemeStr.empty() &&
         FileUtil::Stat(COOLWSD::FileServerRoot + "/browser/dist/" + safeThemeStr).exists();
 
-    const std::string themePrefix =  hasIntegrationTheme && useIntegrationTheme ? safeThemeStr + "/" : "";
-    const std::string linkCSS = "<link rel=\"stylesheet\" href=\"" + responseRoot + "/browser/" +
-                                COOLWSD_VERSION_HASH + "/" + themePrefix + "%s.css\">";
-    const std::string themeScriptJS = "<script src=\"" + responseRoot + "/browser/" +
-                                      COOLWSD_VERSION_HASH + "/" + themePrefix +
-                                      "%s.js\"></script>";
+    const std::string themePrefix =
+        hasIntegrationTheme && useIntegrationTheme ? safeThemeStr + "/" : "";
 
-    std::string brandCSS = Poco::format(linkCSS, std::string(BRANDING));
-    std::string brandJS = Poco::format(themeScriptJS, std::string(BRANDING));
+    std::string brandCSS;
+    std::string brandJS;
 
     if constexpr (ConfigUtil::isSupportKeyEnabled())
     {
@@ -2566,9 +2564,31 @@ void FileServerRequestHandler::updateThemeResources(std::string& fileContent,
         SupportKey key(keyString);
         if (!key.verify() || key.validDaysRemaining() <= 0)
         {
+            const std::string linkCSS = "<link rel=\"stylesheet\" href=\"" + responseRoot +
+                                        "/browser/" + COOLWSD_VERSION_HASH + "/" + themePrefix +
+                                        "%s.css\">";
+            const std::string themeScriptJS = "<script src=\"" + responseRoot + "/browser/" +
+                                              COOLWSD_VERSION_HASH + "/" + themePrefix +
+                                              "%s.js\"></script>";
             brandCSS = Poco::format(linkCSS, std::string(SUPPORT_KEY_BRANDING_UNSUPPORTED));
             brandJS = Poco::format(themeScriptJS, std::string(SUPPORT_KEY_BRANDING_UNSUPPORTED));
         }
+    }
+
+    if (brandCSS.empty())
+    {
+        const std::string linkCSS = "<link rel=\"stylesheet\" href=\"" + responseRoot +
+                                    "/browser/" + COOLWSD_VERSION_HASH + "/" + themePrefix +
+                                    "%s.css\">";
+        brandCSS = Poco::format(linkCSS, std::string(BRANDING));
+    }
+
+    if (brandJS.empty())
+    {
+        const std::string themeScriptJS = "<script src=\"" + responseRoot + "/browser/" +
+                                          COOLWSD_VERSION_HASH + "/" + themePrefix +
+                                          "%s.js\"></script>";
+        brandJS = Poco::format(themeScriptJS, std::string(BRANDING));
     }
 
     Poco::replaceInPlace(fileContent, std::string("<!--%BRANDING_CSS%-->"), brandCSS);


### PR DESCRIPTION
### Summary
Replaced Poco::format with std::ostringstream in kit/, test/, and wsd/.

Signed-off-by: areg <areg.nakashian@gmail.com>
Change-Id: I576e942478cb318fe7d9737aae3a184b55dc0aae

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

