### PR TITLE
-Werror,-Wunused-private-field

### DIFF
--- a/wsd/AdminModel.hpp
+++ b/wsd/AdminModel.hpp
@@ -33,7 +33,6 @@ public:
         : _sessionId(std::move(sessionId))
         , _userName(std::move(userName))
         , _userId(std::move(userId))
-        , _start(std::time(nullptr))
         , _loadDuration(0)
         , _readOnly(readOnly)
     {
@@ -52,7 +51,6 @@ private:
     const std::string _sessionId;
     const std::string _userName;
     const std::string _userId;
-    const std::time_t _start;
     std::time_t _end = 0;
     std::chrono::milliseconds _loadDuration;
     bool _readOnly = false;
@@ -301,7 +299,6 @@ class Subscriber final
 public:
     explicit Subscriber(std::weak_ptr<WebSocketHandler> ws)
         : _ws(std::move(ws))
-        , _start(std::time(nullptr))
     {
         LOG_INF("Subscriber ctor.");
     }
@@ -327,7 +324,6 @@ private:
 
     std::set<std::string> _subscriptions;
 
-    std::time_t _start;
     std::time_t _end = 0;
 };
 


### PR DESCRIPTION
...seemingly unused ever since their introduction in ada6a74dc019ba30f00e761452da4185ef91306a "loolwsd: Basic layout and interaction with AdminModel" (View::_start) and afb7e7dcff4657b34ffdde60f5ab84b225b25f8a "loolwsd: Make clients subscribe to commands" (Subscriber::_start)


Change-Id: I38f5770a78f5c333fdd24ad33bac9b8ac565e113


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

