### PR TITLE
T60130 tab lacks padding

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -382,7 +382,7 @@ body {
 	flex-direction: column;
 }
 #toolbar-wrapper:not(.mobile) {
-	padding: 3px 0;
+	padding: 3px 5px;
 }
 /* Remove bottom padding in calc as it affects formulabar*/
 #toolbar-wrapper.spreadsheet:not(.mobile) {


### PR DESCRIPTION
Change-Id: Ie08297d87345fe1b292aca1e2599e51cbf72d958


* Resolves: T60130 tab lacks padding
* Target version: master 

### Summary

adds topbar non-mobile far left and right padding

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [hmm] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

