### PR TITLE
iconview: improve color palette UI in format cells dialog

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2486,3 +2486,31 @@ kbd,
 	display: grid;
 	grid-gap: 4px;
 }
+
+/* Calc - Format - Format Cells - Background - Color */
+
+#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview {
+	grid-template-columns: repeat(12, 1fr);
+	width: max-content;
+	line-height: 0;
+	padding: 5px;
+}
+
+#ColorPage.jsdialog #iconview_colors.ui-iconview {
+	max-height: 19vh;
+}
+
+#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry img {  
+	padding: 1px;  
+}
+
+#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry:is(:hover, .selected) {  
+	outline: 2px solid var(--color-primary);
+	border: 1px solid transparent;
+	background-color: transparent;
+	border-radius: 0;
+}
+
+#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry span {  
+	font-size: 0; /* Hide placeholder text to prevent layout shifts in color palette iconview widgets due to lazy loading */
+}


### PR DESCRIPTION
Change-Id: I9d39394e89a177bb3d029a23cb551a8ef4add45a

relevant core patch: https://gerrit.libreoffice.org/c/core/+/187931

### Summary
- enhanced layout and styling of the color page's iconview in the format cells dialog by using a grid layout with consistent spacing and limit the main color palette to certain height to enable scrollbar if needed
- improved colorpage color picker's hover and selection visibility with outline and border
- placeholder texts were hidden to prevent layout shifts caused by lazy loading of color icons (icon-view entries)

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

