### PR TITLE
browser: accessibility: remove aria-label from spinbutton input element

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -331,7 +331,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		spinfield.dir = document.documentElement.dir;
 		spinfield.tabIndex = '0';
 		spinfield.setAttribute('autocomplete', 'off');
-		builder._addAriaLabel(spinfield, data, builder);
+
+		if (!data.labelledBy) {
+			builder._addAriaLabel(spinfield, data, builder);
+		}
 
 		controls['spinfield'] = spinfield;
 


### PR DESCRIPTION
"The input field (posoffx-input) has a visible label (“X-Offset:”) linked using a <label for="...">
element. However, the aria-label="0%" on the input overrides the label association. As a result,
assistive technologies do not announce the visible “X-Offset:” label but instead use the aria-label value,
which is not descriptive."

Change-Id: I1430fa7bab875e46cf03b3c9f83fe88e1db48ca2
Signed-off-by: Henry Castro <hcastro@collabora.com>
