### PR TITLE
Fix black flash on startup of calc (and possibly others)

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -661,6 +661,7 @@ class CanvasSectionContainer {
 
 		this.drawSections();
 		this.flushLayoutingTasks();
+		this.canvas.style.visibility = 'unset';
 	}
 
 	public requestReDraw() {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -652,6 +652,7 @@ L.CanvasTileLayer = L.Layer.extend({
 		}
 
 		this._canvas = L.DomUtil.createWithId('canvas', 'document-canvas', this._canvasContainer);
+		this._canvas.style.visibility = 'hidden';
 		app.sectionContainer = new CanvasSectionContainer(this._canvas, this.isCalc() /* disableDrawing? */);
 		this._container.style.position = 'absolute';
 		this._cursorDataDiv = L.DomUtil.create('div', 'cell-cursor-data', this._canvasContainer);


### PR DESCRIPTION
We immediately show the canvas, but a default canvas is black and looks bad. We shouldn't show the canvas until it's sized correctly and populated with content.

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required