### PR TITLE
ui: Clicking on the page status show the goto page dialog

### DIFF
--- a/browser/src/control/jsdialog/Widget.HTMLContent.ts
+++ b/browser/src/control/jsdialog/Widget.HTMLContent.ts
@@ -77,12 +77,14 @@ function getStatusbarItemElements(
 }
 
 function getPageNumberElements(text: string, builder: any) {
-	return getStatusbarItemElements(
+	const element = getStatusbarItemElements(
 		'StatePageNumber',
 		_('Number of Pages'),
 		text,
 		builder,
 	);
+	element.onclick = () => app.map.sendUnoCommand('.uno:GotoPage');
+	return element;
 }
 
 function getWordCountElements(text: string, builder: any) {
@@ -140,21 +142,25 @@ function getStateTableCellElements(text: string, builder: any) {
 }
 
 function getSlideStatusElements(text: string, builder: any) {
-	return getStatusbarItemElements(
+	const element = getStatusbarItemElements(
 		'SlideStatus',
 		_('Number of Slides'),
 		text,
 		builder,
 	);
+	element.onclick = () => app.map.sendUnoCommand('.uno:GotoPage');
+	return element;
 }
 
 function getPageStatusElements(text: string, builder: any) {
-	return getStatusbarItemElements(
+	const element = getStatusbarItemElements(
 		'PageStatus',
 		_('Number of Pages'),
 		text,
 		builder,
 	);
+	element.onclick = () => app.map.sendUnoCommand('.uno:GotoPage');
+	return element;
 }
 
 function getDocumentStatusElements(text: string, builder: any) {


### PR DESCRIPTION
This is consistent with desktop.
Works in Writer, Draw, Impress.


Change-Id: I158b6db95099efa4431037c2079662dbf663109d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] The dialog is not async in Impress or Draw, I have a LOKit patch for that. (Writer was fixed last week) See https://gerrit.libreoffice.org/c/core/+/187972

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

