### PR TITLE
Calc: Use section borders for validity dropdown.

### DIFF
--- a/browser/src/canvas/CanvasSectionProps.js
+++ b/browser/src/canvas/CanvasSectionProps.js
@@ -55,6 +55,7 @@ L.CSections.DefaultForDocumentObjects = {                         zIndex: 9 };
 L.CSections.HTMLObject     =        {                             zIndex: 9 };
 
 L.CSections.ContentControl =        { name: 'content control'   , zIndex: 11 };
+L.CSections.CalcValidityDropDown =  { name: 'calc validity dropdown', zIndex: 11 };
 
 L.CSections.Scroll =				{ name: 'scroll'			, zIndex: 13 };
 

--- a/browser/src/canvas/sections/CalcValidityDropDownSection.ts
+++ b/browser/src/canvas/sections/CalcValidityDropDownSection.ts
@@ -10,10 +10,35 @@
 */
 
 class CalcValidityDropDown extends HTMLObjectSection {
+	zIndex: number = L.CSections.CalcValidityDropDown.zIndex;
 
-	constructor (sectionName: string, documentPosition: cool.SimplePoint, visible: boolean = true) {
-		super(sectionName, 16, 16, documentPosition, 'spreadsheet-drop-down-marker', visible);
+	constructor (documentPosition: cool.SimplePoint, visible: boolean = true) {
+		super(L.CSections.CalcValidityDropDown.name, 16, 16, documentPosition, 'spreadsheet-drop-down-marker', visible);
+
+		this.sectionProperties.mouseEntered = false;
+	}
+
+	public onMouseEnter(point: Array<number>, e: MouseEvent): void {
+		this.sectionProperties.mouseEntered = true;
+	}
+
+	public onMouseLeave() {
+		this.sectionProperties.mouseEntered = false;
+	}
+
+	public onClick(point: Array<number>, e: MouseEvent): void {
+		e.stopPropagation();
+		e.preventDefault();
+		this.stopPropagating();
+
+		// Calculate the center position of the section. We will send this to core side.
+		point[0] = this.position[0] + this.size[0] / 2;
+		point[1] = this.position[1] + this.size[1] / 2;
+
+		point[0] *= app.pixelsToTwips;
+		point[1] *= app.pixelsToTwips;
+
+		app.map._docLayer._postMouseEvent('buttondown', point[0], point[1], 1, 1, 0);
+		app.map._docLayer._postMouseEvent('buttonup', point[0], point[1], 1, 1, 0);
 	}
 }
-
-app.definitions.calcValidityDropDown = CalcValidityDropDown;

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3184,9 +3184,8 @@ L.CanvasTileLayer = L.Layer.extend({
 		if (this._validatedCellAddress && app.calc.cellCursorVisible && this._validatedCellAddress.equals(app.calc.cellAddress.toArray())) {
 			let position;
 			if (this.sheetGeometry) {
-				position = this.sheetGeometry.getCellRect(this._validatedCellAddress.x, this._validatedCellAddress.y, this._map.getZoomScale(this._map.getZoom(), this._map.options.defaultZoom));
-				const height = position.max.y - position.min.y;
-				position = new app.definitions.simplePoint(app.calc.cellCursorRectangle.x2, app.calc.cellCursorRectangle.y1 + (height - 16) * app.pixelsToTwips);
+				position = this.sheetGeometry.getCellRect(this._validatedCellAddress.x, this._validatedCellAddress.y);
+				position = new app.definitions.simplePoint(app.calc.cellCursorRectangle.x2, (position.max.y - 16) * app.pixelsToTwips);
 			}
 			else
 				position = new app.definitions.simplePoint(app.calc.cellCursorRectangle.x2, app.calc.cellCursorRectangle.y2 - 16 * app.pixelsToTwips);

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3,7 +3,7 @@
  * L.CanvasTileLayer is a layer with canvas based rendering.
  */
 
-/* global app L JSDialog CanvasSectionContainer GraphicSelection CanvasOverlay CDarkOverlay CursorHeaderSection $ _ CPointSet CPolyUtil CPolygon Cursor CCellSelection PathGroupType UNOKey UNOModifier cool OtherViewCellCursorSection TileManager MultiPageViewLayout SplitSection TextSelections CellSelectionMarkers URLPopUpSection */
+/* global app L JSDialog CanvasSectionContainer GraphicSelection CanvasOverlay CDarkOverlay CursorHeaderSection $ _ CPointSet CPolyUtil CPolygon Cursor CCellSelection PathGroupType UNOKey UNOModifier cool OtherViewCellCursorSection TileManager MultiPageViewLayout SplitSection TextSelections CellSelectionMarkers URLPopUpSection CalcValidityDropDown */
 
 function clamp(num, min, max)
 {
@@ -3191,19 +3191,19 @@ L.CanvasTileLayer = L.Layer.extend({
 			else
 				position = new app.definitions.simplePoint(app.calc.cellCursorRectangle.x2, app.calc.cellCursorRectangle.y2 - 16 * app.pixelsToTwips);
 
-			if (!app.sectionContainer.getSectionWithName('DropDownArrow')) {
-				let dropDownSection = new app.definitions.calcValidityDropDown('DropDownArrow', position);
+			if (!app.sectionContainer.getSectionWithName(L.CSections.CalcValidityDropDown.name)) {
+				let dropDownSection = new CalcValidityDropDown(position);
 				app.sectionContainer.addSection(dropDownSection);
 			}
 			else {
-				app.sectionContainer.getSectionWithName('DropDownArrow').setPosition(position.pX, position.pY);
+				app.sectionContainer.getSectionWithName(L.CSections.CalcValidityDropDown.name).setPosition(position.pX, position.pY);
 			}
 		}
 	},
 
 	_removeCellDropDownArrow: function () {
 		if (!this._validatedCellAddress)
-			app.sectionContainer.removeSection('DropDownArrow');
+			app.sectionContainer.removeSection(L.CSections.CalcValidityDropDown.name);
 	},
 
 	_removeSelection: function() {

--- a/browser/src/map/handler/Map.Mouse.js
+++ b/browser/src/map/handler/Map.Mouse.js
@@ -38,8 +38,21 @@ L.Map.Mouse = L.Handler.extend({
 		right: 2
 	},
 
+	_isMouseOnValidityDropdown: function() {
+		if (app.sectionContainer) {
+			const section = app.sectionContainer.getSectionWithName(L.CSections.CalcValidityDropDown.name);
+			if (section)
+				return section.sectionProperties.mouseEntered;
+		}
+
+		return null;
+	},
+
 	_onMouseEvent: window.touch.mouseOnly(function (e) {
 		if (this._map.uiManager.isUIBlocked() || app.map.dontHandleMouse)
+			return;
+
+		if (this._isMouseOnValidityDropdown())
 			return;
 
 		app.idleHandler.notifyActive();


### PR DESCRIPTION
Issue:
* For validity dropdown, mouse click is sent to core side.
* Core side understands that the user clicked on the validity dropdown.
* It sends the required information back.

* But the clickable area for the dropdown is a little small on the core side.
* Users sometimes click close to the edges of the dropdown arrow.
* In that case, click is not recognized by the core side.

Solution:
* Handle the click on the Online side.
* Send the center of the dropdown arrow to the core side with click event.
* It provides larger clickable area for the dropdown.


Change-Id: Ib48f7266f7b0d147761eaccd647caf39df0d6550


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

