### PR TITLE
accessibility: adjusted width for jsdialog in format area ensuring labels are near to their input field

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -244,7 +244,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 .jsdialog.ui-scrollwindow:not(.formulabar) {
 	overflow: auto;
 	max-height: 500px;
-	max-width: 700px;
+	max-width: 650px;
 }
 /* - Also used in SpellingDialog where suggestion come in form
      of an image*/
@@ -2579,6 +2579,11 @@ kbd,
 
 #CharacterPropertiesDialog :is(#font, #fonteffects, #position, #asianlayout) img.jsdialog.ui-drawing-area {
 	width: 650px;
+}
+
+#CharacterPropertiesDialog #position #box7,
+#CharacterPropertiesDialog #FontColor #grid3 {
+	align-items: center;
 }
 
 /* Writer - Format - Paragraph - Text Flow */

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2551,3 +2551,26 @@ kbd,
 #ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry span {
 	font-size: 0; /* Hide placeholder text to prevent layout shifts in color palette iconview widgets due to lazy loading */
 }
+
+/* Writer - Format - Character */
+/* Writer - Format - Paragraph */
+/* Writer - Format - Page Style */
+
+#ParagraphPropertiesDialog #ParaIndentSpacing #maingrid,
+#ParagraphPropertiesDialog #labelTP_NUMPARA #NumParaPage,
+#ParagraphPropertiesDialog #labelTP_DROPCAPS #maingrid52,
+#ParagraphPropertiesDialog #transparence #box1,
+#CharacterPropertiesDialog #fonteffects #FontColor,
+#CharacterPropertiesDialog #fonteffects #TextDecoration,
+#CharacterPropertiesDialog #fonteffects #Effects,
+#TemplateDialog8 #Footnote #FootnoteAreaPage {
+	width: fit-content;
+}
+
+#TemplateDialog8 #Footnote #FootnoteAreaPage .menubutton {
+	margin: 0;
+}
+
+#CharacterPropertiesDialog :is(#font, #fonteffects, #position, #asianlayout) img.jsdialog.ui-drawing-area {
+	width: 650px;
+}

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -930,6 +930,10 @@ img.context-menu-icon {
 	padding-inline-start: 8px;
 }
 
+.jsdialog.ui-frame-label {
+	font-weight: bold;
+}
+
 /* fieldset and legend - form grouping */
 
 .jsdialog .ui-fieldset {
@@ -940,6 +944,7 @@ img.context-menu-icon {
 
 .jsdialog .ui-legend {
 	padding-inline: 0;
+	font-weight: bold;
 }
 
 /* spinfield */
@@ -1475,7 +1480,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 /* Word count dialog */
 
-#label9, #documentlabel-mobile {
+#WordCountDialog #label10,
+#WordCountDialog #documentlabel-mobile {
 	color: #636363 !important;
 }
 

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2574,3 +2574,24 @@ kbd,
 #CharacterPropertiesDialog :is(#font, #fonteffects, #position, #asianlayout) img.jsdialog.ui-drawing-area {
 	width: 650px;
 }
+
+/* Writer - Format - Paragraph - Text Flow */
+/* Writer - Format - Paragraph - Tabs */
+#ParagraphPropertiesDialog #textflow #checkAcrossPage.checkbutton,
+#ParagraphPropertiesDialog #labelTP_TABULATOR #ParagraphTabsPage {
+	grid-column-gap: 0;
+}
+
+/* Writer - Format - Paragraph - Tabs */
+/* Writer - Format - Paragraph - Area - Color */
+#ParagraphPropertiesDialog #labelTP_TABULATOR #entryED_TABTYPE_DECCHAR-input,
+#ParagraphPropertiesDialog #labelTP_TABULATOR #entryED_FILLCHAR_OTHER-input,
+#ColorPage.jsdialog #rgbpreset input,
+#ColorPage.jsdialog #rgbcustom input {
+	max-width: 100px;
+}
+
+/* Writer - Format - Paragraph - Area - Color */
+#ColorPage.jsdialog #rgbpreset {
+	width: max-content;
+}


### PR DESCRIPTION
Change-Id: I9d7b8fab62a97a816e117b8002ff8cfe4300cc41

### Summary
The placement of visible labels that are not in close proximity to their corresponding input fields can
impact the usability and accessibility for users, especially those with cognitive impairments or visual
impairments. It's important to group labels and input fields together to facilitate the identification and
understanding of the function of each input field.

It turns out that after: https://github.com/CollaboraOnline/online/pull/12314, we can just remove the `width: 100%` to put labels closer to their input fields and for `Area` tab, we don't need really need it.

here are screenshots for reference:
<img width="1982" height="820" alt="image (9)" src="https://github.com/user-attachments/assets/ead50aee-9e7e-4536-862f-33d856c552d0" />
<img width="1982" height="821" alt="image (8)" src="https://github.com/user-attachments/assets/ade72435-1c8f-4484-bab3-87eaabc9bbf0" />
<img width="1974" height="821" alt="image (7)" src="https://github.com/user-attachments/assets/3842cc05-6503-4176-b6d1-74de586453af" />
<img width="1977" height="823" alt="image (6)" src="https://github.com/user-attachments/assets/98851de5-079f-4e20-b050-f24031c36d96" />
<img width="1977" height="820" alt="image (5)" src="https://github.com/user-attachments/assets/7d7b713e-7e0f-47cc-83ee-41f5c2a8f98f" />
<img width="1984" height="844" alt="image (4)" src="https://github.com/user-attachments/assets/5fe332e3-d77e-46e0-9ae0-bdef9d377087" />
<img width="2047" height="890" alt="image (3)" src="https://github.com/user-attachments/assets/60755921-c2e6-4d22-a73a-b60005a4b65f" />

It will be same for `Area` tab.
<img width="2058" height="818" alt="image (10)" src="https://github.com/user-attachments/assets/689f660c-6ead-4f6f-8055-69ce15d42fbd" />


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

