### PR TITLE
Calc: allow drawing on activity

### DIFF
--- a/browser/src/control/Control.IdleHandler.ts
+++ b/browser/src/control/Control.IdleHandler.ts
@@ -87,6 +87,7 @@ class IdleHandler {
 				  requirements to position them.
 				*/
 				if (this.map._docLayer) {
+					this.map._docLayer.allowDrawing();
 					this.refreshAnnotations();
 				}
 				else {

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -1081,12 +1081,16 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 		}
 	},
 
+	allowDrawing: function () {
+		// Drawing is disabled from CalcTileLayer construction, enable it now.
+		this._gotFirstCellCursor = true;
+	},
+
 	_onCellCursorMsg: function (textMsg) {
 		L.CanvasTileLayer.prototype._onCellCursorMsg.call(this, textMsg);
 		this._refreshRowColumnHeaders();
 		if (!this._gotFirstCellCursor) {
-			// Drawing is disabled from CalcTileLayer construction, enable it now.
-			this._gotFirstCellCursor = true;
+			this.allowDrawing();
 			TileManager.update();
 			this.enableDrawing();
 		}

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3674,6 +3674,9 @@ L.CanvasTileLayer = L.Layer.extend({
 			app.sectionContainer.resumeDrawing(topLevel);
 	},
 
+	// used in Calc, see CalcTileLayer
+	allowDrawing: function() {},
+
 	enableDrawing: function () {
 		if (this._painter && app.sectionContainer)
 			app.sectionContainer.enableDrawing();


### PR DESCRIPTION
_gotFirstCellCursor is used in Calc to draw only after we loaded the spreadsheet. It is not perfect, I found case where it wasn't enabled due to some problems with deactivation (IdleHandler).

Let's do it safe: we do activate() when we receive signal that document was loaded, that is good enough too. At the same time I don't change any other logic.

Steps to reproduce (not everywhere, on good performance only):
- clear cookies and site data
- open Calc Result: you see only first-screen of tiles,
        scrolling doesn't show more

Not easy to reproduce.
