### PR TITLE
accessibility: improve accessibility for split buttons and dropdown menus

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2296,9 +2296,9 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			// if main button element in split button works same as arrowbackground then make sure arrowbackground not focusable due to a11y conflicts
 			isSplitButton ? arrowbackground.tabIndex = '0' : arrowbackground.tabIndex = '-1';
 
-			if(isArrowInteractive)  {
+			if (isArrowInteractive)  {
 				const buttonText = data.aria && data.aria.label ? data.aria.label : builder._cleanText(data.text);
-				const dropdownAriaLabelText = _('Open ') + buttonText;
+				const dropdownAriaLabelText = _('Open %NAME').replace('%NAME', buttonText);
 				arrowbackground.setAttribute('aria-label', dropdownAriaLabelText);
 				arrowbackground.setAttribute('aria-haspopup', true);
 				arrowbackground.setAttribute('aria-expanded', false);

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2272,7 +2272,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			L.DomUtil.create('i', 'unoarrow', arrowbackground);
 			controls['arrow'] = arrowbackground;
 
-			if (isDropdownButton) {
+			if (!hasDropdownArrow && isDropdownButton) {
 				// Attach both 'click' and 'keydown' event listeners for dropdown buttons only
 				arrowbackground.addEventListener('click', function (event) {
 					openToolBoxMenu(event);

--- a/browser/src/control/jsdialog/Util.Dropdown.js
+++ b/browser/src/control/jsdialog/Util.Dropdown.js
@@ -41,12 +41,14 @@ JSDialog.OpenDropdown = function (id, popupParent, entries, innerCallback, popup
 		]
 	};
 
+	const expanderElement = Array.from(popupParent.children).find(child => child.hasAttribute('aria-expanded')) || popupParent;
+
 	if (popupParent && !popupParent._onClose) {
 		popupParent._onClose = () => {
-			popupParent.setAttribute('aria-expanded', false);
+			expanderElement.setAttribute('aria-expanded', false);
 		};
 	}
-	popupParent.setAttribute('aria-expanded', true);
+	expanderElement.setAttribute('aria-expanded', true);
 
 	var isChecked = function (unoCommand) {
 		var items = L.Map.THIS['stateChangeHandler'];

--- a/browser/src/control/jsdialog/Widget.MenuButton.js
+++ b/browser/src/control/jsdialog/Widget.MenuButton.js
@@ -69,7 +69,6 @@ function _menubuttonControl (parentContainer, data, builder) {
 		var control = builder._unoToolButton(parentContainer, data, builder, options);
 
 		$(control.container).addClass('menubutton');
-		control.container.setAttribute('aria-haspopup', true);
 
 		$(control.button).unbind('click');
 		$(control.label).unbind('click');


### PR DESCRIPTION
- Move ARIA attributes from container divs to interactive elements
- Add role="group" to dropdown containers for proper composite control semantics
- Consolidate duplicate dropdown arrow creation logic
- Fix aria-haspopup placement to only apply when no interactive arrow exists
- Ensure aria-expanded is set on correct focusable elements
- Update element selection logic in dropdown utils to find proper ARIA target
- Remove redundant aria-haspopup from menubutton containers

Fixes accessibility issues where ARIA attributes were incorrectly placed on non-focusable wrapper elements instead of interactive buttons that actually toggle dropdowns.

Change-Id: I6dad052a8d20fe981afeb93c7ddb821b6b22372c

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

