### PR TITLE
Style buttons in Find/Replace and Properties dialogs as tabs

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -5,7 +5,7 @@
 	background: var(--color-background-lighter);
 }
 
-.jsdialog *[disabled]:not(label):not(.ui-frame-container):not(.checkbutton):not(.spinfieldcontainer):not(.ui-grid):not(.ui-content):not(.ui-listbox-container) {
+.jsdialog *[disabled]:not(label):not(.ui-frame-container):not(.checkbutton):not(.spinfieldcontainer):not(.ui-grid):not(.ui-content):not(.ui-listbox-container):not(.ui-pushbutton-wrapper) {
 	border: 1px solid var(--color-border-lighter);
 }
 

--- a/browser/css/device-desktop.css
+++ b/browser/css/device-desktop.css
@@ -20,7 +20,7 @@
 
 /* btns hover status
    Rules not intended for touch devices */
-
+.ui-toggle button:hover,
 .button-secondary:hover,
 button:not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.notebookbar.ui-tab):not(.ui-expander):not(.arrowbackground):not(.ui-combobox-button):hover {
 	cursor: pointer;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -341,6 +341,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	height: 100%;
 }
 
+.ui-toggle button,
 .ui-tab.jsdialog {
 	float: left !important;
 	font-size: var(--default-font-size) !important;
@@ -351,6 +352,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	height: 24px !important;
 	display: flex !important;
 	align-items: center !important;
+	justify-content: center;
 	padding: 0px 1em !important;
 	border: solid 1px transparent !important;
 	border-radius: var(--border-radius) !important;
@@ -363,6 +365,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	visibility: hidden !important;
 }
 
+.ui-toggle.checked button,
 .ui-tab.selected.jsdialog {
 	background-color: var(--color-background-lighter) !important;
 	color: var(--color-text-darker) !important;
@@ -2477,6 +2480,7 @@ kbd,
 #findreplacetabbox {
 	justify-content: start;
 }
+
 
 /* text-area overflow on function wizard window */
 

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -355,7 +355,7 @@ L.Control.JSDialog = L.Control.extend({
 
 		instance.builder.build(instance.content, [instance]);
 		instance.builder.setContainer(instance.content);
-		var primaryBtn = instance.content.querySelector('#' + instance.defaultButtonId);
+		var primaryBtn = instance.content.querySelector('#' + instance.defaultButtonId + ' button');
 		if (primaryBtn)
 			L.DomUtil.addClass(primaryBtn, 'button-primary');
 	},

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1601,6 +1601,12 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			pushbutton.setAttribute('aria-disabled', true);
 		}
 
+		if (data.isToggle) {
+			wrapper.classList.add('ui-toggle');
+			if (data.checked === true)
+				wrapper.classList.add('checked');
+		}
+
 		if (customCallback)
 			pushbutton.onclick = customCallback;
 		else if (builder._responses[pushbutton.id] !== undefined)

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1568,8 +1568,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		}
 		var wrapperClass = window.mode.isMobile() ? '' : 'd-flex justify-content-center';
 		var wrapper = L.DomUtil.create('div', wrapperClass, parentContainer); // need for locking overlay
+		wrapper.id = data.id;
 		var pushbutton = L.DomUtil.create('button', 'ui-pushbutton ' + builder.options.cssClass, wrapper);
-		pushbutton.id = data.id;
 		builder._setAccessKey(pushbutton, builder._getAccessKeyFromText(data.text));
 		var pushbuttonText = builder._customPushButtonTextForId(data.id) !== '' ? builder._customPushButtonTextForId(data.id) : builder._cleanText(data.text);
 		var image;
@@ -1609,10 +1609,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		if (customCallback)
 			pushbutton.onclick = customCallback;
-		else if (builder._responses[pushbutton.id] !== undefined)
-			pushbutton.onclick = builder.callback.bind(builder, 'responsebutton', 'click', { id: pushbutton.id }, builder._responses[pushbutton.id], builder);
+		else if (builder._responses[data.id] !== undefined)
+			pushbutton.onclick = builder.callback.bind(builder, 'responsebutton', 'click', { id: pushbutton.id }, builder._responses[data.id], builder);
 		else
-			pushbutton.onclick = builder.callback.bind(builder, 'pushbutton', data.isToggle ? 'toggle' : 'click', pushbutton, data.command, builder);
+			pushbutton.onclick = builder.callback.bind(builder, 'pushbutton', data.isToggle ? 'toggle' : 'click', wrapper, data.command, builder);
 
 
 		if (data.labelledBy) {
@@ -2862,8 +2862,10 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			newControl.style.gridColumn = backupGridSpan;
 
 			// todo: is that needed? should be in widget impl?
-			if (data.has_default === true && (data.type === 'pushbutton' || data.type === 'okbutton'))
-				L.DomUtil.addClass(newControl, 'button-primary');
+			if (data.has_default === true && (data.type === 'pushbutton' || data.type === 'okbutton')) {
+				const buttonNode = newControl.querySelector('button');
+				if (buttonNode) L.DomUtil.addClass(buttonNode, 'button-primary');
+			}
 		}
 
 		if (focusedId) {

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -267,6 +267,8 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (objectType === 'responsebutton' && data === 1 && !builder.reportValidity())
 			return;
 
+		console.assert(object.id, 'Trying to send command without valid id');
+
 		window.app.console.debug('control: \'' + objectType + '\' id:\'' + object.id + '\' event: \'' + eventType + '\' state: \'' + data + '\'');
 
 		// if user does action - enter following own cursor mode
@@ -1567,7 +1569,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			data.enabled = false;
 		}
 		var wrapperClass = window.mode.isMobile() ? '' : 'd-flex justify-content-center';
-		var wrapper = L.DomUtil.create('div', wrapperClass, parentContainer); // need for locking overlay
+		var wrapper = L.DomUtil.create('div', wrapperClass + ' ui-pushbutton-wrapper ' + builder.options.cssClass, parentContainer); // need for locking overlay
 		wrapper.id = data.id;
 		var pushbutton = L.DomUtil.create('button', 'ui-pushbutton ' + builder.options.cssClass, wrapper);
 		builder._setAccessKey(pushbutton, builder._getAccessKeyFromText(data.text));
@@ -1597,9 +1599,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		const isDisabled = data.enabled === false;
 		if (isDisabled) {
-			pushbutton.setAttribute('disabled', 'disabled');
-			pushbutton.setAttribute('aria-disabled', true);
+			wrapper.setAttribute('disabled', 'disabled');
+			wrapper.setAttribute('aria-disabled', true);
 		}
+
+		JSDialog.SynchronizeDisabledState(wrapper, [pushbutton]);
 
 		if (data.isToggle) {
 			wrapper.classList.add('ui-toggle');
@@ -1610,7 +1614,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		if (customCallback)
 			pushbutton.onclick = customCallback;
 		else if (builder._responses[data.id] !== undefined)
-			pushbutton.onclick = builder.callback.bind(builder, 'responsebutton', 'click', { id: pushbutton.id }, builder._responses[data.id], builder);
+			pushbutton.onclick = builder.callback.bind(builder, 'responsebutton', 'click', { id: data.id }, builder._responses[data.id], builder);
 		else
 			pushbutton.onclick = builder.callback.bind(builder, 'pushbutton', data.isToggle ? 'toggle' : 'click', wrapper, data.command, builder);
 

--- a/cypress_test/integration_tests/common/repair_document_helper.js
+++ b/cypress_test/integration_tests/common/repair_document_helper.js
@@ -42,9 +42,9 @@ function rollbackPastChange(selector, mobile = false) {
 		.click();
 
 	if (mobile) {
-		cy.cGet('#ok.ui-pushbutton.mobile-wizard').click();
+		cy.cGet('#ok.ui-pushbutton-wrapper.mobile-wizard').click();
 	} else {
-		cy.cGet('#ok.ui-pushbutton.jsdialog').click();
+		cy.cGet('#ok.ui-pushbutton-wrapper.jsdialog').click();
 	}
 
 	cy.log('<< rollbackPastChange - end');

--- a/cypress_test/integration_tests/desktop/draw/esign_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/esign_spec.js
@@ -42,7 +42,7 @@ describe(['tagdesktop'], 'Electronic sign operations.', function() {
 		// Finish electronic signing:
 		cy.cGet('#snackbar-container #button').click();
 		cy.get('@sendHash').should('be.called');
-		cy.cGet('#ESignatureDialog button#ok').click();
+		cy.cGet('#ESignatureDialog #ok.ui-pushbutton-wrapper').click();
 		cy.get('@windowOpen').should('be.called');
 		const response = {
 			type: "SUCCESS",
@@ -54,7 +54,7 @@ describe(['tagdesktop'], 'Electronic sign operations.', function() {
 		});
 		cy.get('@getSignature').should('be.called');
 		// Close the dialog showing the just created signature:
-		cy.cGet('#DigitalSignaturesDialog button#close').click();
+		cy.cGet('#DigitalSignaturesDialog #close.ui-pushbutton-wrapper button').click();
 
 		// Then make sure the document now has a (test / "not OK") signature:
 		cy.cGet('#signstatus-button div').should('have.class', 'sign_not_ok');

--- a/cypress_test/integration_tests/desktop/draw/sign_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/sign_spec.js
@@ -14,7 +14,8 @@ describe(['tagdesktop'], 'Signature operations.', function() {
 		cy.cGet('#menu-insert-signatureline').click();
 		// Click on the only signature, not on the header:
 		cy.cGet('#SelectCertificateDialog #signatures .ui-treeview-entry > div:first-child').click();
-		cy.cGet('#SelectCertificateDialog button#ok').click();
+		cy.cGet('#SelectCertificateDialog #ok.ui-pushbutton-wrapper button').click();
+		cy.cGet('#SelectCertificateDialog').should('not.exist');
 		// Make sure the signature line has handles, so it can be moved/resized:
 		cy.cGet('#test-div-shapeHandlesSection').should('exist');
 		// Finish signing:

--- a/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
@@ -24,7 +24,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 		cy.cGet('#title-input.ui-edit').type('New Title');
 		cy.cGet('#comments.ui-textarea').type('New');
 
-		cy.cGet('#ok.ui-pushbutton').click();
+		cy.cGet('#ok.ui-pushbutton-wrapper').click();
 
 		writerHelper.openFileProperties();
 
@@ -32,7 +32,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 		cy.cGet('#title-input.ui-edit').should('have.value', 'New Title');
 		cy.cGet('#comments.ui-textarea').should('have.value', 'New');
 
-		cy.cGet('#cancel.ui-pushbutton').click();
+		cy.cGet('#cancel.ui-pushbutton-wrapper button').click();
 	});
 
 	it('Add Custom Property.', function() {
@@ -40,11 +40,11 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 		cy.cGet('#tabcontrol-3').click();
 
 		// Add property
-		cy.cGet('#add.ui-pushbutton').click();
+		cy.cGet('#add.ui-pushbutton-wrapper').click();
 		cy.cGet('#namebox-input-dialog').type('Mailstop');
 
 		cy.cGet('#valueedit-input').type('123 Address');
-		cy.cGet('#ok.ui-pushbutton').click();
+		cy.cGet('#ok.ui-pushbutton-wrapper button').click();
 
 		// Check property saved
 		writerHelper.openFileProperties();
@@ -52,7 +52,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 		cy.cGet('#valueedit-input').should('have.value', '123 Address');
 		cy.cGet('#namebox-input-dialog').should('have.value', 'Mailstop');
 
-		cy.cGet('#cancel.ui-pushbutton').click();
+		cy.cGet('#cancel.ui-pushbutton-wrapper').click();
 	});
 
 	it('Add Custom Duration Property.', function() {
@@ -60,7 +60,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 		cy.cGet('#tabcontrol-3').click();
 
 		// Add property
-		cy.cGet('#add.ui-pushbutton').click();
+		cy.cGet('#add.ui-pushbutton-wrapper').click();
 		cy.cGet('#namebox-input-dialog').type('Received from');
 		cy.cGet('#typebox-input').select('Duration');
 		cy.cGet('#durationbutton').click();
@@ -70,16 +70,16 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 		cy.cGet('#seconds-input').type('3');
 
 		// click the sub-dialog ok button
-		cy.cGet('#ok.ui-pushbutton').invoke('slice', 1).click();
+		cy.cGet('#ok.ui-pushbutton-wrapper button').invoke('slice', 1).click();
 		cy.wait(100); // give a bit of time to spin the loop and update jsdialogs
-		cy.cGet('#ok.ui-pushbutton').click();
+		cy.cGet('#ok.ui-pushbutton-wrapper button').click();
 
 		// Check property saved
 		writerHelper.openFileProperties();
 		cy.cGet('#tabcontrol-3').click();
 		cy.cGet('#duration-input').should('have.value', '- Y: 1 M: 0 D: 2 H: 0 M: 0 S: 3');
 		cy.cGet('#namebox-input-dialog').should('have.value', 'Received from');
-		cy.cGet('#cancel.ui-pushbutton').click();
+		cy.cGet('#cancel.ui-pushbutton-wrapper button').click();
 	});
 
 	it('Add Custom Yes/No Property.', function() {
@@ -87,17 +87,17 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 		cy.cGet('#tabcontrol-3').click();
 
 		// Add property
-		cy.cGet('#add.ui-pushbutton').click();
+		cy.cGet('#add.ui-pushbutton-wrapper').click();
 		cy.cGet('#namebox-input-dialog').type('Telephone number');
 		cy.cGet('#typebox-input').select('Yes or no');
 		cy.cGet('#yes-input').check();
-		cy.cGet('#ok.ui-pushbutton').click();
+		cy.cGet('#ok.ui-pushbutton-wrapper button').click();
 
 		// Check property saved
 		writerHelper.openFileProperties();
 		cy.cGet('#tabcontrol-3').click();
 		cy.cGet('#yes-input').should('be.checked');
 		cy.cGet('#namebox-input-dialog').should('have.value', 'Telephone number');
-		cy.cGet('#cancel.ui-pushbutton').click();
+		cy.cGet('#cancel.ui-pushbutton-wrapper button').click();
 	});
 });

--- a/cypress_test/integration_tests/desktop/writer/sign_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/sign_spec.js
@@ -15,11 +15,11 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Sign operations.', functio
 		cy.cGet('#signature-button').click();
 		// Without the accompanying fix in place, this test would have failed with:
 		// This element `<button#sign.ui-pushbutton.jsdialog.hidden>` is not visible because it has CSS property: `display: none`
-		cy.cGet('#DigitalSignaturesDialog button#sign').click();
+		cy.cGet('#DigitalSignaturesDialog #sign.ui-pushbutton-wrapper button').click();
 		// Click on the only signature, not on the header:
 		cy.cGet('#SelectCertificateDialog #signatures .ui-treeview-entry > div:first-child').click();
-		cy.cGet('#SelectCertificateDialog button#ok').click();
-		cy.cGet('#DigitalSignaturesDialog button#close').click();
+		cy.cGet('#SelectCertificateDialog #ok.ui-pushbutton-wrapper button').click();
+		cy.cGet('#DigitalSignaturesDialog #close.ui-pushbutton-wrapper button').click();
 
 		// Then make sure the resulting signature is valid:
 		cy.cGet('#signstatus-button div').should('have.class', 'sign_ok');

--- a/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/table_operation_spec.js
@@ -301,8 +301,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Table operations', functio
 		cy.cGet('.unospan-split_merge.unoSplitCell').click();
 		cy.cGet('.lokdialog.ui-dialog-content.ui-widget-content').should('exist');
 		cy.cGet('.lokdialog.ui-dialog-content.ui-widget-content').click();
-		cy.cGet('#ok.ui-pushbutton.jsdialog').should('exist');
-		cy.cGet('#ok.ui-pushbutton.jsdialog').click();
+		cy.cGet('#ok.ui-pushbutton-wrapper.jsdialog').should('exist').click();
 
 		helper.typeIntoDocument('{ctrl}{a}');
 		helper.copy();

--- a/cypress_test/integration_tests/mobile/impress/delete_objects_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/delete_objects_spec.js
@@ -108,7 +108,8 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function()
 			.click();
 
 		cy.cGet('#FontworkGalleryDialog').should('exist');
-		cy.cGet('#ok').click();
+		cy.cGet('#FontworkGalleryDialog #ok.ui-pushbutton-wrapper button').click();
+		cy.cGet('#FontworkGalleryDialog').should('not.exist');
 
 		cy.wait(200);
 

--- a/cypress_test/integration_tests/mobile/writer/insert_content_control_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_content_control_spec.js
@@ -32,7 +32,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Insert objects via insertio
 		cy.cGet('#mobile-wizard-title').should('have.text', 'Content Control List Item Properties');
 		cy.cGet('#displayname-input').type('some text');
 		cy.cGet('#value-input').type('something');
-		cy.cGet('#ContentControlListItemDialog button#ok').click();
+		cy.cGet('#ContentControlListItemDialog #ok.ui-pushbutton-wrapper').click();
 
 		// Verify we are back in parent window and added entries
 		cy.cGet('#mobile-wizard-title').should('have.text', 'Content Control Properties');

--- a/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/repair_document_spec.js
@@ -21,8 +21,7 @@ describe.skip('Repair Document', function() {
 		cy.cGet('#DocumentRepairDialog').should('exist');
 		cy.cGet('#versions').should('exist');
 		cy.cGet('body').contains('#versions .ui-treeview-entry div', 'Input').click();
-		cy.cGet('#ok.ui-pushbutton.jsdialog').should('exist');
-		cy.cGet('#ok.ui-pushbutton.jsdialog').click();
+		cy.cGet('#ok.ui-pushbutton-wrapper.jsdialog').should('exist').click();
 		cy.wait(500);
 		calcHelper.selectEntireSheet();
 		helper.expectTextForClipboard('');

--- a/cypress_test/integration_tests/multiuser/impress/repair_document_spec.js
+++ b/cypress_test/integration_tests/multiuser/impress/repair_document_spec.js
@@ -33,8 +33,7 @@ describe.skip('Repair Document', function() {
 		cy.cGet('#versions').should('exist');
 
 		cy.cGet('body').contains('#versions .ui-treeview-entry div','Typing: “World”').click();
-		cy.cGet('#ok.ui-pushbutton.jsdialog').should('exist');
-		cy.cGet('#ok.ui-pushbutton.jsdialog').click();
+		cy.cGet('#ok.ui-pushbutton-wrapper.jsdialog').should('exist').click();
 		helper.typeIntoDocument('{ctrl}{a}');
 		helper.expectTextForClipboard('Hello');
 


### PR DESCRIPTION
Change-Id: I16c15dd1807b81a1e56cb5353ab17095913caa5c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
-This update makes the Find and Replace buttons visually resemble tabs, improving consistency with common UI patterns.
 The Replace tab is highlighted conditionally based on the visibility of the Replace frame.

### PREVIEW
https://github.com/user-attachments/assets/e66cadb7-2072-4ca2-8ba5-b15ea3ca38c3



- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

