### PR TITLE
docker: make sure start-collabora-online.sh is executable

### DIFF
--- a/docker/from-packages/Dockerfile
+++ b/docker/from-packages/Dockerfile
@@ -136,6 +136,7 @@ RUN --mount=type=secret,id=secret_key \
 # FIXME
 # Use the old starter script until we find out how to replace it.
 COPY /scripts/start-collabora-online.sh /
+RUN chown cool:cool /start-collabora-online.sh && chmod u+x /start-collabora-online.sh
 
 # coolwsd listens on port 9980
 EXPOSE 9980


### PR DESCRIPTION
Change-Id: Ifcd45544800ab45bb4782f2df3fd31cef98410db


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

The run fails without it, since the user is now cool (1001) but start-collabora-online.sh is owned by root.
