### PR TITLE
center align the snackbar button label

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1859,6 +1859,7 @@ button.menubutton.sidebar > span {
 
 .snackbar.jsdialog-container [id$='button'].ui-pushbutton.jsdialog {
 	padding: 8px;
+	justify-content: center;
 }
 
 #snackbar-container-progress .ui-progressbar {


### PR DESCRIPTION
Change-Id: Ide5d60568ffd0f6a5818e10a1be8cff58a5086b5


* Resolves: #12174
* Target version: master 

### Summary
- i could not reproduce this on `Chromium 137.0.7151.103` or on `Mozilla Firefox 139.0.4`. since this might happen on older versions of these browsers, or even on different browsers which i didn't test, i added `justify-content: center` css rule to prevent this issue.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

