### PR TITLE
fix(gtkapp): don't attempt to use mobilesocket

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1797,13 +1797,18 @@ function getInitializerClass() {
 		return new TextDecoder().decode(bytes);
 	};
 
-	// The URL may already contain a query (e.g., 'http://server.tld/foo/wopi/files/bar?desktop=baz') - then just append more params
-	var docParamsPart = docParams ? (global.docURL.includes('?') ? '&' : '?') + docParams : '';
-	var websocketURI = global.makeWsUrlWopiSrc('/cool/', global.docURL + docParamsPart);
-	try {
-		global.socket = global.createWebSocket(websocketURI);
-	} catch (err) {
-		global.app.console.log(err);
+	if (global.ThisIsTheGtkApp) {
+		global.socket = new global.FakeWebSocket();
+		global.TheFakeWebSocket = global.socket;
+	} else {
+		// The URL may already contain a query (e.g., 'http://server.tld/foo/wopi/files/bar?desktop=baz') - then just append more params
+		var docParamsPart = docParams ? (global.docURL.includes('?') ? '&' : '?') + docParams : '';
+		var websocketURI = global.makeWsUrlWopiSrc('/cool/', global.docURL + docParamsPart);
+		try {
+			global.socket = global.createWebSocket(websocketURI);
+		} catch (err) {
+			global.app.console.log(err);
+		}
 	}
 
 	var isRandomUser = global.coolParams.get('randomUser');

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -57,6 +57,9 @@ app.definitions.Socket = L.Class.extend({
 		}
 		if (socket && (socket.readyState === 1 || socket.readyState === 0)) {
 			this.socket = socket;
+		} else if (window.ThisIsTheGtkApp) {
+			// We have already opened the FakeWebSocket over in global.js
+			// But do we then set this.socket at all? Is this case ever reached?
 		} else	{
 			try {
 				this.socket = window.createWebSocket(this.getWebSocketBaseURI(map));


### PR DESCRIPTION
This is a partial revert of Id3874e692d003e534648d06eeacd19fa9c5f2ce5. On iOS and Android this communication method works fine, but there is another platform which is technically considered "mobile" by the code: the gtk app. Since as we don't have an implementation of the cool:/cool/mobilesocket endpoint for it, when we ungated that for all mobile platforms it started blowing up. That's no good!


Change-Id: I8efee81f2c436585658d6c4affe91abff0844d74


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

