### PR TITLE
remove redundant code

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2053,12 +2053,6 @@ void ClientSession::writeQueuedMessages(std::size_t capacity)
 // seekg variant which uses seekoff which was implemented
 bool ClientSession::postProcessCopyPayload(std::istream& in, std::ostream& out)
 {
-    // back to start
-    std::string line;
-    std::getline(in, line);
-    in.clear();
-    in.seekg(0, std::ios::beg);
-
     constexpr std::string_view textPlain = "text/plain";
 
     char data[textPlain.size()];


### PR DESCRIPTION
'line' is unused and we seek back to the start after reading it, so drop this uselessness. There is no scenario where we are not at the start of the stream on calling postProcessCopyPayload.


Change-Id: I65a8b0c83729d801997712ff102b8112629b992b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

