### PR TITLE
Limit context menu icon styling to <img> elements

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -799,7 +799,7 @@ input[type='checkbox']:checked.autofilter, .jsdialog input[type='checkbox']:chec
 
 .context-menu-item.context-menu-submenu::before,
 .context-menu-icon-spacer,
-.context-menu-icon {
+img.context-menu-icon {
 	width: 1rem;
 	height: 1rem;
 	margin-right: 8px;


### PR DESCRIPTION
Change-Id: I537664ca2a63ca625207c60c174dfca10d3266a5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Follow up: https://github.com/CollaboraOnline/online/pull/12419
-Previously, styles targeting .context-menu-icon applied to both <img> and <li> elements, causing layout problems.
-This update restricts the rule to img.context-menu-icon, avoiding unintended styling on checkmark list items.

### PREVIEW

#### BEFORE

<img width="559" height="297" alt="anchor" src="https://github.com/user-attachments/assets/bb2d754b-dc44-4747-8630-3345531eacd4" />

#### WITH THIS PR
<img width="381" height="225" alt="Screenshot from 2025-07-30 16-59-09" src="https://github.com/user-attachments/assets/29d06284-5645-448c-abcc-61e8cb3f844c" />



- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

