### PR TITLE
fix(android): do not hang on document close

### DIFF
--- a/common/SigUtil-dummy.cpp
+++ b/common/SigUtil-dummy.cpp
@@ -10,26 +10,12 @@
  */
 
 #include <config.h>
-#include <Socket.hpp>
+
 #include "SigUtil.hpp"
 
 #include <string>
 
 #include "Log.hpp"
-
-namespace
-{
-/// The valid states of the process.
-enum class RunState : char
-{
-    Run = 0, ///< Normal up-and-running state.
-    ShutDown, ///< Request to shut down gracefully.
-    Terminate ///< Immediate termination.
-};
-
-/// Single flag to control the current run state.
-static std::atomic<RunState> RunStateFlag(RunState::Run);
-} // namespace
 
 namespace SigUtil
 {
@@ -39,35 +25,25 @@ namespace SigUtil
 
     bool getShutdownRequestFlag()
     {
-        return RunStateFlag >= RunState::ShutDown;
+        return false;
     }
 
     bool getTerminationFlag()
     {
-        return RunStateFlag >= RunState::Terminate;
+        return false;
     }
 
     void setTerminationFlag()
     {
-        // While fuzzing, we never want to terminate.
-        if constexpr (!Util::isFuzzing())
-        {
-            // Set the forced-termination flag.
-            RunStateFlag = RunState::Terminate;
-        }
-
-        SocketPoll::wakeupWorld();
     }
 
     void requestShutdown()
     {
-        RunState oldState = RunState::Run;
-        if (RunStateFlag.compare_exchange_strong(oldState, RunState::ShutDown)) {
-            SocketPoll::wakeupWorld();
-        }
     }
 
-    void resetTerminationFlags() { RunStateFlag = RunState::Run; }
+    void resetTerminationFlags()
+    {
+    }
 
     void checkDumpGlobalState([[maybe_unused]] GlobalDumpStateFn dumpState)
     {

--- a/common/SigUtil-server.cpp
+++ b/common/SigUtil-server.cpp
@@ -122,6 +122,10 @@ void requestShutdown()
         SocketPoll::wakeupWorld();
 }
 
+void resetTerminationFlags()
+{
+}
+
     void checkDumpGlobalState(GlobalDumpStateFn dumpState)
     {
         assert(dumpState && "Invalid callback for checkDumpGlobalState");

--- a/common/SigUtil.hpp
+++ b/common/SigUtil.hpp
@@ -33,6 +33,10 @@ namespace SigUtil
     /// Set the flag to stop pump loops forcefully and request shutting down.
     void setTerminationFlag();
 
+    /// Reset the flags to stop pump loops forcefully.
+    /// Only necessary in Mobile.
+    void resetTerminationFlags();
+
     extern "C" { typedef void (*GlobalDumpStateFn)(void); }
 
     void checkDumpGlobalState(GlobalDumpStateFn dumpState);

--- a/ios/Mobile.xcodeproj/project.pbxproj
+++ b/ios/Mobile.xcodeproj/project.pbxproj
@@ -34,7 +34,7 @@
 		BE5EB5C4214FE29900E0826C /* Uri.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BC214FE29900E0826C /* Uri.cpp */; };
 		BE5EB5C5213FE29900E0826C /* KitQueue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BD213FE29900E0826C /* KitQueue.cpp */; };
 		BE5EB5C5214FE29900E0826C /* LogUI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BD214FE29900E0826C /* LogUI.cpp */; };
-		BE5EB5C6213FE29900E0826C /* SigUtil-mobile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BE213FE29900E0826C /* SigUtil-mobile.cpp */; };
+		BE5EB5C6213FE29900E0826C /* SigUtil-dummy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BE213FE29900E0826C /* SigUtil-dummy.cpp */; };
 		BE5EB5C7213FE29900E0826C /* Protocol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5BF213FE29900E0826C /* Protocol.cpp */; };
 		BE5EB5C8213FE29900E0826C /* FileUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5C0213FE29900E0826C /* FileUtil.cpp */; };
 		BE5EB5CF213FE2D000E0826C /* ClientSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BE5EB5CC213FE2D000E0826C /* ClientSession.cpp */; };
@@ -598,7 +598,7 @@
 		BE5EB5BC214FE29900E0826C /* Uri.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Uri.cpp; sourceTree = "<group>"; };
 		BE5EB5BD213FE29900E0826C /* KitQueue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KitQueue.cpp; sourceTree = "<group>"; };
 		BE5EB5BD214FE29900E0826C /* LogUI.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LogUI.cpp; sourceTree = "<group>"; };
-		BE5EB5BE213FE29900E0826C /* SigUtil-mobile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "SigUtil-mobile.cpp"; sourceTree = "<group>"; };
+		BE5EB5BE213FE29900E0826C /* SigUtil-dummy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "SigUtil-dummy.cpp"; sourceTree = "<group>"; };
 		BE5EB5BF213FE29900E0826C /* Protocol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Protocol.cpp; sourceTree = "<group>"; };
 		BE5EB5C0213FE29900E0826C /* FileUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileUtil.cpp; sourceTree = "<group>"; };
 		BE5EB5CC213FE2D000E0826C /* ClientSession.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ClientSession.cpp; sourceTree = "<group>"; };
@@ -2230,7 +2230,7 @@
 				BE58E12F217F295B00249358 /* Session.hpp */,
 				BE5EB5BB213FE29900E0826C /* Session.cpp */,
 				BE58E12B217F295B00249358 /* SigUtil.hpp */,
-				BE5EB5BE213FE29900E0826C /* SigUtil-mobile.cpp */,
+				BE5EB5BE213FE29900E0826C /* SigUtil-dummy.cpp */,
 				A5C2FA582AC1BB3800265946 /* Simd.hpp */,
 				A5C2FA592AC1BB3800265946 /* Simd.cpp */,
 				BE5EB5BA213FE29900E0826C /* SpookyV2.cpp */,
@@ -3703,7 +3703,7 @@
 				BE5EB5D22140039100E0826D /* ClientRequestDispatcher.cpp in Sources */,
 				BEFB1EE121C29CC70081D757 /* L10n.mm in Sources */,
 				BEDCC8992456FFAD00FB02BD /* SceneDelegate.mm in Sources */,
-				BE5EB5C6213FE29900E0826C /* SigUtil-mobile.cpp in Sources */,
+				BE5EB5C6213FE29900E0826C /* SigUtil-dummy.cpp in Sources */,
 				3F3B54E02A392CCB00063C01 /* NetUtil.cpp in Sources */,
 				BE5EB5C1213FE29900E0826C /* Log.cpp in Sources */,
 				A5C2FA5A2AC1BB3900265946 /* Simd.cpp in Sources */,

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4201,6 +4201,8 @@ void COOLWSD::cleanup([[maybe_unused]] int returnValue)
 
 int COOLWSD::main(const std::vector<std::string>& /*args*/)
 {
+    SigUtil::resetTerminationFlags();
+
     int returnValue = EXIT_SOFTWARE;
 
     try {


### PR DESCRIPTION
This fixes a regression from CollaboraOnline/online#11845 which incorrectly excluded shutdown/termination flags from all mobile builds when previously they were excluded from iOS only.

Doing this would save the document properly but kit would never shut down, leaving the user with a perpetual document closing message...

This fix notably doesn't fix some other similar issues we've had with the document lifecycle: in particular, you can't open a document with an app instance that already had a document open even if you close it with this patch added


Change-Id: Ic283d96a94b0e91c795e0bc66d890720e55db836


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

