### PR TITLE
Wasm: Disable problematic code of unclear use

### DIFF
--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -234,40 +234,42 @@ int main(int argc, char* argv_main[])
     std::thread(
         [&]
         {
-            const std::string docURL = std::string(argv_main[1]);
-            const std::string encodedWOPI = std::string(argv_main[2]);
-            const std::string isWOPI = std::string(argv_main[3]);
+            if ((false)) { //TODO: clarify which configuration wants to use this
+                const std::string docURL = std::string(argv_main[1]);
+                const std::string encodedWOPI = std::string(argv_main[2]);
+                const std::string isWOPI = std::string(argv_main[3]);
 
-            std::string url;
-            if (isWOPI == "true")
-                url = "/wasm/" + encodedWOPI;
-            else
-                url = docURL + "/contents";
+                std::string url;
+                if (isWOPI == "true")
+                    url = "/wasm/" + encodedWOPI;
+                else
+                    url = docURL + "/contents";
 
-            printf("isWOPI is %s: Fetching from url %s\n", isWOPI.c_str(), url.c_str());
+                printf("isWOPI is %s: Fetching from url %s\n", isWOPI.c_str(), url.c_str());
 
-            emscripten_fetch_attr_t attr;
-            emscripten_fetch_attr_init(&attr);
-            strcpy(attr.requestMethod, "GET");
-            attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY | EMSCRIPTEN_FETCH_SYNCHRONOUS;
-            emscripten_fetch_t* fetch = emscripten_fetch(
-                &attr, url.data()); // Blocks here until the operation is complete.
-            if (fetch->status == 200)
-            {
-                printf("Finished downloading %llu bytes from URL %s.\n", fetch->numBytes,
-                       fetch->url);
-                // For now, we have a hard-coded filename that we open. Clobber it.
-                FILE* f = fopen(FILE_PATH, "w");
-                const int wrote = fwrite(fetch->data, 1, fetch->numBytes, f);
-                fclose(f);
-                printf("Wrote %d bytes into " FILE_PATH "\n", wrote);
+                emscripten_fetch_attr_t attr;
+                emscripten_fetch_attr_init(&attr);
+                strcpy(attr.requestMethod, "GET");
+                attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY | EMSCRIPTEN_FETCH_SYNCHRONOUS;
+                emscripten_fetch_t* fetch = emscripten_fetch(
+                    &attr, url.data()); // Blocks here until the operation is complete.
+                if (fetch->status == 200)
+                {
+                    printf("Finished downloading %llu bytes from URL %s.\n", fetch->numBytes,
+                           fetch->url);
+                    // For now, we have a hard-coded filename that we open. Clobber it.
+                    FILE* f = fopen(FILE_PATH, "w");
+                    const int wrote = fwrite(fetch->data, 1, fetch->numBytes, f);
+                    fclose(f);
+                    printf("Wrote %d bytes into " FILE_PATH "\n", wrote);
+                }
+                else
+                {
+                    printf("Downloading %s failed, HTTP failure status code: %d.\n", fetch->url,
+                           fetch->status);
+                }
+                emscripten_fetch_close(fetch);
             }
-            else
-            {
-                printf("Downloading %s failed, HTTP failure status code: %d.\n", fetch->url,
-                       fetch->status);
-            }
-            emscripten_fetch_close(fetch);
 
             coolwsd = new COOLWSD();
             coolwsd->run(1, argv);


### PR DESCRIPTION
At least in a plain scenario where online is built with Emscripten (--host=wasm32-local-emscripten) and the resulting browser/dist/cool.html is served (e.g., via `emrun browser/dist/cool.html`), the code that calls emscripten_fetch and writes a local file (originally introduced with c2c0fe6f514feaa9032a89fa2f0cc55af57c8d70 "wasm: accept url as command-line argument" here on the wasm/wasmapp.cpp side and
a7d6d1debc46f618733e180bd1b8ff87e7303ab7 "wasm: pass the docURL to the wasm app" on the browser/src/main.js side) is not actually used:

For example, with recent Chrome 138.0.7204.168, this causes

> isWOPI is false: Fetching from url file:///sample.docx/contents
> Not allowed to load local resource: file:///sample.docx/contents
>  fetchXHR @ online.js:10603
>  performUncachedXhr @ online.js:10813
>  fetchLoadCachedData @ online.js:10670
>  _emscripten_start_fetch @ online.js:10850
>  $emscripten_fetch @ emscripten_fetch.c:146
>  $void* std::__2::__thread_proxy[abi:ne200100]<std::__2::tuple<std::__2::unique_ptr<std::__2::__thread_struct, std::__2::default_delete<std::__2::__thread_struct>>, main(int, char**)::$_1>>(void*) @ wasmapp.cpp:253
>  invokeEntryPoint @ online.js:2028
>  handleMessage @ online.js:1096
> Downloading file:///sample.docx/contents failed, HTTP failure status code: 0.

effectively bypassing all that code.  (The actual loading of the bundled /sample.docx is triggered with the hard-coded

> #define FILE_PATH "/sample.docx"
> static std::string fileURL = "file://" FILE_PATH;
[...]
>         LOG_TRC_NOFILE("Actually sending to Online:" << fileURL);
>         std::cout << "Loading file [" << fileURL << "]" << std::endl;
[...]
>         fakeSocketWrite(fakeClientFd, fileURL.c_str(), fileURL.size());

cf. a5740dcde7760f87ed14ab91ba38a6e48a5a49b7 "Using handle_cool_message and send2JS in wasmapp.cpp", 48c96e70ca5625c2e1e1eae5dacfcfc3f5233f0d "More WASM hacking", and cee9bf493a38cd9b9c22058f4a9e348ffc5adb59 "Change hardcoded sample document name and verify that we get it".)

However, at least when building with recent emsdk 4.0.10 and running on recent Firefox 141.0, that effectively unused code rather causes a "RuntimeError: unreachable executed" at

> online.wasm.__trap@http://localhost:6931/online.wasm:wasm-function[403205]:0x7daf4b0
> abort@http://localhost:6931/online.js:1376:5
> assert@http://localhost:6931/online.js:792:10
> runtimeKeepalivePop@http://localhost:6931/online.js:10274:13
> reportError@http://localhost:6931/online.js:10798:7
> fetchXHR@http://localhost:6931/online.js:10605:16
> performUncachedXhr@http://localhost:6931/online.js:10813:15
> fetchLoadCachedData@http://localhost:6931/online.js:10670:14
> _emscripten_start_fetch@http://localhost:6931/online.js:10850:26
> online.wasm.emscripten_fetch@http://localhost:6931/online.wasm:wasm-function[398712]:0x7d3c6cb
> online.wasm.void* std::__2::__thread_proxy[abi:ne200100]<std::__2::tuple<std::__2::unique_ptr<std::__2::__thread_struct, std::__2::default_delete<std::__2::__thread_struct>>, main(int, char**)::$_1>>(void*)@http://localhost:6931/online.wasm:wasm-function[152]:0x13735e
> invokeEntryPoint@http://localhost:6931/online.js:2028:42
> handleMessage@http://localhost:6931/online.js:1096:27

(Apparently, what happens is that the

>     try {
>       xhr.send(data);
>     } catch(e) {
>       onerror?.(fetch, xhr, e);
>     }

in fetchXHR catches an error and calls reportError, which calls runtimeKeepalivePop first thing, but whose

>       assert(runtimeKeepaliveCounter > 0);

triggers, for whatever reason.)

So, until it is clarified in what scenario that code is actually meant to be used (and it is clarified why the failure case that has harmless outcome in Chrome leads to fatal outcome in Firefox), just disable that code for now.


Change-Id: I710469940d66a752dc02cfa3f82f45a45ced15f0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

