### PR TITLE
g: source branch of in-repo PRs is deleted automatically

### DIFF
--- a/g
+++ b/g
@@ -5,8 +5,7 @@
 # './g review [name]' to submit a pull request, assuming:
 # 1) You have 'gh' installed.
 # 2) You are a committer, so you have the permission to push to a private/nick/name branch.
-# 3) You delete this branch after the PR is merged.
-# 4) "name" is the name of part of the private/user/name remote branch, defaults to the current
+# 3) "name" is the name of part of the private/user/name remote branch, defaults to the current
 #    branch. You have to specify this explicitly if you want to update an existing PR.
 #
 # './g backport <branch> <PR number> [name]' to submit a pull request for a different branch:


### PR DESCRIPTION
It was an outdated comment, we have
<https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches>
configured since then.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I30cd7c82082ba236234e3e2736c02432dd711bf2
