### PR TITLE
notifyirc: update to newer github action

### DIFF
--- a/.github/workflows/notifyirc.yml
+++ b/.github/workflows/notifyirc.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: irc push
-        uses: vmiklos/notify-irc@bfd6f632b683859f6cd074e2ee9db68bef204f7d
+        uses: vmiklos/notify-irc@fd4b1c5613390a6ba6bdd83e5af75b3dacd86ac8
         if: github.event_name == 'push' && github.event.ref == 'refs/heads/master' && github.repository == 'CollaboraOnline/online'
         with:
           channel: "#cool-dev"


### PR DESCRIPTION
Update to notify-irc.git commit fd4b1c5613390a6ba6bdd83e5af75b3dacd86ac8
(Handle missing username key, 2025-07-08), previously this workflow
failed in case the username key in the JSON was missing.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ie471c1f423ccd3e62d93dededae86baf18ae80bd
