### PR TITLE
notebookbar: fix error on reconnect in readonly

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1587,7 +1587,7 @@ app.definitions.Socket = L.Class.extend({
 			this._map.uiManager.setCanvasColorAfterModeChange();
 
 			var uiMode = this._map.uiManager.getCurrentMode();
-			if (uiMode === 'notebookbar') {
+			if (uiMode === 'notebookbar' && this._map.uiManager.notebookbar) {
 				this._map.uiManager.notebookbar.resetInCore();
 				this._map.uiManager.notebookbar.initializeInCore();
 			}


### PR DESCRIPTION
Steps to reproduce:
1. open PDF file in impress or readonly presentation
2. kill server to see reconnecting dialog
3. restart server to try reconnect Result: error

Exception TypeError: Cannot read properties of null (reading 'resetInCore') emitting event status: {"mode": 0,"viewid":... TypeError: Cannot read properties of null (reading 'resetInCore')
    at NewClass._onStatusMsg (http://co25:9980/browser/040b6e26d0/src/core/Socket.js:1415:49)
    at NewClass._onMessage (http://co25:9980/browser/040b6e26d0/src/core/Socket.js:1178:18)
