### PR TITLE
fix(slideshow): fallback to 2D canvas when WebGL2 performance is insufficient

### DIFF
--- a/browser/src/slideshow/RenderContext.ts
+++ b/browser/src/slideshow/RenderContext.ts
@@ -84,7 +84,9 @@ abstract class RenderContext {
 class RenderContextGl extends RenderContext {
 	constructor(canvas: HTMLCanvasElement | OffscreenCanvas) {
 		super(canvas);
-		this.gl = this.canvas.getContext('webgl2') as WebGL2RenderingContext;
+		this.gl = this.canvas.getContext('webgl2', {
+			failIfMajorPerformanceCaveat: true,
+		}) as WebGL2RenderingContext;
 		if (!this.gl) {
 			console.error('WebGL2 not supported');
 			throw new Error('WebGL2 not supported');


### PR DESCRIPTION
fix(slideshow): fallback to 2D canvas when WebGL2 performance is insufficient

Change-Id: I007f3b6168c061d5d106d5e405db20c0d2c83a19


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
To test this PR with Chrome,
1. Go to `chrome://settings/system`
2. Disable `Use graphics acceleration when available` & Re-launch Chrome
3. Try to run slideshow 

Ideal behavior:
If graphics acceleration **on** -> It **should be** run with transition/animations (assuming you have good hardware)
If graphics acceleration **off** -> It **should **Not**** run with transition/animations




