### PR TITLE
cypress: skip unstable paragraph test

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
@@ -21,7 +21,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties
 		impressHelper.selectTextOfShape();
 	}
 
-	it('Apply horizontal alignment on selected text.', function() {
+	it.skip('Apply horizontal alignment on selected text.', function() {
 		selectText();
 		cy.cGet('#document-container g.Page .TextParagraph .TextPosition')
 			.should('have.attr', 'x', '1400');


### PR DESCRIPTION
error usually is:

cy:command ✘  assert	expected **#document-container g.Page .TextParagraph .TextPosition[x="12491"], #document-container g.Page .TextParagraph .TextPosition[x="12492"]** to exist in the DOM

or

cy:command ✘  assert	expected **[ <tspan.TextPosition>, 1 more... ]** to have attribute **x** with the value **'1400'**, but the value was **'23582'**
