### PR TITLE
pdf: handle handle links like other documents

### DIFF
--- a/browser/src/canvas/sections/URLPopUpSection.ts
+++ b/browser/src/canvas/sections/URLPopUpSection.ts
@@ -24,7 +24,7 @@ class URLPopUpSection extends HTMLObjectSection {
 	static horizontalPadding = 6;
 	static popupVerticalMargin = 20;
 
-	constructor(url: string, documentPosition: cool.SimplePoint, linkPosition?: cool.SimplePoint) {
+	constructor(url: string, documentPosition: cool.SimplePoint, linkPosition?: cool.SimplePoint, linkIsClientSide?: boolean) {
         super(URLPopUpSection.sectionName, null, null, documentPosition, URLPopUpSection.cssClass);
 
 		const objectDiv = this.getHTMLObject();
@@ -34,7 +34,7 @@ class URLPopUpSection extends HTMLObjectSection {
 		this.sectionProperties.url = url;
 
 		this.createUIElements(url);
-		this.setUpCallbacks(linkPosition);
+		this.setUpCallbacks(linkPosition, linkIsClientSide);
 
 		document.getElementById('hyperlink-pop-up').title = url;
 
@@ -56,7 +56,7 @@ class URLPopUpSection extends HTMLObjectSection {
 		return this.getHTMLObject().getBoundingClientRect();
 	}
 
-	createUIElements(url: string) {
+	createUIElements(url: string, linkIsClientSide?: boolean) {
 		const parent = this.getHTMLObject();
 		L.DomUtil.createWithId('div', this.containerId, parent);
 
@@ -110,7 +110,7 @@ class URLPopUpSection extends HTMLObjectSection {
 		parent.appendChild(this.arrowDiv);
 	}
 
-	setUpCallbacks(linkPosition?: cool.SimplePoint) {
+	setUpCallbacks(linkPosition?: cool.SimplePoint, linkIsClientSide?: boolean) {
 		document.getElementById(this.linkId).onclick = () => {
 			if (!this.sectionProperties.url.startsWith('#'))
 				app.map.fire('warn', {url: this.sectionProperties.url, map: app.map, cmd: 'openlink'});
@@ -133,19 +133,25 @@ class URLPopUpSection extends HTMLObjectSection {
 		}
 
 		document.getElementById(this.copyButtonId).onclick = () => {
+			if (linkIsClientSide) {
+				app.map._clip.setTextSelectionText(this.sectionProperties.url);
+				app.map._clip._execCopyCutPaste('copy');
+			}
 			// If _navigatorClipboardWrite is available, use it.
-			if (L.Browser.clipboardApiAvailable || window.ThisIsTheiOSApp)
+			else if (L.Browser.clipboardApiAvailable || window.ThisIsTheiOSApp)
 				app.map._clip.filterExecCopyPaste('.uno:CopyHyperlinkLocation', params);
 			else // Or use previous method.
 				app.map.sendUnoCommand('.uno:CopyHyperlinkLocation', params);
 		};
 
 		document.getElementById(this.editButtonId).onclick = () => {
-			app.map.sendUnoCommand('.uno:EditHyperlink', params);
+			if (!linkIsClientSide) // For now link in client side works only on readonly mode
+				app.map.sendUnoCommand('.uno:EditHyperlink', params);
 		};
 
 		document.getElementById(this.removeButtonId).onclick = () => {
-			app.map.sendUnoCommand('.uno:RemoveHyperlink', params);
+			if (!linkIsClientSide) // For now link in client side works only on readonly mode
+				app.map.sendUnoCommand('.uno:RemoveHyperlink', params);
 			URLPopUpSection.closeURLPopUp();
 		};
 	}
@@ -191,11 +197,11 @@ class URLPopUpSection extends HTMLObjectSection {
 		section.containerObject.requestReDraw();
 	}
 
-	public static showURLPopUP(url: string, documentPosition: cool.SimplePoint, linkPosition?: cool.SimplePoint) {
+	public static showURLPopUP(url: string, documentPosition: cool.SimplePoint, linkPosition?: cool.SimplePoint, linkIsClientSide?: boolean) {
 		if (URLPopUpSection.isOpen())
 			URLPopUpSection.closeURLPopUp();
 
-		const section = new URLPopUpSection(url, documentPosition, linkPosition);
+		const section = new URLPopUpSection(url, documentPosition, linkPosition, linkIsClientSide);
 		app.sectionContainer.addSection(section);
 		this.resetPosition(section);
     }

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2748,6 +2748,14 @@ L.CanvasTileLayer = L.Layer.extend({
 				' x=' + x + ' y=' + y + ' count=' + count +
 				' buttons=' + buttons + ' modifier=' + modifier);
 
+		if (type === 'buttonup' && this._map['stateChangeHandler'].getItemValue('PageLinks')) {
+			app.definitions.urlPopUpSection.closeURLPopUp();
+			for (const link of this._map['stateChangeHandler'].getItemValue('PageLinks')) {
+				if (link.rectangle.containsPoint([x, y])) {
+					app.definitions.urlPopUpSection.showURLPopUP(link.uri, new app.definitions.simplePoint(x, y + this.getFiledBasedViewVerticalOffset()), undefined, /*linkIsClientSide:*/true);
+				}
+			}
+		}
 
 		if (type === 'buttondown')
 			this._clearSearchResults();

--- a/browser/src/map/handler/Map.StateChanges.js
+++ b/browser/src/map/handler/Map.StateChanges.js
@@ -3,7 +3,7 @@
  * L.Map.StateChanges stores the state changes commands coming from core
  * LOK_CALLBACK_STATE_CHANGED callback
  */
-/* global $ app */
+/* global $ app cool */
 /*eslint no-extend-native:0*/
 L.Map.mergeOptions({
 	stateChangeHandler: true
@@ -68,6 +68,26 @@ L.Map.StateChangeHandler = L.Handler.extend({
 			if (startPresentationParam === '' || startPresentationParam === 'true' || startPresentationParam === '1') {
 				app.dispatcher.dispatch('presentation');
 			}
+		}
+
+		if (commandName == '.uno:PageLinks') {
+			let links = [];
+			for (const link of state.links) {
+				const end1 = link.rectangle.indexOf('x');
+				const end2 = link.rectangle.indexOf('@');
+				const end3 = link.rectangle.indexOf(',');
+				const new_link = {
+					rectangle: new cool.SimpleRectangle(
+						parseFloat(link.rectangle.substring(end2 + 2, end3)),
+						parseFloat(link.rectangle.substring(end3 + 1)),
+						parseFloat(link.rectangle.substring(0, end1)),
+						parseFloat(link.rectangle.substring(end1 + 1, end2))
+					),
+					uri: link.uri
+				};
+				links.push(new_link);
+			}
+			this._items[commandName] = links;
 		}
 
 		$('#document-container').removeClass('slide-master-mode');


### PR DESCRIPTION
Use the link info (list of rectangles and urls) received from core to
show user a link pop-up in PDF like in other documents.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: Ic348d7e2d5a559deafbad5ab5c845c036d8d79e8
