### PR TITLE
slide preview: avoid changing focus on unnecessary graphicselection

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3067,7 +3067,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			this._map._textInput.hideCursor();
 			// Maintain input if a dialog or search-box has the focus.
 			if (this._map.editorHasFocus() && !this._map.uiManager.isAnyDialogOpen() && !this._map.isSearching()
-				&& !JSDialog.IsAnyInputFocused())
+				&& !JSDialog.IsAnyInputFocused() && !this._map._docLayer._preview.partsFocused)
 				this._map.focus(false);
 		}
 


### PR DESCRIPTION
avoid changing focus on empty graphicselection message this message is sent when first time slide is changed, even if there were no prior selection this message received, which caused losing focus from preview when navigating with keys


Change-Id: I254a204bbd02e8b3d4f5536444983d94ee2564ae


* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

