### PR TITLE
Notebookbar: add inline label to Share button on the top bar

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -34,6 +34,8 @@ button.ui-tab.notebookbar {
 	color: var(--color-main-text);
 }
 
+#shareas { & .unolabel { color: var(--color-main-text) } }
+
 .ui-tab.notebookbar[style*='block'] {
 	display: inline-flex !important;
 }

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -689,6 +689,7 @@ L.Control.Notebookbar = L.Control.extend({
 				'type': 'customtoolitem',
 				'text': _('Share'),
 				'command': 'shareas',
+				'inlineLabel': true,
 				'accessibility': { focusBack: false, combination: 'ZS', de: null }
 			});
 		}

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -77,6 +77,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'type': 'customtoolitem',
 				'text': _('Share'),
 				'command': 'shareas',
+				'inlineLabel': true,
 				'accessibility': { focusBack: false, combination: 'ZS', de: null }
 			});
 		}


### PR DESCRIPTION
Change-Id: I2b2db04f78c882036127b54020dc53e4b5fa33f7

* Target version: master

<img width="227" height="64" alt="screenshot_30072025_101259" src="https://github.com/user-attachments/assets/a3be358f-c6d9-4fed-9496-e26ed4f1cdc0" />

I have hard-coded the color in css as I didn't see any other color being used for a label at the top bar

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

