### PR TITLE
style previews: use black text on white in dark mode

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -560,6 +560,11 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 [data-theme='dark'] .StyleListPanel #TemplatePanel [id='3'] button { background: transparent url('images/dark/lc_framestyle.svg') no-repeat center; }
 [data-theme='dark'] .StyleListPanel #TemplatePanel [id='6'] button { background: transparent url('images/dark/lc_tablestyle.svg') no-repeat center; }
 
+/* background is always white for previews, use black text */
+[data-theme='dark'] .StyleListPanel #treeview .ui-treeview-cell-text {
+	color: var(--color-main-background);
+}
+
 .StyleListPanel .ui-treeview-entry img.ui-treeview-custom-render {
 	max-height: 32px;
 }


### PR DESCRIPTION
Style previews are shown always in true colors so the background color is white. If image previews are off we need to use black font to make it visible.