### PR TITLE
Notebookbar: Picture context tab: Add pre-canned menubuttons

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1826,6 +1826,30 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	background: transparent;
 }
 
+#picture-brightness-entry-0 img { filter: brightness(0.6) }
+#picture-brightness-entry-1 img { filter: brightness(0.8) }
+#picture-brightness-entry-2 img { filter: brightness(1) }
+#picture-brightness-entry-3 img { filter: brightness(1.2) }
+#picture-brightness-entry-4 img { filter: brightness(1.4) }
+
+#picture-contrast-entry-0 img { filter: contrast(0.6) }
+#picture-contrast-entry-1 img { filter: contrast(0.8) }
+#picture-contrast-entry-2 img { filter: contrast(1) }
+#picture-contrast-entry-3 img { filter: contrast(1.2) }
+#picture-contrast-entry-4 img { filter: contrast(1.4) }
+
+#picture-colormode-entry-1 img { filter: grayscale(1) } /* grayscale */
+#picture-colormode-entry-2 img { filter: grayscale(1) contrast(5) } /* black/white */
+#picture-colormode-entry-3 img { filter: opacity(0.2) } /* watermark */
+
+#picture-transparency-entry-0 img { filter: opacity(1) }
+#picture-transparency-entry-1 img { filter: opacity(0.85) }
+#picture-transparency-entry-2 img { filter: opacity(0.7) }
+#picture-transparency-entry-3 img { filter: opacity(0.5) }
+#picture-transparency-entry-4 img { filter: opacity(0.35) }
+#picture-transparency-entry-5 img { filter: opacity(0.2) }
+#picture-transparency-entry-6 img { filter: opacity(0.05) }
+
 @media only screen and (max-width: 600px) {
 	#userListSummary,
 	#userListHeader {

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -2638,6 +2638,19 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'type': 'container',
 				'children': [
 					{
+						'id': 'picture-brightness:PictureBrightness',
+						'type': 'menubutton',
+						'command': '.uno:GrafLuminance',
+						'icon': 'lc_setbrightness.svg',
+						'accessibility': { focusBack: true, combination: 'BN', de: null }
+					},
+				]
+			},
+			{ type: 'separator', id: 'picture-transparency-break', orientation: 'vertical' },
+			{
+				'type': 'container',
+				'children': [
+					{
 						'type': 'toolbox',
 						'children': [
 							{

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -2652,6 +2652,13 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'accessibility': { focusBack: true, combination: 'CN', de: null }
 					},
 					{
+						'id': 'picture-colormode:PictureColorMode',
+						'type': 'menubutton',
+						'command': '.uno:GrafMode',
+						'icon': 'lc_setgraphtransparency.svg',
+						'accessibility': { focusBack: true, combination: 'CO', de: null }
+					},
+					{
 						'id': 'picture-transparency:PictureTransparency',
 						'type': 'menubutton',
 						'command': '.uno:GrafTransparence',

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -2641,6 +2641,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'id': 'picture-brightness:PictureBrightness',
 						'type': 'menubutton',
 						'command': '.uno:GrafLuminance',
+						'text': _UNO('.uno:GrafLuminance'),
 						'icon': 'lc_setbrightness.svg',
 						'accessibility': { focusBack: true, combination: 'BN', de: null }
 					},
@@ -2648,6 +2649,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'id': 'picture-contrast:PictureContrast',
 						'type': 'menubutton',
 						'command': '.uno:GrafContrast',
+						'text': _UNO('.uno:GrafContrast'),
 						'icon': 'lc_setcontrast.svg',
 						'accessibility': { focusBack: true, combination: 'CN', de: null }
 					},
@@ -2655,6 +2657,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'id': 'picture-colormode:PictureColorMode',
 						'type': 'menubutton',
 						'command': '.uno:GrafMode',
+						'text': _UNO('.uno:GrafMode'),
 						'icon': 'lc_setgraphtransparency.svg',
 						'accessibility': { focusBack: true, combination: 'CO', de: null }
 					},
@@ -2662,6 +2665,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'id': 'picture-transparency:PictureTransparency',
 						'type': 'menubutton',
 						'command': '.uno:GrafTransparence',
+						'text': _UNO('.uno:GrafTransparence'),
 						'icon': 'lc_setgraphtransparency.svg',
 						'accessibility': { focusBack: true, combination: 'TP', de: null }
 					},

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -2651,6 +2651,13 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'icon': 'lc_setcontrast.svg',
 						'accessibility': { focusBack: true, combination: 'CN', de: null }
 					},
+					{
+						'id': 'picture-transparency:PictureTransparency',
+						'type': 'menubutton',
+						'command': '.uno:GrafTransparence',
+						'icon': 'lc_setgraphtransparency.svg',
+						'accessibility': { focusBack: true, combination: 'TP', de: null }
+					},
 				]
 			},
 			{ type: 'separator', id: 'picture-transparency-break', orientation: 'vertical' },

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -2644,6 +2644,13 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'icon': 'lc_setbrightness.svg',
 						'accessibility': { focusBack: true, combination: 'BN', de: null }
 					},
+					{
+						'id': 'picture-contrast:PictureContrast',
+						'type': 'menubutton',
+						'command': '.uno:GrafContrast',
+						'icon': 'lc_setcontrast.svg',
+						'accessibility': { focusBack: true, combination: 'CN', de: null }
+					},
 				]
 			},
 			{ type: 'separator', id: 'picture-transparency-break', orientation: 'vertical' },

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -2542,6 +2542,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'id': 'picture-brightness:PictureBrightness',
 						'type': 'menubutton',
 						'command': '.uno:GrafLuminance',
+						'text': _UNO('.uno:GrafLuminance'),
 						'icon': 'lc_setbrightness.svg',
 						'accessibility': { focusBack: true, combination: 'BN', de: null }
 					},
@@ -2549,6 +2550,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'id': 'picture-contrast:PictureContrast',
 						'type': 'menubutton',
 						'command': '.uno:GrafContrast',
+						'text': _UNO('.uno:GrafContrast'),
 						'icon': 'lc_setcontrast.svg',
 						'accessibility': { focusBack: true, combination: 'CN', de: null }
 					},
@@ -2556,6 +2558,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'id': 'picture-colormode:PictureColorMode',
 						'type': 'menubutton',
 						'command': '.uno:GrafMode',
+						'text': _UNO('.uno:GrafMode'),
 						'icon': 'lc_setgraphtransparency.svg',
 						'accessibility': { focusBack: true, combination: 'CO', de: null }
 					},
@@ -2563,6 +2566,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'id': 'picture-transparency:PictureTransparency',
 						'type': 'menubutton',
 						'command': '.uno:GrafTransparence',
+						'text': _UNO('.uno:GrafTransparence'),
 						'icon': 'lc_setgraphtransparency.svg',
 						'accessibility': { focusBack: true, combination: 'TP', de: null }
 					},

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -2552,6 +2552,13 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'icon': 'lc_setcontrast.svg',
 						'accessibility': { focusBack: true, combination: 'CN', de: null }
 					},
+					{
+						'id': 'picture-transparency:PictureTransparency',
+						'type': 'menubutton',
+						'command': '.uno:GrafTransparence',
+						'icon': 'lc_setgraphtransparency.svg',
+						'accessibility': { focusBack: true, combination: 'TP', de: null }
+					},
 				]
 			},
 			{ type: 'separator', id: 'picture-transparency-break', orientation: 'vertical' },

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -2553,6 +2553,13 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'accessibility': { focusBack: true, combination: 'CN', de: null }
 					},
 					{
+						'id': 'picture-colormode:PictureColorMode',
+						'type': 'menubutton',
+						'command': '.uno:GrafMode',
+						'icon': 'lc_setgraphtransparency.svg',
+						'accessibility': { focusBack: true, combination: 'CO', de: null }
+					},
+					{
 						'id': 'picture-transparency:PictureTransparency',
 						'type': 'menubutton',
 						'command': '.uno:GrafTransparence',

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -2539,6 +2539,19 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'type': 'container',
 				'children': [
 					{
+						'id': 'picture-brightness:PictureBrightness',
+						'type': 'menubutton',
+						'command': '.uno:GrafLuminance',
+						'icon': 'lc_setbrightness.svg',
+						'accessibility': { focusBack: true, combination: 'BN', de: null }
+					},
+				]
+			},
+			{ type: 'separator', id: 'picture-transparency-break', orientation: 'vertical' },
+			{
+				'type': 'container',
+				'children': [
+					{
 						'type': 'toolbox',
 						'children': [
 							{

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -2545,6 +2545,13 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 						'icon': 'lc_setbrightness.svg',
 						'accessibility': { focusBack: true, combination: 'BN', de: null }
 					},
+					{
+						'id': 'picture-contrast:PictureContrast',
+						'type': 'menubutton',
+						'command': '.uno:GrafContrast',
+						'icon': 'lc_setcontrast.svg',
+						'accessibility': { focusBack: true, combination: 'CN', de: null }
+					},
 				]
 			},
 			{ type: 'separator', id: 'picture-transparency-break', orientation: 'vertical' },

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -3224,6 +3224,13 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'icon': 'lc_setbrightness.svg',
 						'accessibility': { focusBack: true, combination: 'BN', de: null }
 					},
+					{
+						'id': 'picture-contrast:PictureContrast',
+						'type': 'menubutton',
+						'command': '.uno:GrafContrast',
+						'icon': 'lc_setcontrast.svg',
+						'accessibility': { focusBack: true, combination: 'CN', de: null }
+					},
 				]
 			},
 			{ type: 'separator', id: 'picture-transparency-break', orientation: 'vertical' },

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -3231,6 +3231,13 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'icon': 'lc_setcontrast.svg',
 						'accessibility': { focusBack: true, combination: 'CN', de: null }
 					},
+					{
+						'id': 'picture-transparency:PictureTransparency',
+						'type': 'menubutton',
+						'command': '.uno:GrafTransparence',
+						'icon': 'lc_setgraphtransparency.svg',
+						'accessibility': { focusBack: true, combination: 'TP', de: null }
+					},
 				]
 			},
 			{ type: 'separator', id: 'picture-transparency-break', orientation: 'vertical' },

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -3221,6 +3221,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'id': 'picture-brightness:PictureBrightness',
 						'type': 'menubutton',
 						'command': '.uno:GrafLuminance',
+						'text': _UNO('.uno:GrafLuminance'),
 						'icon': 'lc_setbrightness.svg',
 						'accessibility': { focusBack: true, combination: 'BN', de: null }
 					},
@@ -3228,6 +3229,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'id': 'picture-contrast:PictureContrast',
 						'type': 'menubutton',
 						'command': '.uno:GrafContrast',
+						'text': _UNO('.uno:GrafContrast'),
 						'icon': 'lc_setcontrast.svg',
 						'accessibility': { focusBack: true, combination: 'CN', de: null }
 					},
@@ -3235,6 +3237,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'id': 'picture-colormode:PictureColorMode',
 						'type': 'menubutton',
 						'command': '.uno:GrafMode',
+						'text': _UNO('.uno:GrafMode'),
 						'icon': 'lc_setgraphtransparency.svg',
 						'accessibility': { focusBack: true, combination: 'CO', de: null }
 					},
@@ -3242,6 +3245,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'id': 'picture-transparency:PictureTransparency',
 						'type': 'menubutton',
 						'command': '.uno:GrafTransparence',
+						'text': _UNO('.uno:GrafTransparence'),
 						'icon': 'lc_setgraphtransparency.svg',
 						'accessibility': { focusBack: true, combination: 'TP', de: null }
 					},

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -3218,6 +3218,19 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'type': 'container',
 				'children': [
 					{
+						'id': 'picture-brightness:PictureBrightness',
+						'type': 'menubutton',
+						'command': '.uno:GrafLuminance',
+						'icon': 'lc_setbrightness.svg',
+						'accessibility': { focusBack: true, combination: 'BN', de: null }
+					},
+				]
+			},
+			{ type: 'separator', id: 'picture-transparency-break', orientation: 'vertical' },
+			{
+				'type': 'container',
+				'children': [
+					{
 						'type': 'toolbox',
 						'children': [
 							{

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -3232,6 +3232,13 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'accessibility': { focusBack: true, combination: 'CN', de: null }
 					},
 					{
+						'id': 'picture-colormode:PictureColorMode',
+						'type': 'menubutton',
+						'command': '.uno:GrafMode',
+						'icon': 'lc_setgraphtransparency.svg',
+						'accessibility': { focusBack: true, combination: 'CO', de: null }
+					},
+					{
 						'id': 'picture-transparency:PictureTransparency',
 						'type': 'menubutton',
 						'command': '.uno:GrafTransparence',

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -582,32 +582,6 @@ function generatePictureTransparencyMenu(
 	return menuItems;
 }
 
-function generatePictureColorModeMenu(
-	unoCommand: string,
-): Array<MenuDefinition> {
-	//see enum GraphicDrawMode in include/vcl/GraphicAttributes.hxx
-	const colorModeValues = [
-		{ value: 0, text: _('Default') },
-		{ value: 1, text: _('Grayscale') },
-		{ value: 2, text: _('Black/White') },
-		{ value: 3, text: _('Watermark') },
-	];
-
-	const menuItems: Array<MenuDefinition> = [];
-
-	for (let i = 0; i < colorModeValues.length; i++) {
-		menuItems.push({
-			id: colorModeValues[i].text,
-			uno:
-				'.uno:' + unoCommand + '?ColorMode:short=' + colorModeValues[i].value,
-			text: '' + colorModeValues[i].text,
-			img: 'insertgraphic',
-		} as MenuDefinition);
-	}
-
-	return menuItems;
-}
-
 menuDefinitions.set('NewSlideLayoutMenu', [
 	{
 		type: 'json',
@@ -639,9 +613,27 @@ menuDefinitions.set(
 	generatePictureTransparencyMenu('GrafTransparence'),
 );
 
-menuDefinitions.set(
-	'PictureColorMode',
-	generatePictureColorModeMenu('GrafMode'),
-);
+menuDefinitions.set('PictureColorMode', [
+	{
+		text: _('Default'),
+		img: 'insertgraphic',
+		uno: '.uno:GrafMode?ColorMode:short=0',
+	},
+	{
+		text: _('Grayscale'),
+		img: 'insertgraphic',
+		uno: '.uno:GrafMode?ColorMode:short=1',
+	},
+	{
+		text: _('Black/White'),
+		img: 'insertgraphic',
+		uno: '.uno:GrafMode?ColorMode:short=2',
+	},
+	{
+		text: _('Watermark'),
+		img: 'insertgraphic',
+		uno: '.uno:GrafMode?ColorMode:short=3',
+	},
+] as Array<MenuDefinition>);
 
 JSDialog.MenuDefinitions = menuDefinitions;

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -590,6 +590,44 @@ function generatePictureContrastGrid(unoCommand: string): GridWidgetJSON {
 	return grid as any as GridWidgetJSON;
 }
 
+function generatePictureTransparencyGrid(unoCommand: string): GridWidgetJSON {
+	const transparencyValues = [
+		{ value: 0, text: _('zero') },
+		{ value: 15, text: _('fifteen') },
+		{ value: 30, text: _('thirty') },
+		{ value: 50, text: _('fifty') },
+		{ value: 65, text: _('sixtyfive') },
+		{ value: 80, text: _('eighty') },
+		{ value: 95, text: _('ninetyfive') },
+	];
+
+	const grid = {
+		id: 'picturetranparencygrid',
+		type: 'grid',
+		cols: 7,
+		rows: 1,
+		children: new Array<WidgetJSON>(),
+	};
+
+	for (let i = 0; i < grid.cols; i++) {
+		grid.children.push({
+			id: transparencyValues[i].text,
+			type: 'toolitem',
+			command:
+				'.uno:' +
+				unoCommand +
+				'?Transparency:short=' +
+				transparencyValues[i].value,
+			text: '' + transparencyValues[i].value,
+			noLabel: false,
+			left: i,
+			top: 0,
+		} as any as WidgetJSON);
+	}
+
+	return grid as any as GridWidgetJSON;
+}
+
 menuDefinitions.set('NewSlideLayoutMenu', [
 	{
 		type: 'json',
@@ -618,6 +656,14 @@ menuDefinitions.set('PictureContrast', [
 	{
 		type: 'json',
 		content: generatePictureContrastGrid('GrafContrast'),
+	},
+	{ type: 'separator' }, // required to show dropdown arrow
+] as Array<MenuDefinition>);
+
+menuDefinitions.set('PictureTransparency', [
+	{
+		type: 'json',
+		content: generatePictureTransparencyGrid('GrafTransparence'),
 	},
 	{ type: 'separator' }, // required to show dropdown arrow
 ] as Array<MenuDefinition>);

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -557,6 +557,39 @@ function generatePictureBrightnessGrid(unoCommand: string): GridWidgetJSON {
 	return grid as any as GridWidgetJSON;
 }
 
+function generatePictureContrastGrid(unoCommand: string): GridWidgetJSON {
+	const contrastValues = [
+		{ value: -40, text: _('minusforty') },
+		{ value: -20, text: _('minustwenty') },
+		{ value: 0, text: _('zero') },
+		{ value: 20, text: _('twenty') },
+		{ value: 40, text: _('forty') },
+	];
+
+	const grid = {
+		id: 'picturecontrastgrid',
+		type: 'grid',
+		cols: 5,
+		rows: 1,
+		children: new Array<WidgetJSON>(),
+	};
+
+	for (let i = 0; i < grid.cols; i++) {
+		grid.children.push({
+			id: contrastValues[i].text,
+			type: 'toolitem',
+			command:
+				'.uno:' + unoCommand + '?Contrast:short=' + contrastValues[i].value,
+			text: '' + contrastValues[i].value,
+			noLabel: false,
+			left: i,
+			top: 0,
+		} as any as WidgetJSON);
+	}
+
+	return grid as any as GridWidgetJSON;
+}
+
 menuDefinitions.set('NewSlideLayoutMenu', [
 	{
 		type: 'json',
@@ -577,6 +610,14 @@ menuDefinitions.set('PictureBrightness', [
 	{
 		type: 'json',
 		content: generatePictureBrightnessGrid('GrafLuminance'),
+	},
+	{ type: 'separator' }, // required to show dropdown arrow
+] as Array<MenuDefinition>);
+
+menuDefinitions.set('PictureContrast', [
+	{
+		type: 'json',
+		content: generatePictureContrastGrid('GrafContrast'),
 	},
 	{ type: 'separator' }, // required to show dropdown arrow
 ] as Array<MenuDefinition>);

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -524,7 +524,9 @@ function generateLayoutPopupGrid(unoCommand: string): GridWidgetJSON {
 	return grid as any as GridWidgetJSON;
 }
 
-function generatePictureBrightnessGrid(unoCommand: string): GridWidgetJSON {
+function generatePictureBrightnessMenu(
+	unoCommand: string,
+): Array<MenuDefinition> {
 	const brightnessValues = [
 		{ value: -40, text: _('minusforty') },
 		{ value: -20, text: _('minustwenty') },
@@ -533,31 +535,24 @@ function generatePictureBrightnessGrid(unoCommand: string): GridWidgetJSON {
 		{ value: 40, text: _('forty') },
 	];
 
-	const grid = {
-		id: 'picturebrightnessgrid',
-		type: 'grid',
-		cols: 5,
-		rows: 1,
-		children: new Array<WidgetJSON>(),
-	};
+	const menuItems: Array<MenuDefinition> = [];
 
-	for (let i = 0; i < grid.cols; i++) {
-		grid.children.push({
+	for (let i = 0; i < brightnessValues.length; i++) {
+		menuItems.push({
 			id: brightnessValues[i].text,
-			type: 'toolitem',
-			command:
+			uno:
 				'.uno:' + unoCommand + '?Brightness:short=' + brightnessValues[i].value,
 			text: '' + brightnessValues[i].value,
-			noLabel: false,
-			left: i,
-			top: 0,
-		} as any as WidgetJSON);
+			img: 'insertgraphic',
+		} as MenuDefinition);
 	}
 
-	return grid as any as GridWidgetJSON;
+	return menuItems;
 }
 
-function generatePictureContrastGrid(unoCommand: string): GridWidgetJSON {
+function generatePictureContrastMenu(
+	unoCommand: string,
+): Array<MenuDefinition> {
 	const contrastValues = [
 		{ value: -40, text: _('minusforty') },
 		{ value: -20, text: _('minustwenty') },
@@ -566,31 +561,23 @@ function generatePictureContrastGrid(unoCommand: string): GridWidgetJSON {
 		{ value: 40, text: _('forty') },
 	];
 
-	const grid = {
-		id: 'picturecontrastgrid',
-		type: 'grid',
-		cols: 5,
-		rows: 1,
-		children: new Array<WidgetJSON>(),
-	};
+	const menuItems: Array<MenuDefinition> = [];
 
-	for (let i = 0; i < grid.cols; i++) {
-		grid.children.push({
+	for (let i = 0; i < contrastValues.length; i++) {
+		menuItems.push({
 			id: contrastValues[i].text,
-			type: 'toolitem',
-			command:
-				'.uno:' + unoCommand + '?Contrast:short=' + contrastValues[i].value,
+			uno: '.uno:' + unoCommand + '?Contrast:short=' + contrastValues[i].value,
 			text: '' + contrastValues[i].value,
-			noLabel: false,
-			left: i,
-			top: 0,
-		} as any as WidgetJSON);
+			img: 'insertgraphic',
+		} as MenuDefinition);
 	}
 
-	return grid as any as GridWidgetJSON;
+	return menuItems;
 }
 
-function generatePictureTransparencyGrid(unoCommand: string): GridWidgetJSON {
+function generatePictureTransparencyMenu(
+	unoCommand: string,
+): Array<MenuDefinition> {
 	const transparencyValues = [
 		{ value: 0, text: _('zero') },
 		{ value: 15, text: _('fifteen') },
@@ -601,34 +588,27 @@ function generatePictureTransparencyGrid(unoCommand: string): GridWidgetJSON {
 		{ value: 95, text: _('ninetyfive') },
 	];
 
-	const grid = {
-		id: 'picturetranparencygrid',
-		type: 'grid',
-		cols: 7,
-		rows: 1,
-		children: new Array<WidgetJSON>(),
-	};
+	const menuItems: Array<MenuDefinition> = [];
 
-	for (let i = 0; i < grid.cols; i++) {
-		grid.children.push({
+	for (let i = 0; i < transparencyValues.length; i++) {
+		menuItems.push({
 			id: transparencyValues[i].text,
-			type: 'toolitem',
-			command:
+			uno:
 				'.uno:' +
 				unoCommand +
 				'?Transparency:short=' +
 				transparencyValues[i].value,
 			text: '' + transparencyValues[i].value,
-			noLabel: false,
-			left: i,
-			top: 0,
-		} as any as WidgetJSON);
+			img: 'insertgraphic',
+		} as MenuDefinition);
 	}
 
-	return grid as any as GridWidgetJSON;
+	return menuItems;
 }
 
-function generatePictureColorModeGrid(unoCommand: string): GridWidgetJSON {
+function generatePictureColorModeMenu(
+	unoCommand: string,
+): Array<MenuDefinition> {
 	//see enum GraphicDrawMode in include/vcl/GraphicAttributes.hxx
 	const colorModeValues = [
 		{ value: 0, text: _('Default') },
@@ -637,28 +617,19 @@ function generatePictureColorModeGrid(unoCommand: string): GridWidgetJSON {
 		{ value: 3, text: _('Watermark') },
 	];
 
-	const grid = {
-		id: 'picturecolormodegrid',
-		type: 'grid',
-		cols: 4,
-		rows: 1,
-		children: new Array<WidgetJSON>(),
-	};
+	const menuItems: Array<MenuDefinition> = [];
 
-	for (let i = 0; i < grid.cols; i++) {
-		grid.children.push({
+	for (let i = 0; i < colorModeValues.length; i++) {
+		menuItems.push({
 			id: colorModeValues[i].text,
-			type: 'toolitem',
-			command:
+			uno:
 				'.uno:' + unoCommand + '?ColorMode:short=' + colorModeValues[i].value,
-			text: colorModeValues[i].text,
-			noLabel: false,
-			left: i,
-			top: 0,
-		} as any as WidgetJSON);
+			text: '' + colorModeValues[i].text,
+			img: 'insertgraphic',
+		} as MenuDefinition);
 	}
 
-	return grid as any as GridWidgetJSON;
+	return menuItems;
 }
 
 menuDefinitions.set('NewSlideLayoutMenu', [
@@ -677,36 +648,24 @@ menuDefinitions.set('ChangeSlideLayoutMenu', [
 	{ type: 'separator' }, // required to show dropdown arrow
 ] as Array<MenuDefinition>);
 
-menuDefinitions.set('PictureBrightness', [
-	{
-		type: 'json',
-		content: generatePictureBrightnessGrid('GrafLuminance'),
-	},
-	{ type: 'separator' }, // required to show dropdown arrow
-] as Array<MenuDefinition>);
+menuDefinitions.set(
+	'PictureBrightness',
+	generatePictureBrightnessMenu('GrafLuminance'),
+);
 
-menuDefinitions.set('PictureContrast', [
-	{
-		type: 'json',
-		content: generatePictureContrastGrid('GrafContrast'),
-	},
-	{ type: 'separator' }, // required to show dropdown arrow
-] as Array<MenuDefinition>);
+menuDefinitions.set(
+	'PictureContrast',
+	generatePictureContrastMenu('GrafContrast'),
+);
 
-menuDefinitions.set('PictureTransparency', [
-	{
-		type: 'json',
-		content: generatePictureTransparencyGrid('GrafTransparence'),
-	},
-	{ type: 'separator' }, // required to show dropdown arrow
-] as Array<MenuDefinition>);
+menuDefinitions.set(
+	'PictureTransparency',
+	generatePictureTransparencyMenu('GrafTransparence'),
+);
 
-menuDefinitions.set('PictureColorMode', [
-	{
-		type: 'json',
-		content: generatePictureColorModeGrid('GrafMode'),
-	},
-	{ type: 'separator' }, // required to show dropdown arrow
-] as Array<MenuDefinition>);
+menuDefinitions.set(
+	'PictureColorMode',
+	generatePictureColorModeMenu('GrafMode'),
+);
 
 JSDialog.MenuDefinitions = menuDefinitions;

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -527,22 +527,15 @@ function generateLayoutPopupGrid(unoCommand: string): GridWidgetJSON {
 function generatePictureBrightnessMenu(
 	unoCommand: string,
 ): Array<MenuDefinition> {
-	const brightnessValues = [
-		{ value: -40, text: _('minusforty') },
-		{ value: -20, text: _('minustwenty') },
-		{ value: 0, text: _('zero') },
-		{ value: 20, text: _('twenty') },
-		{ value: 40, text: _('forty') },
-	];
+	const brightnessValues = [-40, -20, 0, 20, 40];
 
 	const menuItems: Array<MenuDefinition> = [];
 
 	for (let i = 0; i < brightnessValues.length; i++) {
 		menuItems.push({
-			id: brightnessValues[i].text,
-			uno:
-				'.uno:' + unoCommand + '?Brightness:short=' + brightnessValues[i].value,
-			text: '' + brightnessValues[i].value,
+			id: 'brightness' + brightnessValues[i],
+			uno: '.uno:' + unoCommand + '?Brightness:short=' + brightnessValues[i],
+			text: brightnessValues[i] + '%',
 			img: 'insertgraphic',
 		} as MenuDefinition);
 	}
@@ -553,21 +546,15 @@ function generatePictureBrightnessMenu(
 function generatePictureContrastMenu(
 	unoCommand: string,
 ): Array<MenuDefinition> {
-	const contrastValues = [
-		{ value: -40, text: _('minusforty') },
-		{ value: -20, text: _('minustwenty') },
-		{ value: 0, text: _('zero') },
-		{ value: 20, text: _('twenty') },
-		{ value: 40, text: _('forty') },
-	];
+	const contrastValues = [-40, -20, 0, 20, 40];
 
 	const menuItems: Array<MenuDefinition> = [];
 
 	for (let i = 0; i < contrastValues.length; i++) {
 		menuItems.push({
-			id: contrastValues[i].text,
-			uno: '.uno:' + unoCommand + '?Contrast:short=' + contrastValues[i].value,
-			text: '' + contrastValues[i].value,
+			id: 'contrast' + contrastValues[i],
+			uno: '.uno:' + unoCommand + '?Contrast:short=' + contrastValues[i],
+			text: contrastValues[i] + '%',
 			img: 'insertgraphic',
 		} as MenuDefinition);
 	}
@@ -578,27 +565,16 @@ function generatePictureContrastMenu(
 function generatePictureTransparencyMenu(
 	unoCommand: string,
 ): Array<MenuDefinition> {
-	const transparencyValues = [
-		{ value: 0, text: _('zero') },
-		{ value: 15, text: _('fifteen') },
-		{ value: 30, text: _('thirty') },
-		{ value: 50, text: _('fifty') },
-		{ value: 65, text: _('sixtyfive') },
-		{ value: 80, text: _('eighty') },
-		{ value: 95, text: _('ninetyfive') },
-	];
+	const transparencyValues = [0, 15, 30, 50, 65, 80, 95];
 
 	const menuItems: Array<MenuDefinition> = [];
 
 	for (let i = 0; i < transparencyValues.length; i++) {
 		menuItems.push({
-			id: transparencyValues[i].text,
+			id: 'transparency' + transparencyValues[i],
 			uno:
-				'.uno:' +
-				unoCommand +
-				'?Transparency:short=' +
-				transparencyValues[i].value,
-			text: '' + transparencyValues[i].value,
+				'.uno:' + unoCommand + '?Transparency:short=' + transparencyValues[i],
+			text: transparencyValues[i] + '%',
 			img: 'insertgraphic',
 		} as MenuDefinition);
 	}

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -628,6 +628,39 @@ function generatePictureTransparencyGrid(unoCommand: string): GridWidgetJSON {
 	return grid as any as GridWidgetJSON;
 }
 
+function generatePictureColorModeGrid(unoCommand: string): GridWidgetJSON {
+	//see enum GraphicDrawMode in include/vcl/GraphicAttributes.hxx
+	const colorModeValues = [
+		{ value: 0, text: _('Default') },
+		{ value: 1, text: _('Grayscale') },
+		{ value: 2, text: _('Black/White') },
+		{ value: 3, text: _('Watermark') },
+	];
+
+	const grid = {
+		id: 'picturecolormodegrid',
+		type: 'grid',
+		cols: 4,
+		rows: 1,
+		children: new Array<WidgetJSON>(),
+	};
+
+	for (let i = 0; i < grid.cols; i++) {
+		grid.children.push({
+			id: colorModeValues[i].text,
+			type: 'toolitem',
+			command:
+				'.uno:' + unoCommand + '?ColorMode:short=' + colorModeValues[i].value,
+			text: colorModeValues[i].text,
+			noLabel: false,
+			left: i,
+			top: 0,
+		} as any as WidgetJSON);
+	}
+
+	return grid as any as GridWidgetJSON;
+}
+
 menuDefinitions.set('NewSlideLayoutMenu', [
 	{
 		type: 'json',
@@ -664,6 +697,14 @@ menuDefinitions.set('PictureTransparency', [
 	{
 		type: 'json',
 		content: generatePictureTransparencyGrid('GrafTransparence'),
+	},
+	{ type: 'separator' }, // required to show dropdown arrow
+] as Array<MenuDefinition>);
+
+menuDefinitions.set('PictureColorMode', [
+	{
+		type: 'json',
+		content: generatePictureColorModeGrid('GrafMode'),
 	},
 	{ type: 'separator' }, // required to show dropdown arrow
 ] as Array<MenuDefinition>);

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -524,6 +524,39 @@ function generateLayoutPopupGrid(unoCommand: string): GridWidgetJSON {
 	return grid as any as GridWidgetJSON;
 }
 
+function generatePictureBrightnessGrid(unoCommand: string): GridWidgetJSON {
+	const brightnessValues = [
+		{ value: -40, text: _('minusforty') },
+		{ value: -20, text: _('minustwenty') },
+		{ value: 0, text: _('zero') },
+		{ value: 20, text: _('twenty') },
+		{ value: 40, text: _('forty') },
+	];
+
+	const grid = {
+		id: 'picturebrightnessgrid',
+		type: 'grid',
+		cols: 5,
+		rows: 1,
+		children: new Array<WidgetJSON>(),
+	};
+
+	for (let i = 0; i < grid.cols; i++) {
+		grid.children.push({
+			id: brightnessValues[i].text,
+			type: 'toolitem',
+			command:
+				'.uno:' + unoCommand + '?Brightness:short=' + brightnessValues[i].value,
+			text: '' + brightnessValues[i].value,
+			noLabel: false,
+			left: i,
+			top: 0,
+		} as any as WidgetJSON);
+	}
+
+	return grid as any as GridWidgetJSON;
+}
+
 menuDefinitions.set('NewSlideLayoutMenu', [
 	{
 		type: 'json',
@@ -536,6 +569,14 @@ menuDefinitions.set('ChangeSlideLayoutMenu', [
 	{
 		type: 'json',
 		content: generateLayoutPopupGrid('AssignLayout'),
+	},
+	{ type: 'separator' }, // required to show dropdown arrow
+] as Array<MenuDefinition>);
+
+menuDefinitions.set('PictureBrightness', [
+	{
+		type: 'json',
+		content: generatePictureBrightnessGrid('GrafLuminance'),
 	},
 	{ type: 'separator' }, // required to show dropdown arrow
 ] as Array<MenuDefinition>);

--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -330,6 +330,7 @@ var unoCommandsArray = {
 	'FreezePanesRow':{spreadsheet:{menu:_('Freeze First Row'),},},
 	'FullScreen':{global:{menu:_('F~ull Screen'),},},
 	'FunctionDialog':{spreadsheet:{menu:_('~Function...'),},},
+	'GrafLuminance':{global:{menu:_('Brightness'),},},
 	'GoalSeekDialog':{spreadsheet:{menu:_('~Goal Seek...'),},},
 	'GraphicDialog':{text:{menu:_('~Properties...'),},},
 	'GridUse':{global:{menu:_('Snap to Grid'),},},

--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -330,6 +330,7 @@ var unoCommandsArray = {
 	'FreezePanesRow':{spreadsheet:{menu:_('Freeze First Row'),},},
 	'FullScreen':{global:{menu:_('F~ull Screen'),},},
 	'FunctionDialog':{spreadsheet:{menu:_('~Function...'),},},
+	'GrafContrast':{global:{menu:_('Contrast'),},},
 	'GrafLuminance':{global:{menu:_('Brightness'),},},
 	'GoalSeekDialog':{spreadsheet:{menu:_('~Goal Seek...'),},},
 	'GraphicDialog':{text:{menu:_('~Properties...'),},},

--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -332,6 +332,7 @@ var unoCommandsArray = {
 	'FunctionDialog':{spreadsheet:{menu:_('~Function...'),},},
 	'GrafContrast':{global:{menu:_('Contrast'),},},
 	'GrafLuminance':{global:{menu:_('Brightness'),},},
+	'GrafMode':{global:{menu:_('Color Mode'),},},
 	'GrafTransparence':{global:{menu:_('Transparency'),},},
 	'GoalSeekDialog':{spreadsheet:{menu:_('~Goal Seek...'),},},
 	'GraphicDialog':{text:{menu:_('~Properties...'),},},

--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -332,6 +332,7 @@ var unoCommandsArray = {
 	'FunctionDialog':{spreadsheet:{menu:_('~Function...'),},},
 	'GrafContrast':{global:{menu:_('Contrast'),},},
 	'GrafLuminance':{global:{menu:_('Brightness'),},},
+	'GrafTransparence':{global:{menu:_('Transparency'),},},
 	'GoalSeekDialog':{spreadsheet:{menu:_('~Goal Seek...'),},},
 	'GraphicDialog':{text:{menu:_('~Properties...'),},},
 	'GridUse':{global:{menu:_('Snap to Grid'),},},


### PR DESCRIPTION
* Target version: master 

### Summary
- Add Brightness menubutton
- Add Contrast menubutton
- Add Transparency menubutton
- Add Color Mode menubutton
- Add labels for menubuttons
- Add icons with different css filters

<img width="3395" height="436" alt="20250722_14h49m54s_grim" src="https://github.com/user-attachments/assets/c50f8881-b758-4800-a1ba-ad2cc23fa055" />

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

