### PR TITLE
null deref of UploadRequest

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -2756,7 +2756,12 @@ void DocumentBroker::uploadToStorageInternal(const std::shared_ptr<ClientSession
     StorageBase::AsyncUploadCallback asyncUploadCallback =
         [this](const StorageBase::AsyncUpload& asyncUp)
     {
-        assert(_uploadRequest && "Expected to have a valid UploadRequest instance");
+        // asyncUploadCallback called twice, 2nd time with onHandshakeFail/callOnConnectFail
+        if (!_uploadRequest)
+        {
+            LOG_WRN("Expected to have a valid UploadRequest instance");
+            return;
+        }
 
         switch (asyncUp.state())
         {


### PR DESCRIPTION
```
 #7  0x000000000072aabb in DocumentBroker::UploadRequest::setComplete (this=0x0) at wsd/DocumentBroker.hpp:1300
 #8  operator() (__closure=0x2655cd50, asyncUp=...) at wsd/DocumentBroker.cpp:2769
 #9  0x00000000007e2c06 in std::function<void (StorageBase::AsyncRequest<StorageBase::UploadResult> const&)>::operator()(StorageBase::AsyncRequest<StorageBase::UploadResult> const&) const (__args#0=..., this=0x2655cd50)
     at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:591
 #10 operator() (__closure=0x2655cd50) at wsd/wopi/WopiStorage.cpp:886
 #11 0x000000000066e9dc in std::function<void (std::shared_ptr<http::Session> const&)>::operator()(std::shared_ptr<http::Session> const&) const (__args#0=std::shared_ptr<http::Session> (use count 2, weak count 1) = {...}, this=0x293fa878)
     at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/std_function.h:591
 #12 http::Session::callOnConnectFail (this=this@entry=0x293fa780) at ./net/HttpRequest.hpp:1696
 #13 0x000000000085f924 in http::Session::onHandshakeFail (this=0x293fa780) at net/HttpRequest.hpp:1721
 #14 0x00000000008843ce in StreamSocket::handshakeFail (this=0x28a12b10) at net/Socket.hpp:1860
 #15 SslStreamSocket::handleSslError (this=this@entry=0x28a12b10, rc=rc@entry=0, last_errno=@0x729e39dd65c4: 0, context=context@entry=0xd56791 "read") at ./net/SslSocket.hpp:504
 #16 0x0000000000885452 in SslStreamSocket::handleSslState (this=0x28a12b10, rc=0, context=0xd56791 "read") at ./net/SslSocket.hpp:324
 #17 0x0000000000886841 in StreamSocket::readIncomingData (this=0x28a12b10) at net/Socket.hpp:1452
 #18 0x0000000000885b65 in StreamSocket::handlePoll (this=0x28a12b10, disposition=..., now=std::chrono::_V2::steady_clock time_point = { 2819892471969967ns }, events=1) at net/Socket.hpp:1677
 #19 0x000000000087aaed in SocketPoll::poll (this=0x29da8a10, timeoutMaxMicroS=<optimized out>, justPoll=justPoll@entry=false) at /opt/rh/devtoolset-12/root/usr/include/c++/12/bits/stl_vector.h:1123
 #20 0x000000000072441a in SocketPoll::poll (justPoll=false, timeoutMax=..., this=<optimized out>) at ./net/Socket.hpp:891
 #21 DocumentBroker::pollThread (this=0x2945d010) at wsd/DocumentBroker.cpp:380
 #22 0x000000000074f46b in DocumentBroker::DocumentBrokerPoll::pollingThread (this=<optimized out>) at wsd/DocumentBroker.cpp:172
```
_uploadRequest.reset is only called in one place, if _uploadRequest->isComplete() is true, and this callback is the only thing that calls setComplete, so presumably this callback was called twice, and _uploadRequest was reset before the second callback.


Change-Id: Ic48a0f9bffd2d05c8b6332022ae2defa32f6b3fd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

