### PR TITLE
Status bar: Pager: Improve Tooltip to reflect the new functionality

### DIFF
--- a/browser/src/control/jsdialog/Widget.HTMLContent.ts
+++ b/browser/src/control/jsdialog/Widget.HTMLContent.ts
@@ -79,7 +79,7 @@ function getStatusbarItemElements(
 function getPageNumberElements(text: string, builder: any) {
 	const element = getStatusbarItemElements(
 		'StatePageNumber',
-		_('Number of Pages'),
+		_('Number of Pages. Click to open the Go to Page dialog box.'),
 		text,
 		builder,
 	);


### PR DESCRIPTION
With the following changes:

25.04 https://gerrit.libreoffice.org/c/core/+/187669
master https://gerrit.libreoffice.org/c/core/+/187733

We now have a dialog that gets open when user clicks the status bar's
pager. Update the tooltip to increase discoverability of the new feature.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ieda2040c2725b54250ce5bb9aa2e3301fbef68a7
