### PR TITLE
Change contributors card image to a new beaver image

### DIFF
--- a/scripts/contributors-credit.js
+++ b/scripts/contributors-credit.js
@@ -22,7 +22,7 @@ tags = [
     "make",
 ]
 images = [
-    "debug-code.jpg",
+    "beaver/contributors-copyrighted.png",
 ]
 showimage = false
 showtitle = true


### PR DESCRIPTION
- as we did add all the beaver ilustrations in our IO page
- this patch will change the contributors card image to a new beaver image


Change-Id: I24f1ff115676dae53d4797ee5c6b13de0601e62d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

