### PR TITLE
color picker entry

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -807,7 +807,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	display: inline-block;
 }
 
-/* 
+/*
 * Hide the spacer icon if the entire context menu list does not contain any <img>.
 * This prevents unnecessary visual gaps when no icons are present.
 */
@@ -815,7 +815,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	display: none;
 }
 
-/* 
+/*
  * Applies consistent spacing across all items in a mixed submenu.
  * 1. The entire context menu list has no <img> at all (icon-less menu)
  * 2. The submenu contains a checkmark but has no <img>
@@ -899,7 +899,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 	justify-content: flex-start;
 }
 
-.jsdialog input[type='radio'] {
+.jsdialog input[type='radio']:not(.ui-color-picker-entry) {
 	margin: 1px 8px;
 	border: none;
 	height: 18px;
@@ -1724,6 +1724,9 @@ button.menubutton.sidebar > span {
 	cursor: pointer;
 	width: 16px;
 	height: 16px;
+	appearance: none;
+	webkit-appearance: none;
+	margin: 0;
 }
 
 .ui-color-picker-entry:hover,
@@ -2597,17 +2600,17 @@ kbd,
 	max-height: 19vh;
 }
 
-#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry img {  
-	padding: 1px;  
+#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry img {
+	padding: 1px;
 }
 
-#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry:is(:hover, .selected) {  
+#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry:is(:hover, .selected) {
 	outline: 2px solid var(--color-primary);
 	border: 1px solid transparent;
 	background-color: transparent;
 	border-radius: 0;
 }
 
-#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry span {  
+#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry span {
 	font-size: 0; /* Hide placeholder text to prevent layout shifts in color palette iconview widgets due to lazy loading */
 }

--- a/browser/src/control/jsdialog/Widget.ColorPicker.ts
+++ b/browser/src/control/jsdialog/Widget.ColorPicker.ts
@@ -125,7 +125,6 @@ function createColor(
 	color.name = 'color';
 	color.style.backgroundColor = '#' + colorItem;
 	color.setAttribute('index', index);
-	color.tabIndex = 0;
 	color.innerHTML = isCurrent ? '&#149;' : '&#160;';
 	if (themeData) color.setAttribute('theme', themeData);
 

--- a/browser/src/control/jsdialog/Widget.ColorPicker.ts
+++ b/browser/src/control/jsdialog/Widget.ColorPicker.ts
@@ -137,7 +137,11 @@ function createColor(
 	else if (window.app.colorNames) colorTooltip = findColorName(colorItem);
 	else colorTooltip = _('Unknown color');
 
-	color.setAttribute('data-cooltip', colorTooltip);
+	if (window.enableAccessibility) {
+		color.setAttribute('aria-label', colorTooltip);
+	} else {
+		color.setAttribute('data-cooltip', colorTooltip);
+	}
 
 	// Assuming 'color' is your target HTMLElement
 	color.addEventListener('click', (event: MouseEvent) => {

--- a/browser/src/control/jsdialog/Widget.ColorPicker.ts
+++ b/browser/src/control/jsdialog/Widget.ColorPicker.ts
@@ -117,12 +117,13 @@ function createColor(
 	themeColors: ThemeColor[],
 ): Element {
 	const color = L.DomUtil.create(
-		'div',
+		'input',
 		builder.options.cssClass + ' ui-color-picker-entry',
 		parentContainer,
 	);
+	color.type = 'radio';
+	color.name = 'color';
 	color.style.backgroundColor = '#' + colorItem;
-	color.setAttribute('name', colorItem);
 	color.setAttribute('index', index);
 	color.tabIndex = 0;
 	color.innerHTML = isCurrent ? '&#149;' : '&#160;';

--- a/browser/src/control/jsdialog/Widget.ColorPicker.ts
+++ b/browser/src/control/jsdialog/Widget.ColorPicker.ts
@@ -123,6 +123,7 @@ function createColor(
 	);
 	color.type = 'radio';
 	color.name = 'color';
+	color.value = colorItem;
 	color.style.backgroundColor = '#' + colorItem;
 	color.setAttribute('index', index);
 	color.innerHTML = isCurrent ? '&#149;' : '&#160;';
@@ -171,7 +172,7 @@ function handleColorSelection(
 	widgetData: ColorPaletteWidgetData,
 ) {
 	const palette = generatePalette(getCurrentPaletteName());
-	const colorCode = target.getAttribute('name');
+	const colorCode = target.getAttribute('value');
 	const themeData = target.getAttribute('theme');
 
 	if (colorCode != null) {

--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -71,7 +71,7 @@ function selectColorFromPalette(color) {
 	cy.log('>> selectColorFromPalette - start');
 
 	cy.cGet('.ui-color-picker').should('be.visible');
-	cy.cGet('.ui-color-picker-entry[name="' + color + '"]').click();
+	cy.cGet('.ui-color-picker-entry[value="' + color + '"]').click();
 	cy.cGet('.ui-color-picker').should('not.exist');
 
 	cy.log('<< selectColorFromPalette - end');


### PR DESCRIPTION
- **browser: accessibility: convert color picker entry to radio button group**
- **browser: accessibility: adjust CSS properties for color picker entry**
- **browser: accessibility: remove explicit tabindex from focusable button**
- **browser: accessibility: add aria-label to color picker entry**


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

