### PR TITLE
backport(co-25.04-mobile): fix(mobile): disable video insertion

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1220,13 +1220,14 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'command': '.uno:InsertGraphic',
 				'accessibility': { focusBack: true, combination: 'IG', de: null }
 			},
-			{
-				'id': 'insert-insert-multimedia:InsertMultimediaMenu',
-				'type': 'menubutton',
-				'text': _UNO('.uno:InsertAVMedia'),
-				'command': 'insertmultimedia',
-				'accessibility': { focusBack: true, combination: 'MM', de: null }, // IM was already taken, so 'MM' for MultiMedia
-			},
+			!window.ThisIsAMobileApp ?
+				{
+					'id': 'insert-insert-multimedia:InsertMultimediaMenu',
+					'type': 'menubutton',
+					'text': _UNO('.uno:InsertAVMedia'),
+					'command': 'insertmultimedia',
+					'accessibility': { focusBack: true, combination: 'MM', de: null }, // IM was already taken, so 'MM' for MultiMedia
+				} : {},
 			{
 				'type': 'container',
 				'children': [


### PR DESCRIPTION
This is a trivial backport of #12429

Video insertion appears not to work in either iOS or Android

- in Android it does nothing
- in iOS it gives an "invalid syntax" error
- in iOS if you click the "take video" button it crashes the app, losing unsaved data

These are not ideal effects - particularly not the crash of the app which is highly undesirable.

In the future we will add this functionality back, but right now the "crash the app and lose my data" button needs to be gone for the 25.04.3 release


Change-Id: I6a6a6964b411be3c65b57e9b46b2a3a9b2b01c1c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

