### PR TITLE
Adapt Wasm build to core -gseparate-dwarf change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ gtk/mobile
 /wasm/online.js
 /wasm/online.wasm
 /wasm/online.wasm.debug.wasm
+/wasm/online.wasm.debug.wasm.dwp
 /wasm/soffice.data
 /wasm/soffice.data.js.metadata
 

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -738,7 +738,8 @@ WASM_FILES= \
 
 if ENABLE_DEBUG
 WASM_FILES += \
-	$(DIST_FOLDER)/online.wasm.debug.wasm
+	$(DIST_FOLDER)/online.wasm.debug.wasm \
+	$(DIST_FOLDER)/online.wasm.debug.wasm.dwp
 endif
 
 endif

--- a/wasm/Makefile.am
+++ b/wasm/Makefile.am
@@ -87,8 +87,17 @@ online_LDFLAGS = \
 online_LDFLAGS += $(if $(filter -g,$(CXXFLAGS)),-Wno-limited-postlink-optimizations)
 
 if ENABLE_DEBUG
+
 online_LDFLAGS += \
-	-gseparate-dwarf
+	-gseparate-dwarf -gsplit-dwarf -gpubnames
+
+%.wasm.dwp: %.wasm
+	emdwp -e $< -o $@
+
+online.wasm.debug.wasm: | online$(EXEEXT)
+
+all-local: online.wasm.debug.wasm.dwp
+
 endif
 
 if ENABLE_WASM_ADDITIONAL_FILES
@@ -102,3 +111,7 @@ exports: @LOBUILDDIR@/workdir/CustomTarget/desktop/soffice_bin-emscripten-export
 
 soffice.dat%: @LOBUILDDIR@/instdir/program/soffice.dat%
 	cp $< $@
+
+clean-local:
+	rm -f \
+		online.wasm.debug.wasm.dwp

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1423,7 +1423,8 @@ std::string FileServerRequestHandler::getRequestPathname(const HTTPRequest& requ
         {
             isWasm = true;
         }
-        else if (endPoint == "online.wasm.debug.wasm" || endPoint == "soffice.data.js.metadata")
+        else if (endPoint == "online.wasm.debug.wasm" || endPoint == "online.wasm.debug.wasm.dwp" ||
+                 endPoint == "soffice.data.js.metadata")
         {
             isWasm = true;
         }


### PR DESCRIPTION
...<https://git.libreoffice.org/core/+/3d3ffd12bdf672634b855eb536e418c520b7e30c%5E%21> "Emscripten: Put back -gseparate-dwarf", after which I witnessed some browser debug sessions to report

> [C/C++ DevTools Support (DWARF)] Loading debug symbols for http://localhost:6931/online.wasm (via online.wasm.debug.wasm)…
> [C/C++ DevTools Support (DWARF)] Failed to load debug symbols for http://localhost:6931/online.wasm (TypeError: Failed to fetch)

now, the same as described in the core commit message.  So use the same approach here and add -gsplit-dwarf and create an additional online.wasm.debug.dwp.


Change-Id: Id3f6eec963105f33007b0a24fad384c7e7a10f2e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

