### PR TITLE
HttpRequest: rename finish function to more explicit error

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1054,7 +1054,7 @@ public:
     }
 
     /// If not already in done state, finish with State::Error.
-    void finish()
+    void error()
     {
         // We expect to have completed successfully, or timed out,
         // anything else means we didn't get complete data.
@@ -1724,7 +1724,7 @@ private:
 
         _connected = false;
         if (_response)
-            _response->finish();
+            _response->error();
 
         _fd = -1; // No longer our socket fd.
     }


### PR DESCRIPTION
Change-Id: I951b0d7ac24f7b3f5d49748a2c6964fd31555a7e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

To keep the function name explicit.


