### PR TITLE
Revert "Manage changes dialog alignments"

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -48,7 +48,7 @@
 }
 
 #AcceptRejectChangesDialog {
-	width: 100%;
+	width: max-content;
 	max-width: 1000px;
 }
 #AcceptRejectChangesDialog #RedlineViewPage.jsdialog.ui-grid-cell {
@@ -56,34 +56,9 @@
 	flex-direction: column;
 	gap: 8px;
 }
-
-#AcceptRejectChangesDialog #grid3.jsdialog.ui-grid {
-	margin-top: 8px;
-	grid-gap: 8px;
+#AcceptRejectChangesDialog #RedlineFilterPage .ui-timefield {
+	margin: 5px;
 }
-
-#AcceptRejectChangesDialog #writerchanges.jsdialog.ui-treeview {
-	display: grid;
-	grid-template-columns: repeat(2, 1fr) repeat(2, minmax(min-content, auto));
-	column-gap: 8px;
-}
-
-#AcceptRejectChangesDialog .jsdialog.ui-grid .has-img,
-#AcceptRejectChangesDialog .jsdialog.ui-grid .menubutton {
-	margin: 0 !important;
-	width: 100% !important;
-}
-
-#AcceptRejectChangesDialog .ui-treeview-headers,
-#AcceptRejectChangesDialog .jsdialog.ui-treeview-entry { 
-	display: contents;
-}	
-
-#AcceptRejectChangesDialog .jsdialog.ui-treeview-entry > div:nth-child(2),
-#AcceptRejectChangesDialog .ui-treeview-headers .ui-treeview-icon-column {
-	display: none;
-}
-
 .jsdialog.one-child-popup {
 	border: 0;
 	margin: 0 !important;


### PR DESCRIPTION
This reverts commit d30f5b1348a640404dc1332a4d2dbba3c7a39350.

It was causing issues in the Manage Changes dialog in Writer when we had lots of actions with tree structure and icons



