### PR TITLE
fix:replace var with const/let in calendar widget

### DIFF
--- a/browser/src/control/jsdialog/Widget.Calendar.js
+++ b/browser/src/control/jsdialog/Widget.Calendar.js
@@ -25,7 +25,7 @@
 /* global JSDialog $ */
 
 function _calendarControl(parentContainer, data, builder) {
-	var container = L.DomUtil.create('div', 'ui-calendar ' + builder.options.cssClass, parentContainer);
+	const container = L.DomUtil.create('div', 'ui-calendar ' + builder.options.cssClass, parentContainer);
 	container.id = data.id;
 
 	$.datepicker.setDefaults($.datepicker.regional[window.langParamLocale.language]);
@@ -44,6 +44,6 @@ function _calendarControl(parentContainer, data, builder) {
 }
 
 JSDialog.calendar = function (parentContainer, data, builder) {
-	var buildInnerData = _calendarControl(parentContainer, data, builder);
+	const buildInnerData = _calendarControl(parentContainer, data, builder);
 	return buildInnerData;
 };


### PR DESCRIPTION
Change-Id: If4ac42ed4c803094be058180784bccdda6037b1a


* Addresses: #12108, but does not resolve completely
* Target version: master 

### Summary
Replaced var with const in this file https://github.com/CollaboraOnline/online/blob/master/browser/src/control/jsdialog/Widget.Calendar.js

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

