### PR TITLE
wsd: test: retry external http requests

### DIFF
--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -36,6 +36,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iterator>
+#include <stdexcept>
 #include <string>
 #include <thread>
 
@@ -267,7 +268,13 @@ pocoGetRetry(const Poco::URI& uri, int retry = 3,
         try
         {
             LOG_INF("pocoGet #" << attempt << ": " << uri.toString());
-            return pocoGet(uri);
+            auto res = pocoGet(uri);
+            if (!res.first)
+            {
+                throw std::runtime_error("Server unavilable");
+            }
+
+            return res;
         }
         catch (const std::exception& ex)
         {


### PR DESCRIPTION
The external http requests can timeout
and fail. We should retry them to have
more reliable test executions.

Change-Id: I50683e25de443f45d23233cadba10c6b2e3db02d
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
