### PR TITLE
notebookbar: add transitions tab

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -485,6 +485,7 @@ COOL_JS_LST =\
 	src/control/Control.SaveState.ts \
 	src/control/Control.UIManager.ts \
 	src/control/Control.DocumentNameInput.js \
+	src/control/Notebookbar.ImpressTransitionTab.ts \
 	src/control/Control.Notebookbar.js \
 	src/control/Control.NotebookbarWriter.js \
 	src/control/Control.NotebookbarCalc.js \
@@ -1030,6 +1031,7 @@ pot:
 		src/control/Control.MobileWizardBuilder.js \
 		src/control/Control.NavigatorPanel.ts \
 		src/control/Control.QuickFindPanel.ts \
+		src/control/Notebookbar.ImpressTransitionTab.ts \
 		src/control/Control.Notebookbar.js \
 		src/control/Control.NotebookbarBuilder.js \
 		src/control/Control.NotebookbarCalc.js \

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -460,6 +460,7 @@ COOL_JS_LST =\
 	src/control/jsdialog/Widget.OverflowGroup.ts \
 	src/control/jsdialog/Widget.OverflowManager.ts \
 	src/control/jsdialog/Widget.Progressbar.js \
+	src/control/jsdialog/Widget.RadioButton.ts \
 	src/control/jsdialog/Widget.ScrolledWindow.js \
 	src/control/jsdialog/Widget.SearchEdit.ts \
 	src/control/jsdialog/Widget.SidebarContainers.ts \
@@ -1061,6 +1062,7 @@ pot:
 		src/control/jsdialog/Widget.PageMarginEntry.ts \
 		src/control/jsdialog/Widget.HTMLContent.ts \
 		src/control/jsdialog/Widget.MobileBorderSelector.js \
+		src/control/jsdialog/Widget.RadioButton.ts \
 		src/control/jsdialog/Widget.SidebarContainers.ts \
 		src/control/jsdialog/Widget.TreeView.ts \
 		src/core/Socket.js \

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -195,7 +195,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	display: block;
 }
 
-.jsdialog.ui-grid {
+.ui-grid {
 	border-spacing: 0px;
 	width: 100%;
 	display: grid;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -896,6 +896,7 @@ img.context-menu-icon {
 }
 /* Radio button */
 
+.ui-radiobutton,
 .radiobutton.jsdialog {
 	display: flex;
 	align-items: center;
@@ -910,6 +911,7 @@ img.context-menu-icon {
 	display: block;
 }
 
+.ui-radiobutton > label,
 .jsdialog .radiobutton > label {
 	vertical-align: middle;
 	white-space: nowrap;

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -523,6 +523,11 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 
 /* Review Tab */
 
+/* Transition Tab */
+
+#transitions_icons.ui-iconview {
+	max-height: 75px;
+}
 
 /* Table Tab */
 

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -90,7 +90,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		this._controlHandlers = {};
 		this._controlHandlers['overflowgroup'] = JSDialog.OverflowGroup;
 		this._controlHandlers['overflowmanager'] = JSDialog.OverflowManager;
-		this._controlHandlers['radiobutton'] = this._radiobuttonControl;
+		this._controlHandlers['radiobutton'] = JSDialog.RadioButton;
 		this._controlHandlers['progressbar'] = JSDialog.progressbar;
 		this._controlHandlers['pagemarginentry'] = JSDialog.pageMarginEntry;
 		this._controlHandlers['checkbox'] = this._checkboxControl;
@@ -1288,57 +1288,6 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			var child = item.children[0];
 			builder.build(parentContainer, [child]);
 		}
-		return false;
-	},
-
-	_radiobuttonControl: function(parentContainer, data, builder) {
-		var container = L.DomUtil.createWithId('div', data.id, parentContainer);
-		L.DomUtil.addClass(container, 'radiobutton');
-		L.DomUtil.addClass(container, builder.options.cssClass);
-
-		var radiobutton = L.DomUtil.create('input', '', container);
-		radiobutton.type = 'radio';
-		radiobutton.id = data.id + '-input';
-		radiobutton.tabIndex = '0';
-
-		if (data.image) {
-			var image = L.DomUtil.create('img', '', radiobutton);
-			image.src = data.image;
-			L.DomUtil.addClass(container, 'has-image');
-		}
-
-		if (data.group)
-			radiobutton.name = data.group;
-
-		var radiobuttonLabel = L.DomUtil.createWithId('label', data.id + '-label', container);
-		radiobuttonLabel.textContent = builder._cleanText(data.text);
-		radiobuttonLabel.htmlFor = data.id + '-input';
-
-		var toggleFunction = function() {
-			builder.callback('radiobutton', 'change', container, this.checked, builder);
-		};
-
-		$(radiobuttonLabel).click(() => {
-			if (radiobutton.hasAttribute('disabled')) return;
-
-			$(radiobutton).prop('checked', true);
-			toggleFunction.bind({checked: true})();
-		});
-
-		const isDisabled = data.enabled === false;
-		if (isDisabled) {
-			radiobutton.setAttribute('disabled', 'disabled');
-			radiobutton.setAttribute('aria-disabled', isDisabled);
-		}
-
-		if (data.checked === 'true' || data.checked === true)
-			$(radiobutton).prop('checked', true);
-
-		radiobutton.addEventListener('change', toggleFunction);
-
-		if (data.hidden)
-			$(radiobutton).hide();
-
 		return false;
 	},
 

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -13,7 +13,7 @@
  * L.Control.NotebookbarImpress - definition of notebookbar content in Impress
  */
 
-/* global _ _UNO app */
+/* global _ _UNO app JSDialog */
 
 L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 
@@ -111,6 +111,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'name': 'Design',
 				'accessibility': { focusBack: false, combination: 'P', de: null }
 			},
+			JSDialog.ImpressTransitionTab.getEntry(),
 			{
 				'id': 'Slideshow-tab-label',
 				'text': _('Slide Show'),
@@ -178,6 +179,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			this.getHomeTab(),
 			this.getInsertTab(),
 			this.getDesignTab(),
+			this.getTransitionTab(),
 			this.getSlideshowTab(),
 			this.getReviewTab(),
 			this.getFormatTab(),
@@ -435,6 +437,11 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 		}
 
 		return this.getTabPage('File', content);
+	},
+
+	getTransitionTab: function() {
+		const tab = JSDialog.ImpressTransitionTab;
+		return this.getTabPage(tab.getName(), tab.getContent());
 	},
 
 	getSlideshowTab: function() {

--- a/browser/src/control/Notebookbar.ImpressTransitionTab.ts
+++ b/browser/src/control/Notebookbar.ImpressTransitionTab.ts
@@ -1,0 +1,129 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Notebookbar.ImpressTransitionTab.ts
+ */
+
+class ImpressTransitionTab implements NotebookbarTab {
+	public getName(): string {
+		return 'Transition';
+	}
+
+	public getEntry(): NotebookbarTabEntry {
+		return {
+			id: 'Transition-tab-label',
+			text: _('Transition'),
+			name: this.getName(),
+			accessibility: {
+				focusBack: false,
+				combination: 'A',
+				de: null,
+			} as NotebookbarAccessibilityDescriptor,
+		} as NotebookbarTabEntry;
+	}
+
+	/* ids have to match transition pane ids from the .ui in the core */
+	public getContent(): NotebookbarTabContent {
+		const content = [
+			{
+				id: 'transitions_icons',
+				type: 'iconview',
+			} as IconViewJSON,
+			{
+				id: 'transitions-icons-separator',
+				type: 'separator',
+				orientation: 'vertical',
+			} as SeparatorWidgetJSON,
+			{
+				id: 'transition-modify-group',
+				type: 'grid',
+				rows: 2,
+				cols: 2,
+				children: [
+					{
+						id: 'variant_label',
+						type: 'fixedtext',
+						text: _('Variant'),
+						top: '0',
+						left: '0',
+					} as TextWidget,
+					{
+						id: 'variant_list',
+						type: 'listbox',
+						text: '',
+						entries: [],
+						top: '0',
+						left: '1',
+					} as ListBoxWidget,
+					{
+						id: 'duration_label',
+						type: 'fixedtext',
+						text: _('Duration'),
+						top: '1',
+						left: '0',
+					} as TextWidget,
+					{
+						id: 'transition_duration',
+						type: 'spinfield',
+						text: '',
+						top: '1',
+						left: '1',
+					},
+				],
+			} as GridWidgetJSON,
+			{
+				id: 'transition-modify-separator',
+				type: 'separator',
+				orientation: 'vertical',
+			} as SeparatorWidgetJSON,
+			{
+				id: 'Transition-advance-group',
+				type: 'grid',
+				rows: 2,
+				cols: 2,
+				children: [
+					{
+						id: 'rb_mouse_click',
+						type: 'radiobutton',
+						text: _('On mouse click'),
+						top: '0',
+						left: '0',
+						width: '2',
+					} as RadioButtonWidget,
+					{
+						id: 'rb_auto_after',
+						type: 'radiobutton',
+						text: _('After'),
+						top: '1',
+						left: '0',
+					} as RadioButtonWidget,
+					{
+						id: 'auto_after_value',
+						type: 'spinfield',
+						text: '',
+						top: '1',
+						left: '1',
+					},
+				],
+			} as GridWidgetJSON,
+			{
+				id: 'transition-advance-separator',
+				type: 'separator',
+				orientation: 'vertical',
+			} as SeparatorWidgetJSON,
+		];
+
+		return content as NotebookbarTabContent;
+	}
+}
+
+JSDialog.ImpressTransitionTab = new ImpressTransitionTab();

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -19,8 +19,9 @@ interface WidgetJSON {
 	type: string; // type of widget
 	enabled?: boolean; // enabled state
 	visible?: boolean; // visibility state
-	children: Array<WidgetJSON>; // child nodes
+	children?: Array<WidgetJSON>; // child nodes
 	title?: string;
+	text?: string; // TODO: remove, its for not yet defined widget types
 	top?: string; // placement in the grid - row
 	left?: string; // placement in the grid - column
 	width?: string; // inside grid - width in number of columns
@@ -117,6 +118,29 @@ interface PopupData extends JSDialogJSON {
 	persistKeyboard?: boolean;
 	posx: number;
 	posy: number;
+}
+
+// Notebookbar
+
+type NotebookbarAccessibilityDescriptor = {
+	focusBack: boolean;
+	combination: string;
+	de?: string | null; // combination specific for german
+};
+
+type NotebookbarTabEntry = {
+	id: string;
+	text: string; // visible in the UI
+	name: string; // identifier for tab widget
+	accessibility: NotebookbarAccessibilityDescriptor;
+};
+
+type NotebookbarTabContent = Array<WidgetJSON>;
+
+interface NotebookbarTab {
+	getName: () => string;
+	getEntry: () => NotebookbarTabEntry;
+	getContent: () => NotebookbarTabContent;
 }
 
 // callback triggered for custom rendered entries

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -199,6 +199,15 @@ interface ListBoxWidget extends WidgetJSON {
 	entries: Array<string>;
 }
 
+// type: 'radiobutton'
+interface RadioButtonWidget extends WidgetJSON {
+	text: string;
+	image?: string; // replacement image
+	group?: string; // identifier of radio group
+	checked?: boolean;
+	hidden?: boolean;
+}
+
 interface ComboBoxWidget extends WidgetJSON {
 	text?: string;
 	entries?: Array<string | number>;

--- a/browser/src/control/jsdialog/Util.MessageRouter.ts
+++ b/browser/src/control/jsdialog/Util.MessageRouter.ts
@@ -18,6 +18,8 @@ declare var JSDialog: any;
 class JSDialogMessageRouter {
 	// show labels instead of editable fields in message boxes
 	private _preProcessMessageDialog(msgData: WidgetJSON) {
+		if (!msgData.children) return;
+
 		for (var i in msgData.children) {
 			var child = msgData.children[i];
 			if (child.type === 'multilineedit') child.type = 'fixedtext';

--- a/browser/src/control/jsdialog/Widget.ButtonBox.ts
+++ b/browser/src/control/jsdialog/Widget.ButtonBox.ts
@@ -33,10 +33,12 @@ JSDialog.buttonBox = function (
 	var leftAlignButtons = [];
 	var rightAlignButton = [];
 
-	for (var i in data.children) {
-		var child = data.children[i];
-		if (child.id === 'help') leftAlignButtons.push(child);
-		else rightAlignButton.push(child);
+	if (data.children) {
+		for (const i in data.children) {
+			const child = data.children[i];
+			if (child.id === 'help') leftAlignButtons.push(child);
+			else rightAlignButton.push(child);
+		}
 	}
 
 	var left = L.DomUtil.create(
@@ -45,8 +47,8 @@ JSDialog.buttonBox = function (
 		container,
 	);
 
-	for (i in leftAlignButtons) {
-		child = leftAlignButtons[i];
+	for (const i in leftAlignButtons) {
+		const child = leftAlignButtons[i];
 		if (builder._controlHandlers[child.type]) {
 			builder._controlHandlers[child.type](left, child, builder);
 			builder.postProcess(left, child);
@@ -61,8 +63,8 @@ JSDialog.buttonBox = function (
 	if (data.layoutstyle && data.layoutstyle === 'end')
 		L.DomUtil.addClass(container, 'end');
 
-	for (i in rightAlignButton) {
-		child = rightAlignButton[i];
+	for (const i in rightAlignButton) {
+		const child = rightAlignButton[i];
 		if (builder._controlHandlers[child.type]) {
 			builder._controlHandlers[child.type](right, child, builder);
 			builder.postProcess(right, child);

--- a/browser/src/control/jsdialog/Widget.OverflowGroup.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowGroup.ts
@@ -91,7 +91,11 @@ function setupOverflowMenu(
 	};
 }
 
-function findFirstToolitem(items: Array<WidgetJSON>): WidgetJSON | null {
+function findFirstToolitem(
+	items: Array<WidgetJSON> | undefined,
+): WidgetJSON | null {
+	if (!items) return null;
+
 	for (const item of items) {
 		if (
 			item.type.indexOf('toolitem') >= 0 ||
@@ -155,7 +159,8 @@ JSDialog.OverflowGroup = function (
 	if (data.name) label.innerText = data.name;
 
 	// content
-	builder.build(contentContainer, data.children, false);
+	if (data.children) builder.build(contentContainer, data.children, false);
+	else console.error('OverflowGroup: no content provided');
 
 	// first toolitem in the group
 	const firstItem = findFirstToolitem(data.children);

--- a/browser/src/control/jsdialog/Widget.RadioButton.ts
+++ b/browser/src/control/jsdialog/Widget.RadioButton.ts
@@ -1,0 +1,86 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * JSDialog.RadioButton - radio button widget with label
+ */
+
+declare var JSDialog: any;
+
+function radiobuttonControl(
+	parentContainer: HTMLElement,
+	data: RadioButtonWidget,
+	builder: JSBuilder,
+) {
+	const container = L.DomUtil.createWithId('div', data.id, parentContainer);
+	L.DomUtil.addClass(container, 'radiobutton ui-radiobutton');
+	L.DomUtil.addClass(container, builder.options.cssClass);
+
+	const radiobutton = L.DomUtil.create('input', '', container);
+	radiobutton.type = 'radio';
+	radiobutton.id = data.id + '-input';
+	radiobutton.tabIndex = '0';
+
+	if (data.image) {
+		const image = L.DomUtil.create('img', '', radiobutton);
+		image.src = data.image;
+		L.DomUtil.addClass(container, 'has-image');
+	}
+
+	if (data.group) radiobutton.name = data.group;
+
+	const radiobuttonLabel = L.DomUtil.createWithId(
+		'label',
+		data.id + '-label',
+		container,
+	);
+	radiobuttonLabel.textContent = builder._cleanText(data.text);
+	radiobuttonLabel.htmlFor = data.id + '-input';
+
+	const toggleFunction = () => {
+		builder.callback(
+			'radiobutton',
+			'change',
+			container,
+			$(radiobutton).prop('checked'),
+			builder,
+		);
+	};
+
+	$(radiobuttonLabel).click(() => {
+		if (radiobutton.hasAttribute('disabled')) return;
+
+		$(radiobutton).prop('checked', true);
+		toggleFunction.bind({ checked: true })();
+	});
+
+	const isDisabled = data.enabled === false;
+	if (isDisabled) {
+		radiobutton.setAttribute('disabled', 'disabled');
+		radiobutton.setAttribute('aria-disabled', isDisabled);
+	}
+
+	if (data.checked === true) $(radiobutton).prop('checked', true);
+
+	radiobutton.addEventListener('change', toggleFunction);
+
+	if (data.hidden) $(radiobutton).hide();
+
+	return false;
+}
+
+JSDialog.RadioButton = function (
+	parentContainer: HTMLElement,
+	data: RadioButtonWidget,
+	builder: JSBuilder,
+) {
+	return radiobuttonControl(parentContainer, data, builder);
+};


### PR DESCRIPTION
- it uses widgets previously present in the sidebar
- allow grids in notebookbar to be applied
- move radiobutton to TS and add type

<img width="822" height="116" alt="Snapshot_2025-08-06_10-17-25" src="https://github.com/user-attachments/assets/62efaf39-d2cc-4ad2-894b-5ca3949243f0" />
