### PR TITLE
Scale the calc validity dropwdown arrow's size with dpiScale.

### DIFF
--- a/browser/src/canvas/sections/CalcValidityDropDownSection.ts
+++ b/browser/src/canvas/sections/CalcValidityDropDownSection.ts
@@ -10,10 +10,12 @@
 */
 
 class CalcValidityDropDown extends HTMLObjectSection {
+	public static dropDownArrowSize = 16; // Size of the validity drop-down arrow in CSS pixels.
+
 	zIndex: number = L.CSections.CalcValidityDropDown.zIndex;
 
 	constructor (documentPosition: cool.SimplePoint, visible: boolean = true) {
-		super(L.CSections.CalcValidityDropDown.name, 16, 16, documentPosition, 'spreadsheet-drop-down-marker', visible);
+		super(L.CSections.CalcValidityDropDown.name, CalcValidityDropDown.dropDownArrowSize, CalcValidityDropDown.dropDownArrowSize, documentPosition, 'spreadsheet-drop-down-marker', visible);
 
 		this.sectionProperties.mouseEntered = false;
 	}

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3185,10 +3185,10 @@ L.CanvasTileLayer = L.Layer.extend({
 			let position;
 			if (this.sheetGeometry) {
 				position = this.sheetGeometry.getCellRect(this._validatedCellAddress.x, this._validatedCellAddress.y);
-				position = new app.definitions.simplePoint(app.calc.cellCursorRectangle.x2, (position.max.y - 16) * app.pixelsToTwips);
+				position = new app.definitions.simplePoint(app.calc.cellCursorRectangle.x2, (position.max.y - CalcValidityDropDown.dropDownArrowSize * app.dpiScale) * app.pixelsToTwips);
 			}
 			else
-				position = new app.definitions.simplePoint(app.calc.cellCursorRectangle.x2, app.calc.cellCursorRectangle.y2 - 16 * app.pixelsToTwips);
+				position = new app.definitions.simplePoint(app.calc.cellCursorRectangle.x2, app.calc.cellCursorRectangle.y2 - CalcValidityDropDown.dropDownArrowSize * app.dpiScale * app.pixelsToTwips);
 
 			if (!app.sectionContainer.getSectionWithName(L.CSections.CalcValidityDropDown.name)) {
 				let dropDownSection = new CalcValidityDropDown(position);


### PR DESCRIPTION
    Issue:
    Its scale is calculated wrong when dpiScale is different than one and OS-level display scale is used.


Change-Id: I6921b62d90b9b9ab356420918a7cbd0464768d48


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

