### PR TITLE
helm: feat: Allow configurable coolwsd.xml and coolkitconfig.xcu

### DIFF
--- a/kubernetes/helm/collabora-online/templates/configmap.yaml
+++ b/kubernetes/helm/collabora-online/templates/configmap.yaml
@@ -22,3 +22,11 @@ data:
   aliasgroup{{ add $k 1 }}: {{ $alias }}
   {{- end }}
   {{- end }}
+  {{- if .Values.collabora.coolkitconfig_xcu_content }}
+  coolkitconfig.xcu: |
+    {{ .Values.collabora.coolkitconfig_xcu_content | nindent 4 }}
+  {{- end }}
+  {{- if .Values.collabora.coolwsd_xml_content }}
+  coolwsd.xml: |
+    {{ .Values.collabora.coolwsd_xml_content | nindent 4 }}
+  {{- end }}

--- a/kubernetes/helm/collabora-online/templates/deployment.yaml
+++ b/kubernetes/helm/collabora-online/templates/deployment.yaml
@@ -132,6 +132,16 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.collabora.coolkitconfig_xcu_content }}
+            - name: coolwsd-config
+              mountPath: /etc/coolwsd/coolkitconfig.xcu
+              subPath: coolkitconfig.xcu
+            {{- end }}
+            {{- if .Values.collabora.coolwsd_xml_content }}
+            - name: coolwsd-config
+              mountPath: /etc/coolwsd/coolwsd.xml
+              subPath: coolwsd.xml
+            {{- end }}
             {{- if .Values.collabora.proofKeysSecretRef }}
             - name: wopi-proof
               mountPath: /etc/coolwsd/proof_key
@@ -163,6 +173,20 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if or .Values.collabora.coolkitconfig_xcu_content .Values.collabora.coolwsd_xml_content }}
+        - name: coolwsd-config
+          configMap:
+            name: {{ include "collabora-online.fullname" . }}
+            items:
+              {{- if .Values.collabora.coolkitconfig_xcu_content }}
+              - key: coolkitconfig.xcu
+                path: coolkitconfig.xcu
+              {{- end }}
+              {{- if .Values.collabora.coolwsd_xml_content }}
+              - key: coolwsd.xml
+                path: coolwsd.xml
+              {{- end }}
+        {{- end }}
         {{- if .Values.collabora.proofKeysSecretRef }}
         - name: wopi-proof
           secret:

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -52,6 +52,12 @@ collabora:
   # finally set proofKeysSecretRef to the name of the secret
   proofKeysSecretRef: ""
 
+  # Provide custom coolwsd configuration files here.
+  # Note: Content provided will override the default files (coolkitconfig.xcu, coolwsd.xml)
+  # in the container. Ensure you provide the complete file content, not just partial changes.
+  coolkitconfig_xcu_content: ""
+  coolwsd_xml_content: ""
+
 prometheus:
   servicemonitor:
     enabled: false


### PR DESCRIPTION
- Introduces the ability to provide custom content for `coolwsd.xml` and `coolkitconfig.xcu` via Helm values. These files will be mounted into `/etc/coolwsd/` in the Collabora Online pod, overriding any defaults.

Change-Id: I3c0dc43a1e651eeeb81910f90bfd93e0ea88b9e3

* Target version: master
