### PR TITLE
Remove redundant tooltips from elements with aria-label or img alt

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1605,9 +1605,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			builder._addAriaLabel(pushbutton, data, builder);
 		}
 
-		const buttonTitle = (data.aria && data.aria.label) || builder._cleanText(data.text);
-		if(buttonTitle)
-			pushbutton.setAttribute('title', buttonTitle);
+		const tooltipText = (data.aria && data.aria.label) || data.text;
+		if (!pushbuttonText && tooltipText) {
+			pushbutton.setAttribute('data-cooltip', builder._cleanText(tooltipText));
+			L.control.attachTooltipEventListener(pushbutton, builder.map);
+		}
 
 		builder.map.hideRestrictedItems(data, wrapper, pushbutton);
 		builder.map.disableLockedItem(data, wrapper, pushbutton);
@@ -2304,6 +2306,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			e.stopPropagation();
 		};
 
+		const hasLabel = !!controls.label;
 		var mouseEnterFunction = window.touch.mouseOnly(function () {
 			if (builder.map.tooltip)
 				builder.map.tooltip.beginShow(div);
@@ -2320,9 +2323,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (data.isCustomTooltip) {
 			this._handleCutomTooltip(div, builder);
 		}
-		else {
+		else if (!hasLabel) {
 			$(div).on('mouseenter', mouseEnterFunction);
 			$(div).on('mouseleave', mouseLeaveFunction);
+		} else {
+			div.removeAttribute('data-cooltip'); // If there is a label, we don't need the tooltip
 		}
 
 		div.addEventListener('keydown', function(e) {

--- a/browser/src/control/Control.NavigatorPanel.ts
+++ b/browser/src/control/Control.NavigatorPanel.ts
@@ -155,13 +155,14 @@ class NavigatorPanel extends SidebarBase {
 		this.floatingNavIcon.className =
 			'notebookbar unoNavigator unospan-view-navigator unotoolbutton visible';
 		this.floatingNavIcon.setAttribute('tabindex', '-1');
-		this.floatingNavIcon.setAttribute('data-cooltip', _('Navigator'));
+		const navigatorText = _('Navigator');
+		this.floatingNavIcon.setAttribute('data-cooltip', navigatorText);
 		L.control.attachTooltipEventListener(this.floatingNavIcon, this.map);
 
 		// Create the button wrapper (square container)
 		const buttonWrapper = document.createElement('div');
 		buttonWrapper.className = 'navigator-btn-wrapper'; // Class for styling
-		buttonWrapper.setAttribute('aria-label', _('Navigator'));
+		buttonWrapper.setAttribute('aria-label', navigatorText);
 
 		// Create the button
 		const button = document.createElement('button');

--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -543,8 +543,6 @@ class TreeViewControl {
 		// regular columns
 		for (const index in entry.columns) {
 			td = L.DomUtil.create('div', '', tr);
-			if (entry.text) td.setAttribute('data-cooltip', entry.text);
-			L.control.attachTooltipEventListener(td, builder.map);
 			rowElements.push(td);
 
 			span = L.DomUtil.create(


### PR DESCRIPTION
this commit will prevent displaying tooltip when element already contains label or visible text

Change-Id: I30308c1fa6730bd6120bc1e314bf7faa5a8f1b2e

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

