### PR TITLE
Add xml parameter logoURL

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -66,6 +66,7 @@ html[dir='rtl'] .sub-menu-arrow {
 .document-logo {
 	width: 35px;
 	height: 38px;
+	background-size: 35px 35px;
 }
 
 #document-titlebar {
@@ -104,18 +105,6 @@ html[dir='rtl'] .sub-menu-arrow {
 	float: right;
 	background-color: var(--color-background-lighter);
 	height: 100%;
-}
-
-.writer-icon-img {
-	background-size: 35px 35px;
-}
-
-.calc-icon-img {
-	background-size: 35px 35px;
-}
-
-.impress-icon-img {
-	background-size: 35px 35px;
 }
 
 #document-name-input {

--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -34,6 +34,9 @@
 	position: relative;
 	width: 30px;
 	height: 30px;
+	background-size: 16px 16px;
+	background-repeat: no-repeat;
+	background-position: center;
 }
 
 .document-title {
@@ -363,23 +366,14 @@ nav.hasnotebookbar #save.saved::after {
 
 .writer-icon-img {
 	background-image: url('images/x-office-document.svg');
-	background-size: 16px 16px;
-	background-repeat: no-repeat;
-	background-position: center;
 }
 
 .calc-icon-img {
 	background-image: url('images/x-office-spreadsheet.svg');
-	background-size: 16px 16px;
-	background-repeat: no-repeat;
-	background-position: center;
 }
 
 .impress-icon-img {
 	background-image: url('images/x-office-presentation.svg');
-	background-size: 16px 16px;
-	background-repeat: no-repeat;
-	background-position: center;
 }
 
 .draw-icon-img {

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -56,6 +56,7 @@ m4_ifelse(MOBILEAPP, [true],
 
 <input type="hidden" id="init-product-branding-name" value="%PRODUCT_BRANDING_NAME%" />
 <input type="hidden" id="init-product-branding-url" value="%PRODUCT_BRANDING_URL%" />
+<input type="hidden" id="init-logo-url" value="%LOGO_URL%" />
 
 <input type="hidden" id="init-uri-prefix" value="m4_ifelse(MOBILEAPP, [], [%SERVICE_ROOT%/browser/%VERSION%/])" />
 <input type="hidden" id="init-branding-name" value="%BRANDING_THEME%" />

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -297,6 +297,10 @@ class InitializerBase {
 		if (typeof productURL === 'string' && productURL.length) {
 			window.brandProductURL = productURL;
 		}
+		let logoURL = document.getElementById("init-logo-url").value;
+		if (typeof logoURL === 'string' && logoURL.length) {
+			window.logoURL= logoURL;
+		}
 
 		this.initiateCoolParams();
 	}

--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -2392,21 +2392,27 @@ class Menubar extends window.L.Control {
 	 * Creates the file icon in the menubar header.
 	 */
 	private _createFileIcon(): void {
-		var liItem = window.L.DomUtil.create('li', '');
-		liItem.id = 'document-header';
-		liItem.setAttribute('role', 'menuitem');
-		var aItem = window.L.DomUtil.create('div', 'document-logo', liItem);
-		$(aItem).data('id', 'document-logo');
-		$(aItem).data('type', 'action');
-		aItem.setAttribute('role', 'img');
-		aItem.setAttribute('aria-label', _('file type icon'));
+		if (!(window.logoURL && window.logoURL == "none")) {
+			var liItem = window.L.DomUtil.create('li', '');
+			liItem.id = 'document-header';
+			liItem.setAttribute('role', 'menuitem');
+			var aItem = window.L.DomUtil.create('div', 'document-logo', liItem);
+			$(aItem).data('id', 'document-logo');
+			$(aItem).data('type', 'action');
+			aItem.setAttribute('role', 'img');
+			aItem.setAttribute('aria-label', _('file type icon'));
 
-		if (this._menubarCont != null)
-			this._menubarCont.insertBefore(liItem, this._menubarCont.firstChild);
+			if (window.logoURL) {
+				aItem.style.backgroundImage = "url(" + window.logoURL + ")";
+			}
 
-		var $docLogo = $(aItem);
-		$docLogo.bind('click', {self: this}, this._createDocument);
-		$docLogo.bind('click', this._createDocument.bind(this));
+			if (this._menubarCont != null)
+				this._menubarCont.insertBefore(liItem, this._menubarCont.firstChild);
+
+			var $docLogo = $(aItem);
+			$docLogo.bind('click', {self: this}, this._createDocument);
+			$docLogo.bind('click', this._createDocument.bind(this));
+		}
 	}
 
 	/**

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -81,28 +81,41 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 
 		var docLogoHeader = window.L.DomUtil.create('div', '');
 		docLogoHeader.id = 'document-header';
+		if (!window.logoURL || window.logoURL != "none") {
+			var docLogoHeader = window.L.DomUtil.create('div', '');
+			docLogoHeader.id = 'document-header';
 
-		var iconClass = 'document-logo';
-		var iconTooltip;
-		if (docType === 'text') {
-			iconClass += ' writer-icon-img';
-			iconTooltip = 'Writer';
-		} else if (docType === 'spreadsheet') {
-			iconClass += ' calc-icon-img';
-			iconTooltip = 'Calc';
-		} else if (docType === 'presentation') {
-			iconClass += ' impress-icon-img';
-			iconTooltip = 'Impress';
-		} else if (docType === 'drawing') {
-			iconClass += ' draw-icon-img';
-			iconTooltip = 'Draw';
+			var iconClass = 'document-logo';
+			var iconTooltip;
+			if (!window.logoURL) {
+				if (docType === 'text') {
+					iconClass += ' writer-icon-img';
+					iconTooltip = 'Writer';
+				} else if (docType === 'spreadsheet') {
+					iconClass += ' calc-icon-img';
+					iconTooltip = 'Calc';
+				} else if (docType === 'presentation') {
+					iconClass += ' impress-icon-img';
+					iconTooltip = 'Impress';
+				} else if (docType === 'drawing') {
+					iconClass += ' draw-icon-img';
+					iconTooltip = 'Draw';
+				}
+			}
+			var docLogo = window.L.DomUtil.create('div', iconClass, docLogoHeader);
+			$(docLogo).data('id', 'document-logo');
+			$(docLogo).data('type', 'action');
+			if (iconTooltip) {
+				docLogo.setAttribute('data-cooltip', iconTooltip);
+			}
+			window.L.control.attachTooltipEventListener(docLogo, this.map);
+			$('.main-nav').prepend(docLogoHeader);
+
+			if (window.logoURL) {
+				docLogo.style.backgroundImage = "url(" + window.logoURL + ")";
+			}
 		}
-		var docLogo = window.L.DomUtil.create('div', iconClass, docLogoHeader);
-		$(docLogo).data('id', 'document-logo');
-		$(docLogo).data('type', 'action');
-		docLogo.setAttribute('data-cooltip', iconTooltip);
-		window.L.control.attachTooltipEventListener(docLogo, this.map);
-		$('.main-nav').prepend(docLogoHeader);
+
 		var isDarkMode = window.prefs.getBoolean('darkTheme');
 		if (!isDarkMode)
 			$('#invertbackground').hide();

--- a/browser/src/global.d.ts
+++ b/browser/src/global.d.ts
@@ -318,6 +318,7 @@ interface Window {
 	wopiSettingBaseUrl: string;
 	socketProxy: boolean;
 	langParam: string;
+	logoURL?: string;
 
 	socket: SockInterface;
 	errorMessages: ErrorMessages;

--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -291,6 +291,7 @@ static const std::unordered_map<std::string, std::string> DefAppConfig = {
     { "user_interface.use_integration_theme", "true" },
     { "user_interface.brandProductName", "" },
     { "user_interface.brandProductURL", "" },
+    { "user_interface.logoURL", "" },
     { "wasm.enable", "false" },
     { "wasm.force", "false" },
     { "watermark.opacity", "0.2" },

--- a/configure.ac
+++ b/configure.ac
@@ -1052,7 +1052,8 @@ else
       <enable type=\"bool\" desc=\"Controls whether the welcome screen should be shown to the users on new install and updates. When enabled, your custom welcome screen must be created at /usr/share/coolwsd/browser/dist/welcome/welcome.html.\" default=\"false\">false</enable>
     </welcome>"
     CONFIG_INTERFACE_FRAGMENT="<brandProductName desc=\"Change the displayed name the application will have for the user.\" type=\"string\"></brandProductName>
-    <brandProductURL desc=\"Change the product URL, empty makes disable the link\" type=\"string\">https://www.collaboraonline.com</brandProductURL>"
+    <brandProductURL desc=\"Change the product URL, empty makes disable the link\" type=\"string\">https://www.collaboraonline.com</brandProductURL>
+    <logoURL desc=\"Change the URL of the logo used by Collabora Online, use none to hide it.\" type=\"string\"></logoURL>"
 fi
 
 AC_SUBST([WELCOME_CONFIG_FRAGMENT])

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1773,8 +1773,10 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
 
         std::string brandProductURL = ConfigUtil::getConfigValue<std::string>(config, "user_interface.brandProductURL", "");
         std::string brandProductName = ConfigUtil::getConfigValue<std::string>(config, "user_interface.brandProductName", "");
+        std::string logoUrl = ConfigUtil::getConfigValue<std::string>(config, "user_interface.logoURL", "");
         Poco::replaceInPlace(preprocess, std::string("%PRODUCT_BRANDING_NAME%"), brandProductName);
         Poco::replaceInPlace(preprocess, std::string("%PRODUCT_BRANDING_URL%"), brandProductURL);
+        Poco::replaceInPlace(preprocess, std::string("%LOGO_URL%"), logoUrl);
     #endif
 
     Poco::replaceInPlace(preprocess, std::string("%ENABLE_WELCOME_MSG%"), enableWelcomeMessage);


### PR DESCRIPTION
In user_interface section.

none implies hiding the logo entirely, "" (the default) keeps the default logo.

The option is only visible in COOL.

Change-Id: If18041337d14ce4b99fe6c69e7c077729853608d

### Summary

Similar to github.com/CollaboraOnline/online/pull/11029

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

