### PR TITLE
san: fix unit-base

### DIFF
--- a/common/Globals.hpp
+++ b/common/Globals.hpp
@@ -11,21 +11,15 @@
 
 #pragma once
 
-#include "Anonymizer.hpp"
 #include "StaticLogHelper.hpp"
-
-// Order of construction is unspecified when static objects are defined in different translation units, so
-// put globals here and include this once to specify order of construction/destruction.
 
 namespace Log {
     /// Helper to avoid destruction ordering issues.
-    StaticHelper Static;
+    extern StaticHelper Static;
 
-    StaticUIHelper StaticUILog;
+    extern StaticUIHelper StaticUILog;
 
     thread_local GenericLogger* StaticHelper::_threadLocalLogger = nullptr;
 }
-
-std::unique_ptr<Anonymizer> Anonymizer::_instance;
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -32,6 +32,7 @@
 #include "Log.hpp"
 #include "StaticLogHelper.hpp"
 #include "Util.hpp"
+#include "Anonymizer.hpp"
 
 namespace
 {
@@ -842,7 +843,16 @@ namespace Log
 
         Log::logger().get(channel).setLevel(lvl);
     }
-
 } // namespace Log
+
+// Order of construction is unspecified when static objects are defined in different translation units, so
+// put globals here to specify order of construction/destruction.
+
+namespace Log {
+    StaticHelper Static;
+    StaticUIHelper StaticUILog;
+}
+
+std::unique_ptr<Anonymizer> Anonymizer::_instance;
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
unit-base started to fail with sanitizers:
	==17710==ERROR: AddressSanitizer: odr-violation (0x55877d6d1d80):
	  [1] size=112 'Log::Static' /home/vmiklos/git/collaboraonline/online-san/./common/Globals.hpp:22
	  [2] size=112 'Log::Static' /home/vmiklos/git/collaboraonline/online-san/./common/Globals.hpp:22
	These globals were registered at these points:
	  [1]:
	    #0 0x55877aa822b3 in __asan_register_globals /home/abuild/rpmbuild/BUILD/llvm-15.0.7.src/build/../projects/compiler-rt/lib/asan/asan_globals.cpp:356:3
	    #1 0x7f1e7ad833b2 in asan.module_ctor KitQueueTests.cpp
	    #2 0x7f1e8035b82d in call_init (/lib64/ld-linux-x86-64.so.2+0x682d) (BuildId: f59375857d38f699e3cc3498d222b9d1e64adbc2)

	  [2]:
	    #0 0x55877aa822b3 in __asan_register_globals /home/abuild/rpmbuild/BUILD/llvm-15.0.7.src/build/../projects/compiler-rt/lib/asan/asan_globals.cpp:356:3
	    #1 0x55877b0a7812 in asan.module_ctor COOLWSD.cpp
	    #2 0x7f1e7ee40fa5 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x40fa5) (BuildId: 8cd6cc55dddb025d49c90d45e7ace66d04f55c4a)

Fix this by moving the definitions from the header to Log.cpp.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I0b8947f0e1c7617f2ec8af7e5fd20631762076d7
