### PR TITLE
fix(slideshow): avoid jerk during transitions by queuing slide layers

### DIFF
--- a/browser/src/slideshow/LayersCompositor.ts
+++ b/browser/src/slideshow/LayersCompositor.ts
@@ -176,6 +176,10 @@ class LayersCompositor extends SlideCompositor {
 		this.layerDrawing.pauseVideos(slideHash);
 	}
 
+	public notifyTransitionStart() {
+		this.layerDrawing.notifyTransitionStart();
+	}
+
 	public notifyTransitionEnd(slideHash: string) {
 		this.layerDrawing.notifyTransitionEnd(slideHash);
 	}

--- a/browser/src/slideshow/SlideCompositor.ts
+++ b/browser/src/slideshow/SlideCompositor.ts
@@ -70,6 +70,8 @@ abstract class SlideCompositor {
 
 	public abstract pauseVideos(slideHash: string): void;
 
+	public abstract notifyTransitionStart(): void;
+
 	public abstract notifyTransitionEnd(slideHash: string): void;
 }
 

--- a/browser/src/slideshow/engine/SlideShowHandler.ts
+++ b/browser/src/slideshow/engine/SlideShowHandler.ts
@@ -359,7 +359,7 @@ class SlideShowHandler {
 				aAnimatedElement.notifySlideStart(this.aContext);
 			});
 		}
-
+		this.slideCompositor.notifyTransitionStart();
 		this.presenter._map.fire('transitionstart', { slide: nNewSlideIndex });
 	}
 


### PR DESCRIPTION
When a transition is active, incoming slide layers are now queued and only processed after the transition ends. This prevents visual glitches caused by prematurely rendering new slide content mid-transition.


Change-Id: Ia0b11f076298eb8891e7b6c6a9f34eba761d8232


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

| Before    | after |
| -------- | ------- |
|  ![Screenshot from 2025-05-26 21-09-04](https://github.com/user-attachments/assets/2fb83582-f37a-4c14-a235-ae570b3e9554) | ![Screenshot from 2025-05-26 21-07-07](https://github.com/user-attachments/assets/316a36a2-ced0-4597-8ca8-b479c516f341) |



### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

