### PR TITLE
move the callback instead of copying it

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1000,11 +1000,11 @@ public:
     typedef std::function<void()> CallbackFn;
 
     /// Add a callback to be invoked in the polling thread
-    void addCallback(const CallbackFn& fn)
+    void addCallback(CallbackFn fn)
     {
         std::lock_guard<std::mutex> lock(_mutex);
         const bool wasEmpty = taskQueuesEmpty();
-        _newCallbacks.emplace_back(fn);
+        _newCallbacks.emplace_back(std::move(fn));
         if (wasEmpty)
             wakeup();
     }


### PR DESCRIPTION
```
 #10 0x0000000000956869 in Util::assertCorrectThread (owner=..., fileName=fileName@entry=0xe74749 "./net/Socket.hpp", lineNo=lineNo@entry=1259) at common/Util.cpp:826
         sameThread = <optimized out>
         __PRETTY_FUNCTION__ = "void Util::assertCorrectThread(std::thread::id, const char*, int)"
 #11 0x0000000000784113 in Socket::assertCorrectThread (lineNo=1259, fileName=0xe74749 "./net/Socket.hpp", this=0x7fdcfc002e50) at ./net/Socket.hpp:382
 No locals.
 #12 StreamSocket::ensureDisconnected (this=this@entry=0x7fdcfc002e50) at ./net/Socket.hpp:1259
 No locals.
 #13 0x0000000000791f16 in StreamSocket::~StreamSocket (this=0x7fdcfc002e50, __in_chrg=<optimized out>) at ./net/Socket.hpp:1244
         b_ = <optimized out>
         oss_ = <optimized out>
 #14 0x000000000071057e in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use (this=0x7fdcfc002e40) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/shared_ptr_base.h:175
 No locals.
 #15 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use_cold (this=0x7fdcfc002e40) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/shared_ptr_base.h:199
 No locals.
 #16 0x0000000000991885 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x7fdcfc002120, __in_chrg=<optimized out>) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/shared_ptr_base.h:1071
 No locals.
 #17 std::__shared_ptr<Socket, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0x7fdcfc002118, __in_chrg=<optimized out>) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/shared_ptr_base.h:1524
 No locals.
 #18 std::shared_ptr<Socket>::~shared_ptr (this=0x7fdcfc002118, __in_chrg=<optimized out>) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/shared_ptr.h:175
 No locals.
 #19 ~<lambda> (this=0x7fdcfc002110, __in_chrg=<optimized out>) at net/Socket.cpp:1076
 No locals.
 #20 std::_Function_base::_Base_manager<SocketDisposition::execute()::<lambda()> >::_M_destroy (__victim=...) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:175
 No locals.
 #21 std::_Function_base::_Base_manager<SocketDisposition::execute()::<lambda()> >::_M_manager (__op=<optimized out>, __source=..., __dest=...) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:203
 No locals.
 #22 std::_Function_handler<void(), SocketDisposition::execute()::<lambda()> >::_M_manager(std::_Any_data &, const std::_Any_data &, std::_Manager_operation) (__dest=..., __source=..., __op=<optimized out>) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:282
 No locals.
 #23 0x000000000099c1e7 in std::_Function_base::~_Function_base (this=0x7fdd00bed990, __in_chrg=<optimized out>) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:244
 No locals.
 #24 std::function<void ()>::~function() (this=0x7fdd00bed990, __in_chrg=<optimized out>) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:334
 No locals.
 #25 SocketDisposition::execute (this=this@entry=0x7fdd00bee010) at net/Socket.cpp:1074
         __PRETTY_FUNCTION__ = "void SocketDisposition::execute()"
 #26 0x000000000078d87f in http::Session::asyncConnect(std::weak_ptr<SocketPoll> const&)::{lambda(std::shared_ptr<StreamSocket>, net::AsyncConnectResult)#1}::operator()(std::shared_ptr<StreamSocket>, net::AsyncConnectResult) const (__closure=0x7fdcfc001c60, socket=..., result=net::AsyncConnectResult::Ok) at ./net/HttpRequest.hpp:1806
         socketPoll = std::shared_ptr<SocketPoll> (use count 2, weak count 1) = {get() = <optimized out>}
         disposition = {static TypeMax = 3, _socketMove = {<std::_Maybe_unary_or_binary_function<void, std::shared_ptr<Socket> const&>> = {<std::unary_function<std::shared_ptr<Socket> const&, void>> = {<No data fields>}, <No data fields>}, <std::_Function_base> = {static _M_max_size = 16, static _M_max_align = 8, _M_functor = {_M_unused = {_M_object = 0x7fdcfc001ec0, _M_const_object = 0x7fdcfc001ec0, _M_function_pointer = 0x7fdcfc001ec0, _M_member_pointer = (void (std::_Undefined_class::*)(std::_Undefined_class * const)) 0x7fdcfc001ec0}, _M_pod_data = "\300\036\000\374\334\177\000\000\000\000\000\000\000\000\000"}, _M_manager = 0x0}, _M_invoker = 0x0}, _socket = std::shared_ptr<Socket> (empty) = {get() = 0x0}, _toPoll = 0x41a2fe00, _disposition = SocketDisposition::Type::TRANSFER}
         poll = std::weak_ptr<SocketPoll> (use count 2, weak count 1) = {get() = 0x41a2fe00}
         this = 0x7fdcd80355b0
```

Change-Id: Id8ec8c07b45e31805d9acbf3a41a56e3ea62b13d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

