### PR TITLE
Fix autofilter checklist box height in Calc by overriding modal min-height

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -866,8 +866,8 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 }
 
 .autofilter #list.ui-treeview,
-#check_list_box.autofilter.ui-treeview {
-	min-height: auto;
+.modalpopup #check_list_box.ui-treeview {
+	min-height: inherit !important;
 }
 /* checkbox */
 


### PR DESCRIPTION
Change-Id: I4935768edb3bf4a1c9a7039aa13ab1ea7f04fb2b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Auto filter Checklist dropdown height was being reset when more options are selected

### PREVIEW

https://github.com/user-attachments/assets/9e4edb1a-dd9c-4650-964b-0b0a490f2dc8

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

