### PR TITLE
Impress: Notebookbar: Rename and rearrange "Slide Show" tab

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -144,9 +144,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'accessibility': { focusBack: false, combination: 'M', de: null }
 			},
 			{
-				'id': 'Slide-tab-label',
-				'text': _('Slide'),
-				'name': 'Slide',
+				'id': 'Slideshow-tab-label',
+				'text': _('Slide Show'),
+				'name': 'Slideshow',
 				'accessibility': { focusBack: false, combination: 'SE', de: null }
 			},
 			{
@@ -175,7 +175,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			this.getTableTab(),
 			this.getDrawTab(),
 			this.getMasterTab(),
-			this.getSlideTab(),
+			this.getSlideshowTab(),
 			this.getViewTab(),
 			this.getHelpTab()
 		];
@@ -370,7 +370,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 		return this.getTabPage('File', content);
 	},
 
-	getSlideTab: function() {
+	getSlideshowTab: function() {
 		var content = [
 			window.mode.isTablet() ?
 				{
@@ -405,7 +405,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				}: {}
 		];
 
-		return this.getTabPage('Slide', content);
+		return this.getTabPage('Slideshow', content);
 	},
 
 	getViewTab: function() {

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -111,6 +111,12 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'accessibility': { focusBack: false, combination: 'P', de: null }
 			},
 			{
+				'id': 'Slideshow-tab-label',
+				'text': _('Slide Show'),
+				'name': 'Slideshow',
+				'accessibility': { focusBack: false, combination: 'SE', de: null }
+			},
+			{
 				'id': 'Review-tab-label',
 				'text': _('Review'),
 				'name': 'Review',
@@ -144,12 +150,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'accessibility': { focusBack: false, combination: 'M', de: null }
 			},
 			{
-				'id': 'Slideshow-tab-label',
-				'text': _('Slide Show'),
-				'name': 'Slideshow',
-				'accessibility': { focusBack: false, combination: 'SE', de: null }
-			},
-			{
 				'id': 'View-tab-label',
 				'text': _('View'),
 				'name': 'View',
@@ -170,12 +170,12 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			this.getHomeTab(),
 			this.getInsertTab(),
 			this.getLayoutTab(),
+			this.getSlideshowTab(),
 			this.getReviewTab(),
 			this.getFormatTab(),
 			this.getTableTab(),
 			this.getDrawTab(),
 			this.getMasterTab(),
-			this.getSlideshowTab(),
 			this.getViewTab(),
 			this.getHelpTab()
 		];


### PR DESCRIPTION
* Target version: master 

### Summary
- Rename "Slide" tab to "Slide Show" tab
- place Slide Show tab after Layout tab

![image](https://github.com/user-attachments/assets/0216f245-7c05-41bc-9235-ed005b3843bd)


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

