### PR TITLE
Wasm: No need for preallocated threads via PTHREAD_POOL_SIZE

### DIFF
--- a/wasm/Makefile.am
+++ b/wasm/Makefile.am
@@ -79,7 +79,7 @@ online_LDADD = \
 
 # TODO these are just copypasta from core
 online_LDFLAGS = \
-	-pthread -s MODULARIZE -s EXPORT_NAME=createOnlineModule -s USE_PTHREADS=1 -s TOTAL_MEMORY=1GB -s PTHREAD_POOL_SIZE=15 --bind -s FORCE_FILESYSTEM=1 -s WASM_BIGINT=1 -s ERROR_ON_UNDEFINED_SYMBOLS=1 -s FETCH=1 -s ASSERTIONS=1 -s EXIT_RUNTIME=0 -s EXPORTED_RUNTIME_METHODS=["UTF16ToString","stringToUTF16","UTF8ToString","stringToNewUTF8","ccall","cwrap","FS","registerType"] -pthread -s USE_PTHREADS=1 -fwasm-exceptions -s EXPORTED_FUNCTIONS=@exports \
+	-pthread -s MODULARIZE -s EXPORT_NAME=createOnlineModule -s USE_PTHREADS=1 -s TOTAL_MEMORY=1GB -s PTHREAD_POOL_SIZE_STRICT=0 --bind -s FORCE_FILESYSTEM=1 -s WASM_BIGINT=1 -s ERROR_ON_UNDEFINED_SYMBOLS=1 -s FETCH=1 -s ASSERTIONS=1 -s EXIT_RUNTIME=0 -s EXPORTED_RUNTIME_METHODS=["UTF16ToString","stringToUTF16","UTF8ToString","stringToNewUTF8","ccall","cwrap","FS","registerType"] -pthread -s USE_PTHREADS=1 -fwasm-exceptions -s EXPORTED_FUNCTIONS=@exports \
 	--pre-js @LOBUILDDIR@/workdir/CustomTarget/static/emscripten_fs_image/soffice.data.js.link
 
 # Silence "running limited binaryen optimizations because DWARF info requested (or indirectly


### PR DESCRIPTION
...as main in wasm/wasmapp.cpp just spawns a detached thread that does all the work, and then exits (effectively doing manually what PROXY_TO_PTHREAD would do automatically for us), so we won't block the browser's main thread (which would block further threads from spawning, for which PTHREAD_POOL_SIZE is a workaround).

But that would lead to harmless console warnings

> Tried to spawn a new thread, but the thread pool is exhausted.
> This might result in a deadlock unless some threads eventually exit or the code explicitly breaks out to the event loop.
> If you want to increase the pool size, use setting `-sPTHREAD_POOL_SIZE=...`.
> If you want to throw an explicit error instead of the risk of deadlocking in those cases, use setting `-sPTHREAD_POOL_SIZE_STRICT=2`.

whenever a new thread is spawned, which can be suppressed with PTHREAD_POOL_SIZE_STRICT=0.

(This had initially been introduced as PTHREAD_POOL_SIZE=4 in fdea5cde94bd75174aaa7d0dbce46869feda921e "WASM WIP link an executable", presumably just copying what core was doing back then (<https://git.libreoffice.org/core/+/8a4173987edfeeb7e49c70617d43e3adc911d333%5E%21> "WASM: add initial support for Emscripten cross build"), then increased to PTHREAD_POOL_SIZE=10 in fc0b538a19ab0b0dc0b057a56c07f57e25ccde61 "Increase PTHREAD_POOL_SIZE", presumably because it wasn't understood that the warnings mentioned above are actually harmless, then increased further to PTHREAD_POOL_SIZE=15 in b1bb133e520b43b34cf5115a2462468c2b9bcc02 "Bump PTHREAD_POOL_SIZE to 15", but without giving any further rationale.)


Change-Id: I37d1c5fc08003cbdf53beec84953997927585ba9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

