### PR TITLE
RTL: Fix spinfield padding for RTL to properly space and center icons and value

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -894,6 +894,10 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	width: 100%;
 }
 
+:dir(rtl) .spinfield {
+	padding: 4px 4px 4px 0;
+}
+
 .spinfieldunit {
 	font-size: var(--default-font-size);
 	color: var(--color-text-dark);


### PR DESCRIPTION
Change-Id: I27b4d91845ab746d6e9d48a6961d5f1ab9f352e1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Fix spinfield padding for RTL to properly space and center icons and value

### Previews

### Before
![Screenshot from 2025-06-20 14-00-11](https://github.com/user-attachments/assets/75e1d715-b584-4dfb-b4c6-1131591ab291)

### After
![Screenshot from 2025-06-20 13-59-27](https://github.com/user-attachments/assets/0dca9b3a-07ef-4de2-a2f5-5f545b249079)

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

