### PR TITLE
Not all messages are in JSON that contain '{' and '}'

### DIFF
--- a/browser/src/map/handler/Map.StateChanges.js
+++ b/browser/src/map/handler/Map.StateChanges.js
@@ -37,7 +37,11 @@ L.Map.StateChangeHandler = L.Handler.extend({
 			var lastIndex = e.state.lastIndexOf('}');
 
 			if (firstIndex !== -1 && lastIndex !== -1) {
-				state = JSON.parse(e.state.substring(firstIndex, lastIndex + 1));
+				try {
+					state = JSON.parse(e.state.substring(firstIndex, lastIndex + 1));
+				} catch (err) {
+					state = e.state; // Not valid JSON, keep as plain text, e.g. "English (Netherlands) {en-NL};en-NL"
+				}
 			} else {
 				state = e.state;
 			}


### PR DESCRIPTION
With a Writer document we got:
1753887346547 INCOMING: statechanged: .uno:LanguageStatus=Englisch (Niederlande) {en-NL};en-NL Exception SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2) emitting event statechanged: .uno:LanguageStatus=Englisch (Niederlande) {en-NL};en-NL

Englisch (Niederlande) {en-NL} is an invalid locale to begin with. At least it is unknown to LOKit. Unfortunately LOKit marks unknown locales with curly braces, that confused our js code.


Change-Id: I823d3c054a12ebe0dd760015660d0712f22fbbb6
