### PR TITLE
clean up formatting and indentation in Widget.Frame

### DIFF
--- a/browser/.beforeprettier
+++ b/browser/.beforeprettier
@@ -69,7 +69,6 @@
 /src/control/jsdialog/Widget.Combobox.js
 /src/control/jsdialog/Widget.DrawingArea.js
 /src/control/jsdialog/Widget.FormulabarEdit.js
-/src/control/jsdialog/Widget.Frame.js
 /src/control/jsdialog/Widget.IconView.js
 /src/control/jsdialog/Widget.LanguageSelector.js
 /src/control/jsdialog/Widget.MenuButton.js

--- a/browser/src/control/jsdialog/Widget.Frame.js
+++ b/browser/src/control/jsdialog/Widget.Frame.js
@@ -33,8 +33,7 @@ function _extractLabelText(data) {
 
 	for (var i = 0; i < data.children.length; i++) {
 		var label = _extractLabelText(data.children[i]);
-		if (label)
-			return label;
+		if (label) return label;
 	}
 
 	return '';
@@ -44,89 +43,120 @@ JSDialog.frame = function _frameHandler(parentContainer, data, builder) {
 	if (data.children.length > 1) {
 		buildFrame(parentContainer, data, builder, isFormControlGroup(data));
 	} else {
-		return builder._controlHandlers['container'](parentContainer, data, builder);
+		return builder._controlHandlers['container'](
+			parentContainer,
+			data,
+			builder,
+		);
 	}
 
 	return false;
 };
 
 function isFormControlGroup(data) {
-    if (!data.children || data.children.length < 2)
-        return false;
+	if (!data.children || data.children.length < 2) return false;
 
-    // First child must be a fixedtext (label) to eligible as a form control group
-    if (data.children[0].type !== 'fixedtext')
-        return false;
+	// First child must be a fixedtext (label) to eligible as a form control group
+	if (data.children[0].type !== 'fixedtext') return false;
 
 	const formControlTypes = new Set([
-		'spinfield', 'edit', 'formattedfield', 'metricfield', 'combobox',
-		'radiobutton', 'checkbox', 'time'
+		'spinfield',
+		'edit',
+		'formattedfield',
+		'metricfield',
+		'combobox',
+		'radiobutton',
+		'checkbox',
+		'time',
 	]);
-    let formControlCount = 0;
-    const minRequiredControls = 2;
+	let formControlCount = 0;
+	const minRequiredControls = 2;
 
-    /**
+	/**
 	 * Recursively counts form controls within a dialog structure tree.
 	 * This function handles the hierarchical nature of JSDialog JSON structures where
 	 * form controls can be nested within various container types.
 	 * Uses early termination to optimize performance once the minimum threshold is reached.
 	 */
-    function countFormControls(node) {
-        if (!node.children) return 0;
+	function countFormControls(node) {
+		if (!node.children) return 0;
 
-        let count = 0;
-        for (const child of node.children) {
-            if (formControlTypes.has(child.type)) {
-                count++;
-            } else {
+		let count = 0;
+		for (const child of node.children) {
+			if (formControlTypes.has(child.type)) {
+				count++;
+			} else {
 				count += countFormControls(child);
 			}
 			if (count >= minRequiredControls) return count;
-        }
-        return count;
-    }
+		}
+		return count;
+	}
 
-    // Skip the first child (label) and count form controls in remaining children
-    for (let i = 1; i < data.children.length; i++) {
-        formControlCount += countFormControls(data.children[i]);
+	// Skip the first child (label) and count form controls in remaining children
+	for (let i = 1; i < data.children.length; i++) {
+		formControlCount += countFormControls(data.children[i]);
 
 		if (formControlCount >= minRequiredControls) return true;
-    }
+	}
 
-    return false;
+	return false;
 }
 
 function buildFrame(parentContainer, data, builder, isFormControlGroup) {
-    let container, frame, label;
+	let container, frame, label;
 
-    if (isFormControlGroup) {
-        container = L.DomUtil.create('fieldset', 'ui-frame-container ui-fieldset ' + builder.options.cssClass, parentContainer);
-        container.id = data.id;
+	if (isFormControlGroup) {
+		container = L.DomUtil.create(
+			'fieldset',
+			'ui-frame-container ui-fieldset ' + builder.options.cssClass,
+			parentContainer,
+		);
+		container.id = data.id;
 
-        frame = container; // No inner frame for form control group
+		frame = container; // No inner frame for form control group
 
-        label = L.DomUtil.create('legend', 'ui-frame-label ui-legend ' + builder.options.cssClass, frame);
-    } else {
-        container = L.DomUtil.create('div', 'ui-frame-container ' + builder.options.cssClass, parentContainer);
-        container.id = data.id;
+		label = L.DomUtil.create(
+			'legend',
+			'ui-frame-label ui-legend ' + builder.options.cssClass,
+			frame,
+		);
+	} else {
+		container = L.DomUtil.create(
+			'div',
+			'ui-frame-container ' + builder.options.cssClass,
+			parentContainer,
+		);
+		container.id = data.id;
 
-        frame = L.DomUtil.create('div', 'ui-frame ' + builder.options.cssClass, container);
-        frame.id = data.id + '-frame';
+		frame = L.DomUtil.create(
+			'div',
+			'ui-frame ' + builder.options.cssClass,
+			container,
+		);
+		frame.id = data.id + '-frame';
 
-        label = L.DomUtil.create('label', 'ui-frame-label ' + builder.options.cssClass, frame);
+		label = L.DomUtil.create(
+			'label',
+			'ui-frame-label ' + builder.options.cssClass,
+			frame,
+		);
 		label.htmlFor = data.id + '-content';
-    }
+	}
 	label.innerText = builder._cleanText(_extractLabelText(data.children[0]));
 	label.id = data.children[0].id;
-	if (data.children[0].visible === false)
-		L.DomUtil.addClass(label, 'hidden');
+	if (data.children[0].visible === false) L.DomUtil.addClass(label, 'hidden');
 	builder.postProcess(frame, data.children[0]);
 
-    const frameChildren = L.DomUtil.create('div', 'ui-expander-content ' + builder.options.cssClass, container);
-    frameChildren.id = data.id + '-content';
-    $(frameChildren).addClass('expanded');
+	const frameChildren = L.DomUtil.create(
+		'div',
+		'ui-expander-content ' + builder.options.cssClass,
+		container,
+	);
+	frameChildren.id = data.id + '-content';
+	$(frameChildren).addClass('expanded');
 
 	// skipping the first child(label/legend)
-    const children = data.children.slice(1);
-    builder.build(frameChildren, children);
+	const children = data.children.slice(1);
+	builder.build(frameChildren, children);
 }


### PR DESCRIPTION
This PR only contains formatting changes.

Change-Id: I64f5812907f43cbb72e986e2c055db6ec717a0c0

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

