### PR TITLE
Fix missing height for big buttons. e.g: comment

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -344,6 +344,8 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 
 .unotoolbutton.notebookbar.has-label:not(.inline) img {
 	width: 24px !important;
+	height: 24px !important;
+	box-sizing: border-box;
 	margin: auto !important;
 	display: block;
 }


### PR DESCRIPTION
Before this commit the buttons were missing the height and the
box-sizing was not set which means that any additional border or
padding would affect the overall size of the button. Best to set it -
border-box - so whatever there is there the size will be always 24px.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I1a1b1e6b6b13a5f43af6280a4ed9cc5186a2039d
