### PR TITLE
Delay canvas resize until redraw

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -166,6 +166,7 @@ class CanvasSectionContainer {
 	private context: CanvasRenderingContext2D;
 	private width: number;
 	private height: number;
+	private needsResize: boolean = false;
 	private positionOnMouseDown: Array<number> = null;
 	private positionOnMouseUp: Array<number> = null;
 	private positionOnClick: Array<number> = null;
@@ -283,7 +284,7 @@ class CanvasSectionContainer {
 	}
 
 	public getViewSize (): Array<number> {
-		return [this.canvas.width, this.canvas.height];
+		return [this.width, this.height];
 	}
 
 	public getLastPanDirection() : Array<number> {
@@ -642,6 +643,22 @@ class CanvasSectionContainer {
 
 	private redrawCallback(timestamp: number) {
 		this.drawRequest = null;
+
+		if (this.needsResize) {
+			this.needsResize = false;
+			this.canvas.width = this.width;
+			this.canvas.height = this.height;
+
+			// CSS pixels can be fractional, but need to round to the same real pixels
+			var cssWidth: number = this.width / app.dpiScale; // NB. beware
+			var cssHeight: number = this.height / app.dpiScale;
+			this.canvas.style.width = cssWidth.toFixed(4) + 'px';
+			this.canvas.style.height = cssHeight.toFixed(4) + 'px';
+
+			// Avoid black default background.
+			this.clearCanvas();
+		}
+
 		this.drawSections();
 		this.flushLayoutingTasks();
 	}
@@ -1333,30 +1350,10 @@ class CanvasSectionContainer {
 			return;
 		}
 
-		// Drawing may happen asynchronously so backup the old contents to avoid
-		// showing a blank canvas.
-		var oldImageData: ImageData = null;
-		if (this.paintedEver && this.canvas.width > 0 && this.canvas.height > 0)
-			oldImageData = this.context.getImageData(0, 0, this.canvas.width, this.canvas.height);
-
-		this.canvas.width = newWidth;
-		this.canvas.height = newHeight;
-
-		// CSS pixels can be fractional, but need to round to the same real pixels
-		var cssWidth: number = newWidth / app.dpiScale; // NB. beware
-		var cssHeight: number = newHeight / app.dpiScale;
-		this.canvas.style.width = cssWidth.toFixed(4) + 'px';
-		this.canvas.style.height = cssHeight.toFixed(4) + 'px';
-
-		// Avoid black default background.
-		if (!oldImageData || this.width < newWidth || this.height < newHeight)
-			this.clearCanvas();
-		if (oldImageData)
-			this.context.putImageData(oldImageData, 0, 0);
-
 		this.clearMousePositions();
-		this.width = this.canvas.width;
-		this.height = this.canvas.height;
+		this.width = newWidth;
+		this.height = newHeight;
+		this.needsResize = true;
 
 		this.reNewAllSections(false);
 	}
@@ -1679,7 +1676,7 @@ class CanvasSectionContainer {
 			}
 			else if (section.windowSection) {
 				section.myTopLeft = [0, 0];
-				section.size = [this.canvas.width, this.canvas.height];
+				section.size = [this.width, this.height];
 				section.isLocated = true;
 				this.windowSectionList.push(section);
 			}


### PR DESCRIPTION
Delay resizing (and thus blanking) the canvas until we're ready to draw the contents. This negates the need to blit an old copy of the canvas when resizing.

* Resolves: #11811 
* Target version: master 

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

