### PR TITLE
Admin: allow incoming websocket requests to use http

### DIFF
--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1044,7 +1044,7 @@ ClientRequestDispatcher::MessageResult ClientRequestDispatcher::handleMessage(Po
             // Admin connections
             LOG_INF("Admin request: " << request.getURI());
             const ServerURL cnxDetails(requestDetails);
-            if (AdminSocketHandler::handleInitialRequest(_socket, request, cnxDetails.getWebServerUrl()))
+            if (AdminSocketHandler::handleInitialRequest(_socket, request, cnxDetails.expectedRequestWebServerURL()))
             {
                 // Hand the socket over to the Admin poll.
                 disposition.setTransfer(Admin::instance(),

--- a/wsd/ServerURL.hpp
+++ b/wsd/ServerURL.hpp
@@ -91,6 +91,14 @@ public:
         return schemeProtocol + "://" + _schemeAuthority;
     }
 
+    std::string expectedRequestWebServerURL() const
+    {
+        // if we are using SSL termination, the incoming request will use http/ws
+        return
+        ((_ssl && !ConfigUtil::isSSLTermination()) ? "https://" : "http://")
+        + _schemeAuthority;
+    }
+
     std::string getSubURLForEndpoint(const std::string &path) const
     {
 #if MOBILEAPP


### PR DESCRIPTION
when ssl.termination is true


Change-Id: I16636a5705e4f7af775f2e676ff35bbd1e404132



### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay

