### PR TITLE
Fix --enable-gtkapp build

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -21,7 +21,6 @@
 
 #if !MOBILEAPP
 #include "SigHandlerTrap.hpp"
-#include <dlfcn.h>
 #endif
 
 #if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
@@ -50,6 +49,9 @@
 
 #if defined __GLIBC__
 #include <malloc.h>
+#if defined(M_TRIM_THRESHOLD)
+#include <dlfcn.h>
+#endif
 #endif
 
 #include <atomic>


### PR DESCRIPTION
### Summary

Fix `--enable-gtkapp` build after 2d83187c764ad69457bdb47efd6050b96af82da9 "add Util::trimMalloc" caused it to fail with
```
gtk/../common/Util.cpp:804:65: error: ‘RTLD_NEXT’ was not declared in this scope
  804 |             auto symbol = reinterpret_cast<void(*)(void)>(dlsym(RTLD_NEXT, "MallocExtension_ReleaseFreeMemory"));
      |                                                                 ^~~~~~~~~
gtk/../common/Util.cpp:804:59: error: ‘dlsym’ was not declared in this scope
  804 |             auto symbol = reinterpret_cast<void(*)(void)>(dlsym(RTLD_NEXT, "MallocExtension_ReleaseFreeMemory"));
      |                                                           ^~~~~
```

### Checklist

- [x ] I have run `make prettier-write` and formatted the code.
- [ x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ x] Documentation (manuals or wiki) has been updated or is not required

