### PR TITLE
Fix menubutton alignment and styling inconsistencies

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -111,6 +111,9 @@ button.jsdialog img {
 	margin: 5px;
 	vertical-align: middle;
 	width: max-content;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .button-primary {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1530,6 +1530,12 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	background-color: var(--color-background-dark);
 }
 
+
+button.menubutton.sidebar > span {
+	box-shadow: none !important;
+	font-size: var(--default-font-size) !important;
+}
+
 .jsdialog .unobutton img {
 	width: var(--btn-img-size);
 	height: var(--btn-img-size);
@@ -1538,7 +1544,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .menubutton .arrow {
 	display: table-cell !important;
 	float: right;
-	margin: 5px 0px 5px 5px;
+	margin: 5px 0 0 5px;
 }
 
 .jsdialog.menubutton[disabled] {

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -110,6 +110,7 @@ img.sidebar.ui-image {
 .sidebar.ui-grid.ui-grid-cell > div:not(.ui-treeview) {
 	justify-content: start;
 	display: flex;
+	align-items: center;
 }
 
 div.sidebar.ui-grid-cell.checkbutton,
@@ -134,9 +135,10 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 
 .sidebar.ui-grid.ui-grid-cell .menubutton {
 	justify-content: space-between;
-	padding: 0;
-	margin-right: 1px;
+	padding: 8px 10px;
+	margin: 5px 0 !important;
 }
+
 
 /* widget width */
 
@@ -169,6 +171,7 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 .sidebar.unotoolbutton {
 	border: 1px solid transparent;
 	margin-right: 3px;
+	padding: 0 !important;
 }
 .sidebar.jsdialog.checkbutton {
 	font-size: var(--default-font-size);


### PR DESCRIPTION


Change-Id: I9986af79314fb03a9dc69e0e1954d1cc9353f0aa


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
The sidebar menubutton had inconsistent alignment and undesirable visual effects on hover:
- Items inside the button were not vertically centered.
- On hover, the font-size changed, causing the button to shrink slightly.
- A box-shadow was applied to the text, creating a jarring visual effect.
- These hover effects occasionally caused a flicker/glitch

**Changes**

- Center-aligned all items within the menubutton to ensure visual consistency.
- Added padding to sidebar menubutton for proper spacing and alignment.
- Removed the font-size change and box-shadow on hover to prevent visual shifts and glitches.

### BEFORE

https://github.com/user-attachments/assets/36b5b1a4-7b22-4980-b128-b6c741b6178b

### AFTER

https://github.com/user-attachments/assets/3250015a-952d-44f8-866c-2434955955ed




- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

