### PR TITLE
iconview: Persist icon-view items as they don't change

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -472,10 +472,6 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	background-color: transparent;
 }
 
-#stylesview .ui-iconview-icon {
-	height: 30px;
-}
-
 /* Insert Tab */
 
 /* Layout Tab */

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -62,7 +62,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	_currentDepth: 0,
 
 	rendersCache: {
-		fontnamecombobox: { persistent: true, images: [] }
+		fontnamecombobox: { persistent: true, images: [] },
+		layoutpanel_icons: { persistent: true, images: [] },
+		transitions_icons: { persistent: true, images: [] },
+		iconview_theme_colors: { persistent: true, images: [] },
+		ctlFavoriteswin: { persistent: true, images: [] },
 	}, // eg. custom renders for combobox entries
 
 	setWindowId: function (id) {

--- a/browser/src/control/jsdialog/Widget.IconView.ts
+++ b/browser/src/control/jsdialog/Widget.IconView.ts
@@ -89,17 +89,11 @@ function _iconViewEntry(
 		entryContainer.setAttribute('aria-pressed', 'true');
 	}
 
-	const icon = L.DomUtil.create(
-		'div',
-		builder.options.cssClass + ' ui-iconview-icon',
-		entryContainer,
-	);
-
 	if (entry.ondemand) {
 		const placeholder = L.DomUtil.create(
 			'span',
 			builder.options.cssClass,
-			icon,
+			entryContainer,
 		);
 		placeholder.innerText = entry.text;
 		if (entry.tooltip) placeholder.title = entry.tooltip;
@@ -113,13 +107,14 @@ function _iconViewEntry(
 			'iconview',
 			entry.row,
 			placeholder,
-			icon,
+			entryContainer,
 			entry.text,
 		);
 	} else {
-		_createEntryImage(icon, builder, entry, entry.image);
-		if (hasText) _createEntryText(icon, entry);
+		_createEntryImage(entryContainer, builder, entry, entry.image);
 	}
+
+	if (hasText) _createEntryText(entryContainer, entry);
 
 	if (!disabled) {
 		const singleClick = parentData.singleclickactivate === true;


### PR DESCRIPTION
1. In the first rendering we only have .ui-iconview-entry > img but when we persist iconview items and try to render again it adds intermediate div. i.e. .ui-iconview-entry > .ui-iconview-icon > img
Due to this context menu on right click on any layout is opening at the bottom part after all layout image. This commit resolve this issue and   keep the original structure after persist.

2. icon-view items other than sidebar are also cached

Change-Id: If4b1b60efb4aed268fe6b8b7a0396e7a41819411

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

