### PR TITLE
chore(android): update SDK version

### DIFF
--- a/android/app/build.gradle.in
+++ b/android/app/build.gradle.in
@@ -5,14 +5,15 @@ apply from: 'appSettings.gradle'
 
 android {
     namespace 'org.libreoffice.androidapp'
-    compileSdkVersion 34
+    compileSdkVersion 35
     buildDir = "${rootProject.getBuildDir()}/app"
     ndkVersion "22.1.7171670"
+    buildFeatures.buildConfig = true
 
     defaultConfig {
         // applicationId, versionCode and versionName are defined in appSettings.gradle
         minSdkVersion 26
-        targetSdkVersion 34
+        targetSdkVersion 35
 
         resValue "string", "app_name", "${liboAppName}"
         resValue "string", "vendor", "${liboVendor}"

--- a/android/build.gradle.in
+++ b/android/build.gradle.in
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.0'
+        classpath 'com.android.tools.build:gradle:8.9.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -9,7 +9,6 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip

--- a/android/lib/build.gradle.in
+++ b/android/lib/build.gradle.in
@@ -5,13 +5,14 @@ apply from: 'libSettings.gradle'
 
 android {
     namespace 'org.libreoffice.androidlib'
-    compileSdkVersion 34
+    compileSdkVersion 35
     buildDir = "${rootProject.getBuildDir()}/lib"
     ndkVersion "22.1.7171670"
+    buildFeatures.buildConfig = true
 
     defaultConfig {
         minSdkVersion 26
-        targetSdkVersion 34
+        targetSdkVersion 35
         versionCode 1
         versionName "1.0"
 
@@ -334,4 +335,19 @@ afterEvaluate {
 	}
 	generateDebugAssets.dependsOn copyDocTemplates, copyKitConfig, generateCoolDebugAssets
 	generateReleaseAssets.dependsOn copyDocTemplates, copyKitConfig, generateCoolReleaseAssets
+
+    // These tasks only exist under some cases (not in Android Studio)...
+    // ...so use tasks.named so they don't fail if they are never registered...
+    // ...also allows us to do the same thing for lots of tasks which are in the same case after the latest Android Gradle Plugin upgrade...
+    tasks.named { it in [
+        "generateDebugLintModel",
+        "generateDebugLintReportModel",
+        "generateDebugLintVitalModel",
+        "generateReleaseLintModel",
+        "generateReleaseLintVitalModel",
+        "lintAnalyzeDebug",
+        "lintVitalAnalyzeRelease",
+    ] }.configureEach {
+        dependsOn copyDocTemplates, copyKitConfig
+    }
 }


### PR DESCRIPTION
As per Google Play policies, we need to update our target SDK version to 35 to stay supported on the latest Android versions, allowing us to continue releasing the app.

There's various different advice about what to do about the compile SDK version: generally I like to follow Android Studio's guidance which suggests they should be the same, so let's update the compile SDK version here too...


Change-Id: I6a6a69640058b47d71b7de3b45fb3a8036513ba1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

