### PR TITLE
colorpicker: Improves color picker hover visibility with outline

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1613,8 +1613,10 @@ button.menubutton.sidebar > span {
 	height: 16px;
 }
 
-.ui-color-picker-entry:hover {
-	border: 1px solid var(--color-primary);
+.ui-color-picker-entry:hover,
+.ui-color-picker-entry:focus-visible {
+	outline: 2px solid var(--color-primary);
+	outline-offset: 1px;
 }
 
 #ui-color-picker-custom,


### PR DESCRIPTION
Change-Id: Ia301f0e6790012fac7415a2c475f17b9d366560c

### Summary
This will make the hover selection clearly visible.
![image](https://github.com/user-attachments/assets/30377dd9-23f9-4b40-acd3-4ebb40ba14bc)

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

