### PR TITLE
Enable system dependent primitive renderer in kit

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -4186,7 +4186,6 @@ bool globalPreinit(const std::string &loTemplate)
 
     // Disable problematic components that may be present from a
     // desktop or developer's install if env. var not set.
-    ::setenv("DISABLE_SYSTEM_DEPENDENT_PRIMITIVE_RENDERER", "1", 1);
     ::setenv("UNODISABLELIBRARY",
              "abp avmediagst avmediavlc cmdmail losessioninstall OGLTrans PresenterScreen "
              "syssh ucpftp1 ucpgio1 ucpimage updatecheckui updatefeed updchk"


### PR DESCRIPTION
This reverts commit 34d958e9790ebe529f642ab23e7622a2c7476730. Which was introduced to mask a problem with Chart editing. After double click on a chart we got all white tiles around the screen and it was not possible to select some interesing data because we didn't see them.

This can be done as fix in the core was merged for the issue: https://cgit.freedesktop.org/libreoffice/core/commit/?h=distro/collabora/co-25.04&id=4f65d3e2446a246a95fb963e1bafff7bfa0966d3

commit	4f65d3e2446a246a95fb963e1bafff7bfa0966d3
CairoSDPR: Correct BackgroundColorPrimitive2D when Viewport set