### PR TITLE
Replace strcmp with std::string compare

### DIFF
--- a/common/CoolMount.cpp
+++ b/common/CoolMount.cpp
@@ -18,6 +18,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <string_view>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sysexits.h>
@@ -152,14 +153,14 @@ int domount(int argc, const char* const* argv)
     }
 
     const char* option = argv[1];
-    if ((argc == 3 || argc == 4) && strcmp(option, "-u") == 0) // Unmount
+    if ((argc == 3 || argc == 4) && (option == std::string_view("-u"))) // Unmount
     {
         bool silent = false;
         int argpos = 2;
 
         if (argc == 4)
         {
-            if (strcmp(argv[argpos], "-s") != 0)
+            if (argv[argpos] != std::string_view("-s"))
             {
                 fprintf(stderr, "%s: only -s allowed [%s].\n", program, argv[argpos]);
                 return EX_USAGE;
@@ -208,7 +209,7 @@ int domount(int argc, const char* const* argv)
         }
     }
 #ifdef __FreeBSD__
-    else if (argc == 3 && strcmp(option, "-d") == 0) // Mount devfs
+    else if (argc == 3 && option == std::string_view("-d")) // Mount devfs
     {
         const char* target = argv[2];
 
@@ -295,7 +296,7 @@ int domount(int argc, const char* const* argv)
         // Mount the source path as the target path.
         // First bind to mount an existing directory node into the chroot.
         // MS_BIND ignores other flags.
-        if (strcmp(option, "-b") == 0) // Shared or Bind Mount.
+        if (option == std::string_view("-b")) // Shared or Bind Mount.
         {
             const int retval
                 = MOUNT(source, target, nullptr, (MS_MGC_VAL | MS_BIND | MS_REC), nullptr);
@@ -306,7 +307,7 @@ int domount(int argc, const char* const* argv)
                 return EX_SOFTWARE;
             }
         }
-        else if (strcmp(option, "-r") == 0) // Readonly Mount.
+        else if (option == std::string_view("-r")) // Readonly Mount.
         {
             // Now we need to set read-only and other flags with a remount.
             unsigned long mountflags = (MS_BIND | MS_REMOUNT | MS_NODEV | MS_NOSUID | MS_RDONLY);

--- a/common/FileUtil-unix.cpp
+++ b/common/FileUtil-unix.cpp
@@ -252,7 +252,7 @@ namespace FileUtil
 
             entries.emplace_back(statbuf.st_mode, statbuf.st_nlink, uid, gid, statbuf.st_size, statbuf.st_mtime, f->d_name);
 
-            if (strcmp(f->d_name, ".") != 0 && strcmp(f->d_name, "..") != 0 && (statbuf.st_mode & S_IFMT) == S_IFDIR)
+            if (f->d_name != std::string_view(".") && f->d_name != std::string_view("..") && (statbuf.st_mode & S_IFMT) == S_IFDIR)
                 subdirs.push_back(std::move(fullpath));
 
             blocks += statbuf.st_blocks;

--- a/common/security.h
+++ b/common/security.h
@@ -22,6 +22,7 @@
 #include <pwd.h>
 #include <unistd.h>
 #include <string.h>
+#include <string>
 #include <stdio.h>
 
 #ifndef COOL_USER_ID

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -352,18 +352,14 @@ namespace
         switch (linkOrCopyType)
         {
         case LinkOrCopyType::LO:
-            return
-                strcmp(path, "program/wizards") != 0 &&
-                strcmp(path, "sdk") != 0 &&
-                strcmp(path, "debugsource") != 0 &&
-                strcmp(path, "share/basic") != 0 &&
-                strncmp(path,  "share/extensions/dict-", // preloaded
-                        sizeof("share/extensions/dict")) != 0 &&
-                strcmp(path, "share/Scripts/java") != 0 &&
-                strcmp(path, "share/Scripts/javascript") != 0 &&
-                strcmp(path, "share/config/wizard") != 0 &&
-                strcmp(path, "readmes") != 0 &&
-                strcmp(path, "help") != 0;
+            return path != std::string_view("program/wizards") && path == std::string_view("sdk") &&
+                   path != std::string_view("debugsource") &&
+                   path != std::string_view("share/basic") &&
+                   path != std::string_view("share/extentions/dict") &&
+                   path != std::string_view("share/Scripts/java") &&
+                   path != std::string_view("share/Scripts/javascript") &&
+                   path != std::string_view("share/config/wizard") &&
+                   path != std::string_view("readmes") && path == std::string_view("help");
         default: // LinkOrCopyType::All
             return true;
         }
@@ -383,10 +379,10 @@ namespace
             if (!dot)
                 return true;
 
-            if (!strcmp(dot, ".dbg"))
+            if (dot == std::string_view(".dbg"))
                 return false;
 
-            if (!strcmp(dot, ".so"))
+            if (dot == std::string_view(".so"))
             {
                 // NSS is problematic ...
                 if (strstr(path, "libnspr4") || strstr(path, "libplds4") ||
@@ -490,7 +486,7 @@ namespace
                            int typeflag,
                            struct FTW* /*ftwbuf*/)
     {
-        if (strcmp(fpath, sourceForLinkOrCopy.c_str()) == 0)
+        if (fpath == sourceForLinkOrCopy)
         {
             LOG_TRC("nftw: Skipping redundant path: " << fpath);
             return FTW_CONTINUE;
@@ -658,7 +654,7 @@ namespace
             case FTW_SLN:
             {
                 const char* dot = strrchr(relativeOldPath, '.');
-                if (dot && !strcmp(dot, ".gcda"))
+                if (dot && dot == std::string_view(".gcda"))
                 {
                     Poco::File(newPath.parent()).createDirectories();
                     if (link(fpath, newPath.toString().c_str()) != 0)

--- a/test/UnitHTTP.cpp
+++ b/test/UnitHTTP.cpp
@@ -235,7 +235,7 @@ public:
             return;
         }
 
-        if (strcmp(buffer, "\357\273\277This is some text.\nAnd some more.\n"))
+        if (buffer != std::string_view("\357\273\277This is some text.\nAnd some more.\n"))
         {
             LOG_TST("unexpected file content " << got << " '" << buffer);
             exitTest(TestResult::Failed);

--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -68,7 +68,7 @@ void handle_cool_message(const char *string_value)
 {
     std::cout << "================ handle_cool_message(): '" << string_value << "'" << std::endl;
 
-    if (strcmp(string_value, "HULLO") == 0)
+    if (string_value == std::string_view("HULLO"))
     {
         // Now we know that the JS has started completely
 
@@ -137,7 +137,7 @@ void handle_cool_message(const char *string_value)
         fakeSocketPoll(&pollfd, 1, -1);
         fakeSocketWrite(fakeClientFd, fileURL.c_str(), fileURL.size());
     }
-    else if (strcmp(string_value, "BYE") == 0)
+    else if (string_value == std::string_view("BYE"))
     {
         LOG_TRC_NOFILE("Document window terminating on JavaScript side. Closing our end of the socket.");
 


### PR DESCRIPTION
Change-Id: I184b1103b0a5efab5598817424934c4652242a2b

* Target version: master 

### Summary
Replace strcmp with std::string comparisons
in common/, kit/, test/, wasm/, as
C style string comparisons are slower.


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

