### PR TITLE
PresenterConsole: Fix Notes toggle style

### DIFF
--- a/browser/src/slideshow/PresenterConsole.js
+++ b/browser/src/slideshow/PresenterConsole.js
@@ -1006,7 +1006,7 @@ class PresenterConsole {
 	toggleButtonState(elem, toggleOn) {
 		if (toggleOn) {
 			// Apply the 'selected' styles on show notes to display toggle effect on button
-			elem.style.filter = 'invert(1)';
+			elem.style.filter = 'brightness(1.4)';
 			elem.style.backgroundColor = 'black';
 			elem.disable = true;
 		} else {


### PR DESCRIPTION
Before this commit the button background was white which was too
bright while not being very evident that is a toggle.

Best to keep it within present console (dark) theme.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ie9d81c72c4549b0c74fb057e39f63dee3e465373
