### PR TITLE
fakesockettest: fix bad downcast

### DIFF
--- a/test/fakesockettest.cpp
+++ b/test/fakesockettest.cpp
@@ -291,6 +291,13 @@ int main(int, char**)
         return 0;
     }
 
+    // Initialize logging that LOK_ASSERT() uses.
+    std::string logLevel("fatal");
+    bool withColor = false;
+    bool logToFile = false;
+    std::map<std::string, std::string> logProperties;
+    Log::initialize("wsd", logLevel, withColor, logToFile, logProperties, false, {});
+
     CPPUNIT_NS::TestResult controller;
     CPPUNIT_NS::TestResultCollector result;
     controller.addListener(&result);


### PR DESCRIPTION
	FakeSocketTest::testBasic.../common/Log.cpp:661:16: runtime error: downcast of address 0x6070000004f0 which does not point to an object of type 'GenericLogger'
	0x6070000004f0: note: object is of type 'Poco::Logger'
	 00 00 00 00  28 db ac 9a 32 7f 00 00  70 db ac 9a 32 7f 00 00  01 00 00 00 be be be be  18 05 00 00
		      ^~~~~~~~~~~~~~~~~~~~~~~
		      vptr for 'Poco::Logger'
	    #0 0x55c44738f721 in Log::logger() /home/vmiklos/git/collaboraonline/online-san/test/../common/Log.cpp:661:16
	    #1 0x55c44738f2b2 in Log::log(Log::Level, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /home/vmiklos/git/collaboraonline/online-san/test/../common/Log.cpp:812:9
	    #2 0x55c4472b25d4 in FakeSocketTest::testBasic() /home/vmiklos/git/collaboraonline/online-san/test/fakesockettest.cpp:78:5

Fix the problem by initializing logging the same way as fuzzers do.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: If621e5cb6dbc363eafcf09dd25c4443b5dedebd0
