### PR TITLE
Impress: Notebookbar updates to "Design", "Slideshow" and "Format"

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -105,9 +105,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'accessibility': { focusBack: false, combination: 'N', de: null }
 			},
 			{
-				'id': 'Layout-tab-label',
-				'text': _('Layout'),
-				'name': 'Layout',
+				'id': 'Design-tab-label',
+				'text': _('Design'),
+				'name': 'Design',
 				'accessibility': { focusBack: false, combination: 'P', de: null }
 			},
 			{
@@ -176,7 +176,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			this.getFileTab(),
 			this.getHomeTab(),
 			this.getInsertTab(),
-			this.getLayoutTab(),
+			this.getDesignTab(),
 			this.getSlideshowTab(),
 			this.getReviewTab(),
 			this.getFormatTab(),
@@ -462,13 +462,27 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 					'accessibility': { focusBack: true, combination: 'PW', de: null }
 				} : {},
 			!window.ThisIsAMobileApp && window.canvasSlideshowEnabled ?
-			        {
+			  {
 					'id': 'slide-presentation-in-console',
 					'type': 'bigcustomtoolitem',
 					'text': _('Presenter Console'),
 					'command': 'presenterconsole',
 					'accessibility': { focusBack: true, combination: 'PW', de: null }
-				}: {}
+				}: {},
+			{ type: 'separator', id: 'slide-zoomin-break', orientation: 'vertical' },
+			{
+				'id': 'showslide',
+				'type': 'bigcustomtoolitem',
+				'text': _UNO('.uno:ShowSlide', 'presentation'),
+				'accessibility': { focusBack: true, combination: 'SS', de: null }
+			},
+			{
+				'id': 'hideslide',
+				'class': 'unohideslide',
+				'type': 'bigcustomtoolitem',
+				'text': _UNO('.uno:HideSlide', 'presentation'),
+				'accessibility': { focusBack: true, combination: 'HS', de: null }
+			},
 		];
 
 		return this.getTabPage('Slideshow', content);
@@ -1263,14 +1277,6 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				],
 				'vertical': 'true'
 			},
-			{ type: 'separator', id: 'format-objecttitledescription-break', orientation: 'vertical' },
-			{
-				'id': 'format-theme-dialog',
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:ThemeDialog'),
-				'command': '.uno:ThemeDialog',
-				'accessibility': { focusBack: false, combination: 'J', de: null }
-			}
 		];
 
 		return this.getTabPage('Format', content);
@@ -1611,10 +1617,18 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 		return this.getTabPage('Insert', content);
 	},
 
-	getLayoutTab: function() {
+	getDesignTab: function() {
 		var content = [
 			{
-				'id': 'slide-size:SlideSizeMenu',
+				'id': 'design-theme-dialog',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:ThemeDialog'),
+				'command': '.uno:ThemeDialog',
+				'accessibility': { focusBack: false, combination: 'J', de: null }
+			},
+			{ type: 'separator', id: 'design-themedialog-break', orientation: 'vertical' },
+			{
+				'id': 'design-slide-size:SlideSizeMenu',
 				'class': 'unoSlideSize',
 				'type': 'menubutton',
 				'text': _('Slide Size'),
@@ -1622,74 +1636,31 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'accessibility': { focusBack: true, combination: 'SS', de: null }
 			},
 			{
-				'id': 'layout-slide-setup',
+				'id': 'design-slide-setup',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:SlideSetup', 'presentation'),
 				'command': '.uno:PageSetup',
 				'accessibility': { focusBack: true, combination: 'SP', de: null }
 			},
 			{
-				'id': 'layout-header-and-footer',
+				'id': 'design-header-and-footer',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:HeaderAndFooter', 'presentation'),
 				'command': '.uno:HeaderAndFooter',
 				'accessibility': { focusBack: true, combination: 'HF', de: null }
 			},
-			{ type: 'separator', id: 'layout-headerandfooter-break', orientation: 'vertical' },
+			{ type: 'separator', id: 'design-headerandfooter-break', orientation: 'vertical' },
 			{
-				'id': 'layout-insert-slide',
+				'id': 'design-selectbackground',
+				'class': 'unoselectbackground',
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:InsertSlide', 'presentation'),
-				'command': '.uno:InsertPage',
-				'accessibility': { focusBack: true, combination: 'IP', de: null }
+				'text': _('Background Image'),
+				'command': '.uno:SelectBackground',
+				'accessibility': { focusBack: true, combination: 'SB', de: null }
 			},
+			{ type: 'separator', id: 'design-backgroundimage-break', orientation: 'vertical' },
 			{
-				'id': 'showslide',
-				'type': 'bigcustomtoolitem',
-				'text': _UNO('.uno:ShowSlide', 'presentation'),
-				'accessibility': { focusBack: true, combination: 'SS', de: null }
-			},
-			{
-				'id': 'hideslide',
-				'class': 'unohideslide',
-				'type': 'bigcustomtoolitem',
-				'text': _UNO('.uno:HideSlide', 'presentation'),
-				'accessibility': { focusBack: true, combination: 'HS', de: null }
-			},
-			{
-				'type': 'container',
-				'children': [
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'id': 'layout-duplicate-slide',
-								'type': 'toolitem',
-								'text': _UNO('.uno:DuplicateSlide', 'presentation'),
-								'command': '.uno:DuplicatePage',
-								'accessibility': { focusBack: true, combination: 'DP', de: null }
-							}
-						]
-					},
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'id': 'layout-selectbackground',
-								'class': 'unoselectbackground',
-								'type': 'toolitem',
-								'text': _UNO('.uno:SelectBackground', 'presentation'),
-								'command': '.uno:SelectBackground',
-								'accessibility': { focusBack: true, combination: 'SB', de: null }
-							}
-						]
-					}
-				],
-				'vertical': 'true'
-			},
-			{ type: 'separator', id: 'layout-selectbackground-break', orientation: 'vertical' },
-			{
-				'id': 'layout-master-slides-panel',
+				'id': 'design-master-slides-panel',
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:MasterSlidesPanel', 'presentation'),
 				'command': '.uno:MasterSlidesPanel',
@@ -1697,7 +1668,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			}
 		];
 
-		return this.getTabPage('Layout', content);
+		return this.getTabPage('Design', content);
 	},
 
 	getMasterTab: function() {


### PR DESCRIPTION
Change-Id: I30bfce079af7cea9d50f4aaaaba99efabf1d5036


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Renamed "Layout" tab to "Design"
- Moved "Theme" button from Format to first position in Design tab
- Removed: Insert Slide, Duplicate Slide, Hide/Show Slide from Design tab
- Moved Hide/Show Slide to  SlideShow tab
- Renamde "Set Background Image" button to "Background Image"

### PREVIEWS
 **Design Tab (Renamed from "Layout", Added "Theme", Removed "Insert Slide, Duplicate Slide, Hide/Show")**
<img width="964" height="126" alt="image" src="https://github.com/user-attachments/assets/5d0d40d4-2e18-45ee-9370-4ec3868e970a" />


**Slide Show (Added "Hide Slide and Show Slide")**
<img width="964" height="126" alt="image" src="https://github.com/user-attachments/assets/fcbdd497-e64e-4d18-9284-8c2a726aa1f0" />

<img width="964" height="126" alt="image" src="https://github.com/user-attachments/assets/dc1276a2-48e7-4e83-bda6-1abe6376ca20" />


**Format ("Removed Theme")**
<img width="964" height="126" alt="image" src="https://github.com/user-attachments/assets/d1b23f69-17d7-4c47-b408-9fa92a0b5295" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

