### PR TITLE
context-toolbar: allow integrators to add a button via PostMessage

### DIFF
--- a/browser/html/framed.doc.html
+++ b/browser/html/framed.doc.html
@@ -254,6 +254,12 @@
             });
       }
 
+      function ShowInsertContextualButton() {
+        post({'MessageId': 'Insert_ContextualButton',
+              'Values': { 'id': 'context-cut', 'imgurl': 'lc_cut.svg', 'hint': 'Cut (added via postmessage)', 'unoCommand': '.uno:Cut'}
+            });
+      }
+
       function ShowNotebookbar(notebookbar) {
         var value = notebookbar ? 'notebookbar' : 'classic';
         post({'MessageId': 'Action_ChangeUIMode',
@@ -628,6 +634,7 @@
           </div>
           <div class="vbox">
             <button onclick="ShowInsertButton(); return false;" title="via Insert_Button">Insert custom button</button>
+            <button onclick="ShowInsertContextualButton(); return false;" title="via Insert_ContextualButton">Insert custom button to contextual toolbar</button>
             <button onclick="insertGraphic(); return false;">Sent InsertGraphic post message</button>
           </div>
           <div class="vbox">

--- a/browser/src/control/Control.ContextToolbar.ts
+++ b/browser/src/control/Control.ContextToolbar.ts
@@ -15,7 +15,7 @@
  */
 
 class ContextToolbar {
-	container: HTMLElement;
+	container!: HTMLElement;
 	builder: JSBuilder;
 	map: any;
 	initialized: boolean = false;
@@ -34,6 +34,10 @@ class ContextToolbar {
 			cssClass: 'notebookbar',
 			suffix: 'context-toolbar',
 		} as JSBuilderOptions);
+		this.createContextToolbarElement();
+	}
+
+	createContextToolbarElement(): void {
 		this.container = L.DomUtil.createWithId(
 			'div',
 			'context-toolbar',
@@ -330,6 +334,8 @@ class ContextToolbar {
 		this.additionalContextButtons.push(contextButton);
 
 		// update context toolbar
+		document.getElementById('context-toolbar')?.remove();
+		this.createContextToolbarElement();
 		this.initialized = false;
 	}
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2293,8 +2293,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		var clickFunction = function (e) {
 			if (!div.hasAttribute('disabled')) {
 				builder.refreshSidebar = true;
-				if (data.postmessage)
-					builder.map.fire('postMessage', {msgId: 'Clicked_Button', args: {Id: data.id} });
+				if (data.postmessage) {
+					let isContextualButton = e.target.offsetParent.id === 'context-toolbar';
+					const msgId = isContextualButton ? 'Clicked_ContextualButton' : 'Clicked_Button';
+					builder.map.fire('postMessage', {msgId: msgId, args: {Id: data.id} });
+				}
 				else if (isRealUnoCommand && data.dropdown !== true)
 					builder.callback('toolbutton', 'click', button, data.command, builder);
 				else {

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -190,6 +190,8 @@ interface ToolItemWidgetJSON extends WidgetJSON {
 	noLabel?: boolean;
 	command: string; // command to trigger options for a panel
 	text: string; // title to show or for tooltip
+	icon: string; // url to an svg
+	postmessage?: boolean; // postmessage to WOPI in case the toolitem is added via postmessage
 }
 
 interface PanelWidgetJSON extends WidgetJSON {

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -462,7 +462,13 @@ L.Map.WOPI = L.Handler.extend({
 			msg.Values && msg.Values.id) {
 			this._map.uiManager.insertButton(msg.Values);
 			return;
-		} else if (msg.MessageId === 'Send_UNO_Command' && msg.Values && msg.Values.Command) {
+		}
+		else if (msg.MessageId === 'Insert_ContextualButton' &&
+			msg.Values && msg.Values.id) {
+			this._map.uiManager.map.contextToolbar.insertAdditionalContextButton(msg.Values);
+			return;
+		}
+		else if (msg.MessageId === 'Send_UNO_Command' && msg.Values && msg.Values.Command) {
 			this._map.sendUnoCommand(msg.Values.Command, msg.Values.Args || '');
 			return;
 		}


### PR DESCRIPTION
This works with the existing "Insert_Button" message. Add the property 'target': 'context-toolbar' to add a button to the contextual toolbar

Change-Id: I1681d5b0499f2c9bb438524b19dfb62dadadf9a4

For Message: `Insert_ContextualButton`, and
Values: 
```
{"id":"somebutton", "imgurl":"lc_printgrid.svg", "unoCommand":"customCommand", "hint":"tooltip"}
```
, the following button will be added

<img width="1175" height="218" alt="screenshot_05082025_181525" src="https://github.com/user-attachments/assets/13e0370c-f438-4bb6-b635-8255115bbfe7" />

Also added an example button to postmessage demo page:

<img width="607" height="252" alt="screenshot_06082025_160236" src="https://github.com/user-attachments/assets/320d49ec-e1e6-4a42-ba57-d8130ee2c62d" />


* Target version: master 

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

