### PR TITLE
Remove fit-content rule from document-title.

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -44,7 +44,6 @@
 	justify-content: center;
 	gap: 5px;
 	flex-direction: column;
-	width: fit-content;
 	flex: 1 1 auto;
 }
 

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -4,13 +4,19 @@
 }
 
 #document-name-input-loading-bar {
-	width: 100%;
+	width: 90%;
 	height: 2px;
 	background-color: var(--color-background-dark);
 	overflow: hidden;
 	position: relative;
 	display: none;
-	margin-block-end: -7px;
+	margin: auto;
+}
+
+.loading-bar-container {
+	text-align: center;
+	width: 95%;
+	display: block;
 }
 
 #document-name-input-loading-bar::after {

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -114,7 +114,9 @@ m4_ifelse(MOBILEAPP,[true],
             <!-- visuallyhidden: hide it visually but keep it available to screen reader and other assistive technology -->
             <label class="visuallyhidden" for="document-name-input" aria-hidden="false">Document name</label>
             <input id="document-name-input" type="text" spellcheck="false" disabled="true" />
-            <div id="document-name-input-loading-bar"></div>
+            <div class="loading-bar-container">
+              <div id="document-name-input-loading-bar"></div>
+            </div>
             <progress id="document-name-input-progress-bar" class="progress-bar" value="0" max="99"></progress>
           </div>
         </div>


### PR DESCRIPTION
It crops document name when the name is long.
Also center the progress bar.


Change-Id: I8301f33cadad3ab8f06618e34b7cba57671b117c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

