### PR TITLE
Revive --enable-gtkapp: Fix missing linker symbols

### DIFF
--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -27,6 +27,7 @@ cmake_list= \
             ../common/Log.cpp \
             ../common/TraceEvent.cpp \
             ../common/Protocol.cpp \
+            ../common/RegexUtil.cpp \
             ../common/Simd.cpp \
             ../common/StringVector.cpp \
             ../common/Session.cpp \


### PR DESCRIPTION
* Target version: master 

### Summary

The cmake_list in gtk/Makefile.am had presumably gone stale for one reason or another, so just add more sources files to it until there are no further missing symbol linker errors.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

