### PR TITLE
Refactor and simplify tile transactions in preparation for multiple workers (and possibly cancellable transactions)

### DIFF
--- a/browser/src/layer/tile/CanvasTileWorkerSrc.js
+++ b/browser/src/layer/tile/CanvasTileWorkerSrc.js
@@ -56,8 +56,11 @@ if ('undefined' === typeof window) {
 						deltas.length,
 					);
 
+					// The main thread has no use for the concatenated rawDelta, delete it here
+					// instead of passing it back.
+					delete tile.rawDelta;
+
 					decompressed.push(tile);
-					buffers.push(tile.rawDelta.buffer);
 					buffers.push(tile.deltas.buffer);
 				}
 


### PR DESCRIPTION
### Summary

This started as a rewrite of my previous reverted scroll optimisations, but has really ended up in a refactor that should have no user-visible change, but may have some performance benefits.

As @mmeeks discovered with my previous patch set, there was the problem that if a decompression was cancelled, you could end up in a state where you don't have the raw deltas that were being decompressed. This patch-set first decouples collecting raw deltas from decompression. In addition, we concatenate the raw deltas only when we're going to decompress them - this has the benefit of cutting down on potential copying as we don't need to store the raw deltas concatenated, we can just keep a list. This should make non-visible tile pre-loading more memory bandwidth efficient.

After this change, I've scrapped the previous system of relying on a stack and event ordering with explicitly tracking decompression requests with monotonic, increasing IDs. This lets us detect when we may have lost an update and has the benefit of letting us GC tiles that have pending decompression requests without risking tile coherency. I think this code reads better and has simplified a lot of non-obvious checks (`hasPendingDelta`/`hasPendingKeyframe` no longer exist), and opens up the possibility of both multiple workers (so we can correctly order results if we choose to allow multiple workers to work on the same tiles) and cancellable transactions (where we now have a single, reliable source of truth with regards to how much of a raw delta stack we've decompressed).

As a bonus, I've also better integrated the worker and non-worker paths so that there is very little non-worker specific code now (but I do think we should start thinking about retiring the non-worker path).

I also conjecture that prior to this patch there may have been some corner-cases where we were doing more work than was necessary (e.g. decompressing tiles that were already decompressed).

This does *not* restore the previous cancellable transaction work - I'm not convinced that it isn't necessary, but multiple workers are probably going to be of greater immediate benefit.

All testing appreciated :)

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

