### PR TITLE
Writer: Remove handlers from Math objects.

### DIFF
--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -87,6 +87,7 @@ class ShapeHandlesSection extends CanvasSectionObject {
 		this.sectionProperties.lastDragDistance = [0, 0];
 		this.sectionProperties.pickedIndexX = 0; // Which corner of shape is closest to snap point when moving the shape.
 		this.sectionProperties.pickedIndexY = 0; // Which corner of shape is closest to snap point when moving the shape.
+		this.sectionProperties.mathObjectBorderColor = 'red'; // Border color for Math objects.
 
 		// These are for snapping the objects to the same level with others' boundaries.
 		this.sectionProperties.closestX = null;
@@ -102,9 +103,19 @@ class ShapeHandlesSection extends CanvasSectionObject {
 		this.convertToTileTwipsIfNeeded();
 		this.getHandles();
 		this.updateSize();
-		this.addSubSections();
-		this.sectionProperties.shapeRectangleProperties = this.getShapeRectangleProperties();
-		this.calculateInitialAnglesOfShapeHandlers();
+
+		if (GraphicSelection?.extraInfo?.isMathObject === true) {
+			// Math objects don't need handles. They are not resizable or rotateable.
+			// In this case, we want to draw a rectangle around it. So the user can be sure that they selected the object.
+
+			// For drawing the rectangle, use CanvasSectionContainer's awesome border drawing feature.
+			this.borderColor = this.sectionProperties.mathObjectBorderColor;
+		} else {
+			this.addSubSections();
+			this.sectionProperties.shapeRectangleProperties = this.getShapeRectangleProperties();
+			this.calculateInitialAnglesOfShapeHandlers();
+			this.borderColor = null;
+		}
 	}
 
 	private convertToTileTwipsIfNeeded() {


### PR DESCRIPTION
Because they are not usable for Math objects.

Draw a rectangle when a Math object is selected, in order to indicate the selection.


Change-Id: Ic8a16b7294dabfbfe2b8b4b0041ab4cf6f7f262b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

