### PR TITLE
backport: fix: Don't allow panning past document edge

### DIFF
--- a/browser/src/map/handler/Map.Drag.js
+++ b/browser/src/map/handler/Map.Drag.js
@@ -62,13 +62,15 @@ L.Map.Drag = L.Handler.extend({
 		var pos = this._map._getMapPanePos();
 		var size = this._map.getLayerMaxBounds().getSize().subtract(this._map.getSize());
 
+		this._draggable._newPos = this._draggable._newPos.add(this._dragEdgeOffset);
+
 		if (this._draggable._newPos.x !== pos.x) {
 			let clampedX = Math.max(
 				Math.min(org.x, this._draggable._newPos.x),
 				org.x - Math.max(size.x, 0)
 			);
-			this._dragEdgeOffset.x = Math.min(this._dragEdgeOffset.x, clampedX - this._draggable._newPos.x);
-			this._draggable._newPos.x = this._draggable._newPos.x + this._dragEdgeOffset.x;
+			this._dragEdgeOffset.x += clampedX - this._draggable._newPos.x;
+			this._draggable._newPos.x = clampedX;
 		}
 
 		if (this._draggable._newPos.y !== pos.y) {
@@ -76,8 +78,8 @@ L.Map.Drag = L.Handler.extend({
 				Math.min(org.y, this._draggable._newPos.y),
 				org.y - Math.max(size.y, 0)
 			);
-			this._dragEdgeOffset.y = Math.min(this._dragEdgeOffset.y, clampedY - this._draggable._newPos.y);
-			this._draggable._newPos.y = this._draggable._newPos.y + this._dragEdgeOffset.y;
+			this._dragEdgeOffset.y += clampedY - this._draggable._newPos.y;
+			this._draggable._newPos.y = clampedY;
 		}
 	},
 


### PR DESCRIPTION
This is a trivial backport of #12128 

In I2eedf2449620c5c8fec9ebf71dbe23d5a643ad5c, I previously made a regression such that when panning with a touchscreen you could go past the document edge on the bottom and right sides of the document.

This was because the offset I introduced there was added too late, such that the clamping to the document edge was already done and so by growing your offset you could move the document off the screen. I also didn't consider that you might be offsetting by running up against the bottom and right sides of the document as I developed and tested this in calc where that restriction doesn't exist.

Instead, panning should work like this:
- Whenever we aren't able to move, we should gain offset
- The offset should act as if it were displacing our finger - in this case we can modify the _newPos as it comes in to the function because it is directly set from the start pos and the difference between the start and end of the swipe before running this code


Change-Id: If6d378d9bf24e7723aad0def11bda62ab686cf01


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

