### PR TITLE
fix: hide signature option when document signing is disabled

### DIFF
--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -2571,6 +2571,11 @@ class Menubar extends L.Control {
 		if (isReadOnly && !app.file.editComment) {
 			this._hiddenItems.push('insert');
 		}
+
+		if (!window.documentSigningEnabled) {
+			this._hiddenItems.push('signature');
+		}
+
 		for (var i in menu) {
 			if (this._checkItemVisibility(menu[i]) === false)
 				continue;


### PR DESCRIPTION
### Summary
"--o:document_signing.enable=false" option disables the signing menu in ui. But it was forgotten to be disabled in "compact" mode.

This change should be made in 6cdbbe04

Before change:

![Selection_20250611-005](https://github.com/user-attachments/assets/56df3427-ff51-40cc-9ed2-ffd3128e8aea)

After change:

![Selection_20250611-007](https://github.com/user-attachments/assets/340c9e15-2d2e-49cd-961e-9664af7cc625)

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

