### PR TITLE
Implement no_auth_header

### DIFF
--- a/browser/admin/adminIntegratorSettings.html
+++ b/browser/admin/adminIntegratorSettings.html
@@ -32,6 +32,7 @@
         id="initial-variables"
         data-access-token="%ACCESS_TOKEN%"
         data-access-token-ttl="%ACCESS_TOKEN_TTL%"
+        data-no-auth-header="%NO_AUTH_HEADER%"
         data-access-header="%ACCESS_HEADER%"
         data-enable-accessibility="%ENABLE_ACCESSIBILITY%"
         data-enable-debug="%ENABLE_DEBUG%"

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -233,6 +233,7 @@ m4_ifelse(MOBILEAPP, [true],
         [
           data-access-token='%ACCESS_TOKEN%'
           data-access-token-ttl='%ACCESS_TOKEN_TTL%'
+          data-no-auth-header='%NO_AUTH_HEADER%'
           data-access-header='%ACCESS_HEADER%'
         ]
       )
@@ -247,6 +248,7 @@ m4_ifelse(MOBILEAPP, [true],
       data-version-path = "%VERSION%"
       data-access-token = "%ACCESS_TOKEN%"
       data-access-token-ttl = "%ACCESS_TOKEN_TTL%"
+      data-no-auth-header = "%NO_AUTH_HEADER%"
       data-access-header = "%ACCESS_HEADER%"
       data-post-message-origin-ext = "%POSTMESSAGE_ORIGIN%"
       data-cool-logging = "%BROWSER_LOGGING%"

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -241,6 +241,7 @@ class InitializerBase {
 		window.versionPath = "";
 		window.accessToken = element.dataset.accessToken;
 		window.accessTokenTTL = element.dataset.accessTokenTtl;
+		window.noAuthHeader = element.dataset.noAuthHeader;
 		window.accessHeader = element.dataset.accessHeader;
 		window.postMessageOriginExt = "";
 		window.coolwsdVersion = "";
@@ -1673,7 +1674,7 @@ function getInitializerClass() {
 	if (global.wopiSrc != '') {
 		global.docURL = decodeURIComponent(global.wopiSrc);
 		if (global.accessToken !== '') {
-			wopiParams = { 'access_token': global.accessToken, 'access_token_ttl': global.accessTokenTTL };
+			wopiParams = { 'access_token': global.accessToken, 'access_token_ttl': global.accessTokenTTL, 'no_auth_header': global.noAuthHeader };
 		}
 		else if (global.accessHeader !== '') {
 			wopiParams = { 'access_header': global.accessHeader };

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1474,12 +1474,13 @@ app.definitions.Socket = L.Class.extend({
 			} else if (textMsg.startsWith('saveas:')) {
 				var accessToken = this._getParameterByName(url, 'access_token');
 				var accessTokenTtl = this._getParameterByName(url, 'access_token_ttl');
+				let noAuthHeader = this._getParameterByName(url, 'no_auth_header');
 
 				if (accessToken !== undefined) {
 					if (accessTokenTtl === undefined) {
 						accessTokenTtl = 0;
 					}
-					this._map.options.docParams = { 'access_token': accessToken, 'access_token_ttl': accessTokenTtl };
+					this._map.options.docParams = { 'access_token': accessToken, 'access_token_ttl': accessTokenTtl, 'no_auth_header': noAuthHeader };
 				}
 				else {
 					this._map.options.docParams = {};

--- a/browser/src/main.js
+++ b/browser/src/main.js
@@ -10,7 +10,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-/* global errorMessages accessToken accessTokenTTL accessHeader createOnlineModule */
+/* global errorMessages accessToken accessTokenTTL noAuthHeader accessHeader createOnlineModule */
 /* global app $ L host idleTimeoutSecs outOfFocusTimeoutSecs _ LocaleService LayoutingService */
 /*eslint indent: [error, "tab", { "outerIIFEBody": 0 }]*/
 
@@ -21,7 +21,7 @@ var wopiParams = {};
 var wopiSrc = global.coolParams.get('WOPISrc');
 
 if (wopiSrc !== '' && accessToken !== '') {
-	wopiParams = { 'access_token': accessToken, 'access_token_ttl': accessTokenTTL };
+	wopiParams = { 'access_token': accessToken, 'access_token_ttl': accessTokenTTL, 'no_auth_header': noAuthHeader };
 }
 else if (wopiSrc !== '' && accessHeader !== '') {
 	wopiParams = { 'access_header': accessHeader };

--- a/common/Authorization.hpp
+++ b/common/Authorization.hpp
@@ -41,16 +41,19 @@ public:
 private:
     std::string _data;
     Type _type;
+    bool _noHeader;
 
 public:
     Authorization()
         : _type(Type::None)
+        , _noHeader(false)
     {
     }
 
-    Authorization(Type type, const std::string& data)
+    Authorization(Type type, const std::string& data, bool noHeader)
         : _data(data)
         , _type(type)
+        , _noHeader(noHeader)
     {
     }
 

--- a/test/RequestDetailsTests.cpp
+++ b/test/RequestDetailsTests.cpp
@@ -766,7 +766,7 @@ void RequestDetailsTests::testAuthorization()
 {
     constexpr std::string_view testname = __func__;
 
-    Authorization auth1(Authorization::Type::Token, "abc");
+    Authorization auth1(Authorization::Type::Token, "abc", false);
     Poco::URI uri1("http://localhost");
     auth1.authorizeURI(uri1);
     LOK_ASSERT_EQUAL(std::string("http://localhost/?access_token=abc"), uri1.toString());
@@ -774,17 +774,17 @@ void RequestDetailsTests::testAuthorization()
     auth1.authorizeRequest(req1);
     LOK_ASSERT_EQUAL(std::string("Bearer abc"), req1.get("Authorization"));
 
-    Authorization auth1modify(Authorization::Type::Token, "modified");
+    Authorization auth1modify(Authorization::Type::Token, "modified", false);
     // still the same uri1, currently "http://localhost/?access_token=abc"
     auth1modify.authorizeURI(uri1);
     LOK_ASSERT_EQUAL(std::string("http://localhost/?access_token=modified"), uri1.toString());
 
-    Authorization auth2(Authorization::Type::Header, "def");
+    Authorization auth2(Authorization::Type::Header, "def", false);
     Poco::Net::HTTPRequest req2;
     auth2.authorizeRequest(req2);
     LOK_ASSERT(!req2.has("Authorization"));
 
-    Authorization auth3(Authorization::Type::Header, "Authorization: Basic huhu== ");
+    Authorization auth3(Authorization::Type::Header, "Authorization: Basic huhu== ", false);
     Poco::URI uri2("http://localhost");
     auth3.authorizeURI(uri2);
     // nothing added with the Authorization header approach
@@ -793,7 +793,7 @@ void RequestDetailsTests::testAuthorization()
     auth3.authorizeRequest(req3);
     LOK_ASSERT_EQUAL(std::string("Basic huhu=="), req3.get("Authorization"));
 
-    Authorization auth4(Authorization::Type::Header, "  Authorization: Basic blah== \n\rX-Something:   additional  ");
+    Authorization auth4(Authorization::Type::Header, "  Authorization: Basic blah== \n\rX-Something:   additional  ", false);
     Poco::Net::HTTPRequest req4;
     auth4.authorizeRequest(req4);
     LOK_ASSERT_MESSAGE("Exected request to have Authorization header", req4.has("Authorization"));
@@ -801,13 +801,13 @@ void RequestDetailsTests::testAuthorization()
     LOK_ASSERT_MESSAGE("Exected request to have X-Something header", req4.has("X-Something"));
     LOK_ASSERT_EQUAL(std::string("additional"), req4.get("X-Something"));
 
-    Authorization auth5(Authorization::Type::Header, "  Authorization: Basic huh== \n\rX-Something-More:   else  \n\r");
+    Authorization auth5(Authorization::Type::Header, "  Authorization: Basic huh== \n\rX-Something-More:   else  \n\r", false);
     Poco::Net::HTTPRequest req5;
     auth5.authorizeRequest(req5);
     LOK_ASSERT_EQUAL(std::string("Basic huh=="), req5.get("Authorization"));
     LOK_ASSERT_EQUAL(std::string("else"), req5.get("X-Something-More"));
 
-    Authorization auth6(Authorization::Type::None, "Authorization: basic huh==");
+    Authorization auth6(Authorization::Type::None, "Authorization: basic huh==", false);
     Poco::Net::HTTPRequest req6;
     CPPUNIT_ASSERT_NO_THROW(auth6.authorizeRequest(req6));
 

--- a/test/UnitInitialLoadFail.cpp
+++ b/test/UnitInitialLoadFail.cpp
@@ -63,6 +63,7 @@ public:
         return std::map<std::string, std::string>{
             {"wopiSrc", "/wopi/files/0"},
             {"accessToken", "anything"},
+            {"noAuthHeader", ""},
             {"permission", ""},
             {"configid", ""}
         };
@@ -169,6 +170,7 @@ public:
         return std::map<std::string, std::string>{
             {"wopiSrc", "/wopi/files/0"},
             {"accessToken", "anything"},
+            {"noAuthHeader", ""},
             {"permission", ""},
             {"configid", ""}
         };

--- a/test/UnitMultiTenant.cpp
+++ b/test/UnitMultiTenant.cpp
@@ -113,6 +113,7 @@ public:
         return std::map<std::string, std::string>{
             {"wopiSrc", "/wopi/files/0"},
             {"accessToken", "anything"},
+            {"noAuthHeader", ""},
             {"permission", ""},
             {"configid", _configId}
         };

--- a/test/UnitUserPresets.cpp
+++ b/test/UnitUserPresets.cpp
@@ -138,6 +138,7 @@ public:
         return std::map<std::string, std::string>{
             {"wopiSrc", "/wopi/files/0"},
             {"accessToken", "anything"},
+            {"noAuthHeader", ""},
             {"permission", ""},
             {"configid", ""}
         };

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -645,11 +645,15 @@ void launchAsyncCheckFileInfo(
     const std::string requestKey = RequestDetails::getRequestKey(
         accessDetails.wopiSrc(), accessDetails.accessToken());
     LOG_DBG("RequestKey: [" << requestKey << "], wopiSrc: [" << accessDetails.wopiSrc()
-                            << "], accessToken: [" << accessDetails.accessToken() << ']');
+            << "], accessToken: [" << accessDetails.accessToken() << "], noAuthHeader: ["
+            << accessDetails.noAuthHeader() << ']');
 
     std::vector<std::string> options = {
         "access_token=" + accessDetails.accessToken(), "access_token_ttl=0"
     };
+
+    if (!accessDetails.noAuthHeader().empty())
+        options.push_back("no_auth_header=" + accessDetails.noAuthHeader());
 
     if (!accessDetails.permission().empty())
         options.push_back("permission=" + accessDetails.permission());
@@ -770,6 +774,7 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
                     auto accessDetails = FileServerRequestHandler::ResourceAccessDetails(
                         mapAccessDetails.at("wopiSrc"),
                         mapAccessDetails.at("accessToken"),
+                        mapAccessDetails.at("noAuthHeader"),
                         mapAccessDetails.at("permission"),
                         mapAccessDetails.at("configid"));
                     launchAsyncCheckFileInfo(_id, accessDetails, RequestVettingStations,

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -92,9 +92,11 @@ public:
         ResourceAccessDetails() = default;
 
         ResourceAccessDetails(std::string wopiSrc, std::string accessToken,
+                              std::string noAuthHeader,
                               std::string permission, std::string wopiConfigId)
             : _wopiSrc(std::move(wopiSrc))
             , _accessToken(std::move(accessToken))
+            , _noAuthHeader(std::move(noAuthHeader))
             , _permission(std::move(permission))
             , _wopiConfigId(std::move(wopiConfigId))
         {
@@ -104,6 +106,7 @@ public:
 
         const std::string wopiSrc() const { return _wopiSrc; }
         const std::string accessToken() const { return _accessToken; }
+        const std::string noAuthHeader() const { return _noAuthHeader; }
         const std::string permission() const { return _permission; }
         // only exists in debugging mode, so built-in wopi debuging server
         // can support multiple 'shared' configs depending on configid=something
@@ -112,6 +115,7 @@ public:
     private:
         std::string _wopiSrc;
         std::string _accessToken;
+        std::string _noAuthHeader;
         std::string _permission;
         std::string _wopiConfigId;
     };


### PR DESCRIPTION
Introduce the `no_auth_header` parameter. Pass this along the `access_token` to specify to never send `Authorization:` headers to the WOPI Host. This is usefull for some case where the WOPI host of the integration has some check of the header that cause errors to be returned.

Most of the time this is not needed.


Change-Id: I9fac6aaa2e9d409ccf4776b0a31164ea2a697084


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

