### PR TITLE
Add missing Format Cell keyboard shortcut to the toolbar's tooltips

### DIFF
--- a/browser/src/control/jsdialog/Util.Shortcuts.ts
+++ b/browser/src/control/jsdialog/Util.Shortcuts.ts
@@ -49,6 +49,7 @@ class ShortcutsUtil {
 	public INSERT_PAGEBREAK = 'Ctrl + Return';
 	public FIND = 'Ctrl + F';
 	public FIND_REPLACE = 'Ctrl + H';
+	public FORMAT_CELL = 'Ctrl + 1';
 
 	constructor() {
 		this.shortcutMap.set('.uno:Save', this.SAVE);
@@ -95,6 +96,7 @@ class ShortcutsUtil {
 		this.shortcutMap.set('search', this.FIND);
 		this.shortcutMap.set('home-search', this.FIND);
 		this.shortcutMap.set('.uno:SearchDialog', this.FIND_REPLACE);
+		this.shortcutMap.set('.uno:FormatCellDialog', this.FORMAT_CELL);
 	}
 
 	public hasShortcut(command: string): boolean {


### PR DESCRIPTION
Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I05537e1a72b9eef5bf7210447213450b3f6cae2d
