### PR TITLE
Calc: Rename Layout Tab to Page Layout

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -39,7 +39,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'id': 'Layout-tab-label',
-				'text': _('Layout'),
+				'text': _('Page Layout'),
 				'name': 'Layout',
 				'accessibility': { focusBack: true,	combination: 'P', de: null }
 			},


### PR DESCRIPTION
It seems users hunt for the keyword "page" when searching for layout
related actions and having only "Layout" seems to induce the
spreadsheet user in thinking it's related to formatting/styling stuff.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: If5ee16574beedd3b5f0fe2d0f835a3d948bbe8a0
