### PR TITLE
fix(android): allow opening documents after close

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4134,6 +4134,9 @@ int COOLWSD::innerMain()
 
     SigUtil::addActivity("finished with status " + std::to_string(returnValue));
 
+    if constexpr (Util::isMobileApp())
+        Util::forcedExit(returnValue);
+
     return returnValue;
 #else // IOS
     return 0;


### PR DESCRIPTION
This fixes a regression from Ie0b68e0b1da83987214a983bf36c7556cc664a8e

In that change, we stopped running Util::forcedExit on a mobile exit
which appears to be a side-effect of assuming it was only used to stop
a Poco SSL deadlock. Unfortunately it seems to have been load-bearing in
closing down the Android app's document (despite that not using SSL) and 
without it we would be left in a state where no further documents could
be opened

Luckily it's a pretty easy fix - adding this line back (gated for mobile
as we don't need it on a server) corrects the problem

Signed-off-by: Skyler Grey <skyler.grey@collabora.com>
Change-Id: Ieab70b0a51016efa8dd7e13fbb90f38711320eea

To test this you probably want #12363, so I have used it as a base for this commit