### PR TITLE
slide: avoid default cut/copy handing for slides

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -846,7 +846,9 @@ L.Map.Keyboard = L.Handler.extend({
 		case this.keyCodes.LEFTWINDOWKEY[MAC]: // Left Cmd (Safari)
 		case this.keyCodes.RIGHTWINDOWKEY[MAC]: // Right Cmd (Safari)
 			// we prepare for a copy or cut event
-			this._map.focus();
+			// slide operations are handled differently avoid changing focus
+			if (!this._map._docLayer._preview.partsFocused)
+				this._map.focus();
 			// Not sure if the commented code is still used, so I didn't remove it.
 			// Anyhow, by when editable area is populated with the focused paragraph
 			// we can't select its content or on next editing the content is overwritten.


### PR DESCRIPTION
copy stopped working for slides from 5a1f572


Change-Id: I661c6b3109c4491abffa9ddc2e24971cdbc52079

* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

