### PR TITLE
Replace some uses of window with globalThis

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1,6 +1,6 @@
 /* -*- js-indent-level: 8 -*- */
 
-/* global app ArrayBuffer Uint8Array _ */
+/* global Module ArrayBuffer Uint8Array _ */
 
 /*
 	For extending window.app object, please see "docstate.js" file.
@@ -503,7 +503,7 @@ class EMSCRIPTENAppInitializer extends MobileAppInitializer {
 		super();
 
 		window.ThisIsTheEmscriptenApp = true;
-		window.postMobileMessage = function(msg) { app.HandleCOOLMessage(app.AllocateUTF8(msg)); };
+		window.postMobileMessage = function(msg) { Module._handle_cool_message(Module.stringToNewUTF8(msg)); };
 		window.postMobileError   = function(msg) { console.log('COOL Error: ' + msg); };
 		window.postMobileDebug   = function(msg) { console.log('COOL Debug: ' + msg); };
 

--- a/browser/src/main.js
+++ b/browser/src/main.js
@@ -10,6 +10,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+/* global globalThis */
 /* global errorMessages accessToken accessTokenTTL noAuthHeader accessHeader createOnlineModule */
 /* global app $ L host idleTimeoutSecs outOfFocusTimeoutSecs _ LocaleService LayoutingService */
 /*eslint indent: [error, "tab", { "outerIIFEBody": 0 }]*/
@@ -99,7 +100,7 @@ if (window.ThisIsTheEmscriptenApp) {
 	var docParamsPart = docParamsString ? (docURL.includes('?') ? '&' : '?') + docParamsString : '';
 	var encodedWOPI = encodeURIComponent(docURL + docParamsPart);
 
-	window.Module = {
+	globalThis.Module = {
 		onRuntimeInitialized: function() {
 			map.loadDocument(global.socket);
 		},
@@ -114,9 +115,9 @@ if (window.ThisIsTheEmscriptenApp) {
 		arguments_: [docURL, encodedWOPI, isWopi ? 'true' : 'false'],
 		arguments: [docURL, encodedWOPI, isWopi ? 'true' : 'false'],
 	};
-	createOnlineModule(window.Module).then(() => {
-		app.HandleCOOLMessage = window.Module['_handle_cool_message'];
-		app.AllocateUTF8 = window.Module['stringToNewUTF8']; });
+	createOnlineModule(globalThis.Module).then(() => {
+		app.HandleCOOLMessage = globalThis.Module['_handle_cool_message'];
+		app.AllocateUTF8 = globalThis.Module['stringToNewUTF8']; });
 } else {
 	map.loadDocument(global.socket);
 }

--- a/browser/src/main.js
+++ b/browser/src/main.js
@@ -115,9 +115,7 @@ if (window.ThisIsTheEmscriptenApp) {
 		arguments_: [docURL, encodedWOPI, isWopi ? 'true' : 'false'],
 		arguments: [docURL, encodedWOPI, isWopi ? 'true' : 'false'],
 	};
-	createOnlineModule(globalThis.Module).then(() => {
-		app.HandleCOOLMessage = globalThis.Module['_handle_cool_message'];
-		app.AllocateUTF8 = globalThis.Module['stringToNewUTF8']; });
+	createOnlineModule(globalThis.Module);
 } else {
 	map.loadDocument(global.socket);
 }

--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -46,13 +46,13 @@ static void send2JS(const std::vector<char>& buffer)
     if (newline != nullptr)
     {
         // The data needs to be an ArrayBuffer
-        js = "window.TheFakeWebSocket.onmessage({'data': Base64ToArrayBuffer('";
+        js = "globalThis.TheFakeWebSocket.onmessage({'data': Base64ToArrayBuffer('";
         js = js + macaron::Base64::Encode(std::string(buffer.data(), buffer.size()));
         js = js + "')});";
     }
     else
     {
-        js = "window.TheFakeWebSocket.onmessage({'data': window.b64d('";
+        js = "globalThis.TheFakeWebSocket.onmessage({'data': globalThis.b64d('";
         js = js + macaron::Base64::Encode(std::string(buffer.data(), buffer.size()));
         js = js + "')});";
     }

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3802,7 +3802,7 @@ int COOLWSD::innerMain()
     // It is not at all obvious that this is the ideal place to do the HULLO thing and call onopen
     // on TheFakeWebSocket. But it seems to work.
     handle_cool_message("HULLO");
-    MAIN_THREAD_EM_ASM(window.TheFakeWebSocket.onopen());
+    MAIN_THREAD_EM_ASM(globalThis.TheFakeWebSocket.onopen());
 #endif
 
     /// The main-poll does next to nothing:


### PR DESCRIPTION
...in preparation of allowing the Wasm code to run in a shared worker (where the global object will be some kind of WorkerGlobalScope rather than a Window).

(Yes, the silly ESLint that is run on browser/src/main.js would complain about "error  'globalThis' is not defined  no-undef" unless explicitly listed in a /* global */ comment.)


Change-Id: I127d27b11aaf8ef29b1cfb8beae9ee4c858e38f2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

