### PR TITLE
progressbar: add infinite loading animation when progress is unknown

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1712,19 +1712,73 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	stop-opacity: 0.2;
 }
 
-/* progressbar */
+/* Regular ProgressBar */
 .ui-progressbar {
+	height: 5px !important;
 	display: flex;
 	align-items: center;
+	overflow: hidden;
 }
 
 .ui-progressbar progress {
 	width: 100%;
+	height: 5px;
+	background-color: rgba(var(--doc-type), 0.2);
+	border: none;
 }
 
-.snackbar .ui-progressbar progress {
-	min-width: 120px;
-	margin-right: 10px;
+[data-theme='dark'] .ui-progressbar progress {
+	background-color: #FFFF;
+}
+
+.ui-progressbar progress::-webkit-progress-bar {
+	background-color: rgba(var(--doc-type), 0.2);
+}
+
+.ui-progressbar progress::-webkit-progress-value,
+.ui-progressbar progress::-moz-progress-bar {
+	background-color: rgba(var(--doc-type));
+}
+
+/* Infinite Mode Styling */
+.ui-progressbar.infinite {
+	position: relative;
+	background-color: rgba(var(--doc-type), 0.2);
+	width: 100%;
+	overflow: hidden;
+}
+
+.ui-progressbar.infinite progress::-webkit-progress-bar,
+.ui-progressbar.infinite progress::-webkit-progress-value,
+.ui-progressbar.infinite progress::-moz-progress-bar {
+	background: transparent;
+}
+
+/* Indeterminate Animation Overlay */
+.ui-progressbar.infinite::after {
+	content: '';
+	position: absolute;
+	top: 0;
+	left: 0;
+	height: 100%;
+	width: 100%;
+	background-color: rgb(var(--doc-type));
+	animation: indeterminateAnimation 1s infinite linear;
+	transform-origin: 0% 50%;
+	z-index: 0;
+	pointer-events: none;
+}
+
+@keyframes indeterminateAnimation {
+	0% {
+		transform: translateX(0) scaleX(0);
+	}
+	40% {
+		transform: translateX(0) scaleX(0.4);
+	}
+	100% {
+		transform: translateX(100%) scaleX(0.5);
+	}
 }
 
 /* snackbar */
@@ -1738,7 +1792,18 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .snackbar #snackbar-container-progress {
 	align-items: center;
 	max-width: calc(80vw);
+	row-gap: 4px;
 }
+
+.snackbar .ui-progressbar progress {
+	min-width: 120px;
+	margin-right: 10px;
+}
+
+.snackbar .ui-progressbar progress::-webkit-progress-bar {
+	background-color: #FFFF;
+}
+
 #mobile-wizard.popup.snackbar,
 .snackbar.jsdialog-container .ui-dialog-content {
 	min-width: 200px;

--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -28,6 +28,7 @@ L.Control.DownloadProgress = L.Control.extend({
 		this._complete = false;
 		this._closed = false;
 		this._isLargeCopy = false;
+		this._infinite = true;
 	},
 
 	_userAlreadyWarned: function () {
@@ -82,19 +83,19 @@ L.Control.DownloadProgress = L.Control.extend({
 		var buttonText = _('Cancel');
 
 		if (inSnackbar) {
-			this._map.uiManager.showProgressBar(msg, buttonText, this._onClose.bind(this));
+			this._map.uiManager.showProgressBar(msg, buttonText, this._onClose.bind(this), undefined, undefined, this._infinite);
 		} else if (this._isLargeCopy) {
 			// downloading for copy, next: show download complete dialog
 			buttonText = _('Copy') + app.util.replaceCtrlAltInMac(' (Ctrl + C)');
 
 			this._map.uiManager.showProgressBarDialog(modalId, this._getDialogTitle(), msg,
-				buttonText, this._onConfirmCopyAction.bind(this), 0, this._onClose.bind(this));
+				buttonText, this._onConfirmCopyAction.bind(this), 0, this._onClose.bind(this), this._infinite);
 
 			JSDialog.enableButtonInModal(modalId, modalId + '-response', false);
 		} else {
 			// downloading for paste, next: dialog will disappear
 			this._map.uiManager.showProgressBarDialog(modalId, this._getDialogTitle(), msg,
-				'', this._onClose.bind(this), 0, this._onClose.bind(this));
+				'', this._onClose.bind(this), 0, this._onClose.bind(this), this._infinite);
 		}
 	},
 
@@ -208,10 +209,10 @@ L.Control.DownloadProgress = L.Control.extend({
 
 	setValue: function (value) {
 		if (this._userAlreadyWarned())
-			this._map.uiManager.setSnackbarProgress(Math.round(value));
+			this._map.uiManager.setSnackbarProgress(Math.round(value), this._infinite);
 		else {
 			var modalId = this._getDownloadProgressDialogId();
-			this._map.uiManager.setDialogProgress(modalId, Math.round(value));
+			this._map.uiManager.setDialogProgress(modalId, Math.round(value), this._infinite);
 		}
 	},
 

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1510,6 +1510,7 @@ class UIManager extends L.Control {
 	 * @param timeout - Duration before auto-dismiss.
 	 * @param hasProgress - Whether to show a progress bar.
 	 * @param withDismiss - Whether a dismiss button is included.
+	 * @param infinite - If true, shows an indeterminate progress bar.
 	 */
 	showSnackbar(
 		label: string,
@@ -1531,16 +1532,18 @@ class UIManager extends L.Control {
 		callback: any,
 		timeout?: number,
 		withDismiss?: boolean,
+		infinite?: boolean,
 	): void {
-		JSDialog.SnackbarController.showSnackbar(message, buttonText, callback, timeout ? timeout : -1, true, withDismiss);
+		JSDialog.SnackbarController.showSnackbar(message, buttonText, callback, timeout ? timeout : -1, true, withDismiss, infinite);
 	}
 
 	/**
 	 * Updates the progress value on the snackbar.
 	 * @param value - Progress value (0–100).
+	 * @param infinite - If true, shows an indeterminate progress bar.
 	 */
-	setSnackbarProgress(value: number): void {
-		JSDialog.SnackbarController.setSnackbarProgress(value);
+	setSnackbarProgress(value: number, infinite?: boolean): void {
+		JSDialog.SnackbarController.setSnackbarProgress(value, infinite);
 	}
 
 	// Modals
@@ -1744,6 +1747,7 @@ class UIManager extends L.Control {
 		callback: any,
 		value?: number,
 		cancelCallback?: any,
+		infinite: boolean = false,
 	): void {
 		var dialogId = this.generateModalId(id);
 		var responseButtonId = id + '-response';
@@ -1765,7 +1769,8 @@ class UIManager extends L.Control {
 				id: dialogId + '-progressbar',
 				type: 'progressbar',
 				value: (value !== undefined && value !== null ? value: 0),
-				maxValue: 100
+				maxValue: 100,
+				infinite: infinite
 			},
 			{
 				id: '',
@@ -1809,8 +1814,9 @@ class UIManager extends L.Control {
 	/**
 	 * Updates the progress value in a progress dialog.
 	 * @param value - Progress value (0–100).
+	 * @param infinite - If true, shows an indeterminate progress bar.
 	 */
-	setDialogProgress(id: string, value: number): void {
+	setDialogProgress(id: string, value: number, infinite: boolean): void {
 		if (!app.socket)
 			return;
 
@@ -1825,7 +1831,8 @@ class UIManager extends L.Control {
 				id: dialogId + '-progressbar',
 				type: 'progressbar',
 				value: value,
-				maxValue: 100
+				maxValue: 100,
+				infinite: infinite
 			}
 		};
 

--- a/browser/src/control/jsdialog/Util.SnackbarController.ts
+++ b/browser/src/control/jsdialog/Util.SnackbarController.ts
@@ -23,6 +23,7 @@ type SnackbarData = {
 	timeout: number;
 	hasProgress: boolean | undefined;
 	withDismiss: boolean | undefined;
+	infinite: boolean | undefined;
 };
 
 class SnackbarController {
@@ -56,6 +57,7 @@ class SnackbarController {
 		timeout: number | undefined,
 		hasProgress: boolean | undefined,
 		withDismiss: boolean | undefined,
+		infinite: boolean | undefined,
 	) {
 		if (!app.socket) return;
 
@@ -66,6 +68,7 @@ class SnackbarController {
 			timeout: timeout,
 			hasProgress: hasProgress,
 			withDismiss: withDismiss,
+			infinite: infinite,
 		});
 
 		this.scheduleSnackbar();
@@ -120,7 +123,13 @@ class SnackbarController {
 								}
 							: {},
 						snackbarData.hasProgress
-							? { id: 'progress', type: 'progressbar', value: 0, maxValue: 100 }
+							? {
+									id: 'progress',
+									type: 'progressbar',
+									value: 0,
+									maxValue: 100,
+									infinite: snackbarData.infinite,
+								}
 							: {},
 						snackbarData.action
 							? {
@@ -187,7 +196,7 @@ class SnackbarController {
 	}
 
 	// value should be in range 0-100
-	public setSnackbarProgress(value: number) {
+	public setSnackbarProgress(value: number, infinite: boolean) {
 		if (!app.socket) return;
 
 		var json = {
@@ -200,6 +209,7 @@ class SnackbarController {
 				type: 'progressbar',
 				value: value,
 				maxValue: 100,
+				infinite: infinite,
 			},
 		};
 

--- a/browser/src/control/jsdialog/Widget.Progressbar.js
+++ b/browser/src/control/jsdialog/Widget.Progressbar.js
@@ -42,6 +42,16 @@ JSDialog.progressbar = function (parentContainer, data, builder) {
 	else
 		progressbar.max = 100;
 
+	const isComplete = progressbar.value === progressbar.max;
+
+	if (data.infinite === true && !isComplete) {
+		L.DomUtil.addClass(div, 'infinite');
+		div.setAttribute('data-progress-type', 'infinite');
+	} else {
+		div.removeAttribute('data-progress-type');
+		div.classList.remove('infinite');
+	}
+
 	if (data.enabled === 'false' || data.enabled === false) {
 		$(progressbar).prop('disabled', true);
 	}


### PR DESCRIPTION
Change-Id: Id86945ff9f75e90dabf944b0530ac9c1df7d916a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Users weren’t seeing any progress indicator when progress info was missing, which could be confusing. Now there’s a smooth infinite animation to let users know something’s happening even if we don’t have exact progress yet.

Updated dialog title from "Download Selection" to "Paste Selection" to reflect user action, complementing existing "Downloading clipboard content" label.

### PREVIEW
[Screencast from 09-06-25 02:36:05.webm](https://github.com/user-attachments/assets/03fe4dd9-abe1-4f8d-a0db-be813f45b433)

- [ ] ...

### Checklist


