### PR TITLE
Updated sparkline contexual group and ungroup icons

### DIFF
--- a/browser/images/dark/lc_groupsparklines.svg
+++ b/browser/images/dark/lc_groupsparklines.svg
@@ -1,12 +1,1 @@
-<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M21 14.5L17 7.5L13 15.5L8.53333 8.04763L4 16.5" stroke="#ED8733" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M12.725 19H2.275C2.12312 19 2 19.2239 2 19.5C2 19.7761 2.12312 20 2.275 20H12.725C12.8769 20 13 19.7761 13 19.5C13 19.2239 12.8769 19 12.725 19Z" fill="#FAFAFA"/>
-<path d="M21.5 4H2.5C2.22386 4 2 4.22386 2 4.5C2 4.77614 2.22386 5 2.5 5H21.5C21.7761 5 22 4.77614 22 4.5C22 4.22386 21.7761 4 21.5 4Z" fill="#FAFAFA"/>
-<path d="M4 8.5L8.5 16L13 8L17.5 14.5L21 8" stroke="#1E8BCD" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M4 2.5C4 2.22386 3.77614 2 3.5 2C3.22386 2 3 2.22386 3 2.5V21.5C3 21.7761 3.22386 22 3.5 22C3.77614 22 4 21.7761 4 21.5V2.5Z" fill="#FAFAFA"/>
-<path d="M13 14V22H22V14H13ZM14 15H21V21H14V15Z" fill="#18AB50"/>
-<path d="M13.5 17.5H21.5V18.5H13.5V17.5Z" fill="#18AB50"/>
-<path d="M18 14.5V21.5H17V14.5H18Z" fill="#18AB50"/>
-<path d="M12 13H13V22H12V13Z" fill="#797774"/>
-<path d="M22 13V14H12V13H22Z" fill="#797774"/>
-</svg>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="m5 4c-.554 0-1 .446-1 1v8c0 .554.446 1 1 1h10c.554 0 1-.446 1-1v-8c0-.554-.446-1-1-1zm0 1h10v8h-10z" fill="#fafafa"/><path d="m9 10c-.554 0-1 .446-1 1v8c0 .554.446 1 1 1h10c.554 0 1-.446 1-1v-8c0-.554-.446-1-1-1zm0 1h10v8h-10z" fill="#fafafa"/><g fill="#83beec"><path d="m2 2v3h3v-3zm1 1h1v1h-1z"/><path d="m19 2v3h3v-3zm1 1h1v1h-1z"/><path d="m2 19v3h3v-3zm1 1h1v1h-1z"/><path d="m19 19v3h3v-3zm1 1h1v1h-1z"/></g></svg>

--- a/browser/images/dark/lc_ungroupsparklines.svg
+++ b/browser/images/dark/lc_ungroupsparklines.svg
@@ -1,11 +1,17 @@
 <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M21 14.5L17 7.5L13 15.5L8.53333 8.04763L4 16.5" stroke="#ED8733" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M12.725 19H2.275C2.12312 19 2 19.2239 2 19.5C2 19.7761 2.12312 20 2.275 20H12.725C12.8769 20 13 19.7761 13 19.5C13 19.2239 12.8769 19 12.725 19Z" fill="#FAFAFA"/>
-<path d="M21.5 4H2.5C2.22386 4 2 4.22386 2 4.5C2 4.77614 2.22386 5 2.5 5H21.5C21.7761 5 22 4.77614 22 4.5C22 4.22386 21.7761 4 21.5 4Z" fill="#FAFAFA"/>
-<path d="M4 8.5L8.5 16L13 8L17 14.5L21 8" stroke="#1E8BCD" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M4 2.5C4 2.22386 3.77614 2 3.5 2C3.22386 2 3 2.22386 3 2.5V21.5C3 21.7761 3.22386 22 3.5 22C3.77614 22 4 21.7761 4 21.5V2.5Z" fill="#FAFAFA"/>
-<path d="M13 14V22H22V14H13ZM14 15H21V21H14V15Z" fill="#D42314"/>
-<path d="M13.5 17.5H21.5V18.5H13.5V17.5Z" fill="#D42314"/>
-<path d="M12 13H13V22H12V13Z" fill="#797774"/>
-<path d="M22 13V14H12V13H22Z" fill="#797774"/>
+  <path d="M18 20V21H11V20H18Z" fill="#FAFAFA"/>
+  <path d="M9 18H8V13H9V18Z" fill="#FAFAFA"/>
+  <path d="M21 18H20V13H21V18Z" fill="#FAFAFA"/>
+  <path d="M18 11H11V10H18V11Z" fill="#FAFAFA"/>
+  <rect x="7" y="19" width="3" height="3" rx="0.5" fill="#FAFAFA"/>
+  <rect x="7" y="9" width="3" height="3" rx="0.5" fill="#FAFAFA"/>
+  <rect x="19" y="19" width="3" height="3" rx="0.5" fill="#FAFAFA"/>
+  <rect x="19" y="9" width="3" height="3" rx="0.5" fill="#FAFAFA"/>
+  <path d="M9 14H6V13H9V14Z" fill="#FAFAFA"/>
+  <path d="M16 11H15V6H16V11Z" fill="#FAFAFA"/>
+  <path d="M4 11H3V6H4V11Z" fill="#FAFAFA"/>
+  <path d="M13 4H6V3H13V4Z" fill="#FAFAFA"/>
+  <rect x="2" y="2" width="3" height="3" rx="0.5" fill="#FAFAFA"/>
+  <rect x="2" y="12" width="3" height="3" rx="0.5" fill="#FAFAFA"/>
+  <rect x="14" y="2" width="3" height="3" rx="0.5" fill="#FAFAFA"/>
 </svg>

--- a/browser/images/lc_groupsparklines.svg
+++ b/browser/images/lc_groupsparklines.svg
@@ -1,12 +1,22 @@
-<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M21 14.5L17 7.5L13 15.5L8.53333 8.04763L4 16.5" stroke="#ED8733" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M12.725 19H2.275C2.12312 19 2 19.2239 2 19.5C2 19.7761 2.12312 20 2.275 20H12.725C12.8769 20 13 19.7761 13 19.5C13 19.2239 12.8769 19 12.725 19Z" fill="#797774"/>
-<path d="M21.5 4H2.5C2.22386 4 2 4.22386 2 4.5C2 4.77614 2.22386 5 2.5 5H21.5C21.7761 5 22 4.77614 22 4.5C22 4.22386 21.7761 4 21.5 4Z" fill="#797774"/>
-<path d="M4 8.5L8.5 16L13 8L17.5 14.5L21 8" stroke="#1E8BCD" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M4 2.5C4 2.22386 3.77614 2 3.5 2C3.22386 2 3 2.22386 3 2.5V21.5C3 21.7761 3.22386 22 3.5 22C3.77614 22 4 21.7761 4 21.5V2.5Z" fill="#797774"/>
-<path d="M13 14V22H22V14H13ZM14 15H21V21H14V15Z" fill="#18AB50"/>
-<path d="M13.5 17.5H21.5V18.5H13.5V17.5Z" fill="#18AB50"/>
-<path d="M18 14.5V21.5H17V14.5H18Z" fill="#18AB50"/>
-<path d="M12 13H13V22H12V13Z" fill="#FAFAFA"/>
-<path d="M22 13V14H12V13H22Z" fill="#FAFAFA"/>
+<?xml-stylesheet type="text/css" href="icons.css" ?>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <g id="symbol"
+     class="icn icn--area-color-line"
+     fill="none"
+     stroke="#3a3a38"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+      >
+      <path d="m 3.5,3.5 h 12 v 10 h -12 z" />
+      <path d="m 8.5,10.5 h 12 v 10 h -12 z" />
+  </g>
+  <g id="symbol"
+	 class="icn icn--highlight-color"  
+     fill="#83beec" 
+     stroke="#1e8bcd" 
+	 stroke-linecap="round" 
+	 stroke-linejoin="round"
+      >
+      <path d="m 2.5,2.5 v 2 h 2 v -2 z m 17,0 v 2 h 2 v -2 z m -17,17 v 2 h 2 v -2 z m 17,0 v 2 h 2 v -2 z" />
+  </g>
 </svg>

--- a/browser/images/lc_ungroupsparklines.svg
+++ b/browser/images/lc_ungroupsparklines.svg
@@ -1,11 +1,17 @@
 <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M21 14.5L17 7.5L13 15.5L8.53333 8.04763L4 16.5" stroke="#ED8733" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M12.725 19H2.275C2.12312 19 2 19.2239 2 19.5C2 19.7761 2.12312 20 2.275 20H12.725C12.8769 20 13 19.7761 13 19.5C13 19.2239 12.8769 19 12.725 19Z" fill="#797774"/>
-<path d="M21.5 4H2.5C2.22386 4 2 4.22386 2 4.5C2 4.77614 2.22386 5 2.5 5H21.5C21.7761 5 22 4.77614 22 4.5C22 4.22386 21.7761 4 21.5 4Z" fill="#797774"/>
-<path d="M4 8.5L8.5 16L13 8L17 14.5L21 8" stroke="#1E8BCD" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M4 2.5C4 2.22386 3.77614 2 3.5 2C3.22386 2 3 2.22386 3 2.5V21.5C3 21.7761 3.22386 22 3.5 22C3.77614 22 4 21.7761 4 21.5V2.5Z" fill="#797774"/>
-<path d="M13 14V22H22V14H13ZM14 15H21V21H14V15Z" fill="#D42314"/>
-<path d="M13.5 17.5H21.5V18.5H13.5V17.5Z" fill="#D42314"/>
-<path d="M12 13H13V22H12V13Z" fill="#FAFAFA"/>
-<path d="M22 13V14H12V13H22Z" fill="#FAFAFA"/>
+  <path d="M18 20V21H11V20H18Z" fill="#3A3A38"/>
+  <path d="M9 18H8V13H9V18Z" fill="#3A3A38"/>
+  <path d="M21 18H20V13H21V18Z" fill="#3A3A38"/>
+  <path d="M18 11H11V10H18V11Z" fill="#3A3A38"/>
+  <rect x="7" y="19" width="3" height="3" rx="0.5" fill="#3A3A38"/>
+  <rect x="7" y="9" width="3" height="3" rx="0.5" fill="#3A3A38"/>
+  <rect x="19" y="19" width="3" height="3" rx="0.5" fill="#3A3A38"/>
+  <rect x="19" y="9" width="3" height="3" rx="0.5" fill="#3A3A38"/>
+  <path d="M9 14H6V13H9V14Z" fill="#3A3A38"/>
+  <path d="M16 11H15V6H16V11Z" fill="#3A3A38"/>
+  <path d="M4 11H3V6H4V11Z" fill="#3A3A38"/>
+  <path d="M13 4H6V3H13V4Z" fill="#3A3A38"/>
+  <rect x="2" y="2" width="3" height="3" rx="0.5" fill="#3A3A38"/>
+  <rect x="2" y="12" width="3" height="3" rx="0.5" fill="#3A3A38"/>
+  <rect x="14" y="2" width="3" height="3" rx="0.5" fill="#3A3A38"/>
 </svg>


### PR DESCRIPTION
Change-Id: I0810c414aaf8fa276bfe8ac3cc15d7ed912cc0d2


* Resolves: # <!-- related github issue -->
* Target version: master 

### SUMMARY
Updated Sparkline contextual group and ungroup icons

### PREVIEWS
<img width="920" height="127" alt="Screenshot from 2025-07-29 18-43-58" src="https://github.com/user-attachments/assets/9d4b7924-34c9-433f-a682-0060ad5db516" />
<img width="920" height="127" alt="Screenshot from 2025-07-29 18-41-21" src="https://github.com/user-attachments/assets/ea372e91-3624-49f7-8699-1aa49309af10" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

