### PR TITLE
Replace strlen on std::strings

### DIFF
--- a/common/SigUtil-server.cpp
+++ b/common/SigUtil-server.cpp
@@ -526,7 +526,7 @@ void requestShutdown()
                << "sudo gdb --q --n --ex 'thread apply all backtrace full' --batch --pid="
                << getpid() << '\n';
         std::string streamStr = stream.str();
-        assert (sizeof (FatalGdbString) > strlen(streamStr.c_str()) + 1);
+        assert(sizeof(FatalGdbString) > streamStr.size() + 1);
         strncpy(FatalGdbString, streamStr.c_str(), sizeof(FatalGdbString)-1);
         FatalGdbString[sizeof(FatalGdbString)-1] = '\0';
     }

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -509,8 +509,8 @@ namespace
             }
         }
 
-        assert(fpath[strlen(sourceForLinkOrCopy.c_str())] == '/');
-        const char *relativeOldPath = fpath + strlen(sourceForLinkOrCopy.c_str()) + 1;
+        assert(fpath[sourceForLinkOrCopy.size()] == '/');
+        const char* relativeOldPath = fpath + sourceForLinkOrCopy.size() + 1;
         const Poco::Path newPath(destinationForLinkOrCopy, Poco::Path(relativeOldPath));
 
         switch (typeflag)
@@ -648,8 +648,8 @@ namespace
         }
 
         assert(path.size() >= sourceForGCDAFiles.size());
-        assert(fpath[strlen(sourceForGCDAFiles.c_str())] == '/');
-        const char* relativeOldPath = fpath + strlen(sourceForGCDAFiles.c_str()) + 1;
+        assert(fpath[sourceForGCDAFiles.size()] == '/');
+        const char* relativeOldPath = fpath + sourceForGCDAFiles.size() + 1;
         const Poco::Path newPath(destForGCDAFiles, Poco::Path(relativeOldPath));
 
         switch (typeflag)


### PR DESCRIPTION
Replace strlen() used on std::string.c_str operations to simply use std::string.size().

Change-Id: I73aa8f84d434fc19964dcf569cd28988e1a1efc3

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

