### PR TITLE
Fix cursor position check.

### DIFF
--- a/browser/src/layer/marker/Cursor.ts
+++ b/browser/src/layer/marker/Cursor.ts
@@ -174,13 +174,7 @@ class Cursor {
 		var canvasOffset = this.position.subtract(origin);
 
 		if (inDocCursor) {
-			var cursorOffset = new cool.Point(
-				origin.x ? canvasOffset.x - splitPos.x : canvasOffset.x,
-				origin.y ? canvasOffset.y - splitPos.y : canvasOffset.y);
-			var paneBounds = new cool.Bounds(new cool.Point(0, 0), paneSize);
-			var cursorBounds = new cool.Bounds(cursorOffset, cursorOffset.add(this.size));
-
-			if (!paneBounds.contains(cursorBounds)) {
+			if (!app.isRectangleVisibleInTheDisplayedArea(app.file.textCursor.rectangle.toArray())) {
 				this.container.style.visibility = 'hidden';
 				this.visible = false;
 				this.addCursorClass(this.visible);


### PR DESCRIPTION
Issue:
When view is splitted in Calc, cursor position needs to be checked against the split-panes. This commit uses app.isRectangleVisibleInTheDisplayedArea to check its visibility.


Change-Id: I5cf7617ec545361416857449d4f67a730aba12d0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

