### PR TITLE
iconview: improve color palette UI for color window

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2525,29 +2525,35 @@ kbd,
 }
 
 /* Calc - Format - Format Cells - Background - Color */
+/* Format -> Character -> Font Effects -> Font color */
 
-#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview {
+#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview,
+:is(#colorwindow_iv_colors, #colorwindow_iv_recentcolors).ui-iconview {
 	grid-template-columns: repeat(12, 1fr);
 	width: max-content;
 	line-height: 0;
 	padding: 5px;
 }
 
-#ColorPage.jsdialog #iconview_colors.ui-iconview {
+#ColorPage.jsdialog #iconview_colors.ui-iconview,
+#colorwindow_iv_colors.ui-iconview {
 	max-height: 19vh;
 }
 
-#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry img {
+#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry img,
+:is(#colorwindow_iv_colors, #colorwindow_iv_recentcolors) .ui-iconview-entry img {  
 	padding: 1px;
 }
 
-#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry:is(:hover, .selected) {
+#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry:is(:hover, .selected),
+:is(#colorwindow_iv_colors, #colorwindow_iv_recentcolors) .ui-iconview-entry:is(:hover, .selected) {  
 	outline: 2px solid var(--color-primary);
 	border: 1px solid transparent;
 	background-color: transparent;
 	border-radius: 0;
 }
 
-#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry span {
+#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry span,
+:is(#colorwindow_iv_colors, #colorwindow_iv_recentcolors) .ui-iconview-entry span {  
 	font-size: 0; /* Hide placeholder text to prevent layout shifts in color palette iconview widgets due to lazy loading */
 }


### PR DESCRIPTION
- enhanced layout and styling of the color window by using a grid layout with consistent spacing and limit the main color palette to certain height to enable scrollbar if needed
- improved color picker's hover and selection visibility with outline and border
- placeholder texts were hidden to prevent layout shifts caused by lazy loading of color icons (icon-view entries)

core patch(requires): https://gerrit.libreoffice.org/c/core/+/188921

Change-Id: I4d169eb35d9bae17dde4c0effb60422ed53da4d9

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

