### PR TITLE
Fix Calc regression: sheet tabs not visible and cannot create new sheet

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -111,9 +111,6 @@ button.jsdialog img {
 	margin: 5px;
 	vertical-align: middle;
 	width: max-content;
-	display: flex;
-	align-items: center;
-	justify-content: center;
 }
 
 .button-primary {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1531,6 +1531,9 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	padding: 8px 10px;
 	margin: 2px 0px;
 	background-color: var(--color-background-dark);
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 


### PR DESCRIPTION
Change-Id: I77983902ca30ad42bd1fcfd4d387428788fcb2d4


* Resolves: #12191 
* Target version: master 

### Summary
This PR fixes a regression from my previous commit that caused the Calc sheet tabs to disappear and blocked the creation of new sheets. The changes restore the tabs’ visibility and functionality, and I also narrowed the styling updates to only affect menubuttons as originally intended, preventing any unwanted side effects. This should get Calc back to working smoothly without impacting other UI elements.


### Preview
![Screenshot from 2025-06-26 10-16-13](https://github.com/user-attachments/assets/2f4c6c20-128c-4cd4-a451-38a0da927eae)

### Previous PR
![image](https://github.com/user-attachments/assets/3d98355f-5b99-4ccb-9200-554b6cb8f20d)

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

