### PR TITLE
mobile: fix closing the app in csv import

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -282,7 +282,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 				 !window._firstDialogHandled &&
 				 (eventType === 'close' ||
 				 (objectType === 'responsebutton' && data == 7))) {
-				app.dispatcher.dispatch('closeapp');
+				let dispatcher = app.dispatcher;
+				if (!dispatcher)
+					dispatcher = new app.definitions['dispatcher']('global');
+
+				dispatcher.dispatch('closeapp');
 			}
 			switch (typeof data) {
 			case 'string':


### PR DESCRIPTION
followup for commit 17e6dd10fc288533bfc9cc00a4d784b4cd1a919c Fix close when map is not present

fixes regression from commit 662a707ec87d0a1855ca81102fa4dd512bece91a Share code for close action

steps to reproduce:
1. open mobile calc using csv file and some web integrator (see import dialog)
2. open second instance of that file when first dialog is still opened result: exception

Events.ts:281 Uncaught TypeError: Cannot read properties of null (reading 'dispatch')
    at NewClass._defaultCallbackHandler (Control.JSDialogBuilder.js:285:20)
    at NewClass.closeDialog (Control.JSDialog.js:128:12)
    at NewClass.close (Control.JSDialog.js:94:10)
    at NewClass.closeAll (Control.JSDialog.js:104:9)
    at UIManager.closeAll (Control.UIManager.ts:1587:22)
    at NewClass._onError (Control.AlertDialog.js:27:24)

