### PR TITLE
Notebookbar: add a unique 'combination' for invert background

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1299,7 +1299,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'class': 'unoinvertbackground',
 				'type': 'bigcustomtoolitem',
 				'text': _('Invert Background'),
-				'accessibility': { focusBack: true, combination: 'DT', de: null }
+				'accessibility': { focusBack: true, combination: 'BG', de: null }
 			},
 			{ type: 'separator', id: 'layout-invertbackground-break', orientation: 'vertical' },
 			{

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -458,7 +458,7 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				'class': 'unoinvertbackground',
 				'type': 'bigcustomtoolitem',
 				'text': _('Invert Background'),
-				'accessibility': { focusBack: true, combination: 'DT', de: null }
+				'accessibility': { focusBack: true, combination: 'BG', de: null }
 			},
 			{ type: 'separator', id: 'view-invertbackground-break', orientation: 'vertical' },
 			{

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -533,7 +533,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'class': 'unoinvertbackground',
 				'type': 'bigcustomtoolitem',
 				'text': _('Invert Background'),
-				'accessibility': { focusBack: true, combination: 'TT', de: null }
+				'accessibility': { focusBack: true, combination: 'BG', de: null }
 			},
 			{ type: 'separator', id: 'view-invertbackground-break', orientation: 'vertical' },
 			{

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1612,7 +1612,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			    'class': 'unoinvertbackground',
 			    'type': 'bigcustomtoolitem',
 			    'text': _('Invert Background'),
-			    'accessibility': { focusBack: true, combination: 'D', de: null }
+			    'accessibility': { focusBack: true, combination: 'BG', de: null }
 			},
 			{ type: 'separator', id: 'view-invertbackground-break', orientation: 'vertical' },
 			{


### PR DESCRIPTION
'Invert Background' used to use same combination as 'Dark Theme'


Change-Id: I92a0beb5a67dacb053dba467b7ea3bd8dcf6452c


* See: https://github.com/CollaboraOnline/online/pull/12218#discussion_r2166469526
* Target version: master 

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

