### PR TITLE
there is no hasPendingUpdate method anymore

### DIFF
--- a/browser/src/canvas/sections/TilesSection.ts
+++ b/browser/src/canvas/sections/TilesSection.ts
@@ -700,7 +700,7 @@ export class TilesSection extends CanvasSectionObject {
 				canvas.fillStyle = 'rgba(255, 0, 0, 0.8)';   // red
 			else if (tile.needsFetch())
 				canvas.fillStyle = 'rgba(255, 255, 0, 0.8)'; // yellow
-			else if (tile.hasPendingUpdate())
+			else if (!tile.isReady())
 				canvas.fillStyle = 'rgba(0, 160, 0, 0.8)'; // dark green
 			else // present
 				canvas.fillStyle = 'rgba(0, 255, 0, 0.5)';   // green


### PR DESCRIPTION
use !tile.isReady which looks like what it was replaced with.

Which makes the debugging overlay appear to work again


Change-Id: I6d8b27ee4ccbc4cb8cbd728a8135e962444a3ca1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

