### PR TITLE
Don't give up on the async clipboard anymore just due to one failure

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1087,11 +1087,6 @@ function getInitializerClass() {
 	document.addEventListener('mouseover', registerGuessEmulatedFromTouch, { capture: true });
 	document.addEventListener('mouseout', registerGuessEmulatedFromTouch, { capture: true });
 
-	if (!global.prefs.getBoolean('clipboardApiAvailable', true)) {
-		// navigator.clipboard.write failed on us once, don't even try it.
-		global.L.Browser.clipboardApiAvailable = false;
-	}
-
 	global.deviceFormFactor = global.mode.getDeviceFormFactor();
 
 	if (global.ThisIsTheiOSApp) {

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -13,7 +13,7 @@
  * local & remote clipboard data.
  */
 
-/* global app DocUtil _ brandProductName $ ClipboardItem Promise GraphicSelection cool */
+/* global app DocUtil _ brandProductName $ ClipboardItem Promise GraphicSelection cool JSDialog */
 
 // Get all interesting clipboard related events here, and handle
 // download logic in one place ...
@@ -932,9 +932,6 @@ L.Clipboard = L.Class.extend({
 				window.app.console.error('navigator.clipboard.write() failed: ' + error.message);
 				// Warn that the copy failed.
 				this._warnCopyPaste();
-				// Once broken, always broken.
-				L.Browser.clipboardApiAvailable = false;
-				window.prefs.set('clipboardApiAvailable', false);
 				// Prefetch selection, so next time copy will work with the keyboard.
 				app.socket.sendMessage('gettextselection mimetype=text/html,text/plain;charset=utf-8');
 			}
@@ -1289,7 +1286,18 @@ L.Clipboard = L.Class.extend({
 
 	_warnCopyPaste: function() {
 		var id = 'copy_paste_warning';
-		this._map.uiManager.showYesNoButton(id + '-box', '', '', _('OK'), null, null, null, true);
+		if (!JSDialog.shouldShowAgain(id))
+			return;
+
+		this._map.uiManager.showYesNoButton(
+				id + '-box',
+				/*title=*/'',
+				/*message=*/'',
+				/*yesButtonText=*/_('OK'),
+				/*noButtonText=*/_('Don’t show this again'),
+				/*yesFunction=*/null,
+				/*noFunction=*/function () {JSDialog.setShowAgain(id, false);},
+				/*cancellable=*/true);
 		this._warnCopyPasteImpl(id);
 	},
 


### PR DESCRIPTION
Instead always show the pre-existing Clipboard failed dialog.

Additionally, a button was added to that dialog to not show it again.

<img width="559" height="283" alt="grafik" src="https://github.com/user-attachments/assets/a4f35320-a5bb-4085-996f-23c4eb20902d" />
