### PR TITLE
Replace Draw tab with Shape and Picture tabs

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -62,11 +62,18 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'accessibility': { focusBack: true,	combination: 'M', de: null }
 			},
 			{
-				'id': 'Draw-tab-label',
-				'text': _('Draw'),
-				'name': 'Draw',
-				'context': 'Draw|DrawLine|3DObject|MultiObject|Graphic|DrawFontwork',
+				'id': 'Shape-tab-label',
+				'text': _('Shape'),
+				'name': 'Shape',
+				'context': 'Draw|DrawLine|3DObject|MultiObject|DrawFontwork',
 				'accessibility': { focusBack: true,	combination: 'D', de: null }
+			},
+			{
+				'id': 'Picture-tab-label',
+				'text': _('Picture'),
+				'name': 'Picture',
+				'context': 'Graphic',
+				'accessibility': { focusBack: true,	combination: 'G', de: null }
 			},
 			{
 				'id': 'View-tab-label',
@@ -92,7 +99,8 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			this.getDataTab(),
 			this.getReviewTab(),
 			this.getFormatTab(),
-			this.getDrawTab(),
+			this.getShapeTab(),
+			this.getPictureTab(),
 			this.getViewTab(),
 			this.getHelpTab()
 		]
@@ -2150,10 +2158,10 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 		return this.getTabPage('Format', content);
 	},
 
-	getDrawTab: function() {
+	getShapeTab: function() {
 		var content = [
 			{
-				'id': 'draw-transform-dialog',
+				'id': 'shape-transform-dialog',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:TransformDialog', 'text'),
 				'command': '.uno:TransformDialog',
@@ -2166,7 +2174,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-flip-vertical',
+								'id': 'shape-flip-vertical',
 								'type': 'toolitem',
 								'text': _UNO('.uno:FlipVertical'),
 								'command': '.uno:FlipVertical',
@@ -2178,7 +2186,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-flip-horizontal',
+								'id': 'shape-flip-horizontal',
 								'type': 'toolitem',
 								'text': _UNO('.uno:FlipHorizontal'),
 								'command': '.uno:FlipHorizontal',
@@ -2196,7 +2204,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-xline-color:ColorPickerMenu',
+								'id': 'shape-xline-color:ColorPickerMenu',
 								'noLabel': true,
 								'type': 'toolitem',
 								'text': _UNO('.uno:XLineColor'),
@@ -2209,7 +2217,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-fill-color:ColorPickerMenu',
+								'id': 'shape-fill-color:ColorPickerMenu',
 								'noLabel': true,
 								'type': 'toolitem',
 								'text': _UNO('.uno:FillColor'),
@@ -2228,21 +2236,21 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-wrap-off',
+								'id': 'shape-wrap-off',
 								'type': 'toolitem',
 								'text': _UNO('.uno:WrapOff', 'text'),
 								'command': '.uno:WrapOff',
 								'accessibility': { focusBack: true,	combination: 'WO', de: null }
 							},
 							{
-								'id': 'draw-wrap-on',
+								'id': 'shape-wrap-on',
 								'type': 'toolitem',
 								'text': _UNO('.uno:WrapOn', 'text'),
 								'command': '.uno:WrapOn',
 								'accessibility': { focusBack: true,	combination: 'WN', de: null }
 							},
 							{
-								'id': 'draw-wrap-ideal',
+								'id': 'shape-wrap-ideal',
 								'type': 'toolitem',
 								'text': _UNO('.uno:WrapIdeal', 'text'),
 								'command': '.uno:WrapIdeal',
@@ -2254,21 +2262,21 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-wrap-left',
+								'id': 'shape-wrap-left',
 								'type': 'toolitem',
 								'text': _UNO('.uno:WrapLeft', 'text'),
 								'command': '.uno:WrapLeft',
 								'accessibility': { focusBack: true,	combination: 'WL', de: null }
 							},
 							{
-								'id': 'draw-wrap-through',
+								'id': 'shape-wrap-through',
 								'type': 'toolitem',
 								'text': _UNO('.uno:WrapThrough', 'text'),
 								'command': '.uno:WrapThrough',
 								'accessibility': { focusBack: true,	combination: 'WT', de: null }
 							},
 							{
-								'id': 'draw-wrap-right',
+								'id': 'shape-wrap-right',
 								'type': 'toolitem',
 								'text': _UNO('.uno:WrapRight', 'text'),
 								'command': '.uno:WrapRight',
@@ -2286,21 +2294,21 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-object-align-left',
+								'id': 'shape-object-align-left',
 								'type': 'toolitem',
 								'text': _UNO('.uno:ObjectAlignLeft'),
 								'command': '.uno:ObjectAlignLeft',
 								'accessibility': { focusBack: true,	combination: 'AL', de: null }
 							},
 							{
-								'id': 'draw-align-center',
+								'id': 'shape-align-center',
 								'type': 'toolitem',
 								'text': _UNO('.uno:AlignCenter'),
 								'command': '.uno:AlignCenter',
 								'accessibility': { focusBack: true,	combination: 'AC', de: null }
 							},
 							{
-								'id': 'draw-object-align-right',
+								'id': 'shape-object-align-right',
 								'type': 'toolitem',
 								'text': _UNO('.uno:ObjectAlignRight'),
 								'command': '.uno:ObjectAlignRight',
@@ -2312,21 +2320,21 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-align-up',
+								'id': 'shape-align-up',
 								'type': 'toolitem',
 								'text': _UNO('.uno:AlignUp'),
 								'command': '.uno:AlignUp',
 								'accessibility': { focusBack: true,	combination: 'AU', de: null }
 							},
 							{
-								'id': 'draw-align-middle',
+								'id': 'shape-align-middle',
 								'type': 'toolitem',
 								'text': _UNO('.uno:AlignMiddle'),
 								'command': '.uno:AlignMiddle',
 								'accessibility': { focusBack: true,	combination: 'AM', de: null }
 							},
 							{
-								'id': 'draw-align-down',
+								'id': 'shape-align-down',
 								'type': 'toolitem',
 								'text': _UNO('.uno:AlignDown'),
 								'command': '.uno:AlignDown',
@@ -2344,14 +2352,14 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-bring-to-front',
+								'id': 'shape-bring-to-front',
 								'type': 'toolitem',
 								'text': _UNO('.uno:BringToFront'),
 								'command': '.uno:BringToFront',
 								'accessibility': { focusBack: true,	combination: 'BF', de: null }
 							},
 							{
-								'id': 'draw-send-to-back',
+								'id': 'shape-send-to-back',
 								'type': 'toolitem',
 								'text': _UNO('.uno:SendToBack'),
 								'command': '.uno:SendToBack',
@@ -2363,14 +2371,14 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-object-forward-one',
+								'id': 'shape-object-forward-one',
 								'type': 'toolitem',
 								'text': _UNO('.uno:ObjectForwardOne'),
 								'command': '.uno:ObjectForwardOne',
 								'accessibility': { focusBack: true,	combination: 'FO', de: null }
 							},
 							{
-								'id': 'draw-object-back-one',
+								'id': 'shape-object-back-one',
 								'type': 'toolitem',
 								'text': _UNO('.uno:ObjectBackOne'),
 								'command': '.uno:ObjectBackOne',
@@ -2382,7 +2390,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'draw-format-group',
+				'id': 'shape-format-group',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:FormatGroup'),
 				'command': '.uno:FormatGroup',
@@ -2395,7 +2403,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-enter-group',
+								'id': 'shape-enter-group',
 								'type': 'toolitem',
 								'text': _UNO('.uno:EnterGroup'),
 								'command': '.uno:EnterGroup',
@@ -2407,7 +2415,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-leave-group',
+								'id': 'shape-leave-group',
 								'type': 'toolitem',
 								'text': _UNO('.uno:LeaveGroup'),
 								'command': '.uno:LeaveGroup',
@@ -2419,7 +2427,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'draw-text',
+				'id': 'shape-text',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:Text'),
 				'command': '.uno:Text',
@@ -2433,7 +2441,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-basic-shapes:InsertShapesMenu',
+								'id': 'shape-basic-shapes:InsertShapesMenu',
 								'type': 'menubutton',
 								'noLabel': true,
 								'text': _('Shapes'),
@@ -2447,7 +2455,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-line',
+								'id': 'shape-line',
 								'type': 'toolitem',
 								'text': _UNO('.uno:Line', 'text'),
 								'command': '.uno:Line',
@@ -2467,7 +2475,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-font-work-gallery-floater',
+								'id': 'shape-font-work-gallery-floater',
 								'type': 'toolitem',
 								'text': _UNO('.uno:FontworkGalleryFloater'),
 								'command': '.uno:FontworkGalleryFloater',
@@ -2482,7 +2490,355 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-vertical-text',
+								'id': 'shape-vertical-text',
+								'type': 'toolitem',
+								'text': _UNO('.uno:VerticalText', 'text'),
+								'command': '.uno:VerticalText',
+								'accessibility': { focusBack: true,	combination: 'DV', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+		];
+
+		return this.getTabPage('Shape', content);
+	},
+
+	getPictureTab: function() {
+		var content = [
+			{
+				'id': 'picture-transform-dialog',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:TransformDialog', 'text'),
+				'command': '.uno:TransformDialog',
+				'accessibility': { focusBack: true,	combination: 'TD', de: null }
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-flip-vertical',
+								'type': 'toolitem',
+								'text': _UNO('.uno:FlipVertical'),
+								'command': '.uno:FlipVertical',
+								'accessibility': { focusBack: true,	combination: 'FV', de: null }
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-flip-horizontal',
+								'type': 'toolitem',
+								'text': _UNO('.uno:FlipHorizontal'),
+								'command': '.uno:FlipHorizontal',
+								'accessibility': { focusBack: true,	combination: 'FH', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-xline-color:ColorPickerMenu',
+								'noLabel': true,
+								'type': 'toolitem',
+								'text': _UNO('.uno:XLineColor'),
+								'command': '.uno:XLineColor',
+								'accessibility': { focusBack: true,	combination: 'DX', de: null }
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-fill-color:ColorPickerMenu',
+								'noLabel': true,
+								'type': 'toolitem',
+								'text': _UNO('.uno:FillColor'),
+								'command': '.uno:FillColor',
+								'accessibility': { focusBack: true,	combination: 'FC', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-wrap-off',
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapOff', 'text'),
+								'command': '.uno:WrapOff',
+								'accessibility': { focusBack: true,	combination: 'WO', de: null }
+							},
+							{
+								'id': 'picture-wrap-on',
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapOn', 'text'),
+								'command': '.uno:WrapOn',
+								'accessibility': { focusBack: true,	combination: 'WN', de: null }
+							},
+							{
+								'id': 'picture-wrap-ideal',
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapIdeal', 'text'),
+								'command': '.uno:WrapIdeal',
+								'accessibility': { focusBack: true,	combination: 'WI', de: null }
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-wrap-left',
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapLeft', 'text'),
+								'command': '.uno:WrapLeft',
+								'accessibility': { focusBack: true,	combination: 'WL', de: null }
+							},
+							{
+								'id': 'picture-wrap-through',
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapThrough', 'text'),
+								'command': '.uno:WrapThrough',
+								'accessibility': { focusBack: true,	combination: 'WT', de: null }
+							},
+							{
+								'id': 'picture-wrap-right',
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapRight', 'text'),
+								'command': '.uno:WrapRight',
+								'accessibility': { focusBack: true,	combination: 'WR', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-object-align-left',
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectAlignLeft'),
+								'command': '.uno:ObjectAlignLeft',
+								'accessibility': { focusBack: true,	combination: 'AL', de: null }
+							},
+							{
+								'id': 'picture-align-center',
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignCenter'),
+								'command': '.uno:AlignCenter',
+								'accessibility': { focusBack: true,	combination: 'AC', de: null }
+							},
+							{
+								'id': 'picture-object-align-right',
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectAlignRight'),
+								'command': '.uno:ObjectAlignRight',
+								'accessibility': { focusBack: true,	combination: 'AR', de: null }
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-align-up',
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignUp'),
+								'command': '.uno:AlignUp',
+								'accessibility': { focusBack: true,	combination: 'AU', de: null }
+							},
+							{
+								'id': 'picture-align-middle',
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignMiddle'),
+								'command': '.uno:AlignMiddle',
+								'accessibility': { focusBack: true,	combination: 'AM', de: null }
+							},
+							{
+								'id': 'picture-align-down',
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignDown'),
+								'command': '.uno:AlignDown',
+								'accessibility': { focusBack: true,	combination: 'AD', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-bring-to-front',
+								'type': 'toolitem',
+								'text': _UNO('.uno:BringToFront'),
+								'command': '.uno:BringToFront',
+								'accessibility': { focusBack: true,	combination: 'BF', de: null }
+							},
+							{
+								'id': 'picture-send-to-back',
+								'type': 'toolitem',
+								'text': _UNO('.uno:SendToBack'),
+								'command': '.uno:SendToBack',
+								'accessibility': { focusBack: true,	combination: 'SB', de: null }
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-object-forward-one',
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectForwardOne'),
+								'command': '.uno:ObjectForwardOne',
+								'accessibility': { focusBack: true,	combination: 'FO', de: null }
+							},
+							{
+								'id': 'picture-object-back-one',
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectBackOne'),
+								'command': '.uno:ObjectBackOne',
+								'accessibility': { focusBack: true,	combination: 'BO', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'id': 'picture-format-group',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:FormatGroup'),
+				'command': '.uno:FormatGroup',
+				'accessibility': { focusBack: true,	combination: 'FG', de: null }
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-enter-group',
+								'type': 'toolitem',
+								'text': _UNO('.uno:EnterGroup'),
+								'command': '.uno:EnterGroup',
+								'accessibility': { focusBack: true,	combination: 'EG', de: null }
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-leave-group',
+								'type': 'toolitem',
+								'text': _UNO('.uno:LeaveGroup'),
+								'command': '.uno:LeaveGroup',
+								'accessibility': { focusBack: true,	combination: 'LG', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'id': 'picture-text',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:Text'),
+				'command': '.uno:Text',
+				'accessibility': { focusBack: true,	combination: 'DT', de: null }
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA6',
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-basic-shapes:InsertShapesMenu',
+								'type': 'menubutton',
+								'noLabel': true,
+								'text': _('Shapes'),
+								'command': '.uno:BasicShapes',
+								'accessibility': { focusBack: true,	combination: 'BS', de: null }
+							}
+						]
+					},
+					{
+						'id': 'LineB7',
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-line',
+								'type': 'toolitem',
+								'text': _UNO('.uno:Line', 'text'),
+								'command': '.uno:Line',
+								'accessibility': { focusBack: true,	combination: 'DL', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'id': 'Insert-Text-Fontwork',
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA153',
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-font-work-gallery-floater',
+								'type': 'toolitem',
+								'text': _UNO('.uno:FontworkGalleryFloater'),
+								'command': '.uno:FontworkGalleryFloater',
+								// Fontwork export/import not supported in other formats.
+								'visible': (app.LOUtil.isFileODF(this.map)) ? 'true' : 'false',
+								'accessibility': { focusBack: true,	combination: 'FW', de: null }
+							}
+						]
+					},
+					{
+						'id': 'LineB163',
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-vertical-text',
 								'type': 'toolitem',
 								'text': _UNO('.uno:VerticalText', 'text'),
 								'command': '.uno:VerticalText',
@@ -2501,7 +2857,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			},
 		];
 
-		return this.getTabPage('Draw', content);
+		return this.getTabPage('Picture', content);
 	}
 });
 

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -2167,6 +2167,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:TransformDialog',
 				'accessibility': { focusBack: true,	combination: 'TD', de: null }
 			},
+			{ type: 'separator', id: 'shape-transformdialog-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2197,6 +2198,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'shape-fliphorizontal-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2229,6 +2231,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'shape-fillcolor-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2287,6 +2290,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'shape-wrapright-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2345,6 +2349,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'shape-aligndown-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2389,6 +2394,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'shape-objectbackone-break', orientation: 'vertical' },
 			{
 				'id': 'shape-format-group',
 				'type': 'bigtoolitem',
@@ -2426,6 +2432,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'shape-leavegroup-break', orientation: 'vertical' },
 			{
 				'id': 'shape-text',
 				'type': 'bigtoolitem',
@@ -2433,6 +2440,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:Text',
 				'accessibility': { focusBack: true,	combination: 'DT', de: null }
 			},
+			{ type: 'separator', id: 'shape-text-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2466,6 +2474,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'shape-line-break', orientation: 'vertical' },
 			{
 				'id': 'Insert-Text-Fontwork',
 				'type': 'container',
@@ -2515,6 +2524,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:TransformDialog',
 				'accessibility': { focusBack: true,	combination: 'TD', de: null }
 			},
+			{ type: 'separator', id: 'picture-transformdialog-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2545,6 +2555,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-fliphorizontal-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2577,6 +2588,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-fillcolor-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2635,6 +2647,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-wrapright-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2693,6 +2706,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-aligndown-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2737,6 +2751,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-objectbackone-break', orientation: 'vertical' },
 			{
 				'id': 'picture-format-group',
 				'type': 'bigtoolitem',
@@ -2774,6 +2789,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-leavegroup-break', orientation: 'vertical' },
 			{
 				'id': 'picture-text',
 				'type': 'bigtoolitem',
@@ -2781,6 +2797,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:Text',
 				'accessibility': { focusBack: true,	combination: 'DT', de: null }
 			},
+			{ type: 'separator', id: 'picture-text-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2814,6 +2831,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-line-break', orientation: 'vertical' },
 			{
 				'id': 'Insert-Text-Fontwork',
 				'type': 'container',
@@ -2849,6 +2867,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-verticaltext-break', orientation: 'vertical' },
 			{
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:Crop'),

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -97,11 +97,18 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				'accessibility': { focusBack: true, combination: 'T', de: null }
 			},
 			{
-				'id': 'Draw-tab-label',
-				'text': _('Draw'),
-				'name': 'Draw',
-				'context': 'Draw|DrawLine|3DObject|MultiObject|Graphic|DrawFontwork',
+				'id': 'Shape-tab-label',
+				'text': _('Shape'),
+				'name': 'Shape',
+				'context': 'Draw|DrawLine|3DObject|MultiObject|DrawFontwork',
 				'accessibility': { focusBack: true, combination: 'D', de: null }
+			},
+			{
+				'id': 'Picture-tab-label',
+				'text': _('Picture'),
+				'name': 'Picture',
+				'context': 'Graphic',
+				'accessibility': { focusBack: true, combination: 'G', de: null }
 			},
 			{
 				'id': 'View-tab-label',
@@ -127,7 +134,8 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 			this.getReviewTab(),
 			this.getFormatTab(),
 			this.getTableTab(),
-			this.getDrawTab(),
+			this.getShapeTab(),
+			this.getPictureTab(),
 			this.getViewTab(),
 			this.getHelpTab()
 		];

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -130,11 +130,18 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'accessibility': { focusBack: false, combination: 'T', de: null }
 			},
 			{
-				'id': 'Draw-tab-label',
-				'text': 'Draw',
-				'name': 'Draw',
-				'context': 'Draw|DrawLine|3DObject|MultiObject|Graphic|DrawFontwork',
+				'id': 'Shape-tab-label',
+				'text': 'Shape',
+				'name': 'Shape',
+				'context': 'Draw|DrawLine|3DObject|MultiObject|DrawFontwork',
 				'accessibility': { focusBack: false, combination: 'D', de: null }
+			},
+			{
+				'id': 'Picture-tab-label',
+				'text': 'Picture',
+				'name': 'Picture',
+				'context': 'Graphic',
+				'accessibility': { focusBack: false, combination: 'I', de: null }
 			},
 			{
 				'id': 'MasterPage-tab-label',
@@ -173,7 +180,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			this.getReviewTab(),
 			this.getFormatTab(),
 			this.getTableTab(),
-			this.getDrawTab(),
+			this.getShapeTab(),
+			this.getPictureTab(),
 			this.getMasterTab(),
 			this.getSlideTab(),
 			this.getViewTab(),
@@ -2270,10 +2278,10 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 		return this.getTabPage('Table', content);
 	},
 
-	getDrawTab: function() {
+	getShapeTab: function() {
 		var content = [
 			{
-				'id': 'draw-transform-dialog',
+				'id': 'shape-transform-dialog',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:TransformDialog', 'text'),
 				'command': '.uno:TransformDialog',
@@ -2286,7 +2294,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-flip-vertical',
+								'id': 'shape-flip-vertical',
 								'type': 'toolitem',
 								'text': _UNO('.uno:FlipVertical'),
 								'command': '.uno:FlipVertical',
@@ -2298,7 +2306,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-flip-horizontal',
+								'id': 'shape-flip-horizontal',
 								'type': 'toolitem',
 								'text': _UNO('.uno:FlipHorizontal'),
 								'command': '.uno:FlipHorizontal',
@@ -2316,7 +2324,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-xline-color:ColorPickerMenu',
+								'id': 'shape-xline-color:ColorPickerMenu',
 								'noLabel': true,
 								'type': 'toolitem',
 								'text': _UNO('.uno:XLineColor'),
@@ -2329,7 +2337,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-fill-color:ColorPickerMenu',
+								'id': 'shape-fill-color:ColorPickerMenu',
 								'noLabel': true,
 								'type': 'toolitem',
 								'text': _UNO('.uno:FillColor'),
@@ -2342,7 +2350,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'draw-convert-curve',
+				'id': 'shape-convert-curve',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:ChangeBezier', 'presentation'),
 				'command': '.uno:ChangeBezier',
@@ -2355,21 +2363,21 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-object-align-left',
+								'id': 'shape-object-align-left',
 								'type': 'toolitem',
 								'text': _UNO('.uno:ObjectAlignLeft'),
 								'command': '.uno:ObjectAlignLeft',
 								'accessibility': { focusBack: true, combination: 'AL', de: null }
 							},
 							{
-								'id': 'draw-align-center',
+								'id': 'shape-align-center',
 								'type': 'toolitem',
 								'text': _UNO('.uno:AlignCenter'),
 								'command': '.uno:AlignCenter',
 								'accessibility': { focusBack: true, combination: 'AC', de: null }
 							},
 							{
-								'id': 'draw-object-align-right',
+								'id': 'shape-object-align-right',
 								'type': 'toolitem',
 								'text': _UNO('.uno:ObjectAlignRight'),
 								'command': '.uno:ObjectAlignRight',
@@ -2381,21 +2389,21 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-align-up',
+								'id': 'shape-align-up',
 								'type': 'toolitem',
 								'text': _UNO('.uno:AlignUp'),
 								'command': '.uno:AlignUp',
 								'accessibility': { focusBack: true, combination: 'AU', de: null }
 							},
 							{
-								'id': 'draw-align-middle',
+								'id': 'shape-align-middle',
 								'type': 'toolitem',
 								'text': _UNO('.uno:AlignMiddle'),
 								'command': '.uno:AlignMiddle',
 								'accessibility': { focusBack: true, combination: 'AM', de: null }
 							},
 							{
-								'id': 'draw-align-down',
+								'id': 'shape-align-down',
 								'type': 'toolitem',
 								'text': _UNO('.uno:AlignDown'),
 								'command': '.uno:AlignDown',
@@ -2413,14 +2421,14 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-bring-to-front',
+								'id': 'shape-bring-to-front',
 								'type': 'toolitem',
 								'text': _UNO('.uno:BringToFront'),
 								'command': '.uno:BringToFront',
 								'accessibility': { focusBack: true, combination: 'BF', de: null }
 							},
 							{
-								'id': 'draw-send-to-back',
+								'id': 'shape-send-to-back',
 								'type': 'toolitem',
 								'text': _UNO('.uno:SendToBack'),
 								'command': '.uno:SendToBack',
@@ -2432,14 +2440,14 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-object-forward-one',
+								'id': 'shape-object-forward-one',
 								'type': 'toolitem',
 								'text': _UNO('.uno:ObjectForwardOne'),
 								'command': '.uno:ObjectForwardOne',
 								'accessibility': { focusBack: true, combination: 'FO', de: null }
 							},
 							{
-								'id': 'draw-object-back-one',
+								'id': 'shape-object-back-one',
 								'type': 'toolitem',
 								'text': _UNO('.uno:ObjectBackOne'),
 								'command': '.uno:ObjectBackOne',
@@ -2451,7 +2459,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'draw-format-group',
+				'id': 'shape-format-group',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:FormatGroup'),
 				'command': '.uno:FormatGroup',
@@ -2464,7 +2472,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-enter-group',
+								'id': 'shape-enter-group',
 								'type': 'toolitem',
 								'text': _UNO('.uno:EnterGroup'),
 								'command': '.uno:EnterGroup',
@@ -2476,7 +2484,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-leave-group',
+								'id': 'shape-leave-group',
 								'type': 'toolitem',
 								'text': _UNO('.uno:LeaveGroup'),
 								'command': '.uno:LeaveGroup',
@@ -2488,7 +2496,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'vertical': 'true'
 			},
 			{
-				'id': 'draw-text',
+				'id': 'shape-text',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:Text'),
 				'command': '.uno:Text',
@@ -2502,7 +2510,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-basic-shapes:InsertShapesMenu',
+								'id': 'shape-basic-shapes:InsertShapesMenu',
 								'type': 'menubutton',
 								'noLabel': true,
 								'text': _('Shapes'),
@@ -2516,7 +2524,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-connector-toolbox:InsertConnectorsMenu',
+								'id': 'shape-connector-toolbox:InsertConnectorsMenu',
 								'type': 'menubutton',
 								'noLabel': true,
 								'text': _UNO('.uno:ConnectorToolbox', 'presentation'),
@@ -2537,7 +2545,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-fontwork-gallery-floater',
+								'id': 'shape-fontwork-gallery-floater',
 								'type': 'toolitem',
 								'text': _UNO('.uno:FontworkGalleryFloater'),
 								'command': '.uno:FontworkGalleryFloater',
@@ -2552,7 +2560,305 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-vertical-text',
+								'id': 'shape-vertical-text',
+								'type': 'toolitem',
+								'text': _UNO('.uno:VerticalText', 'text'),
+								'command': '.uno:VerticalText',
+								'accessibility': { focusBack: true, combination: 'VT', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+		];
+
+		return this.getTabPage('Shape', content);
+	},
+
+	getPictureTab: function() {
+		var content = [
+			{
+				'id': 'picture-transform-dialog',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:TransformDialog', 'text'),
+				'command': '.uno:TransformDialog',
+				'accessibility': { focusBack: false, combination: 'TD', de: null }
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-flip-vertical',
+								'type': 'toolitem',
+								'text': _UNO('.uno:FlipVertical'),
+								'command': '.uno:FlipVertical',
+								'accessibility': { focusBack: true, combination: 'FV', de: null }
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-flip-horizontal',
+								'type': 'toolitem',
+								'text': _UNO('.uno:FlipHorizontal'),
+								'command': '.uno:FlipHorizontal',
+								'accessibility': { focusBack: true, combination: 'FH', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-xline-color:ColorPickerMenu',
+								'noLabel': true,
+								'type': 'toolitem',
+								'text': _UNO('.uno:XLineColor'),
+								'command': '.uno:XLineColor',
+								'accessibility': { focusBack: true, combination: 'LC', de: null }
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-fill-color:ColorPickerMenu',
+								'noLabel': true,
+								'type': 'toolitem',
+								'text': _UNO('.uno:FillColor'),
+								'command': '.uno:FillColor',
+								'accessibility': { focusBack: true, combination: 'FC', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'id': 'picture-convert-curve',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:ChangeBezier', 'presentation'),
+				'command': '.uno:ChangeBezier',
+				'accessibility': { focusBack: true, combination: 'CB', de: null }
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-object-align-left',
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectAlignLeft'),
+								'command': '.uno:ObjectAlignLeft',
+								'accessibility': { focusBack: true, combination: 'AL', de: null }
+							},
+							{
+								'id': 'picture-align-center',
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignCenter'),
+								'command': '.uno:AlignCenter',
+								'accessibility': { focusBack: true, combination: 'AC', de: null }
+							},
+							{
+								'id': 'picture-object-align-right',
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectAlignRight'),
+								'command': '.uno:ObjectAlignRight',
+								'accessibility': { focusBack: true, combination: 'AR', de: null }
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-align-up',
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignUp'),
+								'command': '.uno:AlignUp',
+								'accessibility': { focusBack: true, combination: 'AU', de: null }
+							},
+							{
+								'id': 'picture-align-middle',
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignMiddle'),
+								'command': '.uno:AlignMiddle',
+								'accessibility': { focusBack: true, combination: 'AM', de: null }
+							},
+							{
+								'id': 'picture-align-down',
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignDown'),
+								'command': '.uno:AlignDown',
+								'accessibility': { focusBack: true, combination: 'AD', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-bring-to-front',
+								'type': 'toolitem',
+								'text': _UNO('.uno:BringToFront'),
+								'command': '.uno:BringToFront',
+								'accessibility': { focusBack: true, combination: 'BF', de: null }
+							},
+							{
+								'id': 'picture-send-to-back',
+								'type': 'toolitem',
+								'text': _UNO('.uno:SendToBack'),
+								'command': '.uno:SendToBack',
+								'accessibility': { focusBack: true, combination: 'SB', de: null }
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-object-forward-one',
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectForwardOne'),
+								'command': '.uno:ObjectForwardOne',
+								'accessibility': { focusBack: true, combination: 'FO', de: null }
+							},
+							{
+								'id': 'picture-object-back-one',
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectBackOne'),
+								'command': '.uno:ObjectBackOne',
+								'accessibility': { focusBack: true, combination: 'BO', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'id': 'picture-format-group',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:FormatGroup'),
+				'command': '.uno:FormatGroup',
+				'accessibility': { focusBack: true, combination: 'FG', de: null }
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-enter-group',
+								'type': 'toolitem',
+								'text': _UNO('.uno:EnterGroup'),
+								'command': '.uno:EnterGroup',
+								'accessibility': { focusBack: true, combination: 'EG', de: null }
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-leave-group',
+								'type': 'toolitem',
+								'text': _UNO('.uno:LeaveGroup'),
+								'command': '.uno:LeaveGroup',
+								'accessibility': { focusBack: true, combination: 'LG', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'id': 'picture-text',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:Text'),
+				'command': '.uno:Text',
+				'accessibility': { focusBack: true, combination: 'DT', de: null }
+			},
+			{
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA6',
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-basic-shapes:InsertShapesMenu',
+								'type': 'menubutton',
+								'noLabel': true,
+								'text': _('Shapes'),
+								'command': '.uno:BasicShapes',
+								'accessibility': { focusBack: true, combination: 'BS', de: null }
+							}
+						]
+					},
+					{
+						'id': 'LineB7',
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-connector-toolbox:InsertConnectorsMenu',
+								'type': 'menubutton',
+								'noLabel': true,
+								'text': _UNO('.uno:ConnectorToolbox', 'presentation'),
+								'command': '.uno:ConnectorToolbox',
+								'accessibility': { focusBack: true, combination: 'CT', de: null }
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{
+				'id': 'Insert-Text-Fontwork',
+				'type': 'container',
+				'children': [
+					{
+						'id': 'LineA153',
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-fontwork-gallery-floater',
+								'type': 'toolitem',
+								'text': _UNO('.uno:FontworkGalleryFloater'),
+								'command': '.uno:FontworkGalleryFloater',
+								// Fontwork export/import not supported in other formats.
+								'visible': (app.LOUtil.isFileODF(this.map)) ? 'true' : 'false',
+								'accessibility': { focusBack: true, combination: 'FW', de: null }
+							}
+						]
+					},
+					{
+						'id': 'LineB163',
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-vertical-text',
 								'type': 'toolitem',
 								'text': _UNO('.uno:VerticalText', 'text'),
 								'command': '.uno:VerticalText',
@@ -2571,7 +2877,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			},
 		];
 
-		return this.getTabPage('Draw', content);
+		return this.getTabPage('Picture', content);
 	},
 });
 

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -2287,6 +2287,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:TransformDialog',
 				'accessibility': { focusBack: false, combination: 'TD', de: null }
 			},
+			{ type: 'separator', id: 'shape-transformdialog-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2317,6 +2318,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'shape-fliphorizontal-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2349,6 +2351,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'shape-fillcolor-break', orientation: 'vertical' },
 			{
 				'id': 'shape-convert-curve',
 				'type': 'bigtoolitem',
@@ -2356,6 +2359,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:ChangeBezier',
 				'accessibility': { focusBack: true, combination: 'CB', de: null }
 			},
+			{ type: 'separator', id: 'shape-convertcurve-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2414,6 +2418,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'shape-aligndown-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2458,6 +2463,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'shape-objectbackone-break', orientation: 'vertical' },
 			{
 				'id': 'shape-format-group',
 				'type': 'bigtoolitem',
@@ -2495,6 +2501,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'shape-leavegroup-break', orientation: 'vertical' },
 			{
 				'id': 'shape-text',
 				'type': 'bigtoolitem',
@@ -2502,6 +2509,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:Text',
 				'accessibility': { focusBack: true, combination: 'DT', de: null }
 			},
+			{ type: 'separator', id: 'shape-text-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2536,6 +2544,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'shape-connectortoolbox-break', orientation: 'vertical' },
 			{
 				'id': 'Insert-Text-Fontwork',
 				'type': 'container',
@@ -2585,6 +2594,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:TransformDialog',
 				'accessibility': { focusBack: false, combination: 'TD', de: null }
 			},
+			{ type: 'separator', id: 'picture-transformdialog-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2615,6 +2625,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-fliphorizontal-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2647,6 +2658,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-fillcolor-break', orientation: 'vertical' },
 			{
 				'id': 'picture-convert-curve',
 				'type': 'bigtoolitem',
@@ -2654,6 +2666,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:ChangeBezier',
 				'accessibility': { focusBack: true, combination: 'CB', de: null }
 			},
+			{ type: 'separator', id: 'picture-convertcurve-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2712,6 +2725,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-aligndown-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2756,6 +2770,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-objectbackone-break', orientation: 'vertical' },
 			{
 				'id': 'picture-format-group',
 				'type': 'bigtoolitem',
@@ -2793,6 +2808,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-leavegroup-break', orientation: 'vertical' },
 			{
 				'id': 'picture-text',
 				'type': 'bigtoolitem',
@@ -2800,6 +2816,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:Text',
 				'accessibility': { focusBack: true, combination: 'DT', de: null }
 			},
+			{ type: 'separator', id: 'picture-text-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2834,6 +2851,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-connectortoolbox-break', orientation: 'vertical' },
 			{
 				'id': 'Insert-Text-Fontwork',
 				'type': 'container',
@@ -2869,6 +2887,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
+			{ type: 'separator', id: 'picture-verticaltext-break', orientation: 'vertical' },
 			{
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:Crop'),

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -24,7 +24,8 @@ var reviewTabName = 'Review';
 var formatTabName = 'Format';
 var formTabName = 'Form';
 var tableTabName = 'Table';
-var drawTabName = 'Draw';
+var shapeTabName = 'Shape';
+var pictureTabName = 'Picture';
 var viewTabName = 'View';
 var helpTabName = 'Help';
 var formulaTabName = 'Formula';
@@ -90,11 +91,18 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'accessibility': { focusBack: true, combination: 'T' }
 			},
 			{
-				'text': _('Draw'),
-				'id': drawTabName + '-tab-label',
-				'name': drawTabName,
-				'context': 'Draw|DrawLine|3DObject|MultiObject|Graphic|DrawFontwork',
+				'text': _('Shape'),
+				'id': shapeTabName + '-tab-label',
+				'name': shapeTabName,
+				'context': 'Draw|DrawLine|3DObject|MultiObject|DrawFontwork',
 				'accessibility': { focusBack: true, combination: 'JI', de: 'JI' }
+			},
+			{
+				'text': _('Picture'),
+				'id': pictureTabName + '-tab-label',
+				'name': pictureTabName,
+				'context': 'Graphic',
+				'accessibility': { focusBack: true, combination: 'PI', de: 'PI' }
 			},
 			{
 				'text': _('View'),
@@ -129,7 +137,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			this.getFormatTab(),
 			this.getFormTab(),
 			this.getTableTab(),
-			this.getDrawTab(),
+			this.getShapeTab(),
+			this.getPictureTab(),
 			this.getViewTab(),
 			this.getHelpTab(),
 			this.getFormulaTab()
@@ -2841,7 +2850,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 		return this.getTabPage(formulaTabName, content);
 	},
 
-	getDrawTab: function() {
+	getShapeTab: function() {
 		var isODF = app.LOUtil.isFileODF(this.map);
 		var content = [
 			{
@@ -2849,7 +2858,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'text': _UNO('.uno:TransformDialog', 'text'),
 				'command': '.uno:TransformDialog'
 			},
-			{ type: 'separator', id: 'draw-transformdialog-break', orientation: 'vertical' },
+			{ type: 'separator', id: 'shape-transformdialog-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2876,7 +2885,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				],
 				'vertical': 'true'
 			},
-			{ type: 'separator', id: 'draw-fliphorizontal-break', orientation: 'vertical' },
+			{ type: 'separator', id: 'shape-fliphorizontal-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2884,7 +2893,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-tab-xlinecolor:ColorPickerMenu',
+								'id': 'shape-tab-xlinecolor:ColorPickerMenu',
 								'noLabel': true,
 								'type': 'toolitem',
 								'text': _UNO('.uno:XLineColor'),
@@ -2896,7 +2905,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-tab-fillcolor:ColorPickerMenu',
+								'id': 'shape-tab-fillcolor:ColorPickerMenu',
 								'noLabel': true,
 								'type': 'toolitem',
 								'text': _UNO('.uno:FillColor'),
@@ -2907,7 +2916,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				],
 				'vertical': 'true'
 			},
-			{ type: 'separator', id: 'draw-fillcolor-break', orientation: 'vertical' },
+			{ type: 'separator', id: 'shape-fillcolor-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -2954,7 +2963,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				],
 				'vertical': 'true'
 			},
-			{ type: 'separator', id: 'draw-wrapright-break', orientation: 'vertical' },
+			{ type: 'separator', id: 'shape-wrapright-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -3001,7 +3010,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				],
 				'vertical': 'true'
 			},
-			{ type: 'separator', id: 'draw-aligndown-break', orientation: 'vertical' },
+			{ type: 'separator', id: 'shape-aligndown-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -3038,13 +3047,13 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				],
 				'vertical': 'true'
 			},
-			{ type: 'separator', id: 'draw-objectbackone-break', orientation: 'vertical' },
+			{ type: 'separator', id: 'shape-objectbackone-break', orientation: 'vertical' },
 			{
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:FormatGroup'),
 				'command': '.uno:FormatGroup'
 			},
-			{ type: 'separator', id: 'draw-formatgroup-break', orientation: 'vertical' },
+			{ type: 'separator', id: 'shape-formatgroup-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -3071,13 +3080,13 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				],
 				'vertical': 'true'
 			},
-			{ type: 'separator', id: 'draw-leavegroup-break', orientation: 'vertical' },
+			{ type: 'separator', id: 'shape-leavegroup-break', orientation: 'vertical' },
 			{
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:Text'),
 				'command': '.uno:Text'
 			},
-			{ type: 'separator', id: 'draw-text-break', orientation: 'vertical' },
+			{ type: 'separator', id: 'shape-text-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -3085,7 +3094,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'draw-tab-shapes:InsertShapesMenu',
+								'id': 'shape-tab-shapes:InsertShapesMenu',
 								'type': 'menubutton',
 								'noLabel': true,
 								'text': _('Shapes'),
@@ -3106,7 +3115,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				],
 				'vertical': 'true'
 			},
-			{ type: 'separator', id: 'draw-line-break', orientation: 'vertical' },
+			{ type: 'separator', id: 'shape-line-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -3135,7 +3144,306 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				],
 				'vertical': 'true'
 			},
-			{ type: 'separator', id: 'draw-verticaltext-break', orientation: 'vertical' },
+		];
+
+		return this.getTabPage(shapeTabName, content);
+	},
+
+	getPictureTab: function() {
+		var isODF = app.LOUtil.isFileODF(this.map);
+		var content = [
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:TransformDialog', 'text'),
+				'command': '.uno:TransformDialog'
+			},
+			{ type: 'separator', id: 'picture-transformdialog-break', orientation: 'vertical' },
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FlipVertical'),
+								'command': '.uno:FlipVertical'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FlipHorizontal'),
+								'command': '.uno:FlipHorizontal'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{ type: 'separator', id: 'picture-fliphorizontal-break', orientation: 'vertical' },
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-tab-xlinecolor:ColorPickerMenu',
+								'noLabel': true,
+								'type': 'toolitem',
+								'text': _UNO('.uno:XLineColor'),
+								'command': '.uno:XLineColor'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-tab-fillcolor:ColorPickerMenu',
+								'noLabel': true,
+								'type': 'toolitem',
+								'text': _UNO('.uno:FillColor'),
+								'command': '.uno:FillColor'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{ type: 'separator', id: 'picture-fillcolor-break', orientation: 'vertical' },
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapOff', 'text'),
+								'command': '.uno:WrapOff'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapOn', 'text'),
+								'command': '.uno:WrapOn'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapIdeal', 'text'),
+								'command': '.uno:WrapIdeal'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapLeft', 'text'),
+								'command': '.uno:WrapLeft'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapThrough', 'text'),
+								'command': '.uno:WrapThrough'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:WrapRight', 'text'),
+								'command': '.uno:WrapRight'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{ type: 'separator', id: 'picture-wrapright-break', orientation: 'vertical' },
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectAlignLeft'),
+								'command': '.uno:ObjectAlignLeft'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignCenter'),
+								'command': '.uno:AlignCenter'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectAlignRight'),
+								'command': '.uno:ObjectAlignRight'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignUp'),
+								'command': '.uno:AlignUp'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignMiddle'),
+								'command': '.uno:AlignMiddle'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:AlignDown'),
+								'command': '.uno:AlignDown'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{ type: 'separator', id: 'picture-aligndown-break', orientation: 'vertical' },
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:BringToFront'),
+								'command': '.uno:BringToFront'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:SendToBack'),
+								'command': '.uno:SendToBack'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectForwardOne'),
+								'command': '.uno:ObjectForwardOne'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:ObjectBackOne'),
+								'command': '.uno:ObjectBackOne'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{ type: 'separator', id: 'picture-objectbackone-break', orientation: 'vertical' },
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:FormatGroup'),
+				'command': '.uno:FormatGroup'
+			},
+			{ type: 'separator', id: 'picture-formatgroup-break', orientation: 'vertical' },
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:EnterGroup'),
+								'command': '.uno:EnterGroup'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:LeaveGroup'),
+								'command': '.uno:LeaveGroup'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{ type: 'separator', id: 'picture-leavegroup-break', orientation: 'vertical' },
+			{
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:Text'),
+				'command': '.uno:Text'
+			},
+			{ type: 'separator', id: 'picture-text-break', orientation: 'vertical' },
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'picture-tab-shapes:InsertShapesMenu',
+								'type': 'menubutton',
+								'noLabel': true,
+								'text': _('Shapes'),
+								'command': '.uno:BasicShapes'
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:Line', 'text'),
+								'command': '.uno:Line'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{ type: 'separator', id: 'picture-line-break', orientation: 'vertical' },
+			{
+				'type': 'container',
+				'children': [
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:FontworkGalleryFloater'),
+								'command': '.uno:FontworkGalleryFloater',
+								// Fontwork export/import not supported in other formats.
+								'visible': isODF ? 'true' : 'false',
+							}
+						]
+					},
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:VerticalText', 'text'),
+								'command': '.uno:VerticalText'
+							}
+						]
+					}
+				],
+				'vertical': 'true'
+			},
+			{ type: 'separator', id: 'picture-verticaltext-break', orientation: 'vertical' },
 			{
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:Crop'),
@@ -3144,7 +3452,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			},
 		];
 
-		return this.getTabPage(drawTabName, content);
+		return this.getTabPage(pictureTabName, content);
 	},
 
 	getNotebookbar: function(tabPages, selectedPage) {

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -3053,7 +3053,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'text': _UNO('.uno:FormatGroup'),
 				'command': '.uno:FormatGroup'
 			},
-			{ type: 'separator', id: 'shape-formatgroup-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [
@@ -3352,7 +3351,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'text': _UNO('.uno:FormatGroup'),
 				'command': '.uno:FormatGroup'
 			},
-			{ type: 'separator', id: 'picture-formatgroup-break', orientation: 'vertical' },
 			{
 				'type': 'container',
 				'children': [


### PR DESCRIPTION
* Target version: master 

### Summary
Shape tab and Picture tab will appear when a shape or picture is selected, respectively.

![image](https://github.com/user-attachments/assets/bd321c3e-a1ef-4aa3-a0f4-3633705facc0)

![image](https://github.com/user-attachments/assets/a4a0af7b-d93e-4dce-8837-b17bc156d3eb)


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

