### PR TITLE
context toolbar: fix wrong positioning with zoom

### DIFF
--- a/browser/src/control/Control.ContextToolbar.ts
+++ b/browser/src/control/Control.ContextToolbar.ts
@@ -89,7 +89,7 @@ class ContextToolbar {
 			let statRect;
 			if (!TextSelections || !(statRect = TextSelections.getStartRectangle()))
 				return;
-			const pos = { x: statRect.pX1, y: statRect.pY1 };
+			const pos = { x: statRect.cX1, y: statRect.cY1 };
 			pos.x -=
 				(app.sectionContainer.getDocumentTopLeft()[0] -
 					app.sectionContainer.getDocumentAnchor()[0]) /


### PR DESCRIPTION
problem:
incorrect coordinates were used in equation. now we use css pixel pos


Change-Id: I92de7d0d182ee650adfb38fd3eaef57cb08d0e29


* Target version: master 
* 
### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

