### PR TITLE
gh#12178 Extract Platform-Dependent Code to Reduce `#ifdef`s and Header Pollution

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -370,6 +370,7 @@ wsd_headers = wsd/Admin.hpp \
               wsd/ServerAuditUtil.hpp \
               wsd/ServerURL.hpp \
               wsd/SpecialBrokers.hpp \
+              wsd/SslConfig.hpp \
               wsd/Storage.hpp \
               wsd/TileCache.hpp \
               wsd/TileDesc.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -356,6 +356,7 @@ wsd_headers = wsd/Admin.hpp \
               wsd/Exceptions.hpp \
               wsd/FileServer.hpp \
               wsd/HostUtil.hpp \
+              wsd/PlatformDesktop.hpp \
               wsd/PlatformMobile.hpp \
               wsd/PlatformUnix.hpp \
               wsd/PresetsInstall.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -356,6 +356,7 @@ wsd_headers = wsd/Admin.hpp \
               wsd/Exceptions.hpp \
               wsd/FileServer.hpp \
               wsd/HostUtil.hpp \
+              wsd/PlatformUnix.hpp \
               wsd/PresetsInstall.hpp \
               wsd/Process.hpp \
               wsd/ProofKey.hpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -356,6 +356,7 @@ wsd_headers = wsd/Admin.hpp \
               wsd/Exceptions.hpp \
               wsd/FileServer.hpp \
               wsd/HostUtil.hpp \
+              wsd/PlatformMobile.hpp \
               wsd/PlatformUnix.hpp \
               wsd/PresetsInstall.hpp \
               wsd/Process.hpp \

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -63,10 +63,6 @@
 
 #if !MOBILEAPP
 
-#if ENABLE_SSL
-#include <Poco/Net/SSLManager.h>
-#endif
-
 #include <cerrno>
 #include <stdexcept>
 #include <unordered_map>
@@ -77,6 +73,7 @@
 #include "FileServer.hpp"
 #include "UserMessages.hpp"
 #include <wsd/PlatformUnix.hpp>
+#include <wsd/SslConfig.hpp>
 #include <wsd/RemoteConfig.hpp>
 #include <wsd/SpecialBrokers.hpp>
 
@@ -117,9 +114,6 @@
 #include <MobileApp.hpp>
 #include <Protocol.hpp>
 #include <Session.hpp>
-#if ENABLE_SSL
-#  include <SslSocket.hpp>
-#endif
 #include <wsd/wopi/StorageConnectionManager.hpp>
 #include <wsd/TraceFile.hpp>
 #include <common/ConfigUtil.hpp>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -126,18 +126,7 @@
 
 #include <ServerSocket.hpp>
 
-#if MOBILEAPP
-#include <Kit.hpp>
-#ifdef IOS
-#include "ios.h"
-#elif defined(GTKAPP)
-#include "gtk.hpp"
-#elif defined(__ANDROID__)
-#include "androidapp.hpp"
-#elif WASMAPP
-#include "wasmapp.hpp"
-#endif
-#endif // MOBILEAPP
+#include <wsd/PlatformMobile.hpp>
 
 using Poco::Util::LayeredConfiguration;
 using Poco::Util::Option;

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -61,23 +61,7 @@
 #include "CommandControl.hpp"
 #endif
 
-#if !MOBILEAPP
-
-#include <cerrno>
-#include <stdexcept>
-#include <unordered_map>
-
-#include "Admin.hpp"
-#include "Auth.hpp"
-#include "CacheUtil.hpp"
-#include "FileServer.hpp"
-#include "UserMessages.hpp"
-#include <wsd/PlatformUnix.hpp>
-#include <wsd/SslConfig.hpp>
-#include <wsd/RemoteConfig.hpp>
-#include <wsd/SpecialBrokers.hpp>
-
-#endif // !MOBILEAPP
+#include <wsd/PlatformDesktop.hpp>
 
 #include <Poco/DirectoryIterator.h>
 #include <Poco/Exception.h>
@@ -104,11 +88,6 @@
 #include <wsd/Process.hpp>
 #include <common/JsonUtil.hpp>
 #include <common/FileUtil.hpp>
-
-#if !MOBILEAPP
-#include <common/JailUtil.hpp>
-#include <common/Watchdog.hpp>
-#endif
 
 #include <common/Log.hpp>
 #include <MobileApp.hpp>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -76,6 +76,7 @@
 #include "CacheUtil.hpp"
 #include "FileServer.hpp"
 #include "UserMessages.hpp"
+#include <wsd/PlatformUnix.hpp>
 #include <wsd/RemoteConfig.hpp>
 #include <wsd/SpecialBrokers.hpp>
 
@@ -143,13 +144,6 @@
 #include "wasmapp.hpp"
 #endif
 #endif // MOBILEAPP
-
-#ifdef __linux__
-#if !MOBILEAPP
-#include <common/security.h>
-#include <sys/inotify.h>
-#endif
-#endif
 
 using Poco::Util::LayeredConfiguration;
 using Poco::Util::Option;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -36,21 +36,13 @@
 #include <wsd/ClientSession.hpp>
 #include <wsd/Exceptions.hpp>
 #include <wsd/FileServer.hpp>
+#include <wsd/PlatformDesktop.hpp>
 #include <wsd/PresetsInstall.hpp>
 #include <wsd/Process.hpp>
 #include <wsd/ProxyProtocol.hpp>
 #include <wsd/QuarantineUtil.hpp>
 #include <wsd/Storage.hpp>
 #include <wsd/TileCache.hpp>
-
-#if !MOBILEAPP
-#include <net/HttpHelper.hpp>
-#include <wopi/CheckFileInfo.hpp>
-#include <wopi/StorageConnectionManager.hpp>
-#include <wsd/Admin.hpp>
-
-#include <sys/wait.h> // waitpid()
-#endif // !MOBILEAPP
 
 #include <Poco/DigestStream.h>
 #include <Poco/Exception.h>
@@ -66,7 +58,6 @@
 #include <fstream>
 #include <ios>
 #include <memory>
-#include <sstream>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/wsd/PlatformDesktop.hpp
+++ b/wsd/PlatformDesktop.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#if !MOBILEAPP
+
+#include <cerrno>
+#include <stdexcept>
+#include <unordered_map>
+
+#include "Admin.hpp"
+#include "Auth.hpp"
+#include "CacheUtil.hpp"
+#include "FileServer.hpp"
+#include "UserMessages.hpp"
+#include <wopi/CheckFileInfo.hpp>
+#include <wopi/StorageConnectionManager.hpp>
+#include <net/HttpHelper.hpp>
+#include <sys/wait.h>
+
+#include <common/JailUtil.hpp>
+#include <common/Watchdog.hpp>
+#include <wsd/PlatformUnix.hpp>
+#include <wsd/SslConfig.hpp>
+#include <wsd/RemoteConfig.hpp>
+#include <wsd/SpecialBrokers.hpp>
+
+#endif

--- a/wsd/PlatformMobile.hpp
+++ b/wsd/PlatformMobile.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#if MOBILEAPP
+
+#include <Kit.hpp>
+#ifdef IOS
+#include "ios.h"
+#elif defined(GTKAPP)
+#include "gtk.hpp"
+#elif defined(__ANDROID__)
+#include "androidapp.hpp"
+#elif WASMAPP
+#include "wasmapp.hpp"
+#endif
+
+#endif // MOBILEAPP

--- a/wsd/PlatformUnix.hpp
+++ b/wsd/PlatformUnix.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#ifdef __linux__
+
+#if !MOBILEAPP
+#include <common/security.h>
+#include <sys/inotify.h>
+#endif
+
+#endif

--- a/wsd/SslConfig.hpp
+++ b/wsd/SslConfig.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+#if ENABLE_SSL
+#include <Poco/Net/SSLManager.h>
+#include <SslSocket.hpp>
+#endif


### PR DESCRIPTION
https://github.com/CollaboraOnline/online/issues/12178

### Summary
Extract Platform-Dependent Code to Reduce #ifdefs and Header Pollution.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

