### PR TITLE
autogen: add a way to read options from an autogen.input file

### DIFF
--- a/autogen.py
+++ b/autogen.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+#
+# Copyright the Collabora Online contributors.
+#
+# SPDX-License-Identifier: MPL-2.0
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Reads options from autogen.input, one option at a time, so you don't have to run autogen.sh or
+# configure with parameters.
+
+import os
+import re
+import subprocess
+
+def main():
+    cmdline = ["./autogen.sh"]
+    with open("autogen.input") as stream:
+        for line in stream.readlines():
+            line = line.strip()
+            if line.startswith("#"):
+                continue
+            line = os.path.expandvars(line)
+            # If an environment variable doesn't expand to a result, expand it to an empty string,
+            # like the shell does.
+            line = re.sub(r"\$[A-Za-z_][A-Za-z0-9_]*", "", line)
+            cmdline.append(line)
+    cmdline.append("--enable-option-checking=fatal")
+    print("Running '{}'".format("' '".join(cmdline)))
+    subprocess.run(cmdline, check=True)
+
+if __name__ == "__main__":
+    main()
+
+# vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
core.git autogen.sh is actually a Perl script, and then that can read
options from autogen.input, in a similar style. This has the benefit
that you can track your options as a config file, e.g. comment out lines
while you experiment, etc.

Here provide something similar, but keep autogen.sh as a shell script
and rather provide an autogen.py wrapper around it, so those who like
autogen.input can enjoy it.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I5f65c0f375da2c70ac97acb139ef372d5e1f20c2
