### PR TITLE
fix(android): Add minutes stream operator<<

### DIFF
--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -61,6 +61,13 @@ extern "C"
 #define THREAD_UNSAFE_DUMP_END
 #endif
 
+/// Format minutes with the units suffix until we migrate to C++20.
+inline std::ostream& operator<<(std::ostream& os, const std::chrono::minutes& s)
+{
+    os << s.count() << "m";
+    return os;
+}
+
 /// Format seconds with the units suffix until we migrate to C++20.
 inline std::ostream& operator<<(std::ostream& os, const std::chrono::seconds& s)
 {


### PR DESCRIPTION
Previously we were only logging out times in seconds, nanoseconds and microseconds. In If627a9699396e86d783b4877682c9fae224f95e2 this was changed to log out minutes.

Unfortunately logging out minutes created ambiguity between which formatter should be used. Therefore, the Android build failed.

Refs: If627a9699396e86d783b4877682c9fae224f95e2




Change-Id: Iaaa3a858b3a7bde7cf332df5fd6af2f4c593552e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

