### PR TITLE
Set CJK/CTL settings here for LOKit

### DIFF
--- a/coolkitconfig-mobile.xcu
+++ b/coolkitconfig-mobile.xcu
@@ -45,6 +45,17 @@
 <!-- Hyperlink insertion in MS fileformats, should behave like in excel: hyperlinks inserted into the whole cell, not only for textfields.  -->
 <item oor:path="/org.openoffice.Office.Calc/Compatibility"><prop oor:name="Links" oor:op="fuse"><value>true</value></prop></item>
 
+<!-- CJK/CTL settings -->
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="VerticalText" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="Ruby" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="JapaneseFind" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="EmphasisMarks" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="DoubleLines" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="CJKFont" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="ChangeCaseMap" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="AsianTypography" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CTL"><prop oor:name="CTLFont" oor:op="fuse"><value>true</value></prop></item>
+
 <!-- Themes -->
 <!-- Light Theme -->
 <item oor:path="/org.openoffice.Office.UI/ColorScheme/ColorSchemes">

--- a/coolkitconfig.xcu.in
+++ b/coolkitconfig.xcu.in
@@ -61,6 +61,17 @@
 <!-- Hide MediaPlaybackPanel on sidebar. It does not work in Online. Video playback controls are implemented by the browser.  -->
 <item oor:path="/org.openoffice.Office.UI.Sidebar/Content/PanelList/org.openoffice.Office.UI.Sidebar:Panel['MediaPlaybackPanel']"><prop oor:name="ContextList" oor:op="fuse"><value><it>any</it><it>default</it><it>hidden</it></value></prop></item>
 
+<!-- CJK/CTL settings -->
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="VerticalText" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="Ruby" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="JapaneseFind" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="EmphasisMarks" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="DoubleLines" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="CJKFont" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="ChangeCaseMap" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="AsianTypography" oor:op="fuse"><value>true</value></prop></item>
+<item oor:path="/org.openoffice.Office.Common/I18N/CTL"><prop oor:name="CTLFont" oor:op="fuse"><value>true</value></prop></item>
+
 <!-- Themes -->
 <!-- Light Theme -->
 <item oor:path="/org.openoffice.Office.UI/ColorScheme/ColorSchemes">


### PR DESCRIPTION
share/registry/cjk*.xcd and share/registry/ctl*.xcd are not installed for COOL. Maybe it's a bug, but... These files are in the so called "brand" layer, in collaboraoffice-<lang> deb/rpm that we do not use. On the other hand, why would a feature like inserting vertical text depend on an optional language pack?
It is a valid use case when someone uses English UI and edits CJK/CTL text, or when someone wants to insert vertical text e.g. in English.


Change-Id: I2ed446aeff8a6a0a00c0a489eaa1d26778e1b61e

