### PR TITLE
color picker: do not fail on incorrect cache

### DIFF
--- a/browser/src/control/jsdialog/Widget.ColorPicker.ts
+++ b/browser/src/control/jsdialog/Widget.ColorPicker.ts
@@ -75,21 +75,30 @@ function toW2Palette(corePalette: CoreColorPalette): ColorPalette {
 	return pal;
 }
 
+function sanitizePaletteRow(row: string) {
+	if (row !== undefined) {
+		try {
+			const json = JSON.parse(row);
+			return json.filter((color: string | null) => color !== null);
+		} catch (e) {
+			console.error('Cannot parse palette row from cache: "' + row + '" :' + e);
+		}
+	}
+	return null;
+}
+
 function generatePalette(paletteName: string) {
 	const colorPalette = toW2Palette(
 		window.app.colorPalettes[paletteName].colors,
 	);
-	const customColorRow = window.prefs.get('customColor');
-	const recentRow = window.prefs.get('recentColor');
+	const customColorRow = sanitizePaletteRow(window.prefs.get('customColor'));
+	const recentRow = sanitizePaletteRow(window.prefs.get('recentColor'));
 
-	if (customColorRow !== undefined) {
-		colorPalette.push(JSON.parse(customColorRow));
-	} else {
-		colorPalette.push(['F2F2F2', 'F2F2F2', 'F2F2F2', 'F2F2F2', 'F2F2F2']); // custom colors (up to 4)
-	}
+	if (customColorRow) colorPalette.push(customColorRow);
+	else colorPalette.push(['F2F2F2', 'F2F2F2', 'F2F2F2', 'F2F2F2', 'F2F2F2']); // custom colors (up to 4)
 
-	if (recentRow !== undefined) {
-		colorPalette.push(JSON.parse(recentRow));
+	if (recentRow) {
+		colorPalette.push(recentRow);
 	} else {
 		colorPalette.push([
 			'F2F2F2',


### PR DESCRIPTION
Found on current master:

    Open calc using make run link
    Try background color picker

Result: Works

    Open calc using Nextcloud
    Try background color picker

Result: No dropdown, cannot click in the app due to overlay

in console:

Uncaught TypeError: Cannot read properties of null (reading 'toLowerCase')
    at Widget.ColorPicker.ts:135:64
    at Array.find (<anonymous>)
    at createColor (Widget.ColorPicker.ts:134:28)
    at updatePalette (Widget.ColorPicker.ts:361:3)
    at JSDialog.colorPicker (Widget.ColorPicker.ts:409:2)
    at NewClass.build (Control.JSDialogBuilder.js:3026:24)
    at JSDialog.grid (Widget.Containers.ts:115:12)
    at NewClass.build (Control.JSDialogBuilder.js:3026:24)
    at JSDialog.Dropdown (Widget.DropDown.ts:23:10)
    at NewClass.build (Control.JSDialogBuilder.js:3026:24)


Change-Id: I8daec7bcd7734ab69e8ad33fc17638ad49710102
