### PR TITLE
Add border tool to Writer Notebookbar

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2815,6 +2815,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'type': 'toolitem',
 								'text': _UNO('.uno:NumberFormatDate', 'text'),
 								'command': '.uno:NumberFormatDate'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:NumberFormatPercent', 'text'),
+								'command': '.uno:NumberFormatPercent'
 							}
 						]
 					},
@@ -2827,9 +2832,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'command': '.uno:TableCellBackgroundColor',
 							},
 							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:NumberFormatPercent', 'text'),
-								'command': '.uno:NumberFormatPercent'
+								'id': 'set-border-style:BorderStyleMenuWriter',
+								'type': 'menubutton',
+								'noLabel': true,
+								'text': _UNO('.uno:SetBorderStyle', 'text'),
+								'command': '.uno:SetBorderStyle'
 							}
 						]
 					}

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -1354,6 +1354,13 @@ menuDefinitions.set('BorderStyleMenu', [
 	{ type: 'separator' }, // required to show dropdown arrow
 ] as Array<MenuDefinition>);
 
+menuDefinitions.set(
+	'BorderStyleMenuWriter',
+	(menuDefinitions.get('BorderStyleMenu') || []).filter(
+		(item) => item.uno !== '.uno:FormatCellBorders',
+	),
+);
+
 menuDefinitions.set('InsertShapesMenu', [
 	{ type: 'html', htmlId: 'insertshapespopup' },
 	{ type: 'separator' }, // required to show dropdown arrow


### PR DESCRIPTION
Re-use the widget from Calc, minus the button which opens the 'format cell' dialog

<img width="623" height="133" alt="2025-08-04_15-18" src="https://github.com/user-attachments/assets/035067db-785c-4701-987a-5560500b0eb7" />
