### PR TITLE
backport(co-25.04): fix(writer): correct document opening

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -493,7 +493,7 @@ L.TextInput = L.Layer.extend({
 	// Displays the caret and the under-caret marker.
 	// Fetches the coordinates of the caret from the map's doclayer.
 	showCursor: function() {
-		if (!this._map._docLayer._cursorMarker || app.tile.size.x === 0) {
+		if (!this._map._docLayer._cursorMarker || app.tile.size.x === 0 || !this._map._docLayer._textCSelections) {
 			return;
 		}
 


### PR DESCRIPTION
This is a trivial backport of #12458

On some mobile platforms (we've reproduced this in iOS on Nextcloud and also intermittently in the Firefox mobile view on Linux) there was an error where '_textCSelections' was used before it was defined.

This is a regression from Ide2b3251535a60eef50ef62811fc416f8fa0957e.

Previously, the code that used '_textCSelections' was the showCursor function, and it was gated by something equivalent to

    if (... || !this._map._docLayer._tileWidthTwips) return;

This was changed to be equivalent to

    if (... || app.tile.size.x === 0) return;

and the locations that set _tileWidthTwips were changed to set the tile size.

Unfortunately, they aren't the only places: in docstatefunctions.js an on-'load' listener runs the following

    window.addEventListener('load', function () {
      // ...
    	app.tile.size.pX = app.tile.size.pY = 256;
    });

which means that the code in showCursor is run far too early: before the '_textCSelections' has been initialized. Rather than tying it to some other fragile condition I have just introduced a dependency on the thing the function really relies on: the '_textCSelections' being initialized

This fixes nextcloud/ios#3573


Change-Id: I6a6a696414ff2d57a09d8b94c3732414e8c00bd8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

