### PR TITLE
browser: accessibility: add "aria-label" attribute to drawing image

### DIFF
--- a/browser/src/control/jsdialog/Widget.DrawingArea.js
+++ b/browser/src/control/jsdialog/Widget.DrawingArea.js
@@ -40,10 +40,15 @@ function _drawingAreaControl (parentContainer, data, builder) {
 	image.tabIndex = 0;
 	image.draggable = false;
 	image.ondragstart = function() { return false; };
-	image.setAttribute('data-cooltip', data.text);
 
-	if (builder.map) {
-		L.control.attachTooltipEventListener(image, builder.map);
+	if (data.text) {
+		image.setAttribute('data-cooltip', data.text);
+
+		if (builder.map) {
+			L.control.attachTooltipEventListener(image, builder.map);
+		}
+	} else if (data.aria && data.aria.label) {
+		image.setAttribute('aria-label', data.aria.label);
 	}
 
 	// Line width dialog is affected from delay on image render.


### PR DESCRIPTION
The "aria-label" and "data-cooltip" attributes are mutually exclusive,
so add them appropriately if data exists.

Change-Id: I14e6ab50d3140f5f1b17ec8d14c92443382e7b49
Signed-off-by: Henry Castro <hcastro@collabora.com>
