### PR TITLE
Fix preview shape scale calculation.

### DIFF
--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -197,10 +197,23 @@ class ShapeHandlesSection extends CanvasSectionObject {
 		let topMiddle = this.sectionProperties.info.handles.kinds.rectangle['2'][0];
 		topMiddle = new cool.SimplePoint(parseInt(topMiddle.point.x), parseInt(topMiddle.point.y));
 
-		const center = GraphicSelection.rectangle.center; // number array in twips.
+		const center = this.getShapeCenter();
 
 		const radians = Math.atan2((center[1] - topMiddle.y), (topMiddle.x - center[0]));
 		return radians - Math.PI * 0.5;
+	}
+
+	getShapeCenter(twips = true) {
+		let topLeft = this.sectionProperties.info.handles.kinds.rectangle['1'][0];
+		topLeft = new cool.SimplePoint(parseInt(topLeft.point.x), parseInt(topLeft.point.y));
+
+		let bottomRight = this.sectionProperties.info.handles.kinds.rectangle['8'][0];
+		bottomRight = new cool.SimplePoint(parseInt(bottomRight.point.x), parseInt(bottomRight.point.y));
+
+		if (twips)
+			return [Math.round((topLeft.x + bottomRight.x) / 2), Math.round((topLeft.y + bottomRight.y) / 2)]; // number array in twips.
+		else
+			return [Math.round((topLeft.pX + bottomRight.pX) / 2), Math.round((topLeft.pY + bottomRight.pY) / 2)]; // number array in core pixels.
 	}
 
 	/*
@@ -213,7 +226,7 @@ class ShapeHandlesSection extends CanvasSectionObject {
 
 		return {
 			angleRadian: this.getShapeAngleRadians(),
-			center: GraphicSelection.rectangle.pCenter.slice(),
+			center: this.getShapeCenter(false),
 			height: this.getShapeHeight() * app.twipsToPixels,
 			width: this.getShapeWidth() * app.twipsToPixels
 		};
@@ -943,13 +956,20 @@ class ShapeHandlesSection extends CanvasSectionObject {
 			const viewBox: number[] = this.getViewBox(this.sectionProperties.svg.children[0]);
 			const isImage = this.sectionProperties.svg.querySelectorAll('.Graphic').length > 0;
 
-			if (viewBox || isImage) {
+			const clientRect = (this.sectionProperties.svg.children[0] as SVGElement).getBoundingClientRect();
+
+			if (viewBox && !isImage && clientRect.width > 0 && clientRect.height > 0) {
 				this.sectionProperties.svg.children[0].style.width = widthText;
 				this.sectionProperties.svg.children[0].style.height = heightText;
 			}
 			else {
 				this.sectionProperties.svg.style.width = widthText;
 				this.sectionProperties.svg.style.height = heightText;
+
+				if (isImage) {
+					this.sectionProperties.svg.children[0].style.width = widthText;
+					this.sectionProperties.svg.children[0].style.height = heightText;
+				}
 			}
 
 			const left = GraphicSelection.rectangle.pX1;

--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -937,46 +937,26 @@ class ShapeHandlesSection extends CanvasSectionObject {
 
 	adjustSVGProperties() {
 		if (this.sectionProperties.svg && this.sectionProperties.svg.style.display === '' && GraphicSelection.hasActiveSelection()) {
-
-			const clientRect = (this.sectionProperties.svg.children[0] as SVGElement).getBoundingClientRect();
-			let width: number = clientRect.width;
-			let height: number = clientRect.height;
-
-			if (app.map._docLayer._docType !== 'presentation') {
-				width *= app.getScale();
-				height *= app.getScale();
-			}
-
-			let left = 0, top = 0;
+			const widthText = GraphicSelection.rectangle.cWidth + 'px';
+			const heightText = GraphicSelection.rectangle.cHeight + 'px';
 
 			const viewBox: number[] = this.getViewBox(this.sectionProperties.svg.children[0]);
 			const isImage = this.sectionProperties.svg.querySelectorAll('.Graphic').length > 0;
-			if (viewBox && clientRect.width > 0 && clientRect.height > 0 && !isImage) {
-				this.sectionProperties.svg.children[0].style.width = (width / app.dpiScale) + 'px';
-				this.sectionProperties.svg.children[0].style.height = (height / app.dpiScale) + 'px';
 
-				const widthPixelRatio = viewBox[2] / width;
-				const heightPixelRatio = viewBox[3] / height;
-
-				left = (viewBox[0] / widthPixelRatio) / app.dpiScale;
-				top = (viewBox[1] / heightPixelRatio) / app.dpiScale;
+			if (viewBox || isImage) {
+				this.sectionProperties.svg.children[0].style.width = widthText;
+				this.sectionProperties.svg.children[0].style.height = heightText;
 			}
 			else {
-				left = (this.position[0] / app.dpiScale);
-				top = (this.position[1] / app.dpiScale);
-				const widthText = (this.size[0] / app.dpiScale) + 'px';
-				const heightText = (this.size[1] / app.dpiScale) + 'px';
-
 				this.sectionProperties.svg.style.width = widthText;
 				this.sectionProperties.svg.style.height = heightText;
-				if (isImage) {
-					this.sectionProperties.svg.children[0].setAttribute('width', widthText);
-					this.sectionProperties.svg.children[0].setAttribute('height', heightText);
-				}
 			}
 
-			this.sectionProperties.svg.style.left = (left - (this.documentTopLeft[0] - this.containerObject.getDocumentAnchor()[0]) / app.dpiScale) + 'px';
-			this.sectionProperties.svg.style.top = (top - (this.documentTopLeft[1] - this.containerObject.getDocumentAnchor()[1]) / app.dpiScale) + 'px';
+			const left = GraphicSelection.rectangle.pX1;
+			const top = GraphicSelection.rectangle.pY1;
+
+			this.sectionProperties.svg.style.left = Math.round((left - this.documentTopLeft[0] + this.containerObject.getDocumentAnchor()[0]) / app.dpiScale) + 'px';
+			this.sectionProperties.svg.style.top = Math.round((top - this.documentTopLeft[1] + this.containerObject.getDocumentAnchor()[1]) / app.dpiScale) + 'px';
 			this.sectionProperties.svgPosition = [left, top];
 		}
 		this.hideSVG();


### PR DESCRIPTION
Preview is an HTML object, no need to add dpiScale multiplier. This fixes the shape scaling issue with browser zoom != 100.


Change-Id: I0509e5d7c1a9f606bb106b28485ceb423a6ae5db


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

