### PR TITLE
docker: make images OpenShift compatible

### DIFF
--- a/docker/from-packages/Dockerfile
+++ b/docker/from-packages/Dockerfile
@@ -41,7 +41,7 @@ RUN --mount=type=secret,id=secret_key \
 # Update repos before installing packages
     apt-get update && \
 # Install dependencies of installer of Collabora Online
-    apt-get -y install cpio tzdata libcap2-bin apt-transport-https gnupg2 ca-certificates curl && \
+    apt-get -y install cpio tzdata libcap2-bin apt-transport-https gnupg2 ca-certificates curl libnss-wrapper && \
 # Setup Collabora repo
     repourl="https://collaboraoffice.com/${repo:-repos}/CollaboraOnline/"; \
     secret_key=$(cat /run/secrets/secret_key); \
@@ -122,6 +122,8 @@ RUN --mount=type=secret,id=secret_key \
     find /opt/cool -user cool -exec chown -h 1001:1001 {} \; && \
     usermod -u 1001 cool && groupmod -g 1001 cool && \
     chown cool:cool /etc/coolwsd/coolwsd.xml && \
+# Change permission so that other users and groups can read the config file
+    chmod 644 /etc/coolwsd/coolwsd.xml && \
 # Fix ownership of config directory that will be modified on start of the container by cool user
     chown cool:cool /etc/coolwsd && \
 # Remove perl-base, it's not needed and triggered some license scanner because of Paul Hsieh derivative license

--- a/docker/from-packages/scripts/start-collabora-online.sh
+++ b/docker/from-packages/scripts/start-collabora-online.sh
@@ -26,5 +26,19 @@ cert_params="\
  --o:ssl.ca_file_path=/tmp/ssl/certs/ca/root.crt.pem"
 fi
 
+# OpenShift assign a random UID to container but Collabora Online expects
+# cool user do certain operation like spawning Forkit.
+# Build a tiny passwd file mapping this random assigned UID to "cool" if userId is not "1001"
+user_id=$(id -u)
+group_id=$(id -g)
+if [ "$user_id" -ne 1001 ]; then
+  echo "cool:x:${user_id}:${group_id}::/opt/cool:/usr/sbin/nologin" >/tmp/passwd
+
+  # Tell libc to use our files, via LD_PRELOAD
+  export NSS_WRAPPER_PASSWD=/tmp/passwd
+  export NSS_WRAPPER_GROUP=/etc/group
+  export LD_PRELOAD=libnss_wrapper.so
+fi
+
 # Start coolwsd
 exec /usr/bin/coolwsd --version --use-env-vars ${cert_params} --o:sys_template_path=/opt/cool/systemplate --o:child_root_path=/opt/cool/child-roots --o:file_server_root_path=/usr/share/coolwsd --o:cache_files.path=/opt/cool/cache --o:logging.color=false --o:stop_on_config_change=true ${extra_params} "$@"


### PR DESCRIPTION
Coolwsd expects to run as its internal cool user and to manage child roots, cache and config file under directories owned by that user. OpenShift’s restricted SecurityContextConstraints (SCC) assign a random UID at runtime, so:
  - Files and directories in the container remain owned by cool, not the random UID.
  - coolwsd’s internal security checks reject operations by any UID other than cool.
  - coolwsd can't spawn Forkit process because of random UID.

This patch fixes the problem by using libnss-wrapper to create `/tmp/passwd` with random UID assigned by OpenShift and make libc use this `/tmp/passwd` file. More details on - https://docs.redhat.com/en/documentation/openshift_container_platform/3.11/html-single/creating_images/index#openshift-specific-guidelines


Change-Id: I57e346fa5773b3cb1d815c7815ee73b0b6a0f83f

* Target version: master 

### TODO
- [x] Tested in both OpenShift and normal docker image works as expected :)
