### PR TITLE
place find replace dialog tab buttons at the start and not in the center

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2450,6 +2450,10 @@ kbd,
 	height: 16px;
 }
 
+#findreplacetabbox {
+	justify-content: start;
+}
+
 /* text-area overflow on function wizard window */
 
 #FormulaDialog #ed_formula.ui-textarea {


### PR DESCRIPTION
Change-Id: Ic8a5376dc7022eb13803d24cd20e96822619b2ab


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
accompanies https://gerrit.libreoffice.org/c/core/+/188305. the buttons are center aligned so i added some css to justify them at the start.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

