### PR TITLE
presentation: render text field bitmaps

### DIFF
--- a/browser/src/slideshow/LayerDrawing.ts
+++ b/browser/src/slideshow/LayerDrawing.ts
@@ -172,6 +172,7 @@ class LayerDrawing {
 
 		this.drawBackground(slideHash);
 		this.drawMasterPage(slideHash);
+		this.drawTextField(slideHash);
 		this.drawDrawPage(slideHash);
 		this.drawVideos(slideHash);
 	}
@@ -760,6 +761,27 @@ class LayerDrawing {
 				this.drawBitmap(content.content as ImageInfo);
 			}
 		}
+	}
+
+	private drawTextField(slideHash: string) {
+		const slideInfo = this.getSlideInfo(slideHash);
+		if (slideInfo.empty) {
+			return true;
+		}
+
+		const fields = this.slideTextFieldsMap.get(slideHash);
+		if (!fields) {
+			window.app.console.log(
+				'LayerDrawing: No layer cached text field for draw page: ' + slideHash,
+			);
+			return false;
+		}
+
+		for (const field of fields) {
+			const imageInfo = this.cachedTextFields.get(field[1]).content;
+			this.drawBitmap(imageInfo);
+		}
+		return true;
 	}
 
 	private drawBitmap(imageInfo: ImageInfo | ImageBitmap) {


### PR DESCRIPTION
problem:
regression from d82d7ca8e96e6fb125d527cf8ac066a734216115 
since we switched to using bitmaps for text field, these fields were never invoked for drawing on canvas


Change-Id: I3534671ff878149b1054a87d8e0632548f8e838e


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

