### PR TITLE
Add fallback if we failed to extract JSON in state change

### DIFF
--- a/browser/src/map/handler/Map.StateChanges.js
+++ b/browser/src/map/handler/Map.StateChanges.js
@@ -33,13 +33,18 @@ L.Map.StateChangeHandler = L.Handler.extend({
 		if (typeof (e.state) == 'object') {
 			state = e.state;
 		} else if (typeof (e.state) == 'string') {
-			var firstIndex = e.state.indexOf('{');
-			var lastIndex = e.state.lastIndexOf('}');
+			state = e.state; // fallback if we don't find JSON
+
+			var firstIndex = state.indexOf('{');
+			var lastIndex = state.lastIndexOf('}');
 
 			if (firstIndex !== -1 && lastIndex !== -1) {
-				state = JSON.parse(e.state.substring(firstIndex, lastIndex + 1));
-			} else {
-				state = e.state;
+				const substring = state.substring(firstIndex, lastIndex + 1);
+				try {
+					state = JSON.parse(substring);
+				} catch (e) {
+					console.error('Failed to parse state JSON: "' + substring + '" : ' + e);
+				}
 			}
 		}
 		const commandName = this.ensureUnoCommandPrefix(e.commandName);


### PR DESCRIPTION
Followup for commit d4c7aaa4c404323d51606c8d0789f8ec045f01f9 fixed master slide previews not being updated

Fix for:
1753887346547 INCOMING: statechanged: .uno:LanguageStatus=Englisch (Niederlande) {en-NL};en-NL 15:55:46.547 global.js:1 Exception SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2) emitting event statechanged: .uno:LanguageStatus=Englisch (Niederlande) {en-NL};en-NL SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)
    at JSON.parse (<anonymous>)
    at NewClass._onStateChanged
