### PR TITLE
Browser Settings: Improve border color visibility for view selection

### DIFF
--- a/browser/admin/css/adminIntegratorSettings.css
+++ b/browser/admin/css/adminIntegratorSettings.css
@@ -598,7 +598,7 @@ ul {
 }
 
 .toggle-image.selected {
-	border-color: var(--co-border, #e5eff5);
+	border-color: var(--co-settings-text, #e5eff5);
 	background-color: rgba(0, 120, 212, 0.1);
 }
 


### PR DESCRIPTION
- The `--co-border` color was not clearly visible when switching between Notebookbar and Compact views
- It looked fine in light mode but was barely visible in dark mode
- Replaced it with `--co-settings-text` for better contrast
- Enhances appearance and consistency across both light and dark themes


Change-Id: I30856c7e88c0a058610eac13fb526bcf4aa390ec


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

