### PR TITLE
Support LO's JS UNO scripting machinery in the Wasm build

### DIFF
--- a/browser/src/main.js
+++ b/browser/src/main.js
@@ -99,7 +99,7 @@ if (window.ThisIsTheEmscriptenApp) {
 	var docParamsPart = docParamsString ? (docURL.includes('?') ? '&' : '?') + docParamsString : '';
 	var encodedWOPI = encodeURIComponent(docURL + docParamsPart);
 
-	var Module = {
+	window.Module = {
 		onRuntimeInitialized: function() {
 			map.loadDocument(global.socket);
 		},
@@ -114,9 +114,9 @@ if (window.ThisIsTheEmscriptenApp) {
 		arguments_: [docURL, encodedWOPI, isWopi ? 'true' : 'false'],
 		arguments: [docURL, encodedWOPI, isWopi ? 'true' : 'false'],
 	};
-	createOnlineModule(Module).then(() => {
-		app.HandleCOOLMessage = Module['_handle_cool_message'];
-		app.AllocateUTF8 = Module['stringToNewUTF8']; });
+	createOnlineModule(window.Module).then(() => {
+		app.HandleCOOLMessage = window.Module['_handle_cool_message'];
+		app.AllocateUTF8 = window.Module['stringToNewUTF8']; });
 } else {
 	map.loadDocument(global.socket);
 }

--- a/configure.ac
+++ b/configure.ac
@@ -257,6 +257,11 @@ AC_ARG_WITH([lo-path],
             AS_HELP_STRING([--with-lo-path=<path>],
                            [Path to a working installation directory or instdir of LibreOffice]))
 
+AC_ARG_WITH([lo-sourcedir],
+            AS_HELP_STRING([--with-lo-sourcedir=<path>],
+                           [Mandatory, and relevant, only for a Wasm build.
+                            Path to a LibreOffice core source tree.]))
+
 AC_ARG_WITH([lo-builddir],
             AS_HELP_STRING([--with-lo-builddir=<path>],
                            [Mandatory, and relevant, in a tree where building the iOS or Android app.
@@ -577,6 +582,7 @@ AC_DEFUN([CHK_FILE_VAR], dnl env-var, suffix, file-to-match, msg
 # But not when just configuring for building the JS on Linux, for copying over
 # to the Mac.
 # Android: We need these to setup the CMakeLists.txt properly.
+LOSOURCEDIR=
 LOBUILDDIR=
 ANDROID_ABI="armeabi-v7a"
 ANDROID_ABI_SPLIT="'armeabi-v7a'"
@@ -615,6 +621,14 @@ if test \( "$enable_iosapp" = "yes" -a `uname -s` = "Darwin" \) -o \( "$enable_a
       fi
       ANDROID_ABI_SPLIT=`echo $ANDROID_ABI | sed "s/^/'/g;s/ /','/g;s/$/'/g"`
       AC_MSG_RESULT([$ANDROID_ABI])
+   fi
+
+   if test "$host_os" = emscripten; then
+      AC_MSG_CHECKING([for LibreOffice source tree to build against])
+      if test -z "$with_lo_sourcedir"; then
+         AC_MSG_ERROR([You MUST use the --with-lo-sourcedir option when configuring a Wasm build.])
+      fi
+      LOSOURCEDIR=$(readlink -f "$with_lo_sourcedir")
    fi
 
    AC_MSG_CHECKING([for LibreOffice build tree to build against])
@@ -805,6 +819,7 @@ if test \( "$enable_iosapp" = "yes" -a `uname -s` = "Darwin" \) -o \( "$enable_a
    CHK_FILE_VAR(ZSTDLIB,libzstd.a,Zstd lib,_X86_64)
 fi
 
+AC_SUBST(LOSOURCEDIR)
 AC_SUBST(LOBUILDDIR)
 AC_SUBST(ANDROID_ABI)
 AC_SUBST(ANDROID_ABI_SPLIT)

--- a/wasm/Makefile.am
+++ b/wasm/Makefile.am
@@ -62,7 +62,10 @@ online_DEPENDENCIES = \
 	exports \
 	@LOBUILDDIR@/instdir/program/soffice.js.linkdeps \
 	soffice.data \
-	soffice.data.js.metadata
+	soffice.data.js.metadata \
+	@LOBUILDDIR@/workdir/CustomTarget/static/emscripten_fs_image/soffice.data.js.link \
+	@LOBUILDDIR@/workdir/CustomTarget/static/unoembind/bindings_uno.js \
+	@LOSOURCEDIR@/static/emscripten/uno.js
 
 # note cannot add content of .linkdeps to DEPENDENCIES because it contains -lFoo
 online_LDADD = \
@@ -79,8 +82,10 @@ online_LDADD = \
 
 # TODO these are just copypasta from core
 online_LDFLAGS = \
-	-pthread -s MODULARIZE -s EXPORT_NAME=createOnlineModule -s USE_PTHREADS=1 -s TOTAL_MEMORY=1GB -s PTHREAD_POOL_SIZE_STRICT=0 --bind -s FORCE_FILESYSTEM=1 -s WASM_BIGINT=1 -s ERROR_ON_UNDEFINED_SYMBOLS=1 -s FETCH=1 -s ASSERTIONS=1 -s EXIT_RUNTIME=0 -s EXPORTED_RUNTIME_METHODS=["UTF16ToString","stringToUTF16","UTF8ToString","stringToNewUTF8","ccall","cwrap","FS","registerType"] -pthread -s USE_PTHREADS=1 -fwasm-exceptions -s EXPORTED_FUNCTIONS=@exports \
-	--pre-js @LOBUILDDIR@/workdir/CustomTarget/static/emscripten_fs_image/soffice.data.js.link
+	-pthread -s MODULARIZE -s EXPORT_NAME=createOnlineModule -s USE_PTHREADS=1 -s TOTAL_MEMORY=1GB -s PTHREAD_POOL_SIZE_STRICT=0 --bind -s FORCE_FILESYSTEM=1 -s WASM_BIGINT=1 -s ERROR_ON_UNDEFINED_SYMBOLS=1 -s FETCH=1 -s ASSERTIONS=1 -s EXIT_RUNTIME=0 -s EXPORTED_RUNTIME_METHODS=["UTF16ToString","stringToUTF16","UTF8ToString","stringToNewUTF8","ccall","cwrap","FS","registerType","ClassHandle","HEAPU16","HEAPU32"] -pthread -s USE_PTHREADS=1 -fwasm-exceptions -s EXPORTED_FUNCTIONS=@exports \
+	--pre-js @LOBUILDDIR@/workdir/CustomTarget/static/emscripten_fs_image/soffice.data.js.link \
+	--post-js @LOBUILDDIR@/workdir/CustomTarget/static/unoembind/bindings_uno.js \
+	--post-js @LOSOURCEDIR@/static/emscripten/uno.js
 
 # Silence "running limited binaryen optimizations because DWARF info requested (or indirectly
 # required)":


### PR DESCRIPTION
...following up on
https://git.libreoffice.org/core/+/e02f10d20b461a2033fa80b6a2bed6684f42a85f%5E%21> "Emscripten: Call initJsUnoScripting also from LOKit".

For one, we now need to include via --post-js a couple of LO *.js files, one of them coming from the LO source tree.  So for the Wasm build we now need a --with-lo-sourcedir configure option in addition to the existing --with-lo-builddir one.  (We could presumably make --with-lo-sourcedir mandatory for all builds, and get rid of --with-lokit-path, if we assume that the latter always points to the former's include directory, but that would be a rather wide-reaching change, so leave that at least for now.  Also, we could presumably make --with-lo-builddir default to --with-lo-sourcedir, if the latter is specified but not the former.)

For another, one of the JS UNO scripting machinery's entry points is globalThis.Module, required on both the browser main thread and on worker threads.  For LO's non-MODULARIZED soffice.js, Emscripten sets that up for us, but for the MODULARIZED online.js, we need to set that up manually:  For the browser main thread, we set that now in browser/src/main.js.  For worker threads, it seems to be necessary to patch online.js for now (see <https://groups.google.com/g/emscripten-discuss/c/cMTCPit5xig> "Accessing a thread's module instance in an -sMODULARIZE -pthread setting?").

And lastly, EXPORTED_RUNTIME_METHODS needs to be extended to match the needs of the JS UNO scripting machinery, cf.
<https://git.libreoffice.org/core/+/afe64ad7679e825df196face58be1d2cf8ea7d36%5E%21> "Emscripten: Add ClassHandle to EXPORTED_RUNTIME_METHODS" and <https://git.libreoffice.org/core/+/1c78307f3b2f7efdb5c08f6fa42548a3751c7181%5E%21> "HEAPU16 and HEAPU32 are no longer exported by default by recent Emscripten".

With all that in place, we can then run some sample JS UNO scripting code, e.g. by cloning <https://github.com/allotropia/zetajs> into browser/dist and patching

> --- a/browser/src/main.js
> +++ b/browser/src/main.js
> @@ -113,6 +113,7 @@ if (window.ThisIsTheEmscriptenApp) {
>                 },
>                 arguments_: [docURL, encodedWOPI, isWopi ? 'true' : 'false'],
>                 arguments: [docURL, encodedWOPI, isWopi ? 'true' : 'false'],
> +               uno_scripts: ['zetajs/source/zeta.js', 'zetajs/examples/simple-examples/simple.js'],
>         };
>         createOnlineModule(window.Module).then(() => {
>                 app.HandleCOOLMessage = window.Module['_handle_cool_message'];

One remaining issue is that that zetajs examples/simple-examples/simple.js code could be executed too early, before any document would have been opened, so desktop.getCurrentFrame() would return null (unlike for the LO case, where at least a start center frame would be open).  Until that is addressed properly, something like

> diff --git a/examples/simple-examples/simple.js b/examples/simple-examples/simple.js
> index 89ea23a..f37c8af 100644
> --- a/examples/simple-examples/simple.js
> +++ b/examples/simple-examples/simple.js
> @@ -25,6 +25,8 @@ function demo() {
>    // load document
>    context = zetajs.getUnoComponentContext();
>    desktop = css.frame.Desktop.create(context);
> +setTimeout(() => {
> +  console.error('FRAMES:',desktop.getFrames(),desktop.getActiveFrame(),desktop.getCurrentFrame());
>    xModel = desktop.getCurrentFrame().getController().getModel();
>    if (!xModel?.queryInterface(zetajs.type.interface(css.text.XTextDocument))) {
>      xModel = desktop.loadComponentFromURL(
> @@ -52,6 +54,7 @@ function demo() {
>        }
>      }
>    }
> +}, 5000);
>  }
>
>

might be a cheesy workaround.


Change-Id: If6126a1593f49379452d42dc16d2d3a94f1b7323


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

