### PR TITLE
presentation: use zstd to compress bitmaps for presentations

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -257,6 +257,7 @@ COOL_JS_LST =\
 	src/app/GraphicSelectionMiddleware.ts \
 	src/app/MultiPageViewLayout.ts \
 	src/app/TilesMiddleware.ts \
+	src/app/SlideshowMiddleware.ts \
 	src/app/SearchService.ts \
 	src/app/BaseClass.ts \
 	src/app/Events.ts \

--- a/browser/src/app/SlideshowMiddleware.ts
+++ b/browser/src/app/SlideshowMiddleware.ts
@@ -1,0 +1,65 @@
+// @ts-strict-ignore
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/* global app JSDialog _ $ errorMessages Uint8Array brandProductName GraphicSelection TileManager */
+
+// SlideBitmapManager handles the layers for the slideshow
+// It provides utility to decompress the row data from zstd and then make bitmaps from it
+class SlideBitmapManager {
+	public static pendingLayers: Promise<ImageBitmap>[] = [];
+
+	public static decompressAndCreateImageData(
+		imgRawData: Uint8Array,
+		width: number,
+		height: number,
+	): ImageData {
+		const img = (window as any).fzstd.decompress(imgRawData);
+		const clampedArray = new Uint8ClampedArray(img);
+		return new ImageData(clampedArray, width, height);
+	}
+
+	public static handleRenderSlideEvent(e: any) {
+		if (!e.textMsg.startsWith('slidelayer:')) return;
+		var json = JSON.parse(e.textMsg.substring('slidelayer: '.length));
+		if (json.width && json.height) {
+			var imgData = this.decompressAndCreateImageData(
+				e.imgBytes.subarray(e.imgIndex),
+				json.width,
+				json.height,
+			);
+			e.imgPromise = createImageBitmap(imgData);
+			this.pendingLayers.push(e.imgPromise);
+
+			e.imgPromise.then((img: ImageBitmap) => {
+				e.image = img;
+				e.imageIsComplete = true;
+				app.map.fire('slidelayer', {
+					message: json,
+					image: img,
+				});
+			});
+		}
+	}
+
+	public static handleSlideRenderingComplete(e: any) {
+		if (!e.textMsg.startsWith('sliderenderingcomplete:')) return;
+
+		// make sure all bitmaps are created before firing the complete event
+		Promise.all(this.pendingLayers).then(() => {
+			this.pendingLayers = [];
+			const status = e.textMsg.substring('sliderenderingcomplete: '.length);
+			app.map.fire('sliderenderingcomplete', {
+				success: status === 'success',
+			});
+		});
+	}
+}

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1369,17 +1369,6 @@ L.CanvasTileLayer = L.Layer.extend({
 		} else if (textMsg.startsWith('presentationinfo:')) {
 			var content = JSON.parse(textMsg.substring('presentationinfo:'.length + 1));
 			this._map.fire('presentationinfo', content);
-		} else if (textMsg.startsWith('slidelayer:')) {
-			const content = JSON.parse(textMsg.substring('slidelayer:'.length + 1));
-			this._map.fire('slidelayer', {
-				message: content,
-				image: img
-			});
-		} else if (textMsg.startsWith('sliderenderingcomplete:')) {
-			const status = textMsg.substring('sliderenderingcomplete:'.length + 1);
-			this._map.fire('sliderenderingcomplete', {
-				success: status === 'success'
-			});
 		}
 	},
 

--- a/browser/src/slideshow/LayerDrawing.ts
+++ b/browser/src/slideshow/LayerDrawing.ts
@@ -172,6 +172,7 @@ class LayerDrawing {
 
 		this.drawBackground(slideHash);
 		this.drawMasterPage(slideHash);
+		this.drawTextField(slideHash);
 		this.drawDrawPage(slideHash);
 		this.drawVideos(slideHash);
 	}
@@ -654,6 +655,27 @@ class LayerDrawing {
 
 		for (const layer of layers) {
 			this.drawDrawPageLayer(slideHash, layer);
+		}
+		return true;
+	}
+
+	private drawTextField(slideHash: string) {
+		const slideInfo = this.getSlideInfo(slideHash);
+		if (slideInfo.empty) {
+			return true;
+		}
+
+		const fields = this.slideTextFieldsMap.get(slideHash);
+		if (!fields) {
+			window.app.console.log(
+				'LayerDrawing: No layer cached text field for draw page: ' + slideHash,
+			);
+			return false;
+		}
+
+		for (const field of fields) {
+			const imageInfo = this.cachedTextFields.get(field[1]).content;
+			this.drawBitmap(imageInfo);
 		}
 		return true;
 	}

--- a/browser/src/slideshow/LayerRenderer.ts
+++ b/browser/src/slideshow/LayerRenderer.ts
@@ -305,20 +305,35 @@ class LayerRendererGl implements LayerRenderer {
 		this.disposed = true;
 	}
 
-	hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+	hexToRgba(
+		hex: string,
+	): { r: number; g: number; b: number; a: number } | null {
 		hex = hex.replace(/^#/, '');
 		let bigint: number;
 		if (hex.length === 3) {
 			const r = parseInt(hex.charAt(0) + hex.charAt(0), 16);
 			const g = parseInt(hex.charAt(1) + hex.charAt(1), 16);
 			const b = parseInt(hex.charAt(2) + hex.charAt(2), 16);
-			return { r, g, b };
+			return { r, g, b, a: 0 };
 		} else if (hex.length === 6) {
 			bigint = parseInt(hex, 16);
 			const r = (bigint >> 16) & 255;
 			const g = (bigint >> 8) & 255;
 			const b = bigint & 255;
-			return { r, g, b };
+			return { r, g, b, a: 0 };
+		} else if (hex.length === 8) {
+			bigint = parseInt(hex, 16);
+			const r = (bigint >> 24) & 255;
+			const g = (bigint >> 16) & 255;
+			const b = (bigint >> 8) & 255;
+			const a = bigint & 255;
+			return { r, g, b, a };
+		} else if (hex.length === 4) {
+			const r = parseInt(hex.charAt(0) + hex.charAt(0), 16);
+			const g = parseInt(hex.charAt(1) + hex.charAt(1), 16);
+			const b = parseInt(hex.charAt(2) + hex.charAt(2), 16);
+			const a = parseInt(hex.charAt(3) + hex.charAt(2), 16);
+			return { r, g, b, a };
 		} else {
 			return null;
 		}
@@ -329,9 +344,14 @@ class LayerRendererGl implements LayerRenderer {
 
 		if (slideInfo.background && slideInfo.background.fillColor) {
 			const fillColor = slideInfo.background.fillColor;
-			const rgb = this.hexToRgb(fillColor);
-			if (rgb) {
-				this.gl.clearColor(rgb.r / 255, rgb.g / 255, rgb.b / 255, 1.0);
+			const rgba = this.hexToRgba(fillColor);
+			if (rgba) {
+				this.gl.clearColor(
+					rgba.r / 255,
+					rgba.g / 255,
+					rgba.b / 255,
+					rgba.a / 255,
+				);
 			} else {
 				this.gl.clearColor(1.0, 1.0, 1.0, 1.0);
 			}

--- a/browser/src/slideshow/LayerRenderer.ts
+++ b/browser/src/slideshow/LayerRenderer.ts
@@ -406,8 +406,13 @@ class LayerRenderer2d implements LayerRenderer {
 		}
 		if (imageInfo instanceof ImageBitmap) {
 			this.offscreenContext.drawImage(imageInfo, 0, 0);
-		} else if (imageInfo.type === 'png') {
+		} else if (
+			imageInfo.type === 'png' ||
+			imageInfo.data instanceof ImageBitmap
+		) {
 			this.offscreenContext.drawImage(imageInfo.data as HTMLImageElement, 0, 0);
+		} else {
+			throw 'No supported bitmap to draw found';
 		}
 	}
 

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2485,52 +2485,77 @@ bool ChildSession::renderNextSlideLayer(SlideCompressor &scomp,
 
             uint64_t pixmapHash = hashSubBuffer(pixmap->data(), 0, 0, width, height, width, height) + getViewId();
             std::string json = jsonMsg;
-            if (size_t start = json.find("%IMAGETYPE%"); start != std::string::npos)
-                json.replace(start, 11, "zstd");
             if (size_t start = json.find("%IMAGECHECKSUM%"); start != std::string::npos)
                 json.replace(start, 15, std::to_string(pixmapHash));
 
+            if (EnableExperimental) // ZSTD
             {
-                Poco::JSON::Parser parser;
-                Poco::JSON::Object::Ptr root = parser.parse(json).extract<Poco::JSON::Object::Ptr>();
-                root->set("width", width);
-                root->set("height", height);
-                std::stringstream ss;
-                root->stringify(ss);
-                json = ss.str();
+                if (size_t start = json.find("%IMAGETYPE%"); start != std::string::npos)
+                    json.replace(start, 11, "zstd");
+
+                {
+                    Poco::JSON::Parser parser;
+                    Poco::JSON::Object::Ptr root = parser.parse(json).extract<Poco::JSON::Object::Ptr>();
+                    root->set("width", width);
+                    root->set("height", height);
+                    std::stringstream ss;
+                    root->stringify(ss);
+                    json = ss.str();
+                }
+
+                std::string response = "slidelayer: " + json;
+
+                response += "\n";
+
+                size_t compressed_max_size = ZSTD_COMPRESSBOUND(pixmap->size());
+                size_t max_required_size = response.size() + compressed_max_size;
+                output.resize(max_required_size);
+                std::memcpy(output.data(), response.data(), response.size());
+                std::vector<char> compressedOutPut;
+                compressedOutPut.resize(ZSTD_COMPRESSBOUND(pixmap->size()));
+
+                if (tileMode == LibreOfficeKitTileMode::LOK_TILEMODE_BGRA)
+                {
+                    png_row_info rowInfo;
+                    rowInfo.rowbytes = pixmap->size();
+                    // Following function just needs row size to transform from BGRA to RGBA
+                    // We have a flat array so its safe to pass pixmap size as row size
+                    Png::unpremultiply_bgra_data(nullptr, &rowInfo, pixmap->data());
+                }
+                size_t compSize = ZSTD_compress(&output[response.size()], compressed_max_size,
+                                                pixmap->data(), pixmap->size(), -3);
+
+                if (ZSTD_isError(compSize))
+                {
+                    output.resize(0);
+                    LOG_ERR("Failed to compress slidelayer of size " << pixmap->size() << " with "
+                                                                    << ZSTD_getErrorName(compSize));
+                    return;
+                }
+                output.resize(response.size() + compSize);
+
+                LOG_TRC("Compressed slidelayer of size " << pixmap->size() << " to size " << compSize);
             }
-            std::string response = "slidelayer: " + json;
-
-            response += "\n";
-
-            size_t compressed_max_size = ZSTD_COMPRESSBOUND(pixmap->size());
-            size_t max_required_size = response.size() + compressed_max_size;
-            output.resize(max_required_size);
-            std::memcpy(output.data(), response.data(), response.size());
-            std::vector<char> compressedOutPut;
-            compressedOutPut.resize(ZSTD_COMPRESSBOUND(pixmap->size()));
-
-            if (tileMode == LibreOfficeKitTileMode::LOK_TILEMODE_BGRA)
+            else // PNG
             {
-                png_row_info rowInfo;
-                rowInfo.rowbytes = pixmap->size();
-                // Following function just needs row size to transform from BGRA to RGBA
-                // We have a flat array so its safe to pass pixmap size as row size
-                Png::unpremultiply_bgra_data(nullptr, &rowInfo, pixmap->data());
-            }
-            size_t compSize = ZSTD_compress(&output[response.size()], compressed_max_size,
-                                            pixmap->data(), pixmap->size(), -3);
+                if (size_t start = json.find("%IMAGETYPE%"); start != std::string::npos)
+                    json.replace(start, 11, "png");
 
-            if (ZSTD_isError(compSize))
-            {
-                output.resize(0);
-                LOG_ERR("Failed to compress slidelayer of size " << pixmap->size() << " with "
-                                                                 << ZSTD_getErrorName(compSize));
-                return;
-            }
-            output.resize(response.size() + compSize);
+                std::string response = "slidelayer: " + json;
 
-            LOG_TRC("Compressed slidelayer of size " << pixmap->size() << " to size " << compSize);
+                response += "\n";
+
+                output.reserve(response.size() + pixmap->size());
+                output.resize(response.size());
+
+                std::memcpy(output.data(), response.data(), response.size());
+
+                if (!Png::encodeSubBufferToPNG(pixmap->data(), 0, 0, width, height, width, height, output, tileMode))
+                {
+                    LOG_ERR("Failed to encode into PNG.");
+                    output.resize(0);
+                }
+            }
         });
     return true;
 }

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -63,6 +63,8 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <zlib.h>
+#include <zstd.h>
 
 using Poco::JSON::Object;
 using Poco::JSON::Parser;
@@ -2484,23 +2486,51 @@ bool ChildSession::renderNextSlideLayer(SlideCompressor &scomp,
             uint64_t pixmapHash = hashSubBuffer(pixmap->data(), 0, 0, width, height, width, height) + getViewId();
             std::string json = jsonMsg;
             if (size_t start = json.find("%IMAGETYPE%"); start != std::string::npos)
-                json.replace(start, 11, "png");
+                json.replace(start, 11, "zstd");
             if (size_t start = json.find("%IMAGECHECKSUM%"); start != std::string::npos)
                 json.replace(start, 15, std::to_string(pixmapHash));
 
+            {
+                Poco::JSON::Parser parser;
+                Poco::JSON::Object::Ptr root = parser.parse(json).extract<Poco::JSON::Object::Ptr>();
+                root->set("width", width);
+                root->set("height", height);
+                std::stringstream ss;
+                root->stringify(ss);
+                json = ss.str();
+            }
             std::string response = "slidelayer: " + json;
 
             response += "\n";
 
-            output.reserve(response.size() + pixmap->size());
-            output.resize(response.size());
+            size_t compressed_max_size = ZSTD_COMPRESSBOUND(pixmap->size());
+            size_t max_required_size = response.size() + compressed_max_size;
+            output.resize(max_required_size);
             std::memcpy(output.data(), response.data(), response.size());
+            std::vector<char> compressedOutPut;
+            compressedOutPut.resize(ZSTD_COMPRESSBOUND(pixmap->size()));
 
-            if (!Png::encodeSubBufferToPNG(pixmap->data(), 0, 0, width, height, width, height, output, tileMode))
+            if (tileMode == LibreOfficeKitTileMode::LOK_TILEMODE_BGRA)
             {
-                LOG_ERR("Failed to encode into PNG.");
-                output.resize(0);
+                png_row_info rowInfo;
+                rowInfo.rowbytes = pixmap->size();
+                // Following function just needs row size to transform from BGRA to RGBA
+                // We have a flat array so its safe to pass pixmap size as row size
+                Png::unpremultiply_bgra_data(nullptr, &rowInfo, pixmap->data());
             }
+            size_t compSize = ZSTD_compress(&output[response.size()], compressed_max_size,
+                                            pixmap->data(), pixmap->size(), -3);
+
+            if (ZSTD_isError(compSize))
+            {
+                output.resize(0);
+                LOG_ERR("Failed to compress slidelayer of size " << pixmap->size() << " with "
+                                                                 << ZSTD_getErrorName(compSize));
+                return;
+            }
+            output.resize(response.size() + compSize);
+
+            LOG_TRC("Compressed slidelayer of size " << pixmap->size() << " to size " << compSize);
         });
     return true;
 }


### PR DESCRIPTION
fixes: CollaboraOnline#11740

another version of zstd implementation was reverted due to regression causing some animation to not load properly. i.e text would not be visible when slide is transitioning

original commit: d82d7ca
reverted commit: cb45b4a


Change-Id: I0465527b62c75b5ef9960f3bb67cf6922b405650


* Target version: master 



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

