### PR TITLE
fix(slideshow): ensure program initialisation before first video setup

### DIFF
--- a/browser/src/slideshow/LayerDrawing.ts
+++ b/browser/src/slideshow/LayerDrawing.ts
@@ -182,6 +182,13 @@ class LayerDrawing {
 		if (!videosInfo || videosInfo.length === 0) return;
 		this.videoRenderers.set(slideHash, []);
 
+		if (
+			!this.layerRenderer.getRenderContext().is2dGl() &&
+			!VideoRendererGl.videoProgramInitialized
+		) {
+			VideoRendererGl.createProgram(this.layerRenderer.getRenderContext());
+		}
+
 		for (let i = 0; i < videosInfo.length; ++i) {
 			const videoInfo = videosInfo[i];
 			this.handleVideo(i, slideHash, videoInfo);
@@ -209,13 +216,6 @@ class LayerDrawing {
 	}
 
 	private drawVideos(slideHash: string) {
-		if (
-			!this.layerRenderer.getRenderContext().is2dGl() &&
-			!VideoRendererGl.videoProgramInitialized
-		) {
-			VideoRendererGl.createProgram(this.layerRenderer.getRenderContext());
-		}
-
 		const videoRenderers = this.videoRenderers.get(slideHash);
 		if (!videoRenderers) return;
 


### PR DESCRIPTION
Move WebGL video program initialisation to handleVideos(), ensuring it's created before any video renderer resources are set up. This commit would fix the video not loading on the first slide of the slideshow.


Change-Id: I1a857aa7d1302120e8bdeed765bcff9af21ef364


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
This commit would fix the video not loading on the first slide of the slideshow.