### PR TITLE
allow implied port numbers to equal explicit ones

### DIFF
--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -691,5 +691,37 @@ bool parseUri(std::string uri, std::string& scheme, std::string& host, std::stri
     return !host.empty();
 }
 
+bool sameOrigin(const std::string& expectedOrigin, const std::string& actualOrigin)
+{
+    // common case, and allow empty string to be equivalent
+    if (expectedOrigin == actualOrigin)
+        return true;
+
+    std::string expectedScheme, expectedHostname, expectedPortString;
+    if (!net::parseUri(expectedOrigin, expectedScheme, expectedHostname, expectedPortString))
+    {
+        LOG_ERR("Invalid expected origin URI [" << expectedOrigin << "] to sameOrigin");
+        return false;
+    }
+
+    std::string actualScheme, actualHostname, actualPortString;
+    if (!net::parseUri(actualOrigin, actualScheme, actualHostname, actualPortString))
+    {
+        LOG_ERR("Invalid actual origin URI [" << actualOrigin << "] to sameOrigin");
+        return false;
+    }
+
+    if (expectedScheme != actualScheme || expectedHostname != actualHostname)
+        return false;
+
+    if (expectedPortString.empty())
+        expectedPortString = getDefaultPortForScheme(expectedScheme);
+
+    if (actualPortString.empty())
+        actualPortString = getDefaultPortForScheme(actualScheme);
+
+    return expectedPortString == actualPortString;
+}
+
 } // namespace net
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -123,6 +123,20 @@ inline bool parseUri(std::string uri, std::string& scheme, std::string& host, st
     return parseUri(std::move(uri), scheme, host, port, pathAndQuery);
 }
 
+inline std::string getDefaultPortForScheme(const std::string& scheme)
+{
+    if (scheme == "https://" || scheme == "wss://")
+        return "443";
+    if (scheme == "http://" || scheme == "ws://")
+        return "80";
+    return std::string();
+}
+
+// Returns true if both URIs are equivalent for an origin check. Implicit
+// default port numbers are considered equivalent if explicitly included in the
+// compared against peer.
+bool sameOrigin(const std::string& expectedOrigin, const std::string& actualOrigin);
+
 /// Return the locator given a URI.
 inline std::string parseUrl(const std::string& uri)
 {

--- a/net/WebSocketHandler.hpp
+++ b/net/WebSocketHandler.hpp
@@ -1034,7 +1034,7 @@ protected:
          * 403 Forbidden status code.
          */
         const std::string origin = req.get("Origin", "");
-        if (!allowedOrigin && origin != expectedOrigin)
+        if (!allowedOrigin && !net::sameOrigin(expectedOrigin, origin))
         {
             LOG_ERR("Rejecting WebSocket upgrade with: origin [" << origin << "] expected ["
                                                                  << expectedOrigin << "] instead");

--- a/test/NetUtilWhiteBoxTests.cpp
+++ b/test/NetUtilWhiteBoxTests.cpp
@@ -27,12 +27,14 @@ class NetUtilWhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testParseUri);
     CPPUNIT_TEST(testParseUriUrl);
     CPPUNIT_TEST(testParseUrl);
+    CPPUNIT_TEST(testSameOrigin);
     CPPUNIT_TEST_SUITE_END();
 
     void testBufferClass();
     void testParseUri();
     void testParseUriUrl();
     void testParseUrl();
+    void testSameOrigin();
 };
 
 void NetUtilWhiteBoxTests::testBufferClass()
@@ -271,6 +273,22 @@ void NetUtilWhiteBoxTests::testParseUrl()
 
     LOK_ASSERT_EQUAL(std::string("/some/path"),
                      net::parseUrl("https://sub.domain.com:80/some/path"));
+}
+
+void NetUtilWhiteBoxTests::testSameOrigin()
+{
+    constexpr std::string_view testname = __func__;
+
+    LOK_ASSERT(net::sameOrigin("", ""));
+    LOK_ASSERT(!net::sameOrigin("http://sub.domain.com", ""));
+    LOK_ASSERT(net::sameOrigin("http://sub.domain.com", "http://sub.domain.com"));
+    LOK_ASSERT(net::sameOrigin("https://sub.domain.com", "https://sub.domain.com"));
+    LOK_ASSERT(!net::sameOrigin("http://sub.domain.com", "https://sub.domain.com"));
+    LOK_ASSERT(net::sameOrigin("https://sub.domain.com", "https://sub.domain.com:443"));
+    LOK_ASSERT(net::sameOrigin("http://sub.domain.com", "http://sub.domain.com:80"));
+    LOK_ASSERT(!net::sameOrigin("https://sub.domain.com", "https://sub.domain.com:80"));
+    LOK_ASSERT(!net::sameOrigin("http://sub.domain.com", "http://sub.domain.com:443"));
+    LOK_ASSERT(!net::sameOrigin("http://sub.domain.com:88", "http://sub.domain.com:80"));
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(NetUtilWhiteBoxTests);

--- a/tools/WebSocketDump.cpp
+++ b/tools/WebSocketDump.cpp
@@ -41,7 +41,7 @@ class DumpSocketHandler : public WebSocketHandler
 public:
     DumpSocketHandler(const std::weak_ptr<StreamSocket>& socket,
                       const Poco::Net::HTTPRequest& request)
-        : WebSocketHandler(socket.lock(), request)
+        : WebSocketHandler(socket.lock(), request, true)
     {
     }
 

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -432,8 +432,8 @@ std::atomic<uint64_t> AdminSocketHandler::NextSessionId(1);
 AdminSocketHandler::AdminSocketHandler(Admin* adminManager,
                                        const std::weak_ptr<StreamSocket>& socket,
                                        const Poco::Net::HTTPRequest& request,
-                                       const std::string& expectedOrigin)
-    : WebSocketHandler(socket.lock(), request, expectedOrigin)
+                                       bool allowedOrigin)
+    : WebSocketHandler(socket.lock(), request, allowedOrigin)
     , _admin(adminManager)
     , _isAuthenticated(false)
 {
@@ -479,7 +479,7 @@ void AdminSocketHandler::subscribeAsync(const std::shared_ptr<AdminSocketHandler
 bool AdminSocketHandler::handleInitialRequest(
     const std::weak_ptr<StreamSocket> &socketWeak,
     const Poco::Net::HTTPRequest& request,
-    const std::string& expectedOrigin)
+    bool allowedOrigin)
 {
     if (!COOLWSD::AdminEnabled)
     {
@@ -501,7 +501,7 @@ bool AdminSocketHandler::handleInitialRequest(
     {
         Admin &admin = Admin::instance();
         auto handler = std::make_shared<AdminSocketHandler>(&admin, socketWeak,
-                                                            request, expectedOrigin);
+                                                            request, allowedOrigin);
         socket->setHandler(handler);
 
         AdminSocketHandler::subscribeAsync(handler);

--- a/wsd/Admin.hpp
+++ b/wsd/Admin.hpp
@@ -29,13 +29,13 @@ public:
     AdminSocketHandler(Admin* adminManager,
                        const std::weak_ptr<StreamSocket>& socket,
                        const Poco::Net::HTTPRequest& request,
-                       const std::string& expectedOrigin);
+                       bool allowedOrigin);
 
     /// Handle the initial Admin WS upgrade request.
     /// @returns true if we should give this socket to the Admin poll.
     static bool handleInitialRequest(const std::weak_ptr<StreamSocket> &socket,
                                      const Poco::Net::HTTPRequest& request,
-                                     const std::string& expectedOrigin);
+                                     bool allowedOrigin);
 
     static void subscribeAsync(const std::shared_ptr<AdminSocketHandler>& handler);
 

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -891,6 +891,7 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
 namespace
 {
 
+#if !MOBILEAPP
 bool allowedOriginByHost(const std::string& host, const std::string& actualOrigin)
 {
     // always allow https host to match origin
@@ -914,7 +915,6 @@ bool allowedOrigin(const Poco::Net::HTTPRequest& request, const RequestDetails& 
         return true;
     }
 
-#if !MOBILEAPP
     if (COOLWSD::IndirectionServerEnabled && COOLWSD::GeolocationSetup)
     {
         if (HostUtil::allowedWSOrigin(actualOrigin))
@@ -923,7 +923,6 @@ bool allowedOrigin(const Poco::Net::HTTPRequest& request, const RequestDetails& 
             return true;
         }
     }
-#endif
 
     const std::string host = request.get("Host");
     if (allowedOriginByHost(host, actualOrigin))
@@ -942,6 +941,12 @@ bool allowedOrigin(const Poco::Net::HTTPRequest& request, const RequestDetails& 
 
     return false;
 }
+#else
+bool allowedOrigin(const Poco::Net::HTTPRequest& /*request*/, const RequestDetails& /*requestDetails*/)
+{
+    return true;
+}
+#endif
 }
 
 #if !MOBILEAPP

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -888,6 +888,62 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
 #endif // MOBILEAPP
 }
 
+namespace
+{
+
+bool allowedOriginByHost(const std::string& host, const std::string& actualOrigin)
+{
+    // always allow https host to match origin
+    if (net::sameOrigin("https://" + host, actualOrigin))
+        return true;
+    // allow http too if not ssl enabled
+    if (!ConfigUtil::isSslEnabled() && net::sameOrigin("http://" + host, actualOrigin))
+        return true;
+    return false;
+}
+
+bool allowedOrigin(const Poco::Net::HTTPRequest& request, const RequestDetails& requestDetails)
+{
+    const std::string actualOrigin = request.get("Origin");
+
+    const ServerURL cnxDetails(requestDetails);
+
+    if (net::sameOrigin(cnxDetails.getWebServerUrl(), actualOrigin))
+    {
+        LOG_TRC("Allowed Origin: " << actualOrigin << " to match " << cnxDetails.getWebServerUrl());
+        return true;
+    }
+
+#if !MOBILEAPP
+    if (COOLWSD::IndirectionServerEnabled && COOLWSD::GeolocationSetup)
+    {
+        if (HostUtil::allowedWSOrigin(actualOrigin))
+        {
+            LOG_TRC("Allowed Origin: " << actualOrigin << " to match AllowedWSOriginList");
+            return true;
+        }
+    }
+#endif
+
+    const std::string host = request.get("Host");
+    if (allowedOriginByHost(host, actualOrigin))
+    {
+        LOG_DBG("Allowed Origin: " << actualOrigin << " to match against host: " << host);
+        return true;
+    }
+    if (host != COOLWSD::ServerName && !COOLWSD::ServerName.empty() &&
+        allowedOriginByHost(COOLWSD::ServerName, actualOrigin))
+    {
+        LOG_DBG("Allowed Origin: " << actualOrigin << " to match ServerName: " << COOLWSD::ServerName);
+        return true;
+    }
+
+    LOG_ERR("Rejecting origin [" << actualOrigin << "] expected [" << cnxDetails.getWebServerUrl() << "] instead");
+
+    return false;
+}
+}
+
 #if !MOBILEAPP
 void ClientRequestDispatcher::handleFullMessage(Poco::Net::HTTPRequest& request,
                                                 std::istream& message,
@@ -1043,8 +1099,7 @@ ClientRequestDispatcher::MessageResult ClientRequestDispatcher::handleMessage(Po
         {
             // Admin connections
             LOG_INF("Admin request: " << request.getURI());
-            const ServerURL cnxDetails(requestDetails);
-            if (AdminSocketHandler::handleInitialRequest(_socket, request, cnxDetails.getWebServerUrl()))
+            if (AdminSocketHandler::handleInitialRequest(_socket, request, allowedOrigin(request, requestDetails)))
             {
                 // Hand the socket over to the Admin poll.
                 disposition.setTransfer(Admin::instance(),
@@ -2441,17 +2496,7 @@ bool ClientRequestDispatcher::handleClientWsUpgrade(const Poco::Net::HTTPRequest
                                   << socket->getFD());
 
     // First Upgrade.
-    const ServerURL cnxDetails(requestDetails);
-    bool allowedOrigin = false;
-#if !MOBILEAPP
-    if (COOLWSD::IndirectionServerEnabled && COOLWSD::GeolocationSetup)
-    {
-        const std::string actualOrigin = request.get("Origin");
-        allowedOrigin = HostUtil::allowedWSOrigin(actualOrigin);
-    }
-#endif
-
-    auto ws = std::make_shared<WebSocketHandler>(socket, request, cnxDetails.getWebServerUrl(), allowedOrigin);
+    auto ws = std::make_shared<WebSocketHandler>(socket, request, allowedOrigin(request, requestDetails));
 
     // Response to clients beyond this point is done via WebSocket.
     try

--- a/wsd/Process.hpp
+++ b/wsd/Process.hpp
@@ -200,7 +200,7 @@ public:
                  const std::string& configId,
                  const std::shared_ptr<StreamSocket>& socket, const T& request)
         : WSProcess("ChildProcess", pid, socket,
-                    std::make_shared<WebSocketHandler>(socket, request))
+                    std::make_shared<WebSocketHandler>(socket, request, true))
         , _jailId(jailId)
         , _configId(configId)
         , _urpFromKitFD(socket->getIncomingFD(SharedFDType::URPFromKit))
@@ -287,7 +287,7 @@ class ForKitProcWSHandler final : public WebSocketHandler
 public:
     template <typename T>
     ForKitProcWSHandler(const std::weak_ptr<StreamSocket>& socket, const T& request)
-        : WebSocketHandler(socket.lock(), request)
+        : WebSocketHandler(socket.lock(), request, true)
     {
     }
 


### PR DESCRIPTION
https: //github.com/CollaboraOnline/online/issues/12095

Change-Id: Ia517d9ed52e57bfa45c6a22d906c5ae99e947c26


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

