### PR TITLE
removeEventListener doesn't work with bind(this)

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -371,7 +371,8 @@ class BrowserInitializer extends InitializerBase {
 		window.WOPIpostMessageReady = false;
 
 		// Start listening for Host_PostmessageReady message and save the result for future
-		window.addEventListener('message', this.postMessageHandler.bind(this), false);
+		this._boundPostMessageHandler = this.postMessageHandler.bind(this);
+		window.addEventListener('message', this._boundPostMessageHandler, false);
 
 		const element = document.getElementById("initial-variables");
 
@@ -424,7 +425,7 @@ class BrowserInitializer extends InitializerBase {
 
 		if (msg.MessageId === 'Host_PostmessageReady') {
 			window.WOPIPostmessageReady = true;
-			window.removeEventListener('message', this.postMessageHandler, false);
+			window.removeEventListener('message', this._boundPostMessageHandler, false);
 			console.log('Received Host_PostmessageReady.');
 		}
 	}

--- a/browser/src/control/Control.ESignature.ts
+++ b/browser/src/control/Control.ESignature.ts
@@ -338,12 +338,12 @@ namespace cool {
 
 			// If our window would be closed before the popup, then close the popup as
 			// well.
-			window.addEventListener('beforeunload', this.closePopup.bind(this));
+			window.addEventListener('beforeunload', this.closePopup);
 		}
 
-		closePopup(): boolean {
+		closePopup = (): boolean => {
 			try {
-				window.removeEventListener('beforeunload', this.closePopup.bind(this));
+				window.removeEventListener('beforeunload', this.closePopup);
 
 				if (this.popup) {
 					this.popup.close();
@@ -354,7 +354,7 @@ namespace cool {
 			}
 
 			return true;
-		}
+		};
 
 		// Handles the 'sign hash' response
 		handleSigned(response: SignedResponse): void {

--- a/browser/src/layer/marker/Cursor.ts
+++ b/browser/src/layer/marker/Cursor.ts
@@ -63,9 +63,9 @@ class Cursor {
 		else
 			this.map.on('move', this.update, this);
 
-		window.addEventListener('blur', this.onFocusBlur.bind(this));
-		window.addEventListener('focus', this.onFocusBlur.bind(this));
-		window.addEventListener('resize', this.onResize.bind(this));
+		window.addEventListener('blur', this.onFocusBlur);
+		window.addEventListener('focus', this.onFocusBlur);
+		window.addEventListener('resize', this.onResize);
 	}
 
 	setMouseCursor() {
@@ -99,9 +99,9 @@ class Cursor {
 		this.visible = false;
 		this.domAttached = false;
 
-		window.removeEventListener('blur', this.onFocusBlur.bind(this));
-		window.removeEventListener('focus', this.onFocusBlur.bind(this));
-		window.removeEventListener('resize', this.onResize.bind(this));
+		window.removeEventListener('blur', this.onFocusBlur);
+		window.removeEventListener('focus', this.onFocusBlur);
+		window.removeEventListener('resize', this.onResize);
 	}
 
 	isDomAttached(): boolean {
@@ -119,11 +119,11 @@ class Cursor {
 		return this.visible;
 	}
 
-	onFocusBlur(ev: FocusEvent) {
+	onFocusBlur = (ev: FocusEvent) => {
 		this.addCursorClass(ev.type !== 'blur');
 	}
 
-	onResize() {
+	onResize = () => {
 		if (window.devicePixelRatio !== 1 )
 			this.cursor.style.width = this.width / window.devicePixelRatio + 'px';
 		else

--- a/browser/src/slideshow/PresenterConsole.js
+++ b/browser/src/slideshow/PresenterConsole.js
@@ -142,7 +142,8 @@ class PresenterConsole {
 		this._map.on('transitionstart', this._onTransitionStart, this);
 		this._map.on('transitionend', this._onTransitionEnd, this);
 		this._map.on('tilepreview', this._onTilePreview, this);
-		this._map.on('presentinwindowclose', this._onWindowClose, this);
+		this._boundOnWindowClose = this._onWindowClose.bind(this);
+		this._map.on('presentinwindowclose', this._boundOnWindowClose, this);
 
 		// safe check for current-presentation element
 		const currentPresentationCanvas =
@@ -237,29 +238,22 @@ class PresenterConsole {
 		this._currentSlideContext =
 			this._currentSlideCanvas.getContext('bitmaprenderer');
 
-		this._proxyPresenter.addEventListener(
-			'resize',
-			L.bind(this._onResize, this),
-		);
+		this._boundOnResize = this._onResize.bind(this);
+		this._proxyPresenter.addEventListener('resize', this._boundOnResize);
 
 		if (this._presenter._slideShowWindowProxy) {
 			this._presenter._slideShowWindowProxy.addEventListener(
 				'unload',
-				L.bind(this._onWindowClose, this),
+				this._boundOnWindowClose,
 			);
-			window.addEventListener(
-				'beforeunload',
-				L.bind(this._onWindowClose, this),
-			);
+			window.addEventListener('beforeunload', this._boundOnWindowClose);
 		}
 		this._proxyPresenter.addEventListener(
 			'unload',
 			L.bind(this._onConsoleClose, this),
 		);
-		this._proxyPresenter.addEventListener(
-			'keydown',
-			L.bind(this._onKeyDown, this),
-		);
+		this._boundOnKeyDown = this._onKeyDown.bind(this);
+		this._proxyPresenter.addEventListener('keydown', this._boundOnKeyDown);
 
 		// Declare some basic elements that we will use often in next function calls
 		this._prevButton = this._proxyPresenter.document.querySelector('#prev');
@@ -1107,10 +1101,7 @@ class PresenterConsole {
 		if (this._proxyPresenter && !this._proxyPresenter.closed)
 			this._proxyPresenter.close();
 
-		window.removeEventListener(
-			'beforeunload',
-			L.bind(this._onWindowClose, this),
-		);
+		window.removeEventListener('beforeunload', this._boundOnWindowClose);
 
 		this._presenter._stopFullScreen();
 	}
@@ -1122,14 +1113,8 @@ class PresenterConsole {
 		)
 			this._presenter.slideshowWindowCleanUp();
 
-		this._proxyPresenter.removeEventListener(
-			'resize',
-			L.bind(this._onResize, this),
-		);
-		this._proxyPresenter.removeEventListener(
-			'keydown',
-			L.bind(this._onKeyDown, this),
-		);
+		this._proxyPresenter.removeEventListener('resize', this._boundOnResize);
+		this._proxyPresenter.removeEventListener('keydown', this._boundOnKeyDown);
 		this._proxyPresenter.clearInterval(this._timer);
 		this._proxyPresenter.close();
 

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -520,7 +520,7 @@ class SlideShowPresenter {
 		);
 		this._slideShowCanvas.focus();
 
-		window.addEventListener('resize', this.onSlideWindowResize.bind(this));
+		window.addEventListener('resize', this.onSlideWindowResize);
 		this._getProxyDocumentNode().addEventListener(
 			'keydown',
 			this._onKeyDownHandler,
@@ -552,19 +552,16 @@ class SlideShowPresenter {
 		);
 	}
 
-	slideshowWindowCleanUp() {
+	slideshowWindowCleanUp = () => {
 		clearInterval(this._windowCloseInterval);
 		this._slideShowNavigator.quit();
 		this._map.uiManager.closeSnackbar();
 		this._slideShowCanvas = null;
 		this._presenterContainer = null;
 		this._slideShowWindowProxy = null;
-		window.removeEventListener('resize', this.onSlideWindowResize.bind(this));
-		window.removeEventListener(
-			'beforeunload',
-			this.slideshowWindowCleanUp.bind(this),
-		);
-	}
+		window.removeEventListener('resize', this.onSlideWindowResize);
+		window.removeEventListener('beforeunload', this.slideshowWindowCleanUp);
+	};
 
 	_onImpressModeChangedImpl(e: any, inWindow: boolean) {
 		if (this._onImpressModeChanged && e.mode === 0) {
@@ -649,9 +646,9 @@ class SlideShowPresenter {
 		return true;
 	}
 
-	onSlideWindowResize() {
+	onSlideWindowResize = () => {
 		this.centerCanvas();
-	}
+	};
 
 	_checkAlreadyPresenting() {
 		if (this._slideShowCanvas) return true;


### PR DESCRIPTION
problem:
when an event listener is added with function binding to this using `bind(this)` it creates new function

so when we try to remove listener again pointing to a function again with `bind(this)` it again creates new function

so when adding and removing listeners these functions are different causing original event to be never removed


Change-Id: I68cee02e37f8a0be684f22b03436ace0d3ebbb0b


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

