### PR TITLE
docker: make images OpenShift compatible

### DIFF
--- a/docker/from-packages/Dockerfile
+++ b/docker/from-packages/Dockerfile
@@ -41,7 +41,7 @@ RUN --mount=type=secret,id=secret_key \
 # Update repos before installing packages
     apt-get update && \
 # Install dependencies of installer of Collabora Online
-    apt-get -y install cpio tzdata libcap2-bin apt-transport-https gnupg2 ca-certificates curl && \
+    apt-get -y install cpio tzdata libcap2-bin apt-transport-https gnupg2 ca-certificates curl libnss-wrapper && \
 # Setup Collabora repo
     repourl="https://collaboraoffice.com/${repo:-repos}/CollaboraOnline/"; \
     secret_key=$(cat /run/secrets/secret_key); \
@@ -122,6 +122,8 @@ RUN --mount=type=secret,id=secret_key \
     find /opt/cool -user cool -exec chown -h 1001:1001 {} \; && \
     usermod -u 1001 cool && groupmod -g 1001 cool && \
     chown cool:cool /etc/coolwsd/coolwsd.xml && \
+# Change permission so that other users and groups can read the config file
+    chmod 644 /etc/coolwsd/coolwsd.xml && \
 # Fix ownership of config directory that will be modified on start of the container by cool user
     chown cool:cool /etc/coolwsd && \
 # Remove perl-base, it's not needed and triggered some license scanner because of Paul Hsieh derivative license


### PR DESCRIPTION
Coolwsd expects to run as its internal cool user and to manage child roots, cache and config file under directories owned by that user. OpenShift’s restricted SecurityContextConstraints (SCC) assign a random UID at runtime, so:
  - Files and directories in the container remain owned by cool, not the random UID.
  - coolwsd’s internal security checks reject operations by any UID other than cool.
  - coolwsd can't spawn Forkit process because of random UID.

This patch fixes the problem by using libnss-wrapper to create `/tmp/passwd` with random UID assigned by OpenShift and make libc use this `/tmp/passwd` file. More details on - https://docs.redhat.com/en/documentation/openshift_container_platform/3.11/html-single/creating_images/index#openshift-specific-guidelines

Change-Id: I57e346fa5773b3cb1d815c7815ee73b0b6a0f83f

* Resolves: # <!-- related github issue -->
* Target version: master 

### TODO
- Before merging, test the following scenarios
- [x] Testing in openshift restricted
- [ ] Testing in general k8s and docker