### PR TITLE
remove unused css properties

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -590,34 +590,6 @@ button.leaflet-control-search-next
 	margin: 0px;
 }
 
-/* slide layouts submenu */
-#slidelayoutmenu-grid {
-	display: grid;
-	grid-template-columns: repeat(4, auto);
-}
-
-#slidelayoutmenu-grid button:not(#iconsetoverlay) {
-	box-sizing: border-box;
-	position: relative;
-	padding: 3px;
-	border: 1px solid var(--color-border-dark);
-	border-radius: var(--border-radius);
-	margin: 3px;
-	overflow: auto; /* child margins otherwise don't expand *this* element (parent) */
-	min-width: initial;
-}
-
-#slidelayoutmenu-grid button:hover {
-	border: 1px solid var(--color-border-darker);
-	background-color: var(--color-background-darker) !important;
-}
-
-#slidelayoutmenu-grid #iconsetoverlay {
-	grid-column: 1/4;
-	width: 100%;
-	margin: 0px;
-}
-
 #home-assign-layout {
 	width: fit-content;
 }


### PR DESCRIPTION
Change-Id: Ib9526e1c1a27845a142b3e04a83f5c008ad6f21f


* Resolves: #12167 
* Target version: master 

### Summary
after #12254 replaced the htmlcontent popup with native jsdialog popup, the old css properties are no longer needed.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

