### PR TITLE
Unify TST_LOG and LOG_TST

### DIFF
--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -235,8 +235,8 @@ static constexpr std::size_t skipPathPrefix(const char (&s)[N], std::size_t n = 
         Log::log(Log::Level::FTL, oss_.str());                                                     \
     } while (false)
 
-/// Unconditionally log at INF level.
-#define LOG_ANY(X) LOG_UNCONDITIONAL(INF, X)
+/// Unconditionally log at ANY level.
+#define LOG_ANY(X) LOG_UNCONDITIONAL(ANY, X)
 /// Unconditionally log at TST level. Used for tests only.
 #define LOG_TST(X) LOG_UNCONDITIONAL(TST, X)
 

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -223,15 +223,22 @@ static constexpr std::size_t skipPathPrefix(const char (&s)[N], std::size_t n = 
     END(oss_);                                  \
     LOG_LOG(LVL, oss_.str())
 
-#define LOG_ANY(X)                              \
-    char b_[1024];                              \
-    std::ostringstream oss_(                    \
-        Log::prefix<sizeof(b_) - 1>(b_, "INF"), \
-        std::ostringstream::ate);               \
-    logPrefix(oss_);                            \
-    oss_ << std::boolalpha << X;                \
-    LOG_END(oss_);                              \
-    Log::log(Log::Level::INF, oss_.str());
+/// Unconditionally log. LVL can be anything converted to string.
+#define LOG_UNCONDITIONAL(LVL, X)                                                                  \
+    do                                                                                             \
+    {                                                                                              \
+        char b_[1024];                                                                             \
+        std::ostringstream oss_(Log::prefix<sizeof(b_) - 1>(b_, #LVL), std::ostringstream::ate);   \
+        logPrefix(oss_);                                                                           \
+        oss_ << std::boolalpha << X;                                                               \
+        LOG_END(oss_);                                                                             \
+        Log::log(Log::Level::INF, oss_.str());                                                     \
+    } while (false)
+
+/// Unconditionally log at INF level.
+#define LOG_ANY(X) LOG_UNCONDITIONAL(INF, X)
+/// Unconditionally log at TST level. Used for tests only.
+#define LOG_TST(X) LOG_UNCONDITIONAL(TST, X)
 
 #if defined __GNUC__ || defined __clang__
 #  define LOG_CONDITIONAL(type, area)  \

--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -232,7 +232,7 @@ static constexpr std::size_t skipPathPrefix(const char (&s)[N], std::size_t n = 
         logPrefix(oss_);                                                                           \
         oss_ << std::boolalpha << X;                                                               \
         LOG_END(oss_);                                                                             \
-        Log::log(Log::Level::INF, oss_.str());                                                     \
+        Log::log(Log::Level::FTL, oss_.str());                                                     \
     } while (false)
 
 /// Unconditionally log at INF level.

--- a/common/SigUtil-server.cpp
+++ b/common/SigUtil-server.cpp
@@ -81,7 +81,7 @@ namespace SigUtil
 {
 void triggerDumpState(const std::string &testname)
 {
-    LOG_TST("Dumping state");
+    TST_LOG("Dumping state");
     ::kill(getpid(), SIGUSR1);
 }
 

--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -341,7 +341,7 @@ void UnitKit::postFork()
 void UnitBase::initialize()
 {
     assert(DlHandle != nullptr && "Invalid handle to set");
-    LOG_TST("==================== Starting [" << getTestname() << "] ====================");
+    TST_LOG("==================== Starting [" << getTestname() << "] ====================");
     socketPoll()->startThread();
 }
 
@@ -349,12 +349,12 @@ void UnitBase::setTimeout(std::chrono::milliseconds timeoutMilliSeconds)
 {
     assert(!TimeoutThread.joinable() && "setTimeout must be called before starting a test");
     _timeoutMilliSeconds = timeoutMilliSeconds;
-    LOG_TST(getTestname() << ": setTimeout: " << _timeoutMilliSeconds);
+    TST_LOG(getTestname() << ": setTimeout: " << _timeoutMilliSeconds);
 }
 
 UnitBase::~UnitBase()
 {
-    LOG_TST(getTestname() << ": ~UnitBase: " << (failed() ? "FAILED" : "SUCCESS"));
+    TST_LOG(getTestname() << ": ~UnitBase: " << (failed() ? "FAILED" : "SUCCESS"));
 
     std::shared_ptr<SocketPoll> socketPoll = getSocketPoll();
     if (socketPoll)
@@ -399,12 +399,12 @@ bool UnitBase::filterSendWebSocketMessage(const char* data, const std::size_t le
             }
             catch (const std::exception& exception)
             {
-                LOG_TST("unocommandresult parsing failure: " << exception.what());
+                TST_LOG("unocommandresult parsing failure: " << exception.what());
             }
         }
         else
         {
-            LOG_TST("Expected json unocommandresult. Ignoring: " << message);
+            TST_LOG("Expected json unocommandresult. Ignoring: " << message);
         }
     }
     else if (message.starts_with("loaded:"))
@@ -460,7 +460,7 @@ void UnitBase::exitTest(TestResult result, const std::string& reason)
     {
         if (result != _result)
         {
-            LOG_TST("exitTest got " << name(result) << " but is already finished with "
+            TST_LOG("exitTest got " << name(result) << " but is already finished with "
                                     << name(_result));
         }
 
@@ -469,11 +469,11 @@ void UnitBase::exitTest(TestResult result, const std::string& reason)
 
     if (result == TestResult::Ok)
     {
-        LOG_TST("SUCCESS: exitTest: " << name(result) << (reason.empty() ? "" : ": " + reason));
+        TST_LOG("SUCCESS: exitTest: " << name(result) << (reason.empty() ? "" : ": " + reason));
     }
     else
     {
-        LOG_TST("ERROR: FAILURE: exitTest: " << name(result)
+        TST_LOG("ERROR: FAILURE: exitTest: " << name(result)
                                              << (reason.empty() ? "" : ": " + reason));
 
         if (GlobalResult == TestResult::Ok)
@@ -527,7 +527,7 @@ void UnitBase::timeout()
     // Don't timeout if we had already finished.
     if (isUnitTesting() && !isFinished())
     {
-        LOG_TST("ERROR: Timed out waiting for unit test to complete within "
+        TST_LOG("ERROR: Timed out waiting for unit test to complete within "
                 << _timeoutMilliSeconds);
         exitTest(TestResult::TimedOut);
     }
@@ -541,7 +541,7 @@ void UnitBase::returnValue(int& retValue)
 
 void UnitBase::endTest([[maybe_unused]] const std::string& reason)
 {
-    LOG_TST("Ending test by stopping SocketPoll [" << getTestname() << "]: " << reason);
+    TST_LOG("Ending test by stopping SocketPoll [" << getTestname() << "]: " << reason);
     std::shared_ptr<SocketPoll> socketPoll = getSocketPoll();
     if (socketPoll)
         socketPoll->joinThread();
@@ -552,7 +552,7 @@ void UnitBase::endTest([[maybe_unused]] const std::string& reason)
     if (TimeoutThread.joinable())
         TimeoutThread.join();
 
-    LOG_TST("==================== Finished [" << getTestname() << "] ====================");
+    TST_LOG("==================== Finished [" << getTestname() << "] ====================");
 }
 
 UnitWSD::UnitWSD(const std::string& name)
@@ -621,7 +621,7 @@ void UnitWSD::DocBrokerDestroy(const std::string& key)
             {
                 rememberInstance(_type, GlobalArray[GlobalIndex]);
 
-                LOG_TST("Starting test #" << GlobalIndex + 1 << ": "
+                TST_LOG("Starting test #" << GlobalIndex + 1 << ": "
                                           << GlobalArray[GlobalIndex]->getTestname());
                 UnitWSD *globalWSD = GlobalWSD;
                 if (globalWSD)
@@ -648,10 +648,10 @@ void UnitWSD::onExitTest(TestResult result, const std::string&)
     {
         if (result != TestResult::Ok && !GlobalTestOptions.getKeepgoing())
         {
-            LOG_TST("Failing fast per options, even though there are more tests");
+            TST_LOG("Failing fast per options, even though there are more tests");
             if constexpr (!Util::isMobileApp())
             {
-                LOG_TST("Setting TerminationFlag as the Test Suite failed");
+                TST_LOG("Setting TerminationFlag as the Test Suite failed");
                 SigUtil::setTerminationFlag(); // and wake-up world.
             }
             else
@@ -659,7 +659,7 @@ void UnitWSD::onExitTest(TestResult result, const std::string&)
             return;
         }
 
-        LOG_TST("Have more tests. Waiting for the DocBroker to destroy before starting them");
+        TST_LOG("Have more tests. Waiting for the DocBroker to destroy before starting them");
         return;
     }
 
@@ -670,7 +670,7 @@ void UnitWSD::onExitTest(TestResult result, const std::string&)
 
     if constexpr (!Util::isMobileApp())
     {
-        LOG_TST("Setting TerminationFlag as there are no more tests");
+        TST_LOG("Setting TerminationFlag as there are no more tests");
         SigUtil::setTerminationFlag(); // and wake-up world.
     }
     else
@@ -706,7 +706,7 @@ void UnitKit::onExitTest(TestResult, const std::string&)
 
     if constexpr (!Util::isMobileApp())
     {
-        // LOG_TST("Setting TerminationFlag as there are no more tests");
+        // TST_LOG("Setting TerminationFlag as there are no more tests");
         SigUtil::setTerminationFlag(); // and wake-up world.
     }
     else

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -162,7 +162,7 @@ public:
     /// Returns true if we failed, false otherwise.
     virtual bool onDataLoss(const std::string& reason)
     {
-        LOG_TST("onDataLoss: " << reason);
+        TST_LOG("onDataLoss: " << reason);
         failTest(reason);
         return failed();
     }
@@ -290,7 +290,7 @@ public:
         if (isUnitTesting() && !isFinished() &&
             (elapsedTime - _startTimeMilliSeconds) > getTimeoutMilliSeconds())
         {
-            LOG_TST("ERROR Test exceeded its time limit of "
+            TST_LOG("ERROR Test exceeded its time limit of "
                     << getTimeoutMilliSeconds() << ". It's been running for " << elapsedTime);
             timeout();
         }
@@ -451,12 +451,12 @@ public:
         }
         catch (const std::exception& ex)
         {
-            LOG_TST("ERROR: unexpected exception while invoking WSD Test: " << ex.what());
+            TST_LOG("ERROR: unexpected exception while invoking WSD Test: " << ex.what());
             exitTest(TestResult::Failed);
         }
         catch (...)
         {
-            LOG_TST("ERROR: unexpected unknown exception while invoking WSD Test");
+            TST_LOG("ERROR: unexpected unknown exception while invoking WSD Test");
             exitTest(TestResult::Failed);
         }
     }
@@ -713,7 +713,7 @@ private:
 #define TRANSITION_STATE_MSG(VAR, STATE, MSG)                                                      \
     do                                                                                             \
     {                                                                                              \
-        LOG_TST(MSG << ' ' << name(VAR) << " -> " #STATE);                                         \
+        TST_LOG(MSG << ' ' << name(VAR) << " -> " #STATE);                                         \
         VAR = STATE;                                                                               \
         SocketPoll::wakeupWorld();                                                                 \
     } while (false)

--- a/test/KitPidHelpers.cpp
+++ b/test/KitPidHelpers.cpp
@@ -55,9 +55,8 @@ void helpers::logKitProcesses(const std::string& testname)
 {
     std::set<pid_t> docKitPids = getDocKitPids();
     std::set<pid_t> spareKitPids = getSpareKitPids();
-    TST_LOG("Current kit processes: "
-            << "Doc Kits: " << getPidList(docKitPids)
-            << " Spare Kits: " << getPidList(spareKitPids));
+    TST_LOG("Current kit processes: " << "Doc Kits: " << getPidList(docKitPids)
+                                      << " Spare Kits: " << getPidList(spareKitPids));
 }
 
 void helpers::waitForKitPidsReady(
@@ -110,8 +109,8 @@ void helpers::killPid(const std::string& testname, const pid_t pid)
 {
     TST_LOG("Killing " << pid);
     if (kill(pid, SIGKILL) == -1)
-        TST_LOG("kill(" << pid << ", SIGKILL) failed: " <<
-                Util::symbolicErrno(errno) << ": " << std::strerror(errno));
+        TST_LOG("kill(" << pid << ", SIGKILL) failed: " << Util::symbolicErrno(errno) << ": "
+                        << std::strerror(errno));
 }
 
 void helpers::killAllKitProcesses(
@@ -147,8 +146,7 @@ void helpers::killAllKitProcesses(
     }
 
     TST_LOG("Finished waiting for all previous kit processes to close"
-            << " before: " << getPidList(before)
-            << " current: " << getPidList(getKitPids())
+            << " before: " << getPidList(before) << " current: " << getPidList(getKitPids())
             << " intersection: " << getPidList(inters));
 
     LOK_ASSERT_MESSAGE_SILENT("Timed out waiting for these kit processes to close", pass);

--- a/test/UnitHTTP.cpp
+++ b/test/UnitHTTP.cpp
@@ -45,7 +45,7 @@ public:
     void testContinue()
     {
         //FIXME: use logging
-        LOG_TST("testContinue");
+        TST_LOG("testContinue");
         for (int i = 0; i < 3; ++i)
         {
             std::unique_ptr<Poco::Net::HTTPClientSession> session(helpers::createSession(Poco::URI(helpers::getTestServerURI())));
@@ -82,7 +82,7 @@ public:
 
             if (sent != responseStr)
             {
-                LOG_TST("Test " << i << " failed - mismatching string '" << responseStr << "' vs. '"
+                TST_LOG("Test " << i << " failed - mismatching string '" << responseStr << "' vs. '"
                                 << sent << "'");
                 exitTest(TestResult::Failed);
                 return;
@@ -92,13 +92,13 @@ public:
 
     void writeString(const std::shared_ptr<Poco::Net::StreamSocket> &socket, const std::string& str)
     {
-        LOG_TST("Sending " << str.size() << " bytes:\n" << str);
+        TST_LOG("Sending " << str.size() << " bytes:\n" << str);
         socket->sendBytes(str.c_str(), str.size());
     }
 
     bool expectString(const std::shared_ptr<Poco::Net::StreamSocket> &socket, const std::string& str)
     {
-        LOG_TST("Expecting " << str.size() << " bytes:\n" << str);
+        TST_LOG("Expecting " << str.size() << " bytes:\n" << str);
 
         std::vector<char> buffer(str.size() + 64);
         const int got = socket->receiveBytes(buffer.data(), str.size());
@@ -107,7 +107,7 @@ public:
         if (got != (int)str.size() ||
             strncmp(buffer.data(), str.c_str(), got))
         {
-            LOG_TST("testChunks got " << got << " mismatching strings '" << buffer.data()
+            TST_LOG("testChunks got " << got << " mismatching strings '" << buffer.data()
                                       << " vs. expected '" << str << "'");
             exitTest(TestResult::Failed);
             return false;
@@ -129,7 +129,7 @@ public:
 
     void testChunks()
     {
-        LOG_TST("testChunks");
+        TST_LOG("testChunks");
 
         std::shared_ptr<Poco::Net::StreamSocket> socket = createRawSocket();
 
@@ -188,7 +188,7 @@ public:
 
         writeString(socket, START_CHUNK_HEX("0"));
 
-        LOG_TST("Receiving...");
+        TST_LOG("Receiving...");
         char buffer[4096] = { 0, };
         int got = socket->receiveBytes(buffer, 4096);
 
@@ -211,7 +211,7 @@ public:
         LOK_ASSERT_MESSAGE("Missing separator, got " + std::string(buffer), ptr);
         if (!ptr)
         {
-            LOG_TST("missing separator " << got << " '" << buffer);
+            TST_LOG("missing separator " << got << " '" << buffer);
             exitTest(TestResult::Failed);
             return;
         }
@@ -223,21 +223,21 @@ public:
         }
 
         // Oddly we need another read to get the content.
-        LOG_TST("Receiving...");
+        TST_LOG("Receiving...");
         got = socket->receiveBytes(buffer, 4096);
         LOK_ASSERT_MESSAGE("No content returned.", got >= 0);
         if (got >=0 )
             buffer[got] = '\0';
         else
         {
-            LOG_TST("No content returned " << got);
+            TST_LOG("No content returned " << got);
             exitTest(TestResult::Failed);
             return;
         }
 
         if (strcmp(buffer, "\357\273\277This is some text.\nAnd some more.\n"))
         {
-            LOG_TST("unexpected file content " << got << " '" << buffer);
+            TST_LOG("unexpected file content " << got << " '" << buffer);
             exitTest(TestResult::Failed);
             return;
         }
@@ -247,7 +247,7 @@ public:
     {
         testChunks();
         testContinue();
-        LOG_TST("All tests passed.");
+        TST_LOG("All tests passed.");
         exitTest(TestResult::Ok);
     }
 };

--- a/test/UnitHosting.cpp
+++ b/test/UnitHosting.cpp
@@ -43,7 +43,7 @@ public:
 
 UnitBase::TestResult UnitHosting::testDiscovery()
 {
-    LOG_TST("Getting /hosting/discovery the first time.");
+    TST_LOG("Getting /hosting/discovery the first time.");
     const std::shared_ptr<const http::Response> httpResponse
         = http::get(helpers::getTestServerURI(), "/hosting/discovery");
 
@@ -60,7 +60,7 @@ UnitBase::TestResult UnitHosting::testDiscovery()
     LOK_ASSERT_EQUAL(std::string("text/xml"), httpResponse->header().getContentType());
 
     // Repeat, with a trailing slash in the URL.
-    LOG_TST("Getting /hosting/discovery the second time.");
+    TST_LOG("Getting /hosting/discovery the second time.");
     const std::shared_ptr<const http::Response> httpResponse2
         = http::get(helpers::getTestServerURI(), "/hosting/discovery/");
 
@@ -76,7 +76,7 @@ UnitBase::TestResult UnitHosting::testDiscovery()
     LOK_ASSERT_EQUAL(std::string("OK"), httpResponse2->statusLine().reasonPhrase());
     LOK_ASSERT_EQUAL(std::string("text/xml"), httpResponse2->header().getContentType());
 
-    LOG_TST("Comparing /hosting/discovery from both requests.");
+    TST_LOG("Comparing /hosting/discovery from both requests.");
     LOK_ASSERT_EQUAL(httpResponse2->getBody(), httpResponse->getBody());
 
     return TestResult::Ok;

--- a/test/UnitInitialLoadFail.cpp
+++ b/test/UnitInitialLoadFail.cpp
@@ -59,7 +59,7 @@ public:
                              const std::shared_ptr<StreamSocket>& /*socket*/) override
     {
         std::string uri = Uri::decode(request.getURI());
-        LOG_TST("parallelizeCheckInfo requested: " << uri);
+        TST_LOG("parallelizeCheckInfo requested: " << uri);
         return std::map<std::string, std::string>{
             {"wopiSrc", "/wopi/files/0"},
             {"accessToken", "anything"},
@@ -74,7 +74,7 @@ public:
     {
         if (_getFileCount++ == 0)
         {
-            LOG_TST("handleGetFileRequest: force timeout for 1st load\n");
+            TST_LOG("handleGetFileRequest: force timeout for 1st load\n");
             std::this_thread::sleep_for(std::chrono::milliseconds(5000));
             return true;
         }
@@ -93,17 +93,17 @@ public:
     {
         const std::string message(data, len);
 
-        LOG_TST("onFilterSendWebSocketMessage:" << message);
+        TST_LOG("onFilterSendWebSocketMessage:" << message);
 
         if (message.starts_with("session "))
         {
-            LOG_TST("PASS, session seen: " << message);
+            TST_LOG("PASS, session seen: " << message);
             TRANSITION_STATE(_phase, Phase::LoadSuccess);
         }
 
         if (message.starts_with("error: cmd=storage"))
         {
-            LOG_TST("Load failed, explicit retry: " << message);
+            TST_LOG("Load failed, explicit retry: " << message);
             TRANSITION_STATE(_phase, Phase::LoadAttempt);
         }
 
@@ -119,7 +119,7 @@ public:
                 // Always transition before issuing commands.
                 TRANSITION_STATE(_phase, Phase::WaitLoad);
 
-                LOG_TST("Attempt first load which should timeout once");
+                TST_LOG("Attempt first load which should timeout once");
 
                 initWebsocket("/wopi/files/0?access_token=anything");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc());
@@ -166,7 +166,7 @@ public:
         _ensureNotLeaked = socket;
 
         std::string uri = Uri::decode(request.getURI());
-        LOG_TST("parallelizeCheckInfo requested: " << uri);
+        TST_LOG("parallelizeCheckInfo requested: " << uri);
         return std::map<std::string, std::string>{
             {"wopiSrc", "/wopi/files/0"},
             {"accessToken", "anything"},
@@ -192,11 +192,11 @@ public:
     {
         const std::string message(data, len);
 
-        LOG_TST("onFilterSendWebSocketMessage:" << message);
+        TST_LOG("onFilterSendWebSocketMessage:" << message);
 
         if (message.starts_with("error: cmd=internal kind=unauthorized"))
         {
-            LOG_TST("Expected Unauthorized load failed: " << message);
+            TST_LOG("Expected Unauthorized load failed: " << message);
             TRANSITION_STATE(_phase, Phase::WaitSocketDtor);
         }
 
@@ -212,7 +212,7 @@ public:
                 // Always transition before issuing commands.
                 TRANSITION_STATE(_phase, Phase::WaitUnauthorized);
 
-                LOG_TST("Attempt load which should fail with Unauthorized");
+                TST_LOG("Attempt load which should fail with Unauthorized");
 
                 initWebsocket("/wopi/files/0?access_token=anything");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc());

--- a/test/UnitInvalidation.cpp
+++ b/test/UnitInvalidation.cpp
@@ -46,7 +46,7 @@ void UnitInvalidation::setupSession(const std::shared_ptr<http::WebSocketSession
     helpers::sendTextFrame(session, "commandvalues command=.uno:CellCursor?outputHeight=256&outputWidth=256&tileHeight=2560&tileWidth=2560", testname);
 
     // Let the app get somewhat setup ...
-    LOG_TST("settling ...");
+    TST_LOG("settling ...");
     helpers::drain(session, testname, std::chrono::seconds(2));
 }
 
@@ -95,13 +95,13 @@ void UnitInvalidation::invokeWSDTest()
         std::shared_ptr<http::WebSocketSession> windowOne = helpers::loadDocAndGetSession(
             socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
 
-        LOG_TST("Rendering window one");
+        TST_LOG("Rendering window one");
 
         setupSession(windowOne);
         // ensure all tiles hit the cache and made it to us.
         renderArea(windowOne, 0);
 
-        LOG_TST("Rendering window two");
+        TST_LOG("Rendering window two");
 
         std::shared_ptr<http::WebSocketSession> windowTwo = helpers::loadDocAndGetSession(
             socketPoll, Poco::URI(helpers::getTestServerURI()), documentURL, testname);
@@ -109,7 +109,7 @@ void UnitInvalidation::invokeWSDTest()
         // ensure all the same tiles are served from the cache, and not the LOK view.
         renderArea(windowTwo, 0);
 
-        LOG_TST("Tab switch and edit: window one");
+        TST_LOG("Tab switch and edit: window one");
 
         // Switch to sheet two in window one
         helpers::sendTextFrame(windowOne, "setclientpart part=1", testname);
@@ -138,7 +138,7 @@ void UnitInvalidation::invokeWSDTest()
         helpers::sendTextFrame(windowOne, "key type=input char=13 key=1280", testname);
         helpers::sendTextFrame(windowOne, "key type=up char=0 key=1280", testname);
 
-        LOG_TST("Wait for window one invalidations");
+        TST_LOG("Wait for window one invalidations");
         std::vector<std::string> invalidates;
 
         invalidates = helpers::getAllResponsesTimed(windowOne, "invalidatetiles:", testname, std::chrono::seconds(2));
@@ -156,7 +156,7 @@ void UnitInvalidation::invokeWSDTest()
         LOK_ASSERT(invalidated);
         // We expect invalidates on both part 1 (current) and 0 (dependent)
 
-        LOG_TST("Wait for window two invalidations");
+        TST_LOG("Wait for window two invalidations");
 
         // Notice no invalidation on window two
         invalidates = helpers::getAllResponsesTimed(windowTwo, "invalidatetiles:", testname, std::chrono::seconds(2));

--- a/test/UnitJoinDisconnect.cpp
+++ b/test/UnitJoinDisconnect.cpp
@@ -49,7 +49,7 @@ public:
     {
         const bool firstView = _checkFileInfoCount++ == 0;
 
-        LOG_TST("CheckFileInfo: " << (firstView ? "User#1" : "User#2"));
+        TST_LOG("CheckFileInfo: " << (firstView ? "User#1" : "User#2"));
 
         fileInfo->set("UserCanWrite", "true");
     }
@@ -75,7 +75,7 @@ public:
     void onDocBrokerViewLoaded(const std::string&,
                                const std::shared_ptr<ClientSession>& session) override
     {
-        LOG_TST("View #" << _viewCount + 1 << " [" << session->getName() << "] loaded");
+        TST_LOG("View #" << _viewCount + 1 << " [" << session->getName() << "] loaded");
 
         ++_viewCount;
 
@@ -95,10 +95,10 @@ public:
                 // Always transition before issuing commands.
                 TRANSITION_STATE(_phase, Phase::WaitUser1Loaded);
 
-                LOG_TST("Creating first connection");
+                TST_LOG("Creating first connection");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                LOG_TST("Loading first view");
+                TST_LOG("Loading first view");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc());
                 break;
             }
@@ -122,10 +122,10 @@ public:
                     TRANSITION_STATE(_phase, Phase::DropUser2);
                 }
 
-                LOG_TST("Creating second connection");
+                TST_LOG("Creating second connection");
                 addWebSocket();
 
-                LOG_TST("Loading second view");
+                TST_LOG("Loading second view");
                 WSD_CMD_BY_CONNECTION_INDEX(1, "load url=" + getWopiSrc());
                 break;
             }
@@ -138,7 +138,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::ModifyDoc);
 
-                LOG_TST("Disconnecting first view right after load start");
+                TST_LOG("Disconnecting first view right after load start");
                 deleteSocketAt(1);
                 break;
             }
@@ -147,7 +147,7 @@ public:
                 TRANSITION_STATE(_phase, Phase::Done);
 
                 // Modify the document.
-                LOG_TST("Modifying");
+                TST_LOG("Modifying");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "key type=input char=97 key=0");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "key type=up char=0 key=512");
                 break;

--- a/test/UnitLoadTorture.cpp
+++ b/test/UnitLoadTorture.cpp
@@ -96,9 +96,8 @@ void UnitLoadTorture::loadTorture(const std::string& name, const std::string& do
                 ++num_of_views;
                 --num_to_load;
 
-                TST_LOG(": #" << id << ", new viewId: " << viewid <<
-                        ", loaded views: " << num_of_views <<
-                        ", to load: " << num_to_load);
+                TST_LOG(": #" << id << ", new viewId: " << viewid << ", loaded views: "
+                              << num_of_views << ", to load: " << num_to_load);
 
                 // Get all the views loaded - lean on test timeout to interrupt.
                 while (num_to_load > 0)

--- a/test/UnitMultiTenant.cpp
+++ b/test/UnitMultiTenant.cpp
@@ -51,7 +51,7 @@ public:
 
     void newSubForKit(const std::shared_ptr<ForKitProcess>& /*subforkit*/, const std::string& configId) override
     {
-        LOG_TST("New SubForKit: " << configId);
+        TST_LOG("New SubForKit: " << configId);
         if (configId.find(_configId) == std::string::npos)
             failTest("unexpected subforkit configId");
         LOK_ASSERT_STATE(_phase, Phase::WaitCreateSubForKit);
@@ -62,11 +62,11 @@ public:
     void killSubForKit(const std::string& configId) override
     {
         LOK_ASSERT_STATE(_phase, Phase::WaitKillSubForKit);
-        LOG_TST("Killed SubForKit: " << configId);
+        TST_LOG("Killed SubForKit: " << configId);
         if (_configId == "someconfigid")
         {
             _configId = "someotherconfig";
-            LOG_TST("reload with a different server config" << _configId);
+            TST_LOG("reload with a different server config" << _configId);
             TRANSITION_STATE(_phase, Phase::Load);
         }
         else
@@ -82,7 +82,7 @@ public:
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        TST_LOG("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
 
@@ -109,7 +109,7 @@ public:
                              const std::shared_ptr<StreamSocket>& /*socket*/) override
     {
         std::string uri = Uri::decode(request.getURI());
-        LOG_TST("parallelizeCheckInfo requested: " << uri);
+        TST_LOG("parallelizeCheckInfo requested: " << uri);
         return std::map<std::string, std::string>{
             {"wopiSrc", "/wopi/files/0"},
             {"accessToken", "anything"},
@@ -130,10 +130,10 @@ public:
                 // Always transition before issuing commands.
                 TRANSITION_STATE(_phase, Phase::WaitCreateSubForKit);
 
-                LOG_TST("Creating first connection");
+                TST_LOG("Creating first connection");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                LOG_TST("Loading view");
+                TST_LOG("Loading view");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc());
                 break;
             }

--- a/test/UnitOAuth.cpp
+++ b/test/UnitOAuth.cpp
@@ -121,7 +121,7 @@ public:
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Doc (" << name(_phase) << "): [" << message << ']');
+        TST_LOG("Doc (" << name(_phase) << "): [" << message << ']');
 
         LOK_ASSERT_EQUAL_MESSAGE("CheckFileInfo was not invoked", true, _checkFileInfoCalled);
         _checkFileInfoCalled = false;

--- a/test/UnitPasswordProtected.cpp
+++ b/test/UnitPasswordProtected.cpp
@@ -26,7 +26,7 @@ public:
 
     bool onDocumentError(const std::string& message) override
     {
-        LOG_TST("onDocumentError: [" << message << ']');
+        TST_LOG("onDocumentError: [" << message << ']');
         LOK_ASSERT_EQUAL_MESSAGE("Expect only passwordrequired errors",
                                  std::string("error: cmd=load kind=passwordrequired:to-view"),
                                  message);
@@ -64,7 +64,7 @@ public:
 
     bool onDocumentError(const std::string& message) override
     {
-        LOG_TST("onDocumentError: [" << message << ']');
+        TST_LOG("onDocumentError: [" << message << ']');
         LOK_ASSERT_EQUAL_MESSAGE("Expect only wrongpassword errors",
                                  std::string("error: cmd=load kind=wrongpassword"), message);
 
@@ -83,7 +83,7 @@ public:
                 const std::string docFilename = "password-protected.ods";
                 const std::string documentURL = connectToLocalDocument(docFilename);
 
-                LOG_TST("Loading local document [" << docFilename << "] with URL: " << documentURL);
+                TST_LOG("Loading local document [" << docFilename << "] with URL: " << documentURL);
                 WSD_CMD("load url=" + documentURL + " password=2");
                 break;
             }
@@ -106,7 +106,7 @@ public:
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        TST_LOG("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoad);
 
         passTest("Loaded successfully");
@@ -124,7 +124,7 @@ public:
                 const std::string docFilename = "password-protected.ods";
                 const std::string documentURL = connectToLocalDocument(docFilename);
 
-                LOG_TST("Loading local document [" << docFilename << "] with URL: " << documentURL);
+                TST_LOG("Loading local document [" << docFilename << "] with URL: " << documentURL);
                 WSD_CMD("load url=" + documentURL + " password=1");
                 break;
             }
@@ -147,7 +147,7 @@ public:
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        TST_LOG("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoad);
 
         passTest("Loaded successfully");
@@ -165,7 +165,7 @@ public:
                 const std::string docFilename = "password-protected.docx";
                 const std::string documentURL = connectToLocalDocument(docFilename);
 
-                LOG_TST("Loading local document [" << docFilename << "] with URL: " << documentURL);
+                TST_LOG("Loading local document [" << docFilename << "] with URL: " << documentURL);
                 WSD_CMD("load url=" + documentURL + " password=abc");
                 break;
             }
@@ -188,7 +188,7 @@ public:
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        TST_LOG("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoad);
 
         passTest("Loaded successfully");
@@ -206,7 +206,7 @@ public:
                 const std::string docFilename = "password-protected.doc";
                 const std::string documentURL = connectToLocalDocument(docFilename);
 
-                LOG_TST("Loading local document [" << docFilename << "] with URL: " << documentURL);
+                TST_LOG("Loading local document [" << docFilename << "] with URL: " << documentURL);
                 WSD_CMD("load url=" + documentURL + " password=abc");
                 break;
             }

--- a/test/UnitProxy.cpp
+++ b/test/UnitProxy.cpp
@@ -55,11 +55,13 @@ public:
             LOK_ASSERT_FAIL("Unexpected connection failure");
         });
 
-        httpSession->setFinishedHandler([&](const std::shared_ptr<http::Session>&) {
-            TST_LOG("Got a valid response from the proxy");
-            // any result short of server choking is fine - we may be off-line
-            exitTest(TestResult::Ok);
-        });
+        httpSession->setFinishedHandler(
+            [&](const std::shared_ptr<http::Session>&)
+            {
+                TST_LOG("Got a valid response from the proxy");
+                // any result short of server choking is fine - we may be off-line
+                exitTest(TestResult::Ok);
+            });
 
         httpSession->asyncRequest(_req, _poll);
 

--- a/test/UnitQuarantine.cpp
+++ b/test/UnitQuarantine.cpp
@@ -32,10 +32,10 @@ std::vector<std::string> getQuarantineFiles(const std::string testname,
     std::vector<std::string> files;
     Poco::File(quarantinePath).list(files);
 
-    LOG_TST("Found " << files.size() << " quarantine file in [" << quarantinePath << ']');
+    TST_LOG("Found " << files.size() << " quarantine file in [" << quarantinePath << ']');
     for (std::size_t i = 0; i < files.size(); ++i)
     {
-        LOG_TST("Found quarantine file #" << (i + 1) << ": [" << files[i] << ']');
+        TST_LOG("Found quarantine file #" << (i + 1) << ": [" << files[i] << ']');
     }
 
     return files;
@@ -82,13 +82,13 @@ public:
             auto rootPath = Poco::Path(config.getString("child_root_path", ""));
             rootPath.popDirectory().pushDirectory("quarantine");
             _quarantinePath = FileUtil::createRandomTmpDir(rootPath.toString());
-            LOG_TST("Quarantine path set to [" << _quarantinePath << ']');
+            TST_LOG("Quarantine path set to [" << _quarantinePath << ']');
             config.setString("quarantine_files.path", _quarantinePath);
         }
         else
         {
             _quarantinePath = config.getString("quarantine_files.path", std::string());
-            LOG_TST("Quarantine path found at [" << _quarantinePath << ']');
+            TST_LOG("Quarantine path found at [" << _quarantinePath << ']');
         }
 
         // Make sure the quarantine directory is clean.
@@ -119,7 +119,7 @@ public:
     std::unique_ptr<http::Response>
     assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("Testing " << name(_scenario));
+        TST_LOG("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         assertGetFileCount();
@@ -135,7 +135,7 @@ public:
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
-        LOG_TST("Testing " << name(_scenario));
+        TST_LOG("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         assertPutFileCount();
@@ -154,7 +154,7 @@ public:
 
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
+        TST_LOG("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitDocClose);
@@ -163,18 +163,18 @@ public:
         {
             case Scenario::Disconnect:
                 // Just disconnect.
-                LOG_TST("Disconnecting");
+                TST_LOG("Disconnecting");
                 deleteSocketAt(0);
                 break;
             case Scenario::SaveDiscard:
             case Scenario::SaveOverwrite:
                 // Save the document.
-                LOG_TST("Saving the document");
+                TST_LOG("Saving the document");
                 WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0");
                 break;
             case Scenario::CloseDiscard:
                 // Close the document.
-                LOG_TST("Closing the document");
+                TST_LOG("Closing the document");
                 WSD_CMD("closedocument");
                 break;
             case Scenario::VerifyOverwrite:
@@ -187,7 +187,7 @@ public:
 
     bool onDocumentError(const std::string& message) override
     {
-        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
+        TST_LOG("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         if (getCountCheckFileInfo() == 1)
@@ -203,7 +203,7 @@ public:
                 std::string("error: cmd=storage kind=documentconflict"), message);
 
             // Close the document.
-            LOG_TST("Closing the document");
+            TST_LOG("Closing the document");
             WSD_CMD("closedocument");
         }
 
@@ -213,7 +213,7 @@ public:
     // Called when we have modified document data at exit.
     bool onDataLoss(const std::string& reason) override
     {
-        LOG_TST("Modified document being unloaded: " << reason);
+        TST_LOG("Modified document being unloaded: " << reason);
 
         // We expect this to happen only with the disonnection test,
         // because only in that case there is no user input.
@@ -228,7 +228,7 @@ public:
     // Wait for clean unloading.
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
+        TST_LOG("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         // Uploading fails and we can't have anything but the original.
@@ -272,13 +272,13 @@ public:
             auto rootPath = Poco::Path(config.getString("child_root_path", ""));
             rootPath.popDirectory().pushDirectory("quarantine");
             _quarantinePath = FileUtil::createRandomTmpDir(rootPath.toString());
-            LOG_TST("Quarantine path set to [" << _quarantinePath << ']');
+            TST_LOG("Quarantine path set to [" << _quarantinePath << ']');
             config.setString("quarantine_files.path", _quarantinePath);
         }
         else
         {
             _quarantinePath = config.getString("quarantine_files.path", std::string());
-            LOG_TST("Quarantine path found at [" << _quarantinePath << ']');
+            TST_LOG("Quarantine path found at [" << _quarantinePath << ']');
         }
 
         // Make sure the quarantine directory is clean.
@@ -288,18 +288,18 @@ public:
     void newChild(const std::shared_ptr<ChildProcess>& child) override
     {
         _kitsPids.push_back(child->getPid());
-        LOG_TST("New Kit PID: " << _kitsPids.back());
+        TST_LOG("New Kit PID: " << _kitsPids.back());
     }
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        TST_LOG("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitModifyStatus);
 
         // Modify the doc.
-        LOG_TST("Modifying");
+        TST_LOG("Modifying");
         WSD_CMD("key type=input char=97 key=0");
         WSD_CMD("key type=up char=0 key=512");
 
@@ -308,12 +308,12 @@ public:
 
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Got [" << message << ']');
+        TST_LOG("Got [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifyStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitUpload);
 
-        LOG_TST("Saving the document");
+        TST_LOG("Saving the document");
         WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0");
 
         return true;
@@ -322,7 +322,7 @@ public:
     /// Wait for ModifiedStatus=false before crashing the kit.
     bool onDocumentUnmodified(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitUpload);
 
         TRANSITION_STATE(_phase, Phase::Unload);
@@ -330,7 +330,7 @@ public:
         // Kill the kit.
         for (const auto& pid : _kitsPids)
         {
-            LOG_TST("Killing kit: " << pid);
+            TST_LOG("Killing kit: " << pid);
             ::kill(pid, SIGKILL);
         }
 
@@ -339,14 +339,14 @@ public:
 
     void kitKilled(int count) override
     {
-        LOG_TST("Kit killed");
+        TST_LOG("Kit killed");
         LOK_ASSERT(static_cast<std::size_t>(count) <= _kitsPids.size());
     }
 
     // Called when we have modified document data at exit.
     bool onDataLoss(const std::string& reason) override
     {
-        LOG_TST("Modified document being unloaded: " << reason);
+        TST_LOG("Modified document being unloaded: " << reason);
 
         // We expect this to happen only with the disonnection test,
         // because only in that case there is no user input.
@@ -360,7 +360,7 @@ public:
     // Wait for clean unloading.
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Testing with dockey [" << docKey << "] closed.");
+        TST_LOG("Testing with dockey [" << docKey << "] closed.");
         LOK_ASSERT_STATE(_phase, Phase::Unload);
 
         const std::string documentUrl = Uri::encode(helpers::getTestServerURI() + "/wopi/files/0");
@@ -381,10 +381,10 @@ public:
                 // Always transition before issuing commands.
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Creating first connection");
+                TST_LOG("Creating first connection");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                LOG_TST("Loading view");
+                TST_LOG("Loading view");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc());
                 break;
             }

--- a/test/UnitSaveTorture.cpp
+++ b/test/UnitSaveTorture.cpp
@@ -50,7 +50,7 @@ class UnitSaveTorture : public UnitWSD
     // Force background autosave when saving the modified document
     bool isAutosave() override
     {
-        LOG_TST("isAutosave returns " << forceAutosave);
+        TST_LOG("isAutosave returns " << forceAutosave);
         return forceAutosave;
     }
 
@@ -320,13 +320,13 @@ void UnitSaveTorture::saveTortureOne(
 
     for (size_t i = 0; i < std::size(options); ++i)
     {
-        LOG_TST("saveTorture test stage " << i << " " << options[i].description);
+        TST_LOG("saveTorture test stage " << i << " " << options[i].description);
 
         if (options[i].modifyFirst)
         {
             modifyDocument(wsSession);
 
-            LOG_TST("wait for first modified status");
+            TST_LOG("wait for first modified status");
             LOK_ASSERT_EQUAL(waitForModifiedStatus(name, wsSession), true);
         }
 
@@ -338,13 +338,13 @@ void UnitSaveTorture::saveTortureOne(
 
         if (options[i].modifyAfterSaveStarts)
         {
-            LOG_TST("Modify after saving starts");
+            TST_LOG("Modify after saving starts");
             modifyDocument(wsSession);
 
             LOK_ASSERT_EQUAL(waitForModifiedStatus(name, wsSession, std::chrono::seconds(10)), true);
         }
 
-        LOG_TST("Allow saving to continue");
+        TST_LOG("Allow saving to continue");
         removeStamp("holdsave");
 
         std::vector<char> message;
@@ -366,7 +366,7 @@ void UnitSaveTorture::saveTortureOne(
 
         if (!options[i].modifyAfterSaveStarts)
         {
-            LOG_TST("wait for modified status");
+            TST_LOG("wait for modified status");
 
             // Autosaves and synthetically notifies us of clean modification state
             LOK_ASSERT_EQUAL(waitForModifiedStatus(name, wsSession), false);
@@ -375,7 +375,7 @@ void UnitSaveTorture::saveTortureOne(
         {
             // Restore the document un-modified state
             wsSession->sendMessage(std::string("save dontTerminateEdit=0 dontSaveIfUnmodified=0"));
-            LOG_TST("wait for cleanup of modified state before end of test");
+            TST_LOG("wait for cleanup of modified state before end of test");
             LOK_ASSERT_EQUAL(waitForModifiedStatus(name, wsSession), false);
         }
     }
@@ -461,7 +461,7 @@ public:
 
     virtual void preSaveHook() override
     {
-        LOG_TST("Synchronous non-background save!");
+        TST_LOG("Synchronous non-background save!");
         if (stampExists("abortonsyncsave"))
         {
             std::cerr << "Abort - unexpected non background save !\n\n";

--- a/test/UnitServerSocketAcceptFailure1.cpp
+++ b/test/UnitServerSocketAcceptFailure1.cpp
@@ -70,12 +70,11 @@ inline UnitBase::TestResult UnitServerSocketAcceptFailure1::testHttp()
 {
     const size_t fatal_iter = ExternalServerSocketAcceptFatalErrorInterval - ExternalServerSocketAcceptSimpleErrorInterval;
     setTestname(__func__);
-    TST_LOG("Starting Test: " << testname
-            << ": ServerSocketAcceptSimpleErrorInterval "
-            << ExternalServerSocketAcceptSimpleErrorInterval
-            << ", ServerSocketAcceptFatalErrorInterval "
-            << ExternalServerSocketAcceptFatalErrorInterval
-            << ", fatal_iter (client) " << fatal_iter);
+    TST_LOG("Starting Test: " << testname << ": ServerSocketAcceptSimpleErrorInterval "
+                              << ExternalServerSocketAcceptSimpleErrorInterval
+                              << ", ServerSocketAcceptFatalErrorInterval "
+                              << ExternalServerSocketAcceptFatalErrorInterval
+                              << ", fatal_iter (client) " << fatal_iter);
 
     const std::string documentURL = "/favicon.ico";
 
@@ -108,7 +107,8 @@ inline UnitBase::TestResult UnitServerSocketAcceptFailure1::testHttp()
                 session->syncRequest(request, *socketPoller);
             TST_LOG("Test[" << iteration << "] Connected: " << session->isConnected());
             TST_LOG("Test[" << iteration << "] Response1: " << response->header().toString());
-            TST_LOG("Test[" << iteration << "] Response1 size: " << testname << ": `" << documentURL << "`: " << response->header().getContentLength());
+            TST_LOG("Test[" << iteration << "] Response1 size: " << testname << ": `" << documentURL
+                            << "`: " << response->header().getContentLength());
             if( session->isConnected() ) {
                 connected00 = true;
                 LOK_ASSERT_EQUAL(http::StatusCode::OK, response->statusCode());
@@ -122,7 +122,8 @@ inline UnitBase::TestResult UnitServerSocketAcceptFailure1::testHttp()
         }
         bool connected01 = false;
         {
-            TST_LOG("Test[" << iteration << "] SessionA " << ": connected " << session->isConnected());
+            TST_LOG("Test[" << iteration << "] SessionA " << ": connected "
+                            << session->isConnected());
             if( session->isConnected() )
             {
                 connected01 = true;

--- a/test/UnitSession.cpp
+++ b/test/UnitSession.cpp
@@ -195,7 +195,8 @@ UnitBase::TestResult UnitSession::testFilesOpenConnection()
             const std::shared_ptr<const http::Response> response =
                 session->syncRequest(request, *socketPoller);
             TST_LOG("Response: " << response->header().toString());
-            TST_LOG("Response size: " << testname << "[" << docIdx << "]: `" << documentURL << "`: " << response->header().getContentLength());
+            TST_LOG("Response size: " << testname << "[" << docIdx << "]: `" << documentURL
+                                      << "`: " << response->header().getContentLength());
             LOK_ASSERT_EQUAL(http::StatusCode::OK, response->statusCode());
             LOK_ASSERT_EQUAL(true, session->isConnected());
             LOK_ASSERT(http::Header::ConnectionToken::None ==
@@ -241,7 +242,8 @@ UnitBase::TestResult UnitSession::testFilesCloseConnection()
             const std::shared_ptr<const http::Response> response =
                 session->syncRequest(request, *socketPoller);
             TST_LOG("Response: " << response->header().toString());
-            TST_LOG("Response size: " << testname << "[" << docIdx << "]: `" << documentURL << "`: " << response->header().getContentLength());
+            TST_LOG("Response size: " << testname << "[" << docIdx << "]: `" << documentURL
+                                      << "`: " << response->header().getContentLength());
             LOK_ASSERT_EQUAL(http::StatusCode::OK, response->statusCode());
             LOK_ASSERT_EQUAL(false, session->isConnected());
             LOK_ASSERT(http::Header::ConnectionToken::Close ==
@@ -288,7 +290,8 @@ UnitBase::TestResult UnitSession::testFileServer()
             const std::shared_ptr<const http::Response> response =
                 session->syncRequest(request, *socketPoller);
             TST_LOG("Response: " << response->header().toString());
-            TST_LOG("Response size: " << testname << "[" << docIdx << "]: " << documentURL << ": " << response->header().getContentLength());
+            TST_LOG("Response size: " << testname << "[" << docIdx << "]: " << documentURL << ": "
+                                      << response->header().getContentLength());
             LOK_ASSERT_EQUAL(http::StatusCode::OK, response->statusCode());
             LOK_ASSERT_EQUAL(true, session->isConnected());
             LOK_ASSERT(http::Header::ConnectionToken::None ==

--- a/test/UnitStorage.cpp
+++ b/test/UnitStorage.cpp
@@ -36,13 +36,13 @@ public:
     {
         // Fail the disk-space check in Filter phase.
         newResult = _phase != Phase::Filter;
-        LOG_TST("Result: " << (newResult ? "success" : "out-of-disk-space"));
+        TST_LOG("Result: " << (newResult ? "success" : "out-of-disk-space"));
         return true;
     }
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Loaded: [" << message << ']');
+        TST_LOG("Loaded: [" << message << ']');
 
         LOK_ASSERT_STATE(_phase, Phase::Done);
         passTest("Loaded successfully");
@@ -83,7 +83,7 @@ public:
             case Phase::Filter:
                 break;
             case Phase::Reload:
-                LOG_TST("Reloading the document");
+                TST_LOG("Reloading the document");
                 TRANSITION_STATE(_phase, Phase::Done);
                 initWebsocket("/wopi/files/0?access_token=anything");
                 WSD_CMD("load url=" + getWopiSrc());

--- a/test/UnitStreamSocketCtorFailure1.cpp
+++ b/test/UnitStreamSocketCtorFailure1.cpp
@@ -60,9 +60,8 @@ void UnitStreamSocketCtorFailure1::simulateExternalSocketCtorException(std::shar
 inline UnitBase::TestResult UnitStreamSocketCtorFailure1::testHttp()
 {
     setTestname(__func__);
-    TST_LOG("Starting Test: " << testname
-            << ": StreamSocketCtorFailureInterval "
-            << ExternalStreamSocketCtorFailureInterval);
+    TST_LOG("Starting Test: " << testname << ": StreamSocketCtorFailureInterval "
+                              << ExternalStreamSocketCtorFailureInterval);
 
     const std::string documentURL = "/favicon.ico";
 
@@ -96,7 +95,8 @@ inline UnitBase::TestResult UnitStreamSocketCtorFailure1::testHttp()
                 session->syncRequest(request, *socketPoller);
             TST_LOG("Test[" << iteration << "] Connected: " << session->isConnected());
             TST_LOG("Test[" << iteration << "] Response1: " << response->header().toString());
-            TST_LOG("Test[" << iteration << "] Response1 size: " << testname << ": `" << documentURL << "`: " << response->header().getContentLength());
+            TST_LOG("Test[" << iteration << "] Response1 size: " << testname << ": `" << documentURL
+                            << "`: " << response->header().getContentLength());
             if( session->isConnected() ) {
                 connected00 = true;
                 LOK_ASSERT_EQUAL(http::StatusCode::OK, response->statusCode());
@@ -110,7 +110,8 @@ inline UnitBase::TestResult UnitStreamSocketCtorFailure1::testHttp()
         }
         bool connected01 = false;
         {
-            TST_LOG("Test[" << iteration << "] SessionA " << ": connected " << session->isConnected());
+            TST_LOG("Test[" << iteration << "] SessionA " << ": connected "
+                            << session->isConnected());
             if( session->isConnected() )
             {
                 connected01 = true;

--- a/test/UnitTileCache.cpp
+++ b/test/UnitTileCache.cpp
@@ -59,7 +59,7 @@ public:
         {
             TRANSITION_STATE(_phase, Phase::Tile);
 
-            LOG_TST("Load: initWebsocket");
+            TST_LOG("Load: initWebsocket");
             initWebsocket("/wopi/files/0?access_token=anything");
 
             WSD_CMD("load url=" + getWopiSrc());

--- a/test/UnitTimeoutBase.hpp
+++ b/test/UnitTimeoutBase.hpp
@@ -197,7 +197,8 @@ inline UnitBase::TestResult UnitTimeoutBase1::testHttp(const size_t connectionLi
             }
         }
     }
-    TST_LOG("Test: X01 Connected: " << connected << " / " << connectionsCount << ", limit " << connectionLimit);
+    TST_LOG("Test: X01 Connected: " << connected << " / " << connectionsCount << ", limit "
+                                    << connectionLimit);
     // LOK_ASSERT_EQUAL(MaxConnections, connected);
     LOK_ASSERT(MaxConnections-1 <= connected && connected <= MaxConnections+1);
 
@@ -206,7 +207,9 @@ inline UnitBase::TestResult UnitTimeoutBase1::testHttp(const size_t connectionLi
     TST_LOG("Clearing Poller: " << testname);
     socketPollers.clear();
     // TCP Connection Count: Just an estimation, no locking on server side
-    TST_LOG("TCP Connection Count: " << testname << ", " << StreamSocket::getExternalConnectionCount() << " / " << net::Defaults.maxExtConnections);
+    TST_LOG("TCP Connection Count: " << testname << ", "
+                                     << StreamSocket::getExternalConnectionCount() << " / "
+                                     << net::Defaults.maxExtConnections);
     TST_LOG("Ending Test: " << testname);
     return TestResult::Ok;
 }
@@ -279,7 +282,8 @@ inline UnitBase::TestResult UnitTimeoutBase1::testWSPing(const size_t connection
             LOK_ASSERT_EQUAL(false, session->isConnected());
         }
     }
-    TST_LOG("Test: X01 Connected: " << connected0 << " / " << connectionsCount << ", limit " << connectionLimit);
+    TST_LOG("Test: X01 Connected: " << connected0 << " / " << connectionsCount << ", limit "
+                                    << connectionLimit);
 
     size_t connected = 0;
     for(size_t sockIdx = 0; sockIdx < connectionsCount; ++sockIdx) {
@@ -302,7 +306,8 @@ inline UnitBase::TestResult UnitTimeoutBase1::testWSPing(const size_t connection
         }
     }
     // 5 x Limiter hits occurred!
-    TST_LOG("Test: X02 Connected: " << connected << " / " << connectionsCount << ", limit " << connectionLimit);
+    TST_LOG("Test: X02 Connected: " << connected << " / " << connectionsCount << ", limit "
+                                    << connectionLimit);
     LOK_ASSERT(maxConnections-1 <= connected && connected <= maxConnections+1);
 
     TST_LOG("Clearing Sessions: " << testname);
@@ -310,7 +315,9 @@ inline UnitBase::TestResult UnitTimeoutBase1::testWSPing(const size_t connection
     TST_LOG("Clearing Poller: " << testname);
     socketPollers.clear();
     // TCP Connection Count: Just an estimation, no locking on server side
-    TST_LOG("TCP Connection Count: " << testname << ", " << StreamSocket::getExternalConnectionCount() << " / " << net::Defaults.maxExtConnections);
+    TST_LOG("TCP Connection Count: " << testname << ", "
+                                     << StreamSocket::getExternalConnectionCount() << " / "
+                                     << net::Defaults.maxExtConnections);
     TST_LOG("Ending Test: " << testname);
     return TestResult::Ok;
 }
@@ -405,7 +412,8 @@ inline UnitBase::TestResult UnitTimeoutBase1::testWSDChatPing(const size_t conne
         }
     }
     // 5 x Limiter hits occurred!
-    TST_LOG("Test: X01 Connected: " << connected << " / " << connectionsCount << ", limit " << connectionLimit);
+    TST_LOG("Test: X01 Connected: " << connected << " / " << connectionsCount << ", limit "
+                                    << connectionLimit);
     LOK_ASSERT(maxConnections-1 <= connected && connected <= maxConnections+1);
 
     TST_LOG("Clearing Sessions: " << testname);
@@ -413,7 +421,9 @@ inline UnitBase::TestResult UnitTimeoutBase1::testWSDChatPing(const size_t conne
     TST_LOG("Clearing Poller: " << testname);
     socketPollers.clear();
     // TCP Connection Count: Just an estimation, no locking on server side
-    TST_LOG("TCP Connection Count: " << testname << ", " << StreamSocket::getExternalConnectionCount() << " / " << net::Defaults.maxExtConnections);
+    TST_LOG("TCP Connection Count: " << testname << ", "
+                                     << StreamSocket::getExternalConnectionCount() << " / "
+                                     << net::Defaults.maxExtConnections);
     TST_LOG("Ending Test: " << testname);
     return TestResult::Ok;
 }

--- a/test/UnitTimeoutInactive.cpp
+++ b/test/UnitTimeoutInactive.cpp
@@ -84,7 +84,8 @@ inline UnitBase::TestResult UnitTimeoutInactivity::testHttp(bool forceInactivity
             const std::shared_ptr<const http::Response> response =
                 session->syncRequest(request, *socketPoller);
             TST_LOG("Response1: " << response->header().toString());
-            TST_LOG("Response1 size: " << testname << ": `" << documentURL << "`: " << response->header().getContentLength());
+            TST_LOG("Response1 size: " << testname << ": `" << documentURL
+                                       << "`: " << response->header().getContentLength());
             if( session->isConnected() ) {
                 LOK_ASSERT_EQUAL(http::StatusCode::OK, response->statusCode());
                 LOK_ASSERT(http::Header::ConnectionToken::None ==
@@ -104,7 +105,8 @@ inline UnitBase::TestResult UnitTimeoutInactivity::testHttp(bool forceInactivity
             const std::shared_ptr<const http::Response> response =
                 session->syncRequest(request, *socketPoller);
             TST_LOG("Response2: " << response->header().toString());
-            TST_LOG("Response2 size: " << testname << ": `" << documentURL << "`: " << response->header().getContentLength());
+            TST_LOG("Response2 size: " << testname << ": `" << documentURL
+                                       << "`: " << response->header().getContentLength());
             if( session->isConnected() ) {
                 LOK_ASSERT_EQUAL(http::StatusCode::OK, response->statusCode());
                 LOK_ASSERT(http::Header::ConnectionToken::None ==

--- a/test/UnitWOPI.cpp
+++ b/test/UnitWOPI.cpp
@@ -46,18 +46,18 @@ public:
 
     bool isAutosave() override
     {
-        LOG_TST("In SavingPhase " << name(_savingPhase));
+        TST_LOG("In SavingPhase " << name(_savingPhase));
 
         // we fake autosave when saving the modified document
         const bool res = _savingPhase == SavingPhase::Modified;
-        LOG_TST("isAutosave: " << std::boolalpha << res);
+        TST_LOG("isAutosave: " << std::boolalpha << res);
         return res;
     }
 
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
-        LOG_TST("In SavingPhase " << name(_savingPhase));
+        TST_LOG("In SavingPhase " << name(_savingPhase));
 
         if (_savingPhase == SavingPhase::Unmodified)
         {
@@ -103,7 +103,7 @@ public:
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("In SavingPhase " << name(_savingPhase) << ": [" << message << ']');
+        TST_LOG("In SavingPhase " << name(_savingPhase) << ": [" << message << ']');
         LOK_ASSERT_STATE(_savingPhase, SavingPhase::Unmodified);
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
@@ -114,7 +114,7 @@ public:
 
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("In SavingPhase " << name(_savingPhase) << ": [" << message << ']');
+        TST_LOG("In SavingPhase " << name(_savingPhase) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_savingPhase, SavingPhase::Modified);
@@ -134,7 +134,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());
@@ -181,13 +181,13 @@ public:
     void newChild(const std::shared_ptr<ChildProcess>& child) override
     {
         _children.emplace_back(child->getPid());
-        LOG_TST(">>> Child #" << _children.size());
+        TST_LOG(">>> Child #" << _children.size());
     }
 
     virtual std::unique_ptr<http::Response>
     assertCheckFileInfoRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST(">>> CheckFileInfo #" << _count << ", total memory: " << getMemoryUsage() << " KB");
+        TST_LOG(">>> CheckFileInfo #" << _count << ", total memory: " << getMemoryUsage() << " KB");
 
         SocketPoll::wakeupWorld();
         return std::make_unique<http::Response>(http::StatusCode::NotFound);
@@ -201,7 +201,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::Done);
                 ++_count;
-                LOG_TST("Open #" << _count);
+                TST_LOG("Open #" << _count);
                 initWebsocket("/wopi/files/" + std::to_string(_count) + "?access_token=anything");
             }
             break;
@@ -215,7 +215,7 @@ public:
                         for (;;)
                         {
                             ++_count;
-                            LOG_TST(">>> Open #" << _count << ", total memory: " << getMemoryUsage()
+                            TST_LOG(">>> Open #" << _count << ", total memory: " << getMemoryUsage()
                                                  << " KB");
 
                             const std::string wopiPath = "/wopi/files/invalid_" +
@@ -228,7 +228,7 @@ public:
                             const std::string documentURL = "/cool/" + wopiSrc + "/ws";
 
                             // This is just a client connection that is used from the tests.
-                            LOG_TST("Connecting test client to COOL (#"
+                            TST_LOG("Connecting test client to COOL (#"
                                     << _count << " connection): " << documentURL);
 
                             Poco::URI uri(helpers::getTestServerURI());
@@ -242,12 +242,12 @@ public:
                             if (ws->asyncRequest(req, socketPoll()))
                             {
                                 _webSessions.emplace_back(ws);
-                                LOG_TST("Load #" << _count);
+                                TST_LOG("Load #" << _count);
                                 helpers::sendTextFrame(ws, "load url=" + wopiSrc, getTestname());
                             }
                             else
                             {
-                                LOG_TST("Failed async request #" << _count << " to "
+                                TST_LOG("Failed async request #" << _count << " to "
                                                                  << documentURL);
                             }
                         }

--- a/test/UnitWOPIAsyncUpload_ModifyClose.cpp
+++ b/test/UnitWOPIAsyncUpload_ModifyClose.cpp
@@ -56,7 +56,7 @@ public:
         }
 
         // This during closing the document.
-        LOG_TST("assertPutFileRequest: unexpected");
+        TST_LOG("assertPutFileRequest: unexpected");
         failTest("PutFile multiple times.");
 
         return nullptr;
@@ -65,7 +65,7 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        TST_LOG("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitPutFile);
@@ -80,7 +80,7 @@ public:
     // Wait for clean unloading.
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Destroyed dockey [" << docKey << ']');
+        TST_LOG("Destroyed dockey [" << docKey << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitDestroy);
 
         passTest("Document unloaded as expected.");
@@ -94,7 +94,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());

--- a/test/UnitWOPICrashModified.cpp
+++ b/test/UnitWOPICrashModified.cpp
@@ -46,19 +46,19 @@ public:
 
     void onDocBrokerAttachKitProcess(const std::string& docBroker, int pid) override
     {
-        LOG_TST("DocBroker [" << docBroker << "] attached to pid: " << pid);
+        TST_LOG("DocBroker [" << docBroker << "] attached to pid: " << pid);
         _pid = pid;
     }
 
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
 
-        LOG_TST("Modifying");
+        TST_LOG("Modifying");
         WSD_CMD("key type=input char=97 key=0");
         WSD_CMD("key type=up char=0 key=512");
 
@@ -67,16 +67,16 @@ public:
 
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitDocClose);
 
-        LOG_TST("Killing Kit with PID " << _pid);
+        TST_LOG("Killing Kit with PID " << _pid);
         if (kill(_pid, SIGKILL) == -1)
         {
             const int onrre = errno;
-            LOG_TST("kill(" << _pid << ", SIGKILL) failed: " << Util::symbolicErrno(onrre) << ": "
+            TST_LOG("kill(" << _pid << ", SIGKILL) failed: " << Util::symbolicErrno(onrre) << ": "
                             << std::strerror(onrre));
         }
 
@@ -98,7 +98,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
                 WSD_CMD("load url=" + getWopiSrc());
                 break;

--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -41,7 +41,7 @@ public:
     std::unique_ptr<http::Response>
     assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("Testing " << name(_scenario));
+        TST_LOG("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         assertGetFileCount();
@@ -52,7 +52,7 @@ public:
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("Testing " << name(_scenario));
+        TST_LOG("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         assertPutFileCount();
@@ -66,7 +66,7 @@ public:
                 LOK_ASSERT_FAIL("Unexpectedly overwritting the document in storage");
                 break;
             case Scenario::SaveOverwrite:
-                LOG_TST("Closing the document to verify its contents after reloading");
+                TST_LOG("Closing the document to verify its contents after reloading");
                 WSD_CMD("closedocument");
                 break;
         }
@@ -76,7 +76,7 @@ public:
 
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
+        TST_LOG("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         std::string expectedContents;
@@ -150,7 +150,7 @@ public:
     assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
         ++_uploadAttemptCount;
-        LOG_TST("PutFile: " << _uploadAttemptCount << ", Phase: " << name(_phase));
+        TST_LOG("PutFile: " << _uploadAttemptCount << ", Phase: " << name(_phase));
 
         const std::string wopiTimestamp = request.get("X-COOL-WOPI-Timestamp", std::string());
         LOK_ASSERT_MESSAGE("Unexpected forced upload", !wopiTimestamp.empty());
@@ -158,7 +158,7 @@ public:
         if (_uploadAttemptCount == 1)
         {
             // First attempt, timeout.
-            LOG_TST("PutFile: sleeping");
+            TST_LOG("PutFile: sleeping");
             sleep(ConnectionTimeoutSeconds); // Connection timeout.
             usleep(300'000); // Go over, to be certain we timed-out the upload.
             // Don't sleep for 2 x ConnectionTimeoutSeconds, as the
@@ -166,14 +166,14 @@ public:
         }
 
         // Success.
-        LOG_TST("PutFile: returning success");
+        TST_LOG("PutFile: returning success");
         return nullptr;
     }
 
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
@@ -186,7 +186,7 @@ public:
     /// The document is modified. Save it.
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitUploaded);
@@ -197,7 +197,7 @@ public:
 
     void onDocumentUploaded(bool success) override
     {
-        LOG_TST("Uploaded: " << (success ? "success" : "failure"));
+        TST_LOG("Uploaded: " << (success ? "success" : "failure"));
         LOK_ASSERT_STATE(_phase, Phase::WaitUploaded);
         LOK_ASSERT_EQUAL_MESSAGE("Expected the first upload to fail", _uploadAttemptCount == 1,
                                  !success);
@@ -214,7 +214,7 @@ public:
     // Wait for clean unloading.
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Destroyed dockey [" << docKey << ']');
+        TST_LOG("Destroyed dockey [" << docKey << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitDestroy);
 
         passTest("Document uploaded on closing as expected.");
@@ -228,7 +228,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());
@@ -286,13 +286,13 @@ public:
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
-        LOG_TST("PutFile: " << _uploadAttemptCount << ", Phase: " << name(_phase));
+        TST_LOG("PutFile: " << _uploadAttemptCount << ", Phase: " << name(_phase));
 
         const std::string wopiTimestamp = request.get("X-COOL-WOPI-Timestamp", std::string());
         LOK_ASSERT_MESSAGE("Unexpected forced upload", !wopiTimestamp.empty());
 
         // First attempt, timeout.
-        LOG_TST("PutFile: sleeping");
+        TST_LOG("PutFile: sleeping");
         sleep(ConnectionTimeoutSeconds); // Connection timeout.
         usleep(300'000); // Go over, to be certain we timed-out the upload.
         // Don't sleep for 2 x ConnectionTimeoutSeconds, as the
@@ -303,18 +303,18 @@ public:
         // We do this after the first upload attempt (which will timeout)
         // because otherwise we would've not reached here and returned
         // 'conflict' sooner, in WopiTestServer::handleWopiUpload().
-        LOG_TST("Simulating conflict in storage");
+        TST_LOG("Simulating conflict in storage");
         setFileContent("Modified data in storage");
 
         // Fail.
-        LOG_TST("PutFile: returning a bogus failure");
+        TST_LOG("PutFile: returning a bogus failure");
         return std::make_unique<http::Response>(http::StatusCode::InternalServerError);
     }
 
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
@@ -327,7 +327,7 @@ public:
     /// The document is modified. Save it.
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitUploaded);
@@ -338,7 +338,7 @@ public:
 
     void onDocumentUploaded(bool success) override
     {
-        LOG_TST("Uploaded #" << _uploadAttemptCount << ": " << (success ? "success" : "failure"));
+        TST_LOG("Uploaded #" << _uploadAttemptCount << ": " << (success ? "success" : "failure"));
         LOK_ASSERT_STATE(_phase, Phase::WaitUploaded);
         LOK_ASSERT_MESSAGE("Expected Phase::WaitUploaded or Phase::WaitDestroy",
                            _phase == Phase::WaitUploaded || _phase == Phase::WaitDestroy);
@@ -348,11 +348,11 @@ public:
 
     bool onDocumentError(const std::string& message) override
     {
-        LOG_TST("Testing " << name(_phase) << ": [" << message << ']');
+        TST_LOG("Testing " << name(_phase) << ": [" << message << ']');
         // LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         ++_uploadAttemptCount;
-        LOG_TST("uploadAttemptCount: " << _uploadAttemptCount);
+        TST_LOG("uploadAttemptCount: " << _uploadAttemptCount);
         if (_uploadAttemptCount == 1)
         {
             LOK_ASSERT_EQUAL_MESSAGE("Expect only documentconflict errors",
@@ -367,7 +367,7 @@ public:
             // We are done!
             TRANSITION_STATE(_phase, Phase::WaitDestroy);
 
-            LOG_TST("Discarding own changes via closedocument");
+            TST_LOG("Discarding own changes via closedocument");
             WSD_CMD("closedocument");
         }
 
@@ -377,7 +377,7 @@ public:
     // Wait for clean unloading.
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Destroyed dockey [" << docKey << ']');
+        TST_LOG("Destroyed dockey [" << docKey << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitDestroy);
 
         passTest("Document uploaded on closing as expected.");
@@ -391,7 +391,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());
@@ -450,7 +450,7 @@ public:
     assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
         ++_uploadAttemptCount;
-        LOG_TST("PutFile: " << _uploadAttemptCount << ", Phase: " << name(_phase));
+        TST_LOG("PutFile: " << _uploadAttemptCount << ", Phase: " << name(_phase));
 
         const std::string wopiTimestamp = request.get("X-COOL-WOPI-Timestamp", std::string());
 
@@ -459,12 +459,12 @@ public:
             LOK_ASSERT_MESSAGE("Unexpected forced upload", !wopiTimestamp.empty());
 
             // First attempt, timeout.
-            LOG_TST("PutFile: sleeping");
+            TST_LOG("PutFile: sleeping");
             // Don't sleep for 2 x ConnectionTimeoutSeconds, as the
             // CheckFileInfo request may timeout, since we're stuck here.
             sleep(ConnectionTimeoutSeconds); // Connection timeout.
             usleep(300'000); // Go over, to be certain we timed-out the upload.
-            LOG_TST("PutFile: woke up");
+            TST_LOG("PutFile: woke up");
         }
         else
         {
@@ -472,7 +472,7 @@ public:
         }
 
         // Success.
-        LOG_TST("PutFile: returning success");
+        TST_LOG("PutFile: returning success");
         return nullptr;
     }
 
@@ -486,10 +486,10 @@ public:
             TRANSITION_STATE(_phase, Phase::WaitDestroy);
             WSD_CMD("closedocument");
 
-            LOG_TST("CheckFileInfo: sleeping");
+            TST_LOG("CheckFileInfo: sleeping");
             sleep(ConnectionTimeoutSeconds); // Connection timeout.
             usleep(300'000); // Go over, to be certain we timed-out the upload.
-            LOG_TST("CheckFileInfo: woke up");
+            TST_LOG("CheckFileInfo: woke up");
         }
 
         return nullptr; // Success.
@@ -498,7 +498,7 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
@@ -511,7 +511,7 @@ public:
     /// The document is modified. Save it.
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitUploaded);
@@ -522,7 +522,7 @@ public:
 
     void onDocumentUploaded(bool success) override
     {
-        LOG_TST("Uploaded: " << (success ? "success" : "failure"));
+        TST_LOG("Uploaded: " << (success ? "success" : "failure"));
         LOK_ASSERT(_phase == Phase::WaitUploaded || _phase == Phase::WaitDestroy);
         LOK_ASSERT_EQUAL_MESSAGE("Expected the first upload to fail", _uploadAttemptCount == 1,
                                  !success);
@@ -531,7 +531,7 @@ public:
     // Wait for clean unloading.
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Destroyed dockey [" << docKey << ']');
+        TST_LOG("Destroyed dockey [" << docKey << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitDestroy);
 
         passTest("Document uploaded on closing as expected.");
@@ -545,7 +545,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());

--- a/test/UnitWOPIFailUpload.cpp
+++ b/test/UnitWOPIFailUpload.cpp
@@ -40,9 +40,9 @@ class UnitWOPIFailUpload : public WOPIUploadConflictCommon
 
     void startNewTest() override
     {
-        LOG_TST("===== Starting " << name(_scenario) << " test scenario =====");
+        TST_LOG("===== Starting " << name(_scenario) << " test scenario =====");
 
-        LOG_TST("Resetting the document in storage");
+        TST_LOG("Resetting the document in storage");
         setFileContent(OriginalDocContent); // Reset to test overwriting.
 
         resetCountCheckFileInfo();
@@ -125,7 +125,7 @@ public:
     std::unique_ptr<http::Response>
     assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("Testing " << name(_scenario));
+        TST_LOG("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         assertGetFileCount();
@@ -141,7 +141,7 @@ public:
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
-        LOG_TST("Testing " << name(_scenario));
+        TST_LOG("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         assertPutFileCount();
@@ -159,7 +159,7 @@ public:
 
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
+        TST_LOG("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitDocClose);
@@ -168,18 +168,18 @@ public:
         {
             case Scenario::Disconnect:
                 // Just disconnect.
-                LOG_TST("Disconnecting");
+                TST_LOG("Disconnecting");
                 deleteSocketAt(0);
                 break;
             case Scenario::SaveDiscard:
             case Scenario::SaveOverwrite:
                 // Save the document.
-                LOG_TST("Saving the document");
+                TST_LOG("Saving the document");
                 WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0");
                 break;
             case Scenario::CloseDiscard:
                 // Close the document.
-                LOG_TST("Closing the document");
+                TST_LOG("Closing the document");
                 WSD_CMD("closedocument");
                 break;
             case Scenario::VerifyOverwrite:
@@ -192,7 +192,7 @@ public:
 
     bool onDocumentError(const std::string& message) override
     {
-        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
+        TST_LOG("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         if (getCountCheckFileInfo() == 1)
@@ -209,7 +209,7 @@ public:
         }
 
         // Close the document.
-        LOG_TST("Closing the document");
+        TST_LOG("Closing the document");
         WSD_CMD("closedocument");
 
         return true;
@@ -218,7 +218,7 @@ public:
     // Called when we have modified document data at exit.
     bool onDataLoss(const std::string& reason) override
     {
-        LOG_TST("Modified document being unloaded: " << reason);
+        TST_LOG("Modified document being unloaded: " << reason);
 
         // We expect this to happen only with the disonnection test,
         // because only in that case there is no user input.
@@ -233,7 +233,7 @@ public:
     // Wait for clean unloading.
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
+        TST_LOG("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         // Uploading fails and we can't have anything but the original.
@@ -262,7 +262,7 @@ public:
         // Expect PutFile after closing, since the document is modified.
         if (_phase == Phase::WaitPutFile)
         {
-            LOG_TST("assertPutFileRequest: First PutFile, which will fail");
+            TST_LOG("assertPutFileRequest: First PutFile, which will fail");
 
             TRANSITION_STATE(_phase, Phase::Done);
 
@@ -276,7 +276,7 @@ public:
         }
 
         // This during closing the document.
-        LOG_TST("assertPutFileRequest: Second PutFile, unexpected");
+        TST_LOG("assertPutFileRequest: Second PutFile, unexpected");
 
         LOK_ASSERT_FAIL("PutFile multiple times.");
         failTest("PutFile multiple times.");
@@ -287,7 +287,7 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        TST_LOG("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitPutFile);
@@ -301,7 +301,7 @@ public:
 
     bool onDataLoss(const std::string& reason) override
     {
-        LOG_TST("Modified document being unloaded: " << reason);
+        TST_LOG("Modified document being unloaded: " << reason);
 
         // We expect this to happen, because there should be
         // no upload attempts with expired tockens. And we
@@ -322,7 +322,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/" + getTestname() + "?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());
@@ -374,7 +374,7 @@ public:
     void configCheckFileInfo(const Poco::Net::HTTPRequest& /*request*/,
                              Poco::JSON::Object::Ptr& fileInfo) override
     {
-        LOG_TST("CheckFileInfo: making read-only for " << name(_scenario));
+        TST_LOG("CheckFileInfo: making read-only for " << name(_scenario));
 
         fileInfo->set("UserCanWrite", "false");
         fileInfo->set("UserCanNotWriteRelative", "true");
@@ -404,7 +404,7 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        TST_LOG("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         // Update before transitioning, to avoid triggering immediately.
@@ -419,7 +419,7 @@ public:
 
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Modified: [" << message << ']');
+        TST_LOG("Modified: [" << message << ']');
         failTest("Modified read-only document");
 
         return failed();
@@ -427,7 +427,7 @@ public:
 
     bool onDataLoss(const std::string& reason) override
     {
-        LOG_TST("Data-loss in " << name(_phase) << ": " << reason);
+        TST_LOG("Data-loss in " << name(_phase) << ": " << reason);
 
         // We expect this to happen, since we can't upload the document.
         LOK_ASSERT_MESSAGE("Expected reason to be 'Data-loss detected'",
@@ -440,7 +440,7 @@ public:
 
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Destroyed dockey [" << docKey << ']');
+        TST_LOG("Destroyed dockey [" << docKey << ']');
         LOK_ASSERT_STATE(_phase, Phase::Done);
 
         passTest("No modification or unexpected PutFile on read-only doc");
@@ -454,7 +454,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/" + getTestname() + "?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());
@@ -471,7 +471,7 @@ public:
                     std::chrono::duration_cast<std::chrono::milliseconds>(now - _eventTime);
                 if (elapsed >= std::chrono::seconds(2))
                 {
-                    LOG_TST("No modified status on read-only document after waiting for "
+                    TST_LOG("No modified status on read-only document after waiting for "
                             << elapsed);
                     _eventTime = std::chrono::steady_clock::now();
 
@@ -483,7 +483,7 @@ public:
                     else
                     {
                         TRANSITION_STATE(_phase, Phase::WaitDocClose);
-                        LOG_TST("Saving the document");
+                        TST_LOG("Saving the document");
                         WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0");
                     }
                 }
@@ -498,7 +498,7 @@ public:
                     std::chrono::duration_cast<std::chrono::milliseconds>(now - _eventTime);
                 if (elapsed >= std::chrono::seconds(2))
                 {
-                    LOG_TST("No upload on read-only document after waiting for " << elapsed);
+                    TST_LOG("No upload on read-only document after waiting for " << elapsed);
                     TRANSITION_STATE(_phase, Phase::Done);
                     WSD_CMD("closedocument");
                 }
@@ -573,27 +573,27 @@ public:
         // We save twice. First right after loading, unmodified.
         if (getCountPutFile() == 1)
         {
-            LOG_TST("First PutFile, which will fail");
+            TST_LOG("First PutFile, which will fail");
 
-            LOG_TST("Modifying again");
+            TST_LOG("Modifying again");
             TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
             WSD_CMD("key type=input char=97 key=0");
             WSD_CMD("key type=up char=0 key=512");
 
             // Fail with error.
-            LOG_TST("Simulate PutFile failure");
+            TST_LOG("Simulate PutFile failure");
             return std::make_unique<http::Response>(http::StatusCode::InternalServerError);
         }
 
         if (getCountPutFile() == 2)
         {
-            LOG_TST("Second PutFile, which will also fail");
+            TST_LOG("Second PutFile, which will also fail");
 
             TRANSITION_STATE(_phase, Phase::WaitDestroy);
-            LOG_TST("More than one upload attempted, closing the document");
+            TST_LOG("More than one upload attempted, closing the document");
             WSD_CMD("closedocument");
 
-            LOG_TST("Simulate PutFile failure (again)");
+            TST_LOG("Simulate PutFile failure (again)");
             return std::make_unique<http::Response>(http::StatusCode::InternalServerError);
         }
 
@@ -604,7 +604,7 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
@@ -617,7 +617,7 @@ public:
     /// The document is modified. Save it.
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0 "
@@ -629,7 +629,7 @@ public:
     // Wait for clean unloading.
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Destroyed dockey [" << docKey << ']');
+        TST_LOG("Destroyed dockey [" << docKey << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitDestroy);
 
         passTest("Document uploaded on closing as expected.");
@@ -643,7 +643,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());
@@ -690,19 +690,19 @@ public:
         // We save twice. First right after loading, unmodified.
         if (_phase == Phase::WaitFirstPutFile)
         {
-            LOG_TST("assertPutFileRequest: First PutFile, which will fail");
+            TST_LOG("assertPutFileRequest: First PutFile, which will fail");
 
             // Certainly not exiting yet.
             LOK_ASSERT_EQUAL(std::string("false"), request.get("X-COOL-WOPI-IsExitSave"));
             LOK_ASSERT_EQUAL(false, request.has("X-LOOL-WOPI-IsExitSave"));
 
             // Fail with error.
-            LOG_TST("Returning 500 to simulate PutFile failure");
+            TST_LOG("Returning 500 to simulate PutFile failure");
             return std::make_unique<http::Response>(http::StatusCode::InternalServerError);
         }
 
         // This during closing the document.
-        LOG_TST("assertPutFileRequest: Second PutFile, which will succeed");
+        TST_LOG("assertPutFileRequest: Second PutFile, which will succeed");
         LOK_ASSERT_STATE(_phase, Phase::WaitSecondPutFile);
 
         // Triggered while closing.
@@ -715,7 +715,7 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        TST_LOG("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
@@ -729,7 +729,7 @@ public:
     /// The document is modified. Save it.
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("onDocumentModified: [" << message << ']');
+        TST_LOG("onDocumentModified: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitFirstPutFile);
@@ -742,7 +742,7 @@ public:
 
     void onDocumentUploaded(bool success) override
     {
-        LOG_TST("Uploaded: " << (success ? "success" : "failure"));
+        TST_LOG("Uploaded: " << (success ? "success" : "failure"));
 
         if (_phase == Phase::WaitFirstPutFile)
         {
@@ -755,7 +755,7 @@ public:
     // Wait for clean unloading.
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Destroyed dockey [" << docKey << "] closed.");
+        TST_LOG("Destroyed dockey [" << docKey << "] closed.");
         LOK_ASSERT_STATE(_phase, Phase::WaitSecondPutFile);
 
         TRANSITION_STATE(_phase, Phase::Done);
@@ -772,7 +772,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());

--- a/test/UnitWOPIFileUrl.cpp
+++ b/test/UnitWOPIFileUrl.cpp
@@ -77,7 +77,7 @@ public:
                                    const std::shared_ptr<StreamSocket>& socket) override
     {
         Poco::URI uriReq(request.getURI());
-        LOG_TST("FakeWOPIHost: Handling HTTP " << request.getMethod()
+        TST_LOG("FakeWOPIHost: Handling HTTP " << request.getMethod()
                                                << " request: " << uriReq.toString());
 
         constexpr auto DefaultUrlFilename = "empty.odt";
@@ -90,7 +90,7 @@ public:
             // CheckFileInfo
             if (regInfo.match(uriReq.getPath()))
             {
-                LOG_TST("FakeWOPIHost: Handling WOPI::CheckFileInfo: " << uriReq.getPath());
+                TST_LOG("FakeWOPIHost: Handling WOPI::CheckFileInfo: " << uriReq.getPath());
 
                 Poco::JSON::Object::Ptr fileInfo = getDefaultCheckFileInfoPayload(uriReq);
                 fileInfo->set("BaseFileName", DefaultUrlFilename);
@@ -110,7 +110,7 @@ public:
             if (uriReq.getPath() == FileUrlFilename)
             {
                 const std::string filename = std::string(TDOC) + FileUrlFilename;
-                LOG_TST("FakeWOPIHost: Request, WOPI::GetFile sending FileUrl: " << filename);
+                TST_LOG("FakeWOPIHost: Request, WOPI::GetFile sending FileUrl: " << filename);
 
                 http::Response response(http::StatusCode::OK);
                 HttpHelper::sendFileAndShutdown(socket, filename, response);
@@ -120,7 +120,7 @@ public:
             if (uriReq.getPath() == InvalidFilename)
             {
                 const std::string filename = std::string(TDOC) + InvalidFilename;
-                LOG_TST("FakeWOPIHost: Request, WOPI::GetFile returning 404 for: " << filename);
+                TST_LOG("FakeWOPIHost: Request, WOPI::GetFile returning 404 for: " << filename);
 
                 http::Response httpResponse(http::StatusCode::NotFound);
                 socket->sendAndShutdown(httpResponse);
@@ -139,7 +139,7 @@ public:
                 }
 
                 const std::string filename = std::string(TDOC) + '/' + DefaultUrlFilename;
-                LOG_TST("FakeWOPIHost: Request, WOPI::GetFile sending Default: " << filename);
+                TST_LOG("FakeWOPIHost: Request, WOPI::GetFile sending Default: " << filename);
 
                 http::Response response(http::StatusCode::OK);
                 HttpHelper::sendFileAndShutdown(socket, filename, response);
@@ -148,7 +148,7 @@ public:
         }
         else if (request.getMethod() == "POST")
         {
-            LOG_TST("FakeWOPIHost: Handling PutFile: " << uriReq.getPath());
+            TST_LOG("FakeWOPIHost: Handling PutFile: " << uriReq.getPath());
 
             LOK_ASSERT_STATE(_phase, Phase::WaitPutFile);
 
@@ -164,25 +164,25 @@ public:
                                  "application/json; charset=utf-8");
             socket->sendAndShutdown(httpResponse);
 
-            LOG_TST("Closing document after PutFile");
+            TST_LOG("Closing document after PutFile");
             WSD_CMD("closedocument");
             ++_docId; // Load the next file.
 
             if (_fileUrlState == FileUrlState::Valid)
             {
-                LOG_TST("Valid FileUrl test successful. Now testing Invalid FileUrl.");
+                TST_LOG("Valid FileUrl test successful. Now testing Invalid FileUrl.");
                 _fileUrlState = FileUrlState::Invalid;
                 TRANSITION_STATE(_phase, Phase::Load);
             }
             else if (_fileUrlState == FileUrlState::Invalid)
             {
-                LOG_TST("Invalid FileUrl test successful. Now testing without FileUrl.");
+                TST_LOG("Invalid FileUrl test successful. Now testing without FileUrl.");
                 _fileUrlState = FileUrlState::Absent;
                 TRANSITION_STATE(_phase, Phase::Load);
             }
             else if (_fileUrlState == FileUrlState::Absent)
             {
-                LOG_TST("Testing of FileUrl completed successfully.");
+                TST_LOG("Testing of FileUrl completed successfully.");
                 TRANSITION_STATE(_phase, Phase::Polling);
                 exitTest(TestResult::Ok);
             }
@@ -195,10 +195,10 @@ public:
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        TST_LOG("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
-        LOG_TST(
+        TST_LOG(
             "onDocumentLoaded: Modifying the document and switching to Phase::WaitModifiedStatus");
         TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
 
@@ -210,10 +210,10 @@ public:
 
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("onDocumentModified: [" << message << ']');
+        TST_LOG("onDocumentModified: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
-        LOG_TST("onDocumentModified: Saving document and switching to Phase::WaitPutFile");
+        TST_LOG("onDocumentModified: Saving document and switching to Phase::WaitPutFile");
         TRANSITION_STATE(_phase, Phase::WaitPutFile);
 
         WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0 "
@@ -228,7 +228,7 @@ public:
         {
             case Phase::Load:
             {
-                LOG_TST("Phase::Load");
+                TST_LOG("Phase::Load");
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
                 initWebsocket("/wopi/files/" + std::to_string(_docId) + "?access_token=anything");

--- a/test/UnitWOPIHttpRedirect.cpp
+++ b/test/UnitWOPIHttpRedirect.cpp
@@ -47,12 +47,12 @@ public:
         std::string redirectUri2 = "/wopi/files/2/contents";
         Poco::RegularExpression regContentsRedirected(redirectUri2);
 
-        LOG_TST("FakeWOPIHost: Request URI [" << uriReq.toString() << "]:\n");
+        TST_LOG("FakeWOPIHost: Request URI [" << uriReq.toString() << "]:\n");
 
         // CheckFileInfo - returns redirect response
         if (request.getMethod() == "GET" && regInfo.match(uriReq.getPath()))
         {
-            LOG_TST("FakeWOPIHost: Handling CheckFileInfo (1/2)");
+            TST_LOG("FakeWOPIHost: Handling CheckFileInfo (1/2)");
 
             assertCheckFileInfoRequest(request);
 
@@ -68,7 +68,7 @@ public:
         // CheckFileInfo - for redirected URI
         else if (request.getMethod() == "GET" && regRedirected.match(uriReq.getPath()) && !regContents.match(uriReq.getPath()))
         {
-            LOG_TST("FakeWOPIHost: Handling CheckFileInfo: (2/2)");
+            TST_LOG("FakeWOPIHost: Handling CheckFileInfo: (2/2)");
 
             assertCheckFileInfoRequest(request);
 
@@ -95,7 +95,7 @@ public:
         // GetFile - first try
         else if (request.getMethod() == "GET" && regContents.match(uriReq.getPath()))
         {
-            LOG_TST("FakeWOPIHost: Handling GetFile: " << uriReq.getPath());
+            TST_LOG("FakeWOPIHost: Handling GetFile: " << uriReq.getPath());
 
             assertGetFileRequest(request);
 
@@ -111,7 +111,7 @@ public:
         // GetFile - redirected
         else if (request.getMethod() == "GET" && regContentsRedirected.match(uriReq.getPath()))
         {
-            LOG_TST("FakeWOPIHost: Handling GetFile: " << uriReq.getPath());
+            TST_LOG("FakeWOPIHost: Handling GetFile: " << uriReq.getPath());
 
             assertGetFileRequest(request);
 
@@ -178,12 +178,12 @@ public:
         Poco::RegularExpression regInfo("/wopi/files/[0-9]+");
         static unsigned redirectionCount = 0;
 
-        LOG_TST("FakeWOPIHost: Request URI [" << uriReq.toString() << "]:\n");
+        TST_LOG("FakeWOPIHost: Request URI [" << uriReq.toString() << "]:\n");
 
         // CheckFileInfo - always returns redirect response
         if (request.getMethod() == "GET" && regInfo.match(uriReq.getPath()))
         {
-            LOG_TST("FakeWOPIHost: Handling CheckFileInfo");
+            TST_LOG("FakeWOPIHost: Handling CheckFileInfo");
 
             assertCheckFileInfoRequest(request);
 

--- a/test/UnitWOPILanguages.cpp
+++ b/test/UnitWOPILanguages.cpp
@@ -40,12 +40,12 @@ public:
     /// A view loaded.
     bool onViewLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded #" << ++_loaded_count << ": [" << message << ']');
+        TST_LOG("onDocumentLoaded #" << ++_loaded_count << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::Save);
 
         if (_loaded_count == 1)
         {
-            LOG_TST("Loading second view (Hungarian)");
+            TST_LOG("Loading second view (Hungarian)");
             WSD_CMD_BY_CONNECTION_INDEX(1, "load url=" + getWopiSrc() + " lang=hu");
         }
         else if (_loaded_count == 2)
@@ -61,11 +61,11 @@ public:
     {
         if (success || result == "unmodified")
         {
-            LOG_TST("Document saved as expected");
+            TST_LOG("Document saved as expected");
         }
         else
         {
-            LOG_TST("Document failed to save");
+            TST_LOG("Document failed to save");
             failTest("Failed to save the document (Core is out-of-date or it has a regression: " +
                      message);
         }
@@ -82,13 +82,13 @@ public:
                 // Always transition before issuing commands.
                 TRANSITION_STATE(_phase, Phase::Save);
 
-                LOG_TST("Creating first connection");
+                TST_LOG("Creating first connection");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                LOG_TST("Creating second connection");
+                TST_LOG("Creating second connection");
                 addWebSocket();
 
-                LOG_TST("Loading first view (English)");
+                TST_LOG("Loading first view (English)");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc() + " lang=en");
                 break;
             }
@@ -132,12 +132,12 @@ public:
     /// A view is loaded.
     bool onViewLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded #" << ++_loaded_count << ": [" << message << ']');
+        TST_LOG("onDocumentLoaded #" << ++_loaded_count << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::Load2);
 
         if (_loaded_count == 1)
         {
-            LOG_TST("Loading second view (Pacific/Auckland)");
+            TST_LOG("Loading second view (Pacific/Auckland)");
             WSD_CMD_BY_CONNECTION_INDEX(1, "load url=" + getWopiSrc() +
                                                " lang=en timezone=Pacific/Auckland");
         }
@@ -217,13 +217,13 @@ public:
                 // Always transition before issuing commands.
                 TRANSITION_STATE(_phase, Phase::Load2);
 
-                LOG_TST("Creating first connection");
+                TST_LOG("Creating first connection");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                LOG_TST("Creating second connection");
+                TST_LOG("Creating second connection");
                 addWebSocket();
 
-                LOG_TST("Loading first view (default)");
+                TST_LOG("Loading first view (default)");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc() + " lang=hu");
                 break;
             }
@@ -259,12 +259,12 @@ public:
     /// A view is loaded.
     bool onViewLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded #" << ++_loaded_count << ": [" << message << ']');
+        TST_LOG("onDocumentLoaded #" << ++_loaded_count << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::Load2);
 
         if (_loaded_count == 1)
         {
-            LOG_TST("Loading second view (Pacific/Tarawa)");
+            TST_LOG("Loading second view (Pacific/Tarawa)");
             WSD_CMD_BY_CONNECTION_INDEX(1, "load url=" + getWopiSrc() +
                                                " lang=en timezone=Pacific/Tarawa");
         }
@@ -343,13 +343,13 @@ public:
                 // Always transition before issuing commands.
                 TRANSITION_STATE(_phase, Phase::Load2);
 
-                LOG_TST("Creating first connection");
+                TST_LOG("Creating first connection");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                LOG_TST("Creating second connection");
+                TST_LOG("Creating second connection");
                 addWebSocket();
 
-                LOG_TST("Loading first view (default)");
+                TST_LOG("Loading first view (default)");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc() +
                                                    " lang=hu timezone=Pacific/Midway");
                 break;

--- a/test/UnitWOPILock.cpp
+++ b/test/UnitWOPILock.cpp
@@ -49,7 +49,7 @@ public:
         const bool firstView = _checkFileInfoCount == 0;
         ++_checkFileInfoCount;
 
-        LOG_TST("CheckFileInfo: " << (firstView ? "editor" : "viewer"));
+        TST_LOG("CheckFileInfo: " << (firstView ? "editor" : "viewer"));
 
         fileInfo->set("SupportsLocks", "true");
         fileInfo->set("UserCanWrite", firstView ? "true" : "false");
@@ -65,7 +65,7 @@ public:
     {
         const std::string lockToken = request.get("X-WOPI-Lock", std::string());
         const std::string newLockState = request.get("X-WOPI-Override", std::string());
-        LOG_TST("In " << name(_phase) << ", X-WOPI-Lock: " << lockToken << ", X-WOPI-Override: "
+        TST_LOG("In " << name(_phase) << ", X-WOPI-Lock: " << lockToken << ", X-WOPI-Override: "
                       << newLockState << ", for URI: " << request.getURI());
 
         if (_phase == Phase::Lock)
@@ -97,7 +97,7 @@ public:
     void onDocBrokerViewLoaded(const std::string&,
                                const std::shared_ptr<ClientSession>& session) override
     {
-        LOG_TST("View #" << _viewCount + 1 << " [" << session->getName() << "] loaded");
+        TST_LOG("View #" << _viewCount + 1 << " [" << session->getName() << "] loaded");
 
         ++_viewCount;
         if (_viewCount == 2)
@@ -106,7 +106,7 @@ public:
             TRANSITION_STATE(_phase, Phase::Unlock);
 
             // force kill the session with edit permission
-            LOG_TST("Disconnecting first connection with edit permission");
+            TST_LOG("Disconnecting first connection with edit permission");
             deleteSocketAt(0);
         }
     }
@@ -120,15 +120,15 @@ public:
                 // Always transition before issuing commands.
                 TRANSITION_STATE(_phase, Phase::Lock);
 
-                LOG_TST("Creating first connection");
+                TST_LOG("Creating first connection");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                LOG_TST("Creating second connection");
+                TST_LOG("Creating second connection");
                 addWebSocket();
 
-                LOG_TST("Loading first view (editor)");
+                TST_LOG("Loading first view (editor)");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc());
-                LOG_TST("Loading second view (viewer)");
+                TST_LOG("Loading second view (viewer)");
                 WSD_CMD_BY_CONNECTION_INDEX(1, "load url=" + getWopiSrc());
                 break;
             }
@@ -175,7 +175,7 @@ public:
 
         const bool firstView = _checkFileInfoCount == 1;
 
-        LOG_TST("CheckFileInfo: " << (firstView ? "viewer" : "editor"));
+        TST_LOG("CheckFileInfo: " << (firstView ? "viewer" : "editor"));
 
         fileInfo->set("SupportsLocks", "true");
         fileInfo->set("UserCanWrite", firstView ? "false" : "true");
@@ -191,7 +191,7 @@ public:
     {
         const std::string lockToken = request.get("X-WOPI-Lock", std::string());
         const std::string newLockState = request.get("X-WOPI-Override", std::string());
-        LOG_TST("In " << name(_phase) << ", X-WOPI-Lock: " << lockToken << ", X-WOPI-Override: "
+        TST_LOG("In " << name(_phase) << ", X-WOPI-Lock: " << lockToken << ", X-WOPI-Override: "
                       << newLockState << ", for URI: " << request.getURI());
 
         LOG_ASSERT_MSG(_checkFileInfoCount == 2, "Must have had two CheckFileInfo requests");
@@ -241,7 +241,7 @@ public:
         // LOK_ASSERT_EQUAL(std::string("true"), request.get("X-LOOL-WOPI-IsExitSave"));
 
         // Simulate the viewer closing browser.
-        LOG_TST("Disconnecting Viewer");
+        TST_LOG("Disconnecting Viewer");
         deleteSocketAt(0);
 
         return nullptr; // Success.
@@ -250,7 +250,7 @@ public:
     void onDocBrokerViewLoaded(const std::string&,
                                const std::shared_ptr<ClientSession>& session) override
     {
-        LOG_TST("View #" << _viewCount + 1 << " [" << session->getName()
+        TST_LOG("View #" << _viewCount + 1 << " [" << session->getName()
                          << "] loaded, phase: " << name(_phase));
 
         ++_viewCount;
@@ -259,7 +259,7 @@ public:
             LOK_ASSERT_STATE(_phase, Phase::LoadViewer);
             TRANSITION_STATE(_phase, Phase::Lock);
 
-            LOG_TST("Loading second view (editor)");
+            TST_LOG("Loading second view (editor)");
             WSD_CMD_BY_CONNECTION_INDEX(1, "load url=" + getWopiSrc());
         }
         else if (_viewCount == 2)
@@ -268,7 +268,7 @@ public:
             TRANSITION_STATE(_phase, Phase::WaitModify);
 
             // Modify the doc.
-            LOG_TST("Modifying (editor)");
+            TST_LOG("Modifying (editor)");
             WSD_CMD_BY_CONNECTION_INDEX(1, "key type=input char=97 key=0");
             WSD_CMD_BY_CONNECTION_INDEX(1, "key type=up char=0 key=512");
         }
@@ -277,7 +277,7 @@ public:
     /// The document is modified. Disconnect editor.
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("onDocumentModified: [" << message << "], phase: " << name(_phase));
+        TST_LOG("onDocumentModified: [" << message << "], phase: " << name(_phase));
 
         // We get this twice, skip the second one.
         if (_phase != Phase::Upload)
@@ -294,7 +294,7 @@ public:
     void onDocBrokerRemoveSession(const std::string&,
                                   const std::shared_ptr<ClientSession>& session) override
     {
-        LOG_TST("Removing session [" << session->getName() << "], phase: " << name(_phase));
+        TST_LOG("Removing session [" << session->getName() << "], phase: " << name(_phase));
         if (_phase == Phase::Unlock)
         {
             // LOK_ASSERT_STATE(_phase, Phase::WaitUnload);
@@ -303,7 +303,7 @@ public:
 
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Destroyed dockey [" << docKey << "], phase: " << name(_phase));
+        TST_LOG("Destroyed dockey [" << docKey << "], phase: " << name(_phase));
         LOK_ASSERT_STATE(_phase, Phase::WaitUnload);
 
         TRANSITION_STATE(_phase, Phase::Done);
@@ -389,7 +389,7 @@ public:
     {
         const std::string lockToken = request.get("X-WOPI-Lock", std::string());
         const std::string newLockState = request.get("X-WOPI-Override", std::string());
-        LOG_TST("In " << name(_phase) << ", X-WOPI-Lock: " << lockToken << ", X-WOPI-Override: "
+        TST_LOG("In " << name(_phase) << ", X-WOPI-Lock: " << lockToken << ", X-WOPI-Override: "
                       << newLockState << ", for URI: " << request.getURI());
 
         if (_phase == Phase::Lock)
@@ -433,10 +433,10 @@ public:
                 // Always transition before issuing commands.
                 TRANSITION_STATE(_phase, Phase::Lock);
 
-                LOG_TST("Creating first connection");
+                TST_LOG("Creating first connection");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                LOG_TST("Loading first view (editor)");
+                TST_LOG("Loading first view (editor)");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc());
                 break;
             }
@@ -502,7 +502,7 @@ public:
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("assertPutFileRequest");
+        TST_LOG("assertPutFileRequest");
         LOK_ASSERT_STATE(_phase, Phase::Upload);
 
         TRANSITION_STATE(_phase, Phase::Unlock);
@@ -514,7 +514,7 @@ public:
     {
         const std::string lock = request.get("X-WOPI-Lock", std::string());
         const std::string newLockState = request.get("X-WOPI-Override", std::string());
-        LOG_TST("In " << name(_phase) << ", X-WOPI-Lock: " << lock << ", X-WOPI-Override: "
+        TST_LOG("In " << name(_phase) << ", X-WOPI-Lock: " << lock << ", X-WOPI-Override: "
                       << newLockState << ", for URI: " << request.getURI());
 
         if (_phase == Phase::Lock)
@@ -549,25 +549,25 @@ public:
                                const std::shared_ptr<ClientSession>& session) override
     {
         ++_sessionCount;
-        LOG_TST("New Session [" << session->getName() << "] added. Have " << _sessionCount
+        TST_LOG("New Session [" << session->getName() << "] added. Have " << _sessionCount
                                 << " sessions.");
     }
 
     void onDocBrokerViewLoaded(const std::string&,
                                const std::shared_ptr<ClientSession>& session) override
     {
-        LOG_TST("View for session [" << session->getName() << "] loaded. Have " << _sessionCount
+        TST_LOG("View for session [" << session->getName() << "] loaded. Have " << _sessionCount
                                      << " sessions.");
     }
 
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        TST_LOG("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::Modify);
 
         // Modify the doc.
-        LOG_TST("Modifying");
+        TST_LOG("Modifying");
         WSD_CMD("key type=input char=97 key=0");
         WSD_CMD("key type=up char=0 key=512");
 
@@ -577,12 +577,12 @@ public:
     /// The document is modified. Load the viewer session.
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("onDocumentModified: [" << message << ']');
+        TST_LOG("onDocumentModified: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::Modify);
 
         TRANSITION_STATE(_phase, Phase::Upload);
 
-        LOG_TST("Disconnecting");
+        TST_LOG("Disconnecting");
         deleteSocketAt(0);
 
         return true;
@@ -593,7 +593,7 @@ public:
                                   const std::shared_ptr<ClientSession>& session) override
     {
         --_sessionCount;
-        LOG_TST("Session [" << session->getName() << "] removed. Have " << _sessionCount
+        TST_LOG("Session [" << session->getName() << "] removed. Have " << _sessionCount
                             << " sessions.");
     }
 
@@ -606,10 +606,10 @@ public:
                 // Always transition before issuing commands.
                 TRANSITION_STATE(_phase, Phase::Lock);
 
-                LOG_TST("Creating first connection");
+                TST_LOG("Creating first connection");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                LOG_TST("Loading view");
+                TST_LOG("Loading view");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc());
                 break;
             }
@@ -665,7 +665,7 @@ public:
     {
         const std::string lockToken = request.get("X-WOPI-Lock", std::string());
         const std::string newLockState = request.get("X-WOPI-Override", std::string());
-        LOG_TST("In " << name(_phase) << ", X-WOPI-Lock: " << lockToken << ", X-WOPI-Override: "
+        TST_LOG("In " << name(_phase) << ", X-WOPI-Lock: " << lockToken << ", X-WOPI-Override: "
                       << newLockState << ", for URI: " << request.getURI());
 
         if (_phase == Phase::Lock)
@@ -700,12 +700,12 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << "] in " << name(_phase));
+        TST_LOG("onDocumentLoaded: [" << message << "] in " << name(_phase));
         // As locking is async, it can race with this loaded event.
 
         // Simulate some potential user modification.
         // This triggers the "maybe modified" logic.
-        LOG_TST("Non-modifying key input");
+        TST_LOG("Non-modifying key input");
         WSD_CMD("key type=input char=0 key=16402");
 
         return true;
@@ -720,10 +720,10 @@ public:
                 // Always transition before issuing commands.
                 TRANSITION_STATE(_phase, Phase::Lock);
 
-                LOG_TST("Creating first connection");
+                TST_LOG("Creating first connection");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                LOG_TST("Loading first view (editor)");
+                TST_LOG("Loading first view (editor)");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc());
                 break;
             }

--- a/test/UnitWOPIRenameFile.cpp
+++ b/test/UnitWOPIRenameFile.cpp
@@ -50,7 +50,7 @@ public:
 
         const std::string expected("renamefile filename=" + Uri::encode(FilenameUtf8));
 
-        LOG_TST("Got [" << message << "], expect: [" << expected << ']');
+        TST_LOG("Got [" << message << "], expect: [" << expected << ']');
         if (message.find(expected) == 0)
         {
             LOK_ASSERT_STATE(_phase, Phase::WaitRenameNotification);
@@ -67,7 +67,7 @@ public:
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        TST_LOG("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::RenameFile);
 
         TRANSITION_STATE(_phase, Phase::WaitRenameNotification);

--- a/test/UnitWOPISaveOnExit.cpp
+++ b/test/UnitWOPISaveOnExit.cpp
@@ -51,7 +51,7 @@ public:
     std::unique_ptr<http::Response>
     assertGetFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("Testing " << name(_scenario));
+        TST_LOG("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         assertGetFileCount();
@@ -62,7 +62,7 @@ public:
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("Testing " << name(_scenario));
+        TST_LOG("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         assertPutFileCount();
@@ -70,7 +70,7 @@ public:
         switch (_scenario)
         {
             case Scenario::Disconnect:
-                LOG_TST("Clobbered in the disconnect scenario");
+                TST_LOG("Clobbered in the disconnect scenario");
                 break;
             case Scenario::SaveDiscard:
             case Scenario::CloseDiscard:
@@ -116,7 +116,7 @@ public:
 
     void onDocumentUploaded(bool success) override
     {
-        LOG_TST("Uploaded: " << (success ? "success" : "failure"));
+        TST_LOG("Uploaded: " << (success ? "success" : "failure"));
 
         switch (_scenario)
         {
@@ -128,7 +128,7 @@ public:
             case Scenario::SaveOverwrite:
                 if (getCountPutFile() == 2)
                 {
-                    LOG_TST("Closing the document to verify its contents after reloading");
+                    TST_LOG("Closing the document to verify its contents after reloading");
                     WSD_CMD("closedocument");
                 }
                 break;
@@ -137,7 +137,7 @@ public:
 
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
+        TST_LOG("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         std::string expectedContents;
@@ -209,10 +209,10 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
-        LOG_TST("Modifying the document");
+        TST_LOG("Modifying the document");
         TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
 
         // Modify the currently opened document; type 'a'.
@@ -224,13 +224,13 @@ public:
 
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitUploadAfterSave);
 
         // Save.
-        LOG_TST("Saving the document");
+        TST_LOG("Saving the document");
         WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0");
 
         return true;
@@ -247,7 +247,7 @@ public:
             {
                 // Just disconnect.
                 TRANSITION_STATE(_phase, Phase::WaitUploadOnExit);
-                LOG_TST("Disconnecting");
+                TST_LOG("Disconnecting");
                 deleteSocketAt(0);
             }
         }
@@ -263,7 +263,7 @@ public:
     /// Wait for ModifiedStatus=false before disconnecting.
     bool onDocumentUnmodified(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
 
         LOK_ASSERT_STATE(_phase, Phase::WaitUploadAfterSave);
 
@@ -272,7 +272,7 @@ public:
         {
             // Just disconnect.
             TRANSITION_STATE(_phase, Phase::WaitUploadOnExit);
-            LOG_TST("Disconnecting");
+            TST_LOG("Disconnecting");
             deleteSocketAt(0);
         }
 
@@ -287,7 +287,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());
@@ -336,7 +336,7 @@ public:
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& /*request*/) override
     {
-        LOG_TST("Checking X-COOL-WOPI headers");
+        TST_LOG("Checking X-COOL-WOPI headers");
 
         failTest("Unexpected PutFile on unmodified document");
         return nullptr;
@@ -346,12 +346,12 @@ public:
     /// This is sent right after loading.
     bool onDocumentUnmodified(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitDestroy);
 
-        LOG_TST("Closing document");
+        TST_LOG("Closing document");
         WSD_CMD("closedocument");
 
         return true;
@@ -366,7 +366,7 @@ public:
     // Wait for clean unloading.
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Destroyed dockey [" << docKey << "] closed");
+        TST_LOG("Destroyed dockey [" << docKey << "] closed");
         LOK_ASSERT_STATE(_phase, Phase::WaitDestroy);
 
         TRANSITION_STATE(_phase, Phase::Done);
@@ -383,7 +383,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());
@@ -416,13 +416,13 @@ public:
     /// This is sent right after loading.
     bool onDocumentUnmodified(const std::string& message) override
     {
-        LOG_TST("Got: [" << message << ']');
+        TST_LOG("Got: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitDestroy);
 
         // Disconnect to trigger the auto-save logic.
-        LOG_TST("Disconnecting");
+        TST_LOG("Disconnecting");
         deleteSocketAt(0);
 
         return true;

--- a/test/UnitWOPISlow.cpp
+++ b/test/UnitWOPISlow.cpp
@@ -62,7 +62,7 @@ public:
     std::unique_ptr<http::Response>
     assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
-        LOG_TST("PutFile");
+        TST_LOG("PutFile");
         LOK_ASSERT_STATE(_phase, Phase::WaitPutFile);
 
         // Triggered while closing.
@@ -82,13 +82,13 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Doc (" << name(_phase) << "): [" << message << ']');
+        TST_LOG("Doc (" << name(_phase) << "): [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         // Modify and wait for the notification.
         TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
 
-        LOG_TST("Sending key input #" << ++_inputCount);
+        TST_LOG("Sending key input #" << ++_inputCount);
         WSD_CMD("key type=input char=97 key=0");
         WSD_CMD("key type=up char=0 key=512");
 
@@ -102,18 +102,18 @@ public:
         // Only the first time is handled here.
         if (_phase == Phase::WaitModifiedStatus)
         {
-            LOG_TST("Doc (" << name(_phase) << "): [" << message << ']');
+            TST_LOG("Doc (" << name(_phase) << "): [" << message << ']');
             LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
             // Save and immediately modify, then close the connection.
             WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0 "
                     "extendedData=CustomFlag%3DCustom%20Value%3BAnotherFlag%3DAnotherValue");
 
-            LOG_TST("Sending key input #" << ++_inputCount);
+            TST_LOG("Sending key input #" << ++_inputCount);
             WSD_CMD("key type=input char=97 key=0");
             WSD_CMD("key type=up char=0 key=512");
 
-            LOG_TST("Closing the connection.");
+            TST_LOG("Closing the connection.");
             deleteSocketAt(0);
 
             // Don't transition to WaitPutFile until after closing the socket.
@@ -131,7 +131,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/large-six-hundred.odt?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());
@@ -173,7 +173,7 @@ public:
     assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
     {
         ++_uploadCount;
-        LOG_TST("PutFile #" << _uploadCount);
+        TST_LOG("PutFile #" << _uploadCount);
 
         LOK_ASSERT_EQUAL(std::string("false"), request.get("X-COOL-WOPI-IsAutosave"));
         LOK_ASSERT_EQUAL(std::string("false"), request.get("X-COOL-WOPI-IsExitSave"));
@@ -197,7 +197,7 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Doc (" << name(_phase) << "): [" << message << ']');
+        TST_LOG("Doc (" << name(_phase) << "): [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         // Modify and wait for the notification.
@@ -212,7 +212,7 @@ public:
     /// The document is modified. Save, modify, and close it.
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Doc (" << name(_phase) << "): [" << message << ']');
+        TST_LOG("Doc (" << name(_phase) << "): [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         _stopwatch.restart();
@@ -231,7 +231,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/" + getTestname() + "?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());
@@ -244,7 +244,7 @@ public:
             case Phase::WaitPutFile:
             {
                 // Save while we're waiting.
-                LOG_TST("Sending key input #" << _saveCount);
+                TST_LOG("Sending key input #" << _saveCount);
                 WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0");
             }
             break;

--- a/test/UnitWOPIStuckSave.cpp
+++ b/test/UnitWOPIStuckSave.cpp
@@ -62,7 +62,7 @@ public:
     /// The document is loaded.
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("onDocumentLoaded: [" << message << ']');
+        TST_LOG("onDocumentLoaded: [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
@@ -76,12 +76,12 @@ public:
     /// The document is modified. Save it.
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("onDocumentModified: Doc (WaitModifiedStatus): [" << message << ']');
+        TST_LOG("onDocumentModified: Doc (WaitModifiedStatus): [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitClose);
 
-        LOG_TST("Closing the document, expecting saving, which will get 'stuck'");
+        TST_LOG("Closing the document, expecting saving, which will get 'stuck'");
         WSD_CMD("closedocument");
 
         return true;
@@ -89,13 +89,13 @@ public:
 
     bool onFilterLOKitMessage(const std::shared_ptr<Message>& message) override
     {
-        LOG_TST("Filtering: [" << message->firstLine() << ']');
+        TST_LOG("Filtering: [" << message->firstLine() << ']');
 
         constexpr std::string_view unoSave = ".uno:Save";
         constexpr std::string_view unoModifiedStatus = ".uno:ModifiedStatus";
         if (message->contains(unoSave))
         {
-            LOG_TST("Dropping .uno:Save to simulate stuck save");
+            TST_LOG("Dropping .uno:Save to simulate stuck save");
             return true; // Do not process the message further.
         }
         else if (message->contains(unoModifiedStatus))
@@ -130,7 +130,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket");
+                TST_LOG("Load: initWebsocket");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());

--- a/test/UnitWOPITemplate.cpp
+++ b/test/UnitWOPITemplate.cpp
@@ -42,12 +42,12 @@ public:
                                    const std::shared_ptr<StreamSocket>& socket) override
     {
         const Poco::URI uriReq(request.getURI());
-        LOG_TST("FakeWOPIHost: " << request.getMethod() << " request: " << uriReq.toString());
+        TST_LOG("FakeWOPIHost: " << request.getMethod() << " request: " << uriReq.toString());
 
         // CheckFileInfo
         if (request.getMethod() == "GET" && uriReq.getPath() == "/wopi/files/10")
         {
-            LOG_TST("FakeWOPIHost: Handling CheckFileInfo: " << uriReq.getPath());
+            TST_LOG("FakeWOPIHost: Handling CheckFileInfo: " << uriReq.getPath());
 
             Poco::JSON::Object::Ptr fileInfo = getDefaultCheckFileInfoPayload(uriReq);
             fileInfo->set("BaseFileName", "test.odt");
@@ -67,7 +67,7 @@ public:
                   request.getMethod() == "PROPFIND") &&
                  uriReq.getPath() == "/" + _templateFile)
         {
-            LOG_TST("FakeWOPIHost: Handling " << request.getMethod() << " on " << uriReq.getPath());
+            TST_LOG("FakeWOPIHost: Handling " << request.getMethod() << " on " << uriReq.getPath());
 
             http::Response httpResponse(http::StatusCode::OK);
             httpResponse.set("Allow", "GET");
@@ -78,7 +78,7 @@ public:
         // Get the template
         else if (request.getMethod() == "GET" && uriReq.getPath() == "/" + _templateFile)
         {
-            LOG_TST("FakeWOPIHost: Handling template GetFile: " << uriReq.getPath());
+            TST_LOG("FakeWOPIHost: Handling template GetFile: " << uriReq.getPath());
 
             http::Response response(http::StatusCode::OK);
             HttpHelper::sendFileAndShutdown(socket, TDOC "/" + _templateFile, response);
@@ -88,14 +88,14 @@ public:
         // Save template
         else if (request.getMethod() == "POST" && uriReq.getPath() == "/wopi/files/10/contents")
         {
-            LOG_TST("FakeWOPIHost: Handling PutFile: " << uriReq.getPath());
+            TST_LOG("FakeWOPIHost: Handling PutFile: " << uriReq.getPath());
 
             if (!_savedTemplate)
             {
                 // First, we expect to get a PutFile right after loading.
                 LOK_ASSERT_EQUAL(static_cast<int>(Phase::SaveDoc), static_cast<int>(_phase));
                 _savedTemplate = true;
-                LOG_TST("SaveDoc => CloseDoc");
+                TST_LOG("SaveDoc => CloseDoc");
                 TRANSITION_STATE(_phase, Phase::CloseDoc);
             }
             else
@@ -117,7 +117,7 @@ public:
             return true;
         }
 
-        LOG_TST("FakeWOPIHost: unknown request "
+        TST_LOG("FakeWOPIHost: unknown request "
                 << request.getMethod() << " request: " << uriReq.toString() << ". Defaulting.");
         return false;
     }
@@ -129,7 +129,7 @@ public:
         {
             case Phase::LoadTemplate:
             {
-                LOG_TST("LoadTemplate => SaveDoc");
+                TST_LOG("LoadTemplate => SaveDoc");
                 TRANSITION_STATE(_phase, Phase::SaveDoc);
 
                 initWebsocket("/wopi/files/10?access_token=anything");
@@ -139,7 +139,7 @@ public:
             }
             case Phase::CloseDoc:
             {
-                LOG_TST("CloseDoc => Polling");
+                TST_LOG("CloseDoc => Polling");
                 TRANSITION_STATE(_phase, Phase::Polling);
                 WSD_CMD("closedocument");
                 break;

--- a/test/UnitWOPIVersionRestore.cpp
+++ b/test/UnitWOPIVersionRestore.cpp
@@ -44,7 +44,7 @@ public:
     {
         LOK_ASSERT_STATE(_phase, Phase::WaitPutFile);
 
-        LOG_TST("Document uploaded.");
+        TST_LOG("Document uploaded.");
         _isDocumentSaved = true;
 
         return nullptr;
@@ -52,7 +52,7 @@ public:
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Got [" << message << ']');
+        TST_LOG("Got [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitPutFile);
@@ -93,7 +93,7 @@ public:
             {
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Load: initWebsocket.");
+                TST_LOG("Load: initWebsocket.");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
                 WSD_CMD("load url=" + getWopiSrc());

--- a/test/UnitWSDClient.hpp
+++ b/test/UnitWSDClient.hpp
@@ -25,7 +25,7 @@
 #define WSD_CMD_BY_CONNECTION_INDEX(INDEX, MSG)                                                    \
     do                                                                                             \
     {                                                                                              \
-        LOG_TST("Sending from #" << INDEX << ": " << MSG);                                         \
+        TST_LOG("Sending from #" << INDEX << ": " << MSG);                                         \
         sendCommand(INDEX, MSG);                                                                   \
     } while (false)
 
@@ -90,7 +90,7 @@ protected:
         _wopiSrc = Uri::encode(wopiURL.toString());
 
         // This is just a client connection that is used from the tests.
-        LOG_TST("Connecting test client to COOL (#" << (_wsList.size() + 1)
+        TST_LOG("Connecting test client to COOL (#" << (_wsList.size() + 1)
                                                     << " connection): /cool/" << _wopiSrc << "/ws");
 
         // Insert at the front.
@@ -106,7 +106,7 @@ protected:
     void addWebSocket()
     {
         // This is just a client connection that is used from the tests.
-        LOG_TST("Connecting test client to COOL (#" << (_wsList.size() + 1)
+        TST_LOG("Connecting test client to COOL (#" << (_wsList.size() + 1)
                                                     << " connection): /cool/" << _wopiSrc << "/ws");
 
         // Insert at the back.
@@ -119,7 +119,7 @@ protected:
 
     void endTest(const std::string& reason) override
     {
-        LOG_TST("Ending test by disconnecting " << _wsList.size() << " connection(s): " << reason);
+        TST_LOG("Ending test by disconnecting " << _wsList.size() << " connection(s): " << reason);
         _wsList.clear();
         UnitWSD::endTest(reason);
     }
@@ -139,7 +139,7 @@ protected:
         std::string documentPath, documentURL;
         helpers::getDocumentPathAndURL(docFilename, documentPath, documentURL, getTestname());
 
-        LOG_TST("Connecting to local document [" << docFilename << "] with URL: " << documentURL);
+        TST_LOG("Connecting to local document [" << docFilename << "] with URL: " << documentURL);
         _wsList.emplace_back(
             std::make_unique<UnitWebSocket>(socketPoll(), documentURL, getTestname()));
 
@@ -151,7 +151,7 @@ protected:
     {
         const std::string documentURL = connectToLocalDocument(docFilename);
 
-        LOG_TST("Loading local document [" << docFilename << "] with URL: " << documentURL);
+        TST_LOG("Loading local document [" << docFilename << "] with URL: " << documentURL);
         WSD_CMD("load url=" + documentURL);
     }
 

--- a/test/UnitWopiOwnertermination.cpp
+++ b/test/UnitWopiOwnertermination.cpp
@@ -53,12 +53,12 @@ public:
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Loaded #" << (_loadedIndex + 1) << ": [" << message << ']');
+        TST_LOG("Loaded #" << (_loadedIndex + 1) << ": [" << message << ']');
 
         TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
 
         // Modify the document.
-        LOG_TST("Modifying");
+        TST_LOG("Modifying");
         WSD_CMD_BY_CONNECTION_INDEX(_loadedIndex, "key type=input char=97 key=0");
         WSD_CMD_BY_CONNECTION_INDEX(_loadedIndex, "key type=up char=0 key=512");
 
@@ -68,12 +68,12 @@ public:
     /// The document is modified. Save, modify, and close it.
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Modified #" << (_loadedIndex + 1) << ": [" << message << ']');
+        TST_LOG("Modified #" << (_loadedIndex + 1) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         TRANSITION_STATE(_phase, Phase::WaitDocClose);
 
-        LOG_TST("Closing");
+        TST_LOG("Closing");
         WSD_CMD_BY_CONNECTION_INDEX(_loadedIndex, "closedocument");
 
         return true;
@@ -100,10 +100,10 @@ public:
                 // First time loading, transition.
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 
-                LOG_TST("Creating first connection");
+                TST_LOG("Creating first connection");
                 initWebsocket("/wopi/files/0?access_token=anything");
 
-                LOG_TST("Loading through first connection");
+                TST_LOG("Loading through first connection");
                 WSD_CMD_BY_CONNECTION_INDEX(0, "load url=" + getWopiSrc());
 
                 break;
@@ -114,9 +114,9 @@ public:
 
                 ++_loadedIndex;
 
-                LOG_TST("Creating connection #" << (_loadedIndex + 1));
+                TST_LOG("Creating connection #" << (_loadedIndex + 1));
                 addWebSocket();
-                LOG_TST("Loading through connection #" << (_loadedIndex + 1));
+                TST_LOG("Loading through connection #" << (_loadedIndex + 1));
                 WSD_CMD_BY_CONNECTION_INDEX(_loadedIndex, "load url=" + getWopiSrc());
 
                 break;

--- a/test/WOPIUploadConflictCommon.hpp
+++ b/test/WOPIUploadConflictCommon.hpp
@@ -66,28 +66,28 @@ protected:
     void setExpectedCheckFileInfo(std::size_t value)
     {
         _expectedCheckFileInfo = value;
-        LOG_TST("Expecting " << _expectedCheckFileInfo << " CheckFileInfo requests.");
+        TST_LOG("Expecting " << _expectedCheckFileInfo << " CheckFileInfo requests.");
     }
 
     std::size_t getExpectedGetFile() const { return _expectedGetFile; }
     void setExpectedGetFile(std::size_t value)
     {
         _expectedGetFile = value;
-        LOG_TST("Expecting " << _expectedGetFile << " GetFile requests.");
+        TST_LOG("Expecting " << _expectedGetFile << " GetFile requests.");
     }
 
     std::size_t getExpectedPutRelative() const { return _expectedPutRelative; }
     void setExpectedPutRelative(std::size_t value)
     {
         _expectedPutRelative = value;
-        LOG_TST("Expecting " << _expectedPutRelative << " PutRelative requests.");
+        TST_LOG("Expecting " << _expectedPutRelative << " PutRelative requests.");
     }
 
     std::size_t getExpectedPutFile() const { return _expectedPutFile; }
     void setExpectedPutFile(std::size_t value)
     {
         _expectedPutFile = value;
-        LOG_TST("Expecting " << _expectedPutFile << " PutFile requests.");
+        TST_LOG("Expecting " << _expectedPutFile << " PutFile requests.");
     }
 
 public:
@@ -106,9 +106,9 @@ public:
 
     virtual void startNewTest()
     {
-        LOG_TST("===== Starting " << name(_scenario) << " test scenario =====");
+        TST_LOG("===== Starting " << name(_scenario) << " test scenario =====");
 
-        LOG_TST("Resetting the document in storage");
+        TST_LOG("Resetting the document in storage");
         setFileContent(OriginalDocContent); // Reset to test overwriting.
 
         resetCountCheckFileInfo();
@@ -168,7 +168,7 @@ public:
 
     void assertPutFileCount()
     {
-        LOG_TST("Testing " << name(_scenario));
+        TST_LOG("Testing " << name(_scenario));
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         if (getExpectedPutRelative() < getCountPutRelative())
@@ -187,12 +187,12 @@ public:
 
     bool onDocumentLoaded(const std::string& message) override
     {
-        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
+        TST_LOG("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
 
         if (_scenario != Scenario::VerifyOverwrite)
         {
-            LOG_TST("Modifying the document");
+            TST_LOG("Modifying the document");
             TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
 
             // modify the currently opened document; type 'a'
@@ -201,7 +201,7 @@ public:
         }
         else
         {
-            LOG_TST("Closing the document to finish testing");
+            TST_LOG("Closing the document to finish testing");
             TRANSITION_STATE_MSG(_phase, Phase::WaitDocClose, "Skipping modifications");
             WSD_CMD("closedocument");
         }
@@ -211,11 +211,11 @@ public:
 
     bool onDocumentModified(const std::string& message) override
     {
-        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
+        TST_LOG("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
 
         // Change the underlying document in storage.
-        LOG_TST("Changing document contents in storage");
+        TST_LOG("Changing document contents in storage");
         setFileContent(ConflictingDocContent);
 
         TRANSITION_STATE(_phase, Phase::WaitDocClose);
@@ -223,7 +223,7 @@ public:
         switch (_scenario)
         {
             case Scenario::Disconnect:
-                LOG_TST("Disconnecting");
+                TST_LOG("Disconnecting");
                 deleteSocketAt(0);
                 break;
             case Scenario::SaveDiscard:
@@ -231,14 +231,14 @@ public:
                 // Save the document; wsd should detect now that document has
                 // been changed underneath it and send us:
                 // "error: cmd=storage kind=documentconflict"
-                LOG_TST("Saving the document");
+                TST_LOG("Saving the document");
                 WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0");
                 break;
             case Scenario::CloseDiscard:
                 // Close the document; wsd should detect now that document has
                 // been changed underneath it and send us:
                 // "error: cmd=storage kind=documentconflict"
-                LOG_TST("Closing the document");
+                TST_LOG("Closing the document");
                 WSD_CMD("closedocument");
                 break;
             case Scenario::VerifyOverwrite:
@@ -251,7 +251,7 @@ public:
 
     bool onDocumentError(const std::string& message) override
     {
-        LOG_TST("Testing " << name(_scenario) << ": [" << message << ']');
+        TST_LOG("Testing " << name(_scenario) << ": [" << message << ']');
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         LOK_ASSERT_EQUAL_MESSAGE("Expect only documentconflict errors",
@@ -264,11 +264,11 @@ public:
                 break;
             case Scenario::SaveDiscard:
             case Scenario::CloseDiscard:
-                LOG_TST("Discarding own changes via closedocument");
+                TST_LOG("Discarding own changes via closedocument");
                 WSD_CMD("closedocument");
                 break;
             case Scenario::SaveOverwrite:
-                LOG_TST("Overwriting with own version via savetostorage");
+                TST_LOG("Overwriting with own version via savetostorage");
                 WSD_CMD("savetostorage force=1");
                 break;
             case Scenario::VerifyOverwrite:
@@ -302,7 +302,7 @@ public:
     // Wait for clean unloading.
     void onDocBrokerDestroy(const std::string& docKey) override
     {
-        LOG_TST("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
+        TST_LOG("Testing " << name(_scenario) << " with dockey [" << docKey << "] closed.");
         LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
 
         LOK_ASSERT(getExpectedCheckFileInfo() >= getCountCheckFileInfo());
@@ -310,7 +310,7 @@ public:
         LOK_ASSERT_EQUAL(getExpectedPutRelative(), getCountPutRelative());
         // LOK_ASSERT_EQUAL(getExpectedPutFile(), getCountPutFile()); //FIXME: unreliable for some tests.
 
-        LOG_TST("===== Finished " << name(_scenario) << " test scenario =====");
+        TST_LOG("===== Finished " << name(_scenario) << " test scenario =====");
 
         if (_scenario != Scenario::VerifyOverwrite)
         {
@@ -346,7 +346,7 @@ public:
             {
                 startNewTest();
 
-                LOG_TST("Loading the document for " << name(_scenario));
+                TST_LOG("Loading the document for " << name(_scenario));
 
                 TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
 

--- a/test/WopiProofTests.cpp
+++ b/test/WopiProofTests.cpp
@@ -99,7 +99,7 @@ void WopiProofTests::verifySignature(const std::string& access, const std::strin
     (void)access; (void)uri; (void)ticks;
     (void)discoveryModulus; (void)discoveryExponent;
     (void)msgProofStr;
-    LOG_TST("OpenSSL too old/new to verify keys easily "
+    TST_LOG("OpenSSL too old/new to verify keys easily "
             << OPENSSL_VERSION_TEXT << " needs to be at least 1.1.0, but not 3.0\n");
 #endif
 }

--- a/test/WopiTestServer.hpp
+++ b/test/WopiTestServer.hpp
@@ -83,7 +83,7 @@ protected:
         _fileContent = fileContent;
         const auto oldTime = _fileLastModifiedTime;
         _fileLastModifiedTime = std::chrono::system_clock::now();
-        LOG_TST("setFileContent at " << Util::getIso8601FracformatTime(getFileLastModifiedTime())
+        TST_LOG("setFileContent at " << Util::getIso8601FracformatTime(getFileLastModifiedTime())
                                      << ": [" << COOLProtocol::getAbbreviatedMessage(_fileContent)
                                      << "], previous version was at "
                                      << Util::getIso8601FracformatTime(oldTime));
@@ -102,14 +102,14 @@ protected:
         , _countPutRelative(0)
         , _countPutFile(0)
     {
-        LOG_TST("WopiTestServer created for [" << getTestname() << ']');
+        TST_LOG("WopiTestServer created for [" << getTestname() << ']');
 
         // Read the document data and store as string in memory.
         const auto data = helpers::readDataFromFile(filenameOrContents);
         if (!data.empty())
         {
             // That was a filename, set its contents.
-            LOG_TST("WopiTestServer created with " << data.size() << " bytes from file ["
+            TST_LOG("WopiTestServer created with " << data.size() << " bytes from file ["
                                                    << filenameOrContents << ']');
             _filename = filenameOrContents; // Capture the real filename.
             setFileContent(std::string(data.begin(), data.end()));
@@ -117,7 +117,7 @@ protected:
         else
         {
             // Not a valid filename, assume it's some data.
-            LOG_TST("WopiTestServer created with " << filenameOrContents.size()
+            TST_LOG("WopiTestServer created with " << filenameOrContents.size()
                                                    << " bytes from data.");
             setFileContent(filenameOrContents);
         }
@@ -126,28 +126,28 @@ protected:
     std::size_t getCountCheckFileInfo() const { return _countCheckFileInfo; }
     void resetCountCheckFileInfo()
     {
-        LOG_TST("Resetting countCheckFileInfo [" << _countCheckFileInfo << "] to zero");
+        TST_LOG("Resetting countCheckFileInfo [" << _countCheckFileInfo << "] to zero");
         _countCheckFileInfo = 0;
     }
 
     std::size_t getCountGetFile() const { return _countGetFile; }
     void resetCountGetFile()
     {
-        LOG_TST("Resetting countGetFile [" << _countGetFile << "] to zero");
+        TST_LOG("Resetting countGetFile [" << _countGetFile << "] to zero");
         _countGetFile = 0;
     }
 
     std::size_t getCountPutRelative() const { return _countPutRelative; }
     void resetCountPutRelative()
     {
-        LOG_TST("Resetting countPutRelative [" << _countPutRelative << "] to zero");
+        TST_LOG("Resetting countPutRelative [" << _countPutRelative << "] to zero");
         _countPutRelative = 0;
     }
 
     std::size_t getCountPutFile() const { return _countPutFile; }
     void resetCountPutFile()
     {
-        LOG_TST("Resetting countPutFile [" << _countPutFile << "] to zero");
+        TST_LOG("Resetting countPutFile [" << _countPutFile << "] to zero");
         _countPutFile = 0;
     }
 
@@ -298,7 +298,7 @@ protected:
             std::ostringstream jsonStream;
             fileInfo->stringify(jsonStream);
             std::string json = jsonStream.str();
-            LOG_TST("FakeWOPIHost: Response to CheckFileInfo "
+            TST_LOG("FakeWOPIHost: Response to CheckFileInfo "
                     << Poco::URI(request.getURI()).getPath() << ": 200 OK: " << json);
 
             httpResponse->set("Last-Modified", Util::getHttpTime(getFileLastModifiedTime()));
@@ -306,7 +306,7 @@ protected:
         }
         else
         {
-            LOG_TST("FakeWOPIHost: Response to CheckFileInfo "
+            TST_LOG("FakeWOPIHost: Response to CheckFileInfo "
                     << Poco::URI(request.getURI()).getPath()
                     << httpResponse->statusLine().statusCode() << ' '
                     << httpResponse->statusLine().reasonPhrase());
@@ -332,7 +332,7 @@ protected:
         if (httpResponse->statusLine().statusCategory() ==
             http::StatusLine::StatusCodeClass::Successful)
         {
-            LOG_TST("FakeWOPIHost: Response to GetFile " << Poco::URI(request.getURI()).getPath()
+            TST_LOG("FakeWOPIHost: Response to GetFile " << Poco::URI(request.getURI()).getPath()
                                                          << ": 200 OK (" << getFileContent().size()
                                                          << " bytes)");
             httpResponse->set("Last-Modified", Util::getHttpTime(getFileLastModifiedTime()));
@@ -340,7 +340,7 @@ protected:
         }
         else
         {
-            LOG_TST("FakeWOPIHost: Response to GetFile "
+            TST_LOG("FakeWOPIHost: Response to GetFile "
                     << Poco::URI(request.getURI()).getPath()
                     << httpResponse->statusLine().statusCode() << ' '
                     << httpResponse->statusLine().reasonPhrase());
@@ -360,7 +360,7 @@ protected:
         if (isWopiInfoRequest(uriReq.getPath())) // CheckFileInfo
         {
             ++_countCheckFileInfo;
-            LOG_TST("FakeWOPIHost: Handling CheckFileInfo (#" << _countCheckFileInfo
+            TST_LOG("FakeWOPIHost: Handling CheckFileInfo (#" << _countCheckFileInfo
                                                               << "): " << uriReq.getPath());
 
             return handleCheckFileInfoRequest(request, socket);
@@ -368,13 +368,13 @@ protected:
         else if (isWopiContentRequest(uriReq.getPath())) // GetFile
         {
             ++_countGetFile;
-            LOG_TST("FakeWOPIHost: Handling GetFile (#" << _countGetFile
+            TST_LOG("FakeWOPIHost: Handling GetFile (#" << _countGetFile
                                                         << "): " << uriReq.getPath());
 
             return handleGetFileRequest(request, socket);
         }
 
-        LOG_TST("FakeWOPIHost: not a wopi request, skipping: " << uriReq.getPath());
+        TST_LOG("FakeWOPIHost: not a wopi request, skipping: " << uriReq.getPath());
         return false;
     }
 
@@ -395,14 +395,14 @@ protected:
                     std::unique_ptr<http::Response> response = assertLockRequest(request);
                     if (!response)
                     {
-                        LOG_TST("FakeWOPIHost: " << op << " operation on [" << uriReq.getPath()
+                        TST_LOG("FakeWOPIHost: " << op << " operation on [" << uriReq.getPath()
                                                  << "] succeeded 200 OK");
                         http::Response httpResponse(http::StatusCode::OK);
                         socket->sendAndShutdown(httpResponse);
                     }
                     else
                     {
-                        LOG_TST("FakeWOPIHost: " << op << " operation on [" << uriReq.getPath()
+                        TST_LOG("FakeWOPIHost: " << op << " operation on [" << uriReq.getPath()
                                                  << "]: " << response->statusLine().statusCode()
                                                  << ' ' << response->statusLine().reasonPhrase());
                         socket->sendAndShutdown(*response);
@@ -425,7 +425,7 @@ protected:
                 if (request.get("X-WOPI-Override") == std::string("PUT_RELATIVE"))
                 {
                     ++_countPutRelative;
-                    LOG_TST("FakeWOPIHost: Handling PutRelativeFile (#"
+                    TST_LOG("FakeWOPIHost: Handling PutRelativeFile (#"
                             << _countPutRelative << "): " << uriReq.getPath());
 
                     LOK_ASSERT_EQUAL(std::string("PUT_RELATIVE"), request.get("X-WOPI-Override"));
@@ -451,7 +451,7 @@ protected:
         else if (isWopiContentRequest(uriReq.getPath()))
         {
             ++_countPutFile;
-            LOG_TST("FakeWOPIHost: Handling PutFile (#" << _countPutFile
+            TST_LOG("FakeWOPIHost: Handling PutFile (#" << _countPutFile
                                                         << "): " << uriReq.getPath());
 
             return handleWopiUpload(request, message, socket);
@@ -472,7 +472,7 @@ protected:
                 Util::getIso8601FracformatTime(getFileLastModifiedTime());
             if (wopiTimestamp != fileModifiedTime)
             {
-                LOG_TST("FakeWOPIHost: Document conflict detected, Stored ModifiedTime: ["
+                TST_LOG("FakeWOPIHost: Document conflict detected, Stored ModifiedTime: ["
                         << fileModifiedTime << "], Upload ModifiedTime: [" << wopiTimestamp << ']');
                 http::Response httpResponse(http::StatusCode::Conflict);
                 httpResponse.setBody("{\"COOLStatusCode\":" +
@@ -484,7 +484,7 @@ protected:
         }
         else
         {
-            LOG_TST("FakeWOPIHost: Forced document upload");
+            TST_LOG("FakeWOPIHost: Forced document upload");
         }
 
         std::unique_ptr<http::Response> response = assertPutFileRequest(request);
@@ -492,7 +492,7 @@ protected:
                              http::StatusLine::StatusCodeClass::Successful)
         {
             const std::streamsize size = request.getContentLength();
-            LOG_TST("FakeWOPIHost: Writing document contents in storage (" << size << "bytes)");
+            TST_LOG("FakeWOPIHost: Writing document contents in storage (" << size << "bytes)");
             std::vector<char> buffer(size);
             message.read(buffer.data(), size);
             setFileContent(Util::toString(buffer));
@@ -501,7 +501,7 @@ protected:
         const Poco::URI uriReq(request.getURI());
         if (response)
         {
-            LOG_TST("FakeWOPIHost: Response to POST " << uriReq.getPath() << ": "
+            TST_LOG("FakeWOPIHost: Response to POST " << uriReq.getPath() << ": "
                                                       << response->statusLine().statusCode() << ' '
                                                       << response->statusLine().reasonPhrase());
             socket->sendAndShutdown(*response);
@@ -512,7 +512,7 @@ protected:
             std::string body = "{\"LastModifiedTime\": \"" +
                                Util::getIso8601FracformatTime(getFileLastModifiedTime()) +
                                "\" }";
-            LOG_TST("FakeWOPIHost: Response (default) to POST " << uriReq.getPath() << ": 200 OK "
+            TST_LOG("FakeWOPIHost: Response (default) to POST " << uriReq.getPath() << ": 200 OK "
                                                                 << body);
             http::Response httpResponse(http::StatusCode::OK);
             httpResponse.setBody(std::move(body), "application/json; charset=utf-8");
@@ -553,7 +553,7 @@ protected:
             if (UnitBase::get().isFinished())
                 oss << "\nIgnoring as test has finished";
 
-            LOG_TST(oss.str());
+            TST_LOG(oss.str());
 
             if (UnitBase::get().isFinished())
                 return false;
@@ -572,7 +572,7 @@ protected:
         else if (!uriReq.getPath().starts_with("/cool/")) // Skip requests to the websrv.
         {
             // Complain if we are expected to handle something that we don't.
-            LOG_TST("ERROR: FakeWOPIHost: Request, cannot handle request: " << uriReq.getPath());
+            TST_LOG("ERROR: FakeWOPIHost: Request, cannot handle request: " << uriReq.getPath());
         }
 
         return false;

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -189,7 +189,8 @@ inline void getDocumentPathAndURL(const std::string& docFilename, std::string& d
 inline
 void sendTextFrame(COOLWebSocket& socket, const std::string& string, const std::string& testname)
 {
-    TST_LOG("Sending " << string.size() << " bytes: " << COOLProtocol::getAbbreviatedMessage(string));
+    TST_LOG("Sending " << string.size()
+                       << " bytes: " << COOLProtocol::getAbbreviatedMessage(string));
     socket.sendFrame(string.data(), string.size());
 }
 
@@ -400,8 +401,9 @@ getResponseMessage(COOLWebSocket& ws, const std::string& prefix, const std::stri
                 {
                     if (COOLProtocol::matchPrefix(prefix, message))
                     {
-                        TST_LOG('[' << prefix <<  "] Matched " <<
-                                COOLWebSocket::getAbbreviatedFrameDump(response.data(), bytes, flags));
+                        TST_LOG('[' << prefix << "] Matched "
+                                    << COOLWebSocket::getAbbreviatedFrameDump(response.data(),
+                                                                              bytes, flags));
                         return response;
                     }
                 }
@@ -424,8 +426,9 @@ getResponseMessage(COOLWebSocket& ws, const std::string& prefix, const std::stri
                         throw std::runtime_error(message);
                     }
 
-                    TST_LOG('[' << prefix <<  "] Ignored " <<
-                            COOLWebSocket::getAbbreviatedFrameDump(response.data(), bytes, flags));
+                    TST_LOG('[' << prefix << "] Ignored "
+                                << COOLWebSocket::getAbbreviatedFrameDump(response.data(), bytes,
+                                                                          flags));
                 }
             }
         }
@@ -433,7 +436,7 @@ getResponseMessage(COOLWebSocket& ws, const std::string& prefix, const std::stri
     }
     catch (const Poco::Net::WebSocketException& exc)
     {
-        TST_LOG('[' << prefix <<  "] ERROR in helpers::getResponseMessage: " << exc.message());
+        TST_LOG('[' << prefix << "] ERROR in helpers::getResponseMessage: " << exc.message());
     }
 
     return std::vector<char>();
@@ -879,17 +882,18 @@ inline bool svgMatch(const std::string& testname, const std::vector<char>& respo
     const std::vector<char> expectedSVG = helpers::readDataFromFile(templateFile);
     if (expectedSVG != response)
     {
-        TST_LOG_BEGIN("Svg mismatch: response is\n");
+        std::ostringstream oss;
+        oss << "Svg mismatch: response is\n";
         if(response.empty())
-            TST_LOG_APPEND("<empty>");
+            oss << "<empty>";
         else
-            TST_LOG_APPEND(std::string(response.data(), response.size()));
-        TST_LOG_APPEND("\nvs. expected (from '" << templateFile << "' :\n");
-        TST_LOG_APPEND(std::string(expectedSVG.data(), expectedSVG.size()));
+            oss << std::string(response.data(), response.size());
+        oss << "\nvs. expected (from '" << templateFile << "' :\n";
+        oss << std::string(expectedSVG.data(), expectedSVG.size());
         std::string newName = templateFile;
         newName += ".new";
-        TST_LOG_APPEND("Updated template writing to: " << newName << '\n');
-        TST_LOG_END;
+        oss << "Updated template writing to: " << newName << '\n';
+        TST_LOG(oss.str());
 
         FILE *of = fopen(Poco::Path(TDOC, newName).toString().c_str(), "w");
         LOK_ASSERT(of != nullptr);

--- a/test/integration-http-server.cpp
+++ b/test/integration-http-server.cpp
@@ -175,7 +175,7 @@ void HTTPServerTest::testCoolPostPoco()
 
     std::string csp = response["Content-Security-Policy"];
     StringVector lines = StringVector::tokenize(csp, ';');
-    LOG_TST("CSP - " << csp << " tokens " << lines.size());
+    TST_LOG("CSP - " << csp << " tokens " << lines.size());
     for (size_t i = 0; i < lines.size(); ++i)
     {
         if(lines.startsWith(i, " connect-src") ||
@@ -190,7 +190,7 @@ void HTTPServerTest::testCoolPostPoco()
                     continue;
 
                 Poco::URI uri(split[j]);
-                LOG_TST("URL - " << split[j]);
+                TST_LOG("URL - " << split[j]);
                 LOK_ASSERT_EQUAL(std::string(""), uri.getUserInfo());
                 LOK_ASSERT(uri.getPath() == std::string("") ||
                            uri.getPath() == std::string("*"));

--- a/test/testlog.hpp
+++ b/test/testlog.hpp
@@ -32,70 +32,12 @@ inline std::chrono::milliseconds timeSinceTestStartMs()
 
 } // namespace helpers
 
-//FIXME: use LOG_ macros and unify with the existing logging system.
-// Oh dear std::cerr and/or its re-direction is not
-// necessarily thread safe on Linux
-// This is the canonical test log function.
-inline void writeTestLog(const char* const p)
-{
-    fputs(p, stderr);
-    fflush(stderr);
-}
-
-inline void writeTestLog(const std::string& s) { writeTestLog(s.c_str()); }
-
-#ifdef TST_LOG_REDIRECT
-void tstLog(const std::ostringstream& stream);
-#else
-inline void tstLog(const std::ostringstream& stream) { writeTestLog(stream.str()); }
-#endif
-
-#define TST_LOG_NAME_BEGIN(OSS, NAME, X, FLUSH)                                                    \
-    do                                                                                             \
-    {                                                                                              \
-        char b_[1024];                                                                             \
-        OSS << Log::prefix<sizeof(b_) - 1>(b_, "TST") << NAME << " [" << __func__ << "] (+"        \
-            << helpers::timeSinceTestStartMs() << "): " << std::boolalpha << X;                    \
-        if (FLUSH)                                                                                 \
-            tstLog(OSS);                                                                           \
-    } while (false)
-
-#define TST_LOG_BEGIN(X)                                                                           \
-    do                                                                                             \
-    {                                                                                              \
-        std::ostringstream oss;                                                                    \
-        TST_LOG_NAME_BEGIN(oss, testname, X, true);                                                \
-    } while (false)
-
-#define TST_LOG_APPEND(X)                                                                          \
-    do                                                                                             \
-    {                                                                                              \
-        std::ostringstream str;                                                                    \
-        str << X;                                                                                  \
-        tstLog(str);                                                                               \
-    } while (false)
-
-#define TST_LOG_END_X(OSS)                                                                         \
-    do                                                                                             \
-    {                                                                                              \
-        LOG_END(OSS) "\n";                                                                         \
-        tstLog(OSS);                                                                               \
-    } while (false)
-
-#define TST_LOG_END                                                                                \
-    do                                                                                             \
-    {                                                                                              \
-        std::ostringstream oss_log_end;                                                            \
-        TST_LOG_END_X(oss_log_end);                                                                \
-    } while (false)
-
 #if ENABLE_DEBUG
 #define TST_LOG_NAME(NAME, X)                                                                      \
     do                                                                                             \
     {                                                                                              \
-        std::ostringstream oss_log_name;                                                           \
-        TST_LOG_NAME_BEGIN(oss_log_name, NAME, X, false);                                          \
-        TST_LOG_END_X(oss_log_name);                                                               \
+        LOG_TST(NAME << " [" << __func__ << "] (+" << helpers::timeSinceTestStartMs()              \
+                     << "): " << std::boolalpha << X);                                             \
     } while (false)
 #else // Disable test logs in release.
 #define TST_LOG_NAME(NAME, X)                                                                      \
@@ -108,10 +50,7 @@ inline void tstLog(const std::ostringstream& stream) { writeTestLog(stream.str()
     } while (0)
 #endif // !ENABLE_DEBUG
 
-/// Used by the "old-style" tests. FIXME: Unify.
+/// Used to log the name of the test and the time since starting to run the tests.
 #define TST_LOG(X) TST_LOG_NAME(testname, X)
-
-/// Used by the "new-style" tests. FIXME: Unify.
-#define LOG_TST(X) TST_LOG(X)
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
- **wsd: test: unify test logging with default logging**
- **wsd: test: LOG_ANY must use the highest log-level**
- **wsd: test: rename LOG_ANY's serialized level to 'ANY'**
