### PR TITLE
Fix report issue separator in help section

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -508,10 +508,10 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'text': _('Report an issue'),
 								'command': '.uno:ReportIssue',
 								'accessibility': { focusBack: true, combination: 'K', de: null }
-							}
+							},
+							{ 'type': 'separator', 'id': 'help-reportissue-break', 'orientation': 'vertical' },
 						]
 					},
-					{ type: 'separator', id: 'help-reportissue-break', orientation: 'vertical' },
 					hasLatestUpdates ?
 						{
 							'type': 'toolbox',


### PR DESCRIPTION
Change-Id: I63b053d81469438e058cc0238a7dab466f2fafc0


* Resolves: #
* Target version: master 

### Summary
Fix report issue separator in help section

### PREVIEWS
#### BEFORE
<img width="911" height="121" alt="image (3)" src="https://github.com/user-attachments/assets/96ec0a59-67db-422b-ab5e-82dc36d230d3" />

#### WITH THIS PR
<img width="1111" height="122" alt="Screenshot from 2025-07-21 03-49-45" src="https://github.com/user-attachments/assets/d27828bc-bfd6-4297-8e5b-668a9ea4a1ce" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

