### PR TITLE
wsd: fix: failed to get realpath of /tmp/sharedpresets/template

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3567,8 +3567,9 @@ void lokit_main(
 
                 linkOrCopy(loTemplate, loJailDestPath, linkablePath, LinkOrCopyType::LO);
 
-                linkOrCopy(sharedTemplate, loJailDestImpressTemplatePath + "/", linkablePath,
-                           LinkOrCopyType::All);
+                if (!configId.empty())
+                    linkOrCopy(sharedTemplate, loJailDestImpressTemplatePath + "/", linkablePath,
+                               LinkOrCopyType::All);
 
 #if CODE_COVERAGE
                 // Link the .gcda files.


### PR DESCRIPTION
- happens when mout_jail_tree set to false and coolwsd tries to copy or link the files sharedpresets template instead of mounting it.
- only happens to `num_prespawn_children` as when prespawning we don't have correct sharedpreset directory

```log
Jun 22 01:22:15 server coolwsd[92790]: kit-92790-92790 2025-06-22
01:22:15.348554 +0200 [ kit_spare_038 ] ERR  Failed to get the realpath
of [/opt/cool/child-roots/91829-59db4560/tmp/sharedpresets/template]
(ENOENT: No such file or directory)| common/FileUtil-unix.cpp:63

Jun 22 01:22:15 server coolwsd[92790]: kit-92790-92790 2025-06-22
01:22:15.349576 +0200 [ kit_spare_038 ] ERR  linkOrCopy: nftw() failed
for '/opt/cool/child-roots/91829-59db4560/tmp/sharedpresets/template'|
kit/Kit.cpp:612

Jun 22 01:23:30 server coolwsd[92899]: kit-92899-92899 2025-06-22
01:23:30.532902 +0200 [ kit_spare_039 ] ERR  Failed to get the realpath
of [/opt/cool/child-roots/91829-59db4560/tmp/sharedpresets/template]
(ENOENT: No such file or directory)| common/FileUtil-unix.cpp:63

Jun 22 01:23:30 server coolwsd[92899]: kit-92899-92899 2025-06-22
01:23:30.533029 +0200 [ kit_spare_039 ] ERR  linkOrCopy: nftw() failed
for '/opt/cool/child-roots/91829-59db4560/tmp/sharedpresets/template'|
kit/Kit.cpp:612
```

Change-Id: I4ea4b49cc361cb783af6c150d41c0fc83e1b3cd0

* Resolves: # <!-- related github issue -->
* Target version: master 