### PR TITLE
Accessibility: form control group support via fieldset and legend

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -860,6 +860,18 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	padding-inline-start: 8px;
 }
 
+/* fieldset and legend - form grouping */
+
+.jsdialog .ui-fieldset {
+	border: none;
+	padding-inline: 0;
+	padding-block: 0;
+}
+
+.jsdialog .ui-legend {
+	padding-inline: 0;
+}
+
 /* spinfield */
 
 .spinfieldcontainer {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -849,7 +849,6 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 
 .ui-dialog-content .jsdialog.ui-text {
 	padding-inline-start: 0;
-	margin: auto 5px;
 }
 
 .jsdialog.ui-grid-cell input[type='checkbox'] + label[for^='hidden-part-checkbox'] {
@@ -2480,4 +2479,10 @@ kbd,
 .sidebar-panel #layoutpanel_icons .ui-iconview-entry img,
 #FontworkGalleryDialog .ui-iconview-entry img {
 	padding: 5px 0;
+}
+
+/* Writer - Format - Page Style - Area - Image */
+#ImageTabPage #frame1 .ui-grid-cell {
+	display: grid;
+	grid-gap: 4px;
 }

--- a/browser/src/control/jsdialog/Widget.Frame.js
+++ b/browser/src/control/jsdialog/Widget.Frame.js
@@ -42,32 +42,91 @@ function _extractLabelText(data) {
 
 JSDialog.frame = function _frameHandler(parentContainer, data, builder) {
 	if (data.children.length > 1) {
-		var container = L.DomUtil.create('div', 'ui-frame-container ' + builder.options.cssClass, parentContainer);
-		container.id = data.id;
-
-		var frame = L.DomUtil.create('div', 'ui-frame ' + builder.options.cssClass, container);
-		frame.id = data.id + '-frame';
-		var label = L.DomUtil.create('label', 'ui-frame-label ' + builder.options.cssClass, frame);
-		label.innerText = builder._cleanText(_extractLabelText(data.children[0]));
-		label.id = data.children[0].id;
-		if (data.children[0].visible === false)
-			L.DomUtil.addClass(label, 'hidden');
-		builder.postProcess(frame, data.children[0]);
-
-		var frameChildren = L.DomUtil.create('div', 'ui-expander-content ' + builder.options.cssClass, container);
-		frameChildren.id = data.id + '-content';
-		label.htmlFor = frameChildren.id;
-		$(frameChildren).addClass('expanded');
-
-		var children = [];
-		for (var i = 1; i < data.children.length; i++) {
-			children.push(data.children[i]);
-		}
-
-		builder.build(frameChildren, children);
+		buildFrame(parentContainer, data, builder, isFormControlGroup(data));
 	} else {
 		return builder._controlHandlers['container'](parentContainer, data, builder);
 	}
 
 	return false;
 };
+
+function isFormControlGroup(data) {
+    if (!data.children || data.children.length < 2)
+        return false;
+
+    // First child must be a fixedtext (label) to eligible as a form control group
+    if (data.children[0].type !== 'fixedtext')
+        return false;
+
+	const formControlTypes = new Set([
+		'spinfield', 'edit', 'formattedfield', 'metricfield', 'combobox',
+		'radiobutton', 'checkbox', 'time'
+	]);
+    let formControlCount = 0;
+    const minRequiredControls = 2;
+
+    /**
+	 * Recursively counts form controls within a dialog structure tree.
+	 * This function handles the hierarchical nature of JSDialog JSON structures where
+	 * form controls can be nested within various container types.
+	 * Uses early termination to optimize performance once the minimum threshold is reached.
+	 */
+    function countFormControls(node) {
+        if (!node.children) return 0;
+
+        let count = 0;
+        for (const child of node.children) {
+            if (formControlTypes.has(child.type)) {
+                count++;
+            } else {
+				count += countFormControls(child);
+			}
+			if (count >= minRequiredControls) return count;
+        }
+        return count;
+    }
+
+    // Skip the first child (label) and count form controls in remaining children
+    for (let i = 1; i < data.children.length; i++) {
+        formControlCount += countFormControls(data.children[i]);
+
+		if (formControlCount >= minRequiredControls) return true;
+    }
+
+    return false;
+}
+
+function buildFrame(parentContainer, data, builder, isFormControlGroup) {
+    let container, frame, label;
+
+    if (isFormControlGroup) {
+        container = L.DomUtil.create('fieldset', 'ui-frame-container ui-fieldset ' + builder.options.cssClass, parentContainer);
+        container.id = data.id;
+
+        frame = container; // No inner frame for form control group
+
+        label = L.DomUtil.create('legend', 'ui-frame-label ui-legend ' + builder.options.cssClass, frame);
+    } else {
+        container = L.DomUtil.create('div', 'ui-frame-container ' + builder.options.cssClass, parentContainer);
+        container.id = data.id;
+
+        frame = L.DomUtil.create('div', 'ui-frame ' + builder.options.cssClass, container);
+        frame.id = data.id + '-frame';
+
+        label = L.DomUtil.create('label', 'ui-frame-label ' + builder.options.cssClass, frame);
+		label.htmlFor = data.id + '-content';
+    }
+	label.innerText = builder._cleanText(_extractLabelText(data.children[0]));
+	label.id = data.children[0].id;
+	if (data.children[0].visible === false)
+		L.DomUtil.addClass(label, 'hidden');
+	builder.postProcess(frame, data.children[0]);
+
+    const frameChildren = L.DomUtil.create('div', 'ui-expander-content ' + builder.options.cssClass, container);
+    frameChildren.id = data.id + '-content';
+    $(frameChildren).addClass('expanded');
+
+	// skipping the first child(label/legend)
+    const children = data.children.slice(1);
+    builder.build(frameChildren, children);
+}


### PR DESCRIPTION
* For  Writer -> Format -> Page Style -> Area -> Image dialog to work, we need the following gerrit patch: https://gerrit.libreoffice.org/c/core/+/187592 to work as expected.

* For rest, it should work as expected.

### Summary
Some labels like “Tiling Position:” (id="label9") are visually grouped with the two input fields X-Offset
and Y-Offset, but they are not programmatically associated with them. This causes screen readers to
miss the group context and violates WCAG’s requirement for conveying relationships in a
programmatic way.
here are few examples of before vs after:
![image](https://github.com/user-attachments/assets/d30e6110-e6c6-4099-bc96-02d44e48da4e)

This PR also adds missing grid space for dialog elements
Before:
![before-6](https://github.com/user-attachments/assets/7d1d3098-cf56-450a-a179-84b92dbdb752)

After:
![after-6](https://github.com/user-attachments/assets/d58a94fe-8050-4dde-b31e-9e6ae95eb44b)

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

