### PR TITLE
Drop unused Module.arguments_ property

### DIFF
--- a/browser/src/main.js
+++ b/browser/src/main.js
@@ -111,7 +111,6 @@ if (window.ThisIsTheEmscriptenApp) {
 			if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
 			console.error(text);
 		},
-		arguments_: [docURL, encodedWOPI, isWopi ? 'true' : 'false'],
 		arguments: [docURL, encodedWOPI, isWopi ? 'true' : 'false'],
 	};
 	createOnlineModule(window.Module).then(() => {


### PR DESCRIPTION
...that was introduced in a7d6d1debc46f618733e180bd1b8ff87e7303ab7 "wasm: pass the docURL to the wasm app", alongside Module.arguments, for no apparent reason (Emscripten only uses Module.arguments, see
<https://emscripten.org/docs/api_reference/module.html#Module.arguments>)


Change-Id: Ic7b727e82b567b422c30fdd1aa4193f7c889f2cb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

