### PR TITLE
Remove useless shell export

### DIFF
--- a/cypress_test/Makefile.am
+++ b/cypress_test/Makefile.am
@@ -185,7 +185,6 @@ endef
 # enough, then probably we leak them.
 define start_coolwsd_instance
 	$(eval FREE_PORT:=$(shell $(GET_PORT_BINARY) --host=127.0.0.1 $(ALLOWED_PORTS)))
-	export $FREE_PORT
 	$(if $(findstring php-proxy, $(CYPRESS_INTEGRATION)),\
 		$(if $(findstring $(PHP_PROXY_PORT),$(FREE_PORT)),,$(error CypressError: $(PHP_PROXY_PORT) port is unavailable!)))
 	$(if $(findstring nextcloud, $(CYPRESS_INTEGRATION)),\


### PR DESCRIPTION
That line had been added with 9bcc79b2667ba57b2e7239148f608ceadf073407 "cypress: add option baseURL".  It leads to a make recipe line `export $FREE_PORT`, and, assuming the make var `F` is unset, a shell invocation of `export REE_PORT`, which is rather useless (just as useless as a shell invocation of `export FREE_PORT` would be, as the shell does nothing else, so nobody would be interested in what it would export to its sub-processes).


Change-Id: I278cef9b67dfc14c264d58103b6810f961526da1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

