### PR TITLE
fix inserting of origin in selection html

### DIFF
--- a/dev-notes/dependency-issues.md
+++ b/dev-notes/dependency-issues.md
@@ -1,0 +1,10 @@
+## Poco issues
+
+Known poco issues are:
+
++ In Poco < 1.13.2 there is a known issue that Poco::BasicMemoryStreamBuf
+  doesn't implement seekpos, so calling using the single argument variant of
+  seekg on a MemoryStream fails, this can be worked around by using the double
+  argument variant of seekg which uses Poco::BasicMemoryStreamBuf seekoff
+  which is implemented.
+  See: https://github.com/pocoproject/poco/issues/4492

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2047,13 +2047,17 @@ void ClientSession::writeQueuedMessages(std::size_t capacity)
 }
 
 // Insert our meta origin if we can
+// Note: If @in is Poco::MemoryStream there is a bug in versions < 1.13.3 that
+// Poco::BasicMemoryStreamBuf doesn't implement seekpos, so use of the single
+// argument seekg fails, this can be worked around by using the double argument
+// seekg variant which uses seekoff which was implemented
 bool ClientSession::postProcessCopyPayload(std::istream& in, std::ostream& out)
 {
     // back to start
     std::string line;
     std::getline(in, line);
     in.clear();
-    in.seekg(0);
+    in.seekg(0, std::ios::beg);
 
     constexpr std::string_view textPlain = "text/plain";
 
@@ -2068,12 +2072,12 @@ bool ClientSession::postProcessCopyPayload(std::istream& in, std::ostream& out)
 
     // back to start
     in.clear();
-    in.seekg(0);
+    in.seekg(0, std::ios::beg);
 
     bool json = in.get() == '{';
 
     in.clear();
-    in.seekg(0);
+    in.seekg(0, std::ios::beg);
 
     // copy as far as body
     bool match = Util::copyToMatch(in, out, "<body");


### PR DESCRIPTION
This is a problem since:
https://github.com/CollaboraOnline/online/pull/11485

But only manifests when built against poco < 1.13.3 https://github.com/pocoproject/poco/issues/4492

Because Poco::BasicMemoryStreamBuf::seekpos wasn't implemented before that version.  This can be worked around with the two argument variant of seekp which uses Poco::BasicMemoryStreamBuf::seekoff which was implemented.


Change-Id: Ifdcf03b5613db93c9aaf6b430f9d26e61b4ff0a5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

