### PR TITLE
Add context menu icons to elements

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -30,6 +30,7 @@
 
 	--tooltip-font-size: 0.875rem;
 	--default-font-size: 0.75rem;
+	--medium-font-size: 0.875rem;
 	--header-font-size: 1rem;
 	/* tab min font-size */
 	--tb-min-fs: 0.6875rem;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -757,10 +757,14 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	-webkit-box-shadow: 0 0 3px var(--color-box-shadow);
 	box-shadow: 0 0 3px var(--color-box-shadow);
 }
+
 .context-menu-item {
 	color: var(--color-main-text);
 	background-color: transparent;
+	padding-left: 1em;
+	font-size: var(--medium-font-size) !important;
 }
+
 .context-menu-separator {
 	border-bottom: 1px solid var(--color-border-lighter);
 }
@@ -769,6 +773,45 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	color: var(--color-text-lighter);
 	background-color: var(--color-background-lighter);
 }
+
+.context-menu-item.context-menu-submenu::before {
+	content: '';
+}
+
+.context-menu-item.context-menu-submenu::before,
+.context-menu-icon-spacer,
+.context-menu-icon {
+	width: 1rem;
+	height: 1rem;
+	margin-right: 8px;
+	vertical-align: middle;
+	display: inline-block;
+}
+
+/* 
+* Hide the spacer icon if the entire context menu list does not contain any <img>.
+* This prevents unnecessary visual gaps when no icons are present.
+*/
+.context-menu-list:not(:has(img)) .context-menu-icon-spacer {
+	display: none;
+}
+
+/* 
+ * Applies consistent spacing across all items in a mixed submenu.
+ * 1. The entire context menu list has no <img> at all (icon-less menu)
+ * 2. The submenu contains a checkmark but has no <img>
+ * 3. The submenu contains a radio but has no <img>
+ * 4. The submenu contains a checkmark and also contains <img>
+ * 5. The submenu contains a radio and also contains <img>
+ */
+.context-menu-list:not(:has(img)) .context-menu-item,
+.context-menu-submenu:has(.context-menu-icon-lo-checkmark):not(:has(img)) .context-menu-item,
+.context-menu-submenu:has(.context-menu-icon-radio):not(:has(img)) .context-menu-item,
+.context-menu-submenu:has(.context-menu-icon-lo-checkmark):has(img) .context-menu-item,
+.context-menu-submenu:has(.context-menu-icon-radio):has(img) .context-menu-item {
+	padding-left: 2em;
+}
+
 /* input text */
 
 .ui-dialog .jsdialog.ui-edit:focus-visible {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1599,6 +1599,9 @@ tr.useritem > td > img {
 	text-decoration: none;
 	color: var(--color-main-text);
 	width: 100%;
+	display: flex;
+	align-items: center;
+	white-space: nowrap;
 }
 .menu-entry-icon {
 	width: 32px;

--- a/browser/src/app/LOUtil.ts
+++ b/browser/src/app/LOUtil.ts
@@ -27,6 +27,8 @@ interface IconNameMap {
 	[key: string]: string;
 }
 
+declare var DOMPurify: any;
+
 // LOUtil contains various LO related utility functions used
 // throughout the code.
 
@@ -686,6 +688,13 @@ class LOUtil {
 
 	public static Rectangle = cool.Rectangle;
 	public static createRectangle = cool.createRectangle;
+
+	public static sanitize(html: string): string {
+		if (DOMPurify.isSupported) {
+			return DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
+		}
+		return '';
+	}
 }
 
 app.LOUtil = LOUtil;

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -19,7 +19,7 @@ declare var DOMPurify : any;
 // By default DOMPurify will strip all targets, so set everything
 // as target=_blank with rel=noopener
 DOMPurify.addHook('afterSanitizeAttributes', function (node: HTMLElement) {
-	if (node.tagName === 'A') {
+	if (node.tagName === 'A' && !node.classList.contains('context-menu-link')) {
 		node.setAttribute('target', '_blank');
 		node.setAttribute('rel', 'noopener');
 	}
@@ -459,27 +459,20 @@ export class Comment extends CanvasSectionObject {
 		this.handleKeyDownForPopup(ev, 'mentionPopup');
 	}
 
-	private sanitize (html: string): string {
-		if (DOMPurify.isSupported) {
-			return DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
-		}
-		return '';
-	}
-
 	private updateContent (): void {
 		if(this.sectionProperties.data.html)
-			this.sectionProperties.contentText.innerHTML = this.sanitize(this.sectionProperties.data.html);
+			this.sectionProperties.contentText.innerHTML = app.LOUtil.sanitize(this.sectionProperties.data.html);
 		else
 			this.sectionProperties.contentText.innerText = this.sectionProperties.data.text ? this.sectionProperties.data.text: '';
 		// Get the escaped HTML out and find for possible, useful links
 		var linkedText = Autolinker.link(this.sectionProperties.contentText.outerHTML);
-		this.sectionProperties.contentText.innerHTML = this.sanitize(linkedText);
+		this.sectionProperties.contentText.innerHTML = app.LOUtil.sanitize(linkedText);
 		// Original unlinked text
 		this.sectionProperties.contentText.origText = this.sectionProperties.data.text ? this.sectionProperties.data.text: '';
 		this.sectionProperties.contentText.origHTML = this.sectionProperties.data.html ? this.sectionProperties.data.html: '';
 		this.sectionProperties.nodeModifyText.innerText = this.sectionProperties.data.text ? this.sectionProperties.data.text: '';
 		if (this.sectionProperties.data.html) {
-			this.sectionProperties.nodeModifyText.innerHTML = this.sanitize(this.sectionProperties.data.html);
+			this.sectionProperties.nodeModifyText.innerHTML = app.LOUtil.sanitize(this.sectionProperties.data.html);
 		}
 		this.sectionProperties.contentAuthor.innerText = this.sectionProperties.data.author;
 
@@ -1044,7 +1037,7 @@ export class Comment extends CanvasSectionObject {
 		// It is mandatory to change these values before handleSaveCommentButton is called
 		// calling handleSaveCommentButton in onCancelClick causes problem because that is also called from many other events/function (i.e: onPartChange)
 		if (this.sectionProperties.contentText.origHTML) {
-			this.sectionProperties.nodeModifyText.innerHTML = this.sanitize(this.sectionProperties.contentText.origHTML);
+			this.sectionProperties.nodeModifyText.innerHTML = app.LOUtil.sanitize(this.sectionProperties.contentText.origHTML);
 		}
 		else {
 			this.sectionProperties.nodeModifyText.innerText = this.sectionProperties.contentText.origText;
@@ -1066,7 +1059,7 @@ export class Comment extends CanvasSectionObject {
 		if (e)
 			L.DomEvent.stopPropagation(e);
 		if (this.sectionProperties.contentText.origHTML) {
-			this.sectionProperties.nodeModifyText.innerHTML = this.sanitize(this.sectionProperties.contentText.origHTML);
+			this.sectionProperties.nodeModifyText.innerHTML = app.LOUtil.sanitize(this.sectionProperties.contentText.origHTML);
 		}
 		else {
 			this.sectionProperties.nodeModifyText.innerText = this.sectionProperties.contentText.origText;

--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -103,7 +103,22 @@ L.Control.ContextMenu = L.Control.extend({
 			// spreadsheet
 			'FormatCellDialog', 'DataDataPilotRun',
 			'GroupSparklines', 'UngroupSparklines', 'AutoFill'
-		]
+		],
+
+		commandsWithIcons: [
+			'Cut', 'Copy', 'Paste', 'Delete', 'CompressGraphic', 'Crop', 'FormatPaintbrush', 'ResetAttributes',
+			'NextTrackedChange', 'PreviousTrackedChange', 'PageDialog', 'MergeCells', 'DeleteCell', 'InsertCell',
+			'InsertRowsBefore', 'InsertRowsAfter', 'InsertColumnsBefore', 'InsertColumnsAfter', 'InsertColumnsMenu',
+			'DeleteRows', 'DeleteColumns', 'DeleteTable', 'SetOptimalColumnWidth', 'TableDialog', 'GraphicDialog',
+			'InsertAnnotation', 'SpellingAndGrammarDialog', 'DecrementLevel', 'TransformDialog', 'FormatLine',
+			'FormatArea', 'SetAnchorToPara', 'SetAnchorAtChar', 'SetAnchorToChar', 'WrapOff', 'WrapOn', 'WrapIdeal',
+			'WrapLeft', 'WrapRight', 'WrapThrough', 'WrapThroughTransparencyToggle', 'WrapAnchorOnly', 'WrapContour',
+			'BringToFront', 'ObjectForwardOne', 'ObjectBackOne', 'SendToBack', 'SetObjectToForeground',
+			'SetObjectToBackground', 'InsertCaptionDialog', 'OpenHyperlinkOnCursor', 'EditHyperlink',
+			'CopyHyperlinkLocation', 'RemoveHyperlink', 'RotateRight', 'RotateLeft', 'SetAnchorToCell',
+			'SetAnchorToCellResize', 'SetAnchorToPage', 'FormatCellDialog', 'InsertSparkline', 'AcceptTrackedChange',
+			'RejectTrackedChange', 'ReinstateTrackedChange', 'SetDefault', 'AnimationEffects'
+		],
 	},
 
 
@@ -251,6 +266,17 @@ L.Control.ContextMenu = L.Control.extend({
 		}
 	},
 
+	_getContextMenuIcon: function(command, commandName) {
+		if (!this.options.commandsWithIcons.includes(commandName)) {
+			return '<span class="context-menu-icon-spacer"></span>';
+		}
+
+		const iconName = app.LOUtil.getIconNameOfCommand(command);
+		const iconUrl = app.LOUtil.getImageURL(iconName);
+
+		return '<img class="context-menu-icon" src="' + iconUrl + '" alt/>';
+	},
+
 	_createContextMenuStructure: function(obj) {
 		var docType = this._map.getDocType();
 		var contextMenu = {};
@@ -333,14 +359,16 @@ L.Control.ContextMenu = L.Control.extend({
 					// Get the translated text associated with the command
 					itemName = _UNO(item.command, docType, true);
 				}
-
 				var toSnakeCase = function (text) {
 					return text.replace(/[ _]/gi, '-').replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
 				};
 
+				var iconHtml = this._getContextMenuIcon(item.command, commandName);
+				var contextMenuItem = '<a href="#" class="context-menu-link ' + toSnakeCase(commandName) + '">' + iconHtml + _(itemName) + '</a>';
+				
 				contextMenu[item.command] = {
 					// Using 'click' and <a href='#' is vital for copy/paste security context.
-					name: (window.mode.isMobile() ? _(itemName) : '<a href="#" class="context-menu-link ' + toSnakeCase(commandName) + '">' + _(itemName) + '</a'),
+					name: (window.mode.isMobile() ? _(itemName) : app.LOUtil.sanitize(contextMenuItem)),
 					isHtmlName: true,
 				};
 


### PR DESCRIPTION
Change-Id: If5c294c85bc4194344e8b9809e36367eddbda92b


* Resolves: #12205 
* Target version: master 

### Summary
- Added icons to context menu items to improve usability and make actions easier to identify at a glance, reducing the need to read each label.

### PREVIEWS

1. <img width="278" height="287" alt="image" src="https://github.com/user-attachments/assets/b96f755e-6ca4-4e79-8587-cc26e9a606f4" />
2. <img width="304" height="422" alt="image" src="https://github.com/user-attachments/assets/fdf25752-ed79-49ca-9ab1-cfdda2839ba8" />
3. <img width="452" height="385" alt="image" src="https://github.com/user-attachments/assets/1ee475b7-6e25-4e02-8752-3d85967f16b7" />
4. <img width="499" height="404" alt="image" src="https://github.com/user-attachments/assets/ea92ce04-2fe5-43eb-ae16-af5174477163" />
5. <img width="627" height="517" alt="image" src="https://github.com/user-attachments/assets/f3081711-0681-409e-823a-72e2454e6eab" />
6. <img width="622" height="347" alt="image" src="https://github.com/user-attachments/assets/0a09835b-1a33-41cb-9671-972ac3b5cac0" />
7. <img width="359" height="433" alt="image" src="https://github.com/user-attachments/assets/cdbeac67-02fa-4a4d-9294-efe2fbda5ed2" />
8. <img width="382" height="229" alt="image" src="https://github.com/user-attachments/assets/d6537870-3811-4574-b912-3ce539972f8e" />
9. <img width="373" height="427" alt="image" src="https://github.com/user-attachments/assets/73dcf173-a749-4f51-94db-2737b8e138f7" />
10. 


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

