### PR TITLE
fix: clang 15 compiler error

### DIFF
--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -402,7 +402,7 @@ void AsyncDNS::resolveDNS()
 void AsyncDNS::addLookup(std::string lookup, DNSThreadFn cb, const DNSThreadDumpStateFn& dumpState)
 {
     std::unique_lock<std::mutex> guard(_lock);
-    _lookups.emplace(std::move(lookup), std::move(cb), dumpState);
+    _lookups.push({std::move(lookup), std::move(cb), dumpState});
     guard.unlock();
     _condition.notify_one();
 }


### PR DESCRIPTION
When build with clang 15 I got the following error:

In file included from net/NetUtil.cpp:14:
In file included from ./net/NetUtil.hpp:14:
In file included from
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/chrono:41:
In file included from
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/sstream:38:
In file included from
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/istream:38:
In file included from
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/ios:42:
In file included from
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/ios_base.h:41:
In file included from
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/locale_classes.h:40:
In file included from
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/string:53:
In file included from
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/basic_string.h:39:
In file included from
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/ext/alloc_traits.h:34:
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/alloc_traits.h:518:4:
error: no matching function for call to 'construct_at'
          std::construct_at(__p, std::forward<_Args>(__args)...);
          ^~~~~~~~~~~~~~~~~
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/deque.tcc:170:21:
note: in instantiation of function template specialization
'std::allocator_traits<std::allocator<net::AsyncDNS::Lookup>>::construct<net::AsyncDNS::Lookup,
std::basic_string<char>, std::function<void (const net::HostEntry &)>,
const std::function<std::basic_string<char> ()> &>' requested here
            _Alloc_traits::construct(this->_M_impl,
                           ^
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/stl_queue.h:297:13:
note: in instantiation of function template specialization
'std::deque<net::AsyncDNS::Lookup>::emplace_back<std::basic_string<char>,
std::function<void (const net::HostEntry &)>, const
std::function<std::basic_string<char> ()> &>' requested here
        { return c.emplace_back(std::forward<_Args>(__args)...); }
                   ^
/usr/bin/../lib64/gcc/x86_64-suse-linux/12/../../../../include/c++/12/bits/stl_construct.h:94:5:
note: candidate template ignored: substitution failure [with _Tp =
net::AsyncDNS::Lookup, _Args = <std::basic_string<char>,
std::function<void (const net::HostEntry &)>, const
std::function<std::basic_string<char> ()> &>]: no matching constructor
for initialization of 'net::AsyncDNS::Lookup'
    construct_at(_Tp* __location, _Args&&... __args)
    ^

I solved it by using push with aggreagate initialization in place of
emplace. Obviously it is also possible to solve it by defining a ctor
for Lookup.

Signed-off-by: Marco Cecchetti <marco.cecchetti@collabora.com>
Change-Id: I7f76ef16de50e8557d1551f147ca5b31d4bdf1ae
