### PR TITLE
Don't collapse currently selected comment.

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -261,8 +261,10 @@ export class CommentSection extends CanvasSectionObject {
 		}
 
 		this.isCollapsed = true;
-		this.unselect();
 		for (var i: number = 0; i < this.sectionProperties.commentList.length; i++) {
+			if (this.sectionProperties.selectedComment === this.sectionProperties.commentList[i])
+				continue;
+
 			if (this.sectionProperties.commentList[i].sectionProperties.data.id !== 'new')
 				this.sectionProperties.commentList[i].setCollapsed();
 				$(this.sectionProperties.commentList[i].sectionProperties.container).addClass('collapsed-comment');


### PR DESCRIPTION
If a second user adds a shape to the document and triggers a renewAllSections call, the selected comment of the current user gets collapsed. Fix: Ensure that currently viewed comment is not collapsed.


Change-Id: Ie282cdc153c44a47e463f3f86ff057576c4ed6ee


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

