### PR TITLE
feat(readonly): hide uninteractible elements

### DIFF
--- a/browser/src/canvas/sections/AutoFillMarkerSection.ts
+++ b/browser/src/canvas/sections/AutoFillMarkerSection.ts
@@ -25,6 +25,9 @@ class AutoFillMarkerSection extends CanvasSectionObject {
 	cursorBorderWidth: number = 2;
 	selectionBorderWidth: number = 1;
 
+	_showSection: boolean = true; // Store the internal show/hide section through forced readonly hides...
+	super_setShowSection: (show: boolean) => void; // HACK: used when dealing with CanvasSectionContainer only having setShowSection via addSectionFunctions
+
 	constructor () {
 		super();
 		this.documentObject = true;
@@ -54,6 +57,15 @@ class AutoFillMarkerSection extends CanvasSectionObject {
 		else {
 			this.size = [Math.round(16 * app.dpiScale), Math.round(16 * app.dpiScale)];
 		}
+
+		app.events.on('updatepermission', this.setMaybeReadonlyShowSection.bind(this));
+
+		// HACK: used when dealing with CanvasSectionContainer only having setShowSection via addSectionFunctions
+		// we need to rename the property otherwise
+		// (1) we will not be able to call it again via super, since as it's not a real superclass function
+		// (2) we will not be able to call our own setShowSection as, since as it's set directly on the object, it'll override everything in the prototype...
+		this.super_setShowSection = this.setShowSection;
+		delete this.setShowSection;
 	}
 
 	public onResize () {
@@ -138,6 +150,19 @@ class AutoFillMarkerSection extends CanvasSectionObject {
 		this.context.moveTo(transformX(-0.5), -0.5);
 		this.context.lineTo(transformX(-0.5), translation[1] + 0.5 - borderWidth);
 		this.context.stroke();
+	}
+
+	setShowSection(show: boolean) {
+		this._showSection = show;
+		this.setMaybeReadonlyShowSection();
+	}
+
+	setMaybeReadonlyShowSection() {
+		if (app.map._permission === 'readonly') {
+			this.super_setShowSection(false);
+		} else {
+			this.super_setShowSection(this._showSection);
+		}
 	}
 
 	public onDraw () {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3025,6 +3025,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			&& this._map.editorHasFocus()   // not when document is not focused
 			&& !this._map.isSearching()  	// not when searching within the doc
 			&& !this._isZooming             // not when zooming
+			&& this._map._permission !== 'readonly' // not when we don't have permission to edit
 		) {
 			this._updateCursorPos();
 


### PR DESCRIPTION
We can't write/autofill in readonly mode so showing the blinking cursor and autofill handle is confusing for users.

I've hidden sections here by introducing an accessor over the showSection property as otherwise various other things will interfere with the showing/hiding even in readonly mode. The cursor is the exception: it is hidden by making sure that when it updates it will not be shown if we are in readonly mode

I haven't hidden anything that could still theoretically be used. For example, you can copy from the cell cursor and selecting text/cells/etc. still works fine so I've avoided hiding the cell cursor or selection handes.

If you're testing this out you may run across another bug where entering readonly mode improperly deselects the content, leaving you with some handles displayed around a deselected area. This behavior has not been changed in this commit and fixing it is out-of-scope for me here...


Change-Id: I6a6a6964f71147f5c073991b5a7ef7465a0ba55c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

