### PR TITLE
fix: hide signature option when document signing is disabled

### DIFF
--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -2571,6 +2571,11 @@ class Menubar extends L.Control {
 		if (isReadOnly && !app.file.editComment) {
 			this._hiddenItems.push('insert');
 		}
+
+		if (!window.documentSigningEnabled) {
+			this._hiddenItems.push('signature');
+		}
+
 		for (var i in menu) {
 			if (this._checkItemVisibility(menu[i]) === false)
 				continue;


### PR DESCRIPTION
"--o:document_signing.enable=false" option disables the signing menu in ui.
But it was forgotten to be disabled in "compact" mode.

Should be made in 6cdbbe04

Signed-off-by: Misha M.-Kupriyanov <kupriyanov@strato.de>
Change-Id: I8dbe9b42cb39ef619e1778267cf83f40ca81aed5
(cherry picked from commit e4b0c5c65c94b5f2184ba359fac3307a8ed3e090)
