### PR TITLE
jsdialog: fix error about missing popup after close

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -857,9 +857,16 @@ L.Control.JSDialog = L.Control.extend({
 
 		builder.updateWidget(dialog, data.control);
 
+		const dialogInfos = this.dialogs;
+
 		// after widget update we might have bigger content and need to center the dialog again
 		app.layoutingService.appendLayoutingTask(() => {
-			var dialogInfo = this.dialogs[data.id];
+			var dialogInfo = dialogInfos[data.id];
+			if (!dialogInfo) {
+				console.debug('JSDialog: dialog info with id: "' + data.id + '" not found.');
+				if (dialog) console.debug('JSDialog: old data was: ' + JSON.stringify(dialog));
+				return;
+			}
 			if (dialogInfo.isDocumentAreaPopup) {
 				// In case of AutocompletePopup's update data would have posx, posy
 				dialogInfo.updatePos(new L.Point(data.posx, data.posy));


### PR DESCRIPTION
Steps to reproduce:
- Open Writer
- Show Sidebar
- Open any popup using dropdown (like bulets, underline or color selector)

Result:
LayoutingTask exception: TypeError: Cannot read properties of undefined (reading 'isDocumentAreaPopup') LayoutingService.runTheTopTask	@	LayoutingService.ts:46 (anonymous)	@	LayoutingService.ts:80
requestAnimationFrame
LayoutingService._flushLayoutingQueue	@	LayoutingService.ts:76 setTimeout
LayoutingService._setupTimer	@	LayoutingService.ts:60 LayoutingService._scheduleLayouting	@	LayoutingService.ts:91 LayoutingService.appendLayoutingTask	@	LayoutingService.ts:32 focusToLastElement	@	Control.JSDialog.js:176
closePopover	@	Control.JSDialog.js:165
close	@	Control.JSDialog.js:92
overlay.onclick
