### PR TITLE
Ensure we de-hydrate tiles even of 0 length as we used to.

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -2014,11 +2014,11 @@ class TileManager {
 					'Unusual: attempt to append a delta when we have no keyframe.',
 				);
 			}
-
-			// Only decompress deltas for tiles that are current. This stops
-			// prefetching from blowing past GC limits.
-			if (tile.distanceFromView === 0) this.rehydrateTile(tile, true);
 		}
+
+		// Only decompress deltas for tiles that are current. This stops
+		// prefetching from blowing past GC limits.
+		if (tile.distanceFromView === 0) this.rehydrateTile(tile, true);
 
 		this.queueAcknowledgement(tileMsgObj);
 


### PR DESCRIPTION
This is unpleasant; it seems to be a workaround to wait for a tilecombine result as a zero-length (imgsize=1) delta to arrive in order to work out that we need to de-hydrate the updated while off-screen, so non-de-hydrated tile data that we want to render.

Essentially this undoes this hunk from
commit 947fe72f7c293bfe0ea41340ee86d88184855ab9

-		var hasContent = img != null;
+		var hasContent = img != null && img.rawData.length > 0;

Without appending zero length deltas to the RawDelta list. It should be further investigated later.


Change-Id: I7a581a1c4d1aca495b43d48e344f33f00a31651f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

