### PR TITLE
docker, from source: update core branch to 25.04

### DIFF
--- a/docker/from-source/build.sh
+++ b/docker/from-source/build.sh
@@ -23,7 +23,7 @@ fi;
 echo "Using Docker Hub Repository: '$DOCKER_HUB_REPO' with tag '$DOCKER_HUB_TAG'."
 
 if [ -z "$CORE_BRANCH" ]; then
-  CORE_BRANCH="distro/collabora/co-24.04"
+  CORE_BRANCH="distro/collabora/co-25.04"
 fi;
 echo "Building core branch '$CORE_BRANCH'"
 
@@ -108,7 +108,7 @@ fi
 ##### LOKit (core) #####
 
 # build
-if [ "$CORE_BRANCH" == "distro/collabora/co-24.04" ]; then
+if [ "$CORE_BRANCH" == "distro/collabora/co-25.04" ]; then
   ( cd core && ./autogen.sh --with-distro=CPLinux-LOKit --disable-epm --without-package-format --disable-symbols ) || exit 1
 else
   ( cd core && ./autogen.sh --with-distro=LibreOfficeOnline ) || exit 1


### PR DESCRIPTION
This was forgotten in commit 7c90a1e0db6f09eddb4135162ab5c346366bf197
(docker: use COOL 25.04 repos, 2025-06-19), it seems.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Iac44ab45ed0bc27f290c806ce4f1510e6f486556
