### PR TITLE
fix(mobile): fix password-protected documents

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1477,6 +1477,7 @@ function getInitializerClass() {
 
 			delete this.send;
 			delete this._setPollInterval;
+			delete this.close;
 			// HACK: We need this to complete the override because ProxySocket messed up the protoype chain... evenually I want to convert it to a Real Class which will fix it
 		}
 
@@ -1484,6 +1485,7 @@ function getInitializerClass() {
 			global.postMobileMessage(data);
 		}
 
+		close() {} // We don't support re-opening the mobile socket, so let's make sure we don't close it...
 		_setPollInterval() {} // This is a no-op on mobile since as we will be calling from the native part to notify when we get a message
 	}
 

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -57,9 +57,10 @@ app.definitions.Socket = L.Class.extend({
 		}
 		if (socket && (socket.readyState === 1 || socket.readyState === 0)) {
 			this.socket = socket;
-		} else if (window.ThisIsTheGtkApp || window.ThisIsTheEmscriptenApp) {
-			// We have already opened the FakeWebSocket over in global.js
-			// But do we then set this.socket at all? Is this case ever reached?
+		} else if (window.ThisIsAMobileApp) {
+			// We have already opened the FakeWebSocket or MobileSocket over in global.js
+			// With the FakeWebSocket do we then set this.socket at all?
+			// With the MobileSocket we definitely do - this is load-bearing for opening password protected documents
 		} else	{
 			try {
 				this.socket = window.createWebSocket(this.getWebSocketBaseURI(map));


### PR DESCRIPTION
This fixes a regression from #12037

When a password protected document is opened, Collabora Online tries to reopen the socket in order to reload the document...

...Unfortunately this isn't possible with the mobile socket...

...Luckily that also wasn't possible with the FakeWebSocket so there is a mobile-specific route to load password protected documents anyway...

...Unfortunately we accidentally kept in code that can close the socket on a passworded document, leading to the socket being closed and never properly re-opened

It may be nice to make this work one day, but for now let's just stop the MobileSocket from trying to close or reopen


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

