### PR TITLE
iconview-fix: Wrap builder callbacks to prevent empty widget IDs

### DIFF
--- a/browser/src/control/jsdialog/Widget.DrawingArea.js
+++ b/browser/src/control/jsdialog/Widget.DrawingArea.js
@@ -25,6 +25,8 @@
 
 /* global JSDialog $ UNOKey app */
 
+// All builder.callback calls are wrapped via a local `callback` function
+// to ensure container.id is always correctly set.
 function _drawingAreaControl (parentContainer, data, builder) {
 	var container = window.L.DomUtil.create('div', builder.options.cssClass + ' ui-drawing-area-container', parentContainer);
 	container.id = data.id;
@@ -102,7 +104,7 @@ function _drawingAreaControl (parentContainer, data, builder) {
 		clearTimeout(moveTimer);
 		moveTimer = null;
 		moveFunc = null;
-		builder.callback('drawingarea', 'dblclick', container, coordinates, builder);
+		callback('drawingarea', 'dblclick', container, coordinates, builder);
 	}, this);
 
 	window.L.DomEvent.on(image, 'click touchend', function(e) {
@@ -113,7 +115,7 @@ function _drawingAreaControl (parentContainer, data, builder) {
 		moveTimer = null;
 		moveFunc = null;
 
-		builder.callback('drawingarea', 'click', container, coordinates, builder);
+		callback('drawingarea', 'click', container, coordinates, builder);
 	}, this);
 
 	var onMove = function (e) {
@@ -126,7 +128,7 @@ function _drawingAreaControl (parentContainer, data, builder) {
 
 		var pos = getCoordinatesFromEvent(e);
 		var coordinates = pos[0] + ';' + pos[1];
-		builder.callback('drawingarea', 'mousemove', container, coordinates, builder);
+		callback('drawingarea', 'mousemove', container, coordinates, builder);
 	};
 
 	var endMove = function (e) {
@@ -139,14 +141,14 @@ function _drawingAreaControl (parentContainer, data, builder) {
 
 		var pos = getCoordinatesFromEvent(e);
 		var coordinates = pos[0] + ';' + pos[1];
-		builder.callback('drawingarea', 'mouseup', container, coordinates, builder);
+		callback('drawingarea', 'mouseup', container, coordinates, builder);
 	};
 
 	image.addEventListener('mousedown', function (e) {
 		moveFunc = function () {
 			var pos = getCoordinatesFromEvent(e);
 			var coordinates = pos[0] + ';' + pos[1];
-			builder.callback('drawingarea', 'mousedown', container, coordinates, builder);
+			callback('drawingarea', 'mousedown', container, coordinates, builder);
 		};
 
 		moveTimer = setTimeout(function () {
@@ -163,40 +165,40 @@ function _drawingAreaControl (parentContainer, data, builder) {
 
 	image.addEventListener('keydown', function(event) {
 		if (event.key === 'Enter') {
-			builder.callback('drawingarea', 'keypress', container, UNOKey.RETURN | modifier, builder);
+			callback('drawingarea', 'keypress', container, UNOKey.RETURN | modifier, builder);
 			event.preventDefault();
 		} else if (event.key === 'Escape' || event.key === 'Esc') {
-			builder.callback('drawingarea', 'keypress', container, UNOKey.ESCAPE | modifier, builder);
+			callback('drawingarea', 'keypress', container, UNOKey.ESCAPE | modifier, builder);
 			event.preventDefault();
 		} else if (event.key === 'Left' || event.key === 'ArrowLeft') {
-			builder.callback('drawingarea', 'keypress', container, UNOKey.LEFT | modifier, builder);
+			callback('drawingarea', 'keypress', container, UNOKey.LEFT | modifier, builder);
 			event.preventDefault();
 		} else if (event.key === 'Right' || event.key === 'ArrowRight') {
-			builder.callback('drawingarea', 'keypress', container, UNOKey.RIGHT | modifier, builder);
+			callback('drawingarea', 'keypress', container, UNOKey.RIGHT | modifier, builder);
 			event.preventDefault();
 		} else if (event.key === 'Up' || event.key === 'ArrowUp') {
-			builder.callback('drawingarea', 'keypress', container, UNOKey.UP | modifier, builder);
+			callback('drawingarea', 'keypress', container, UNOKey.UP | modifier, builder);
 			event.preventDefault();
 		} else if (event.key === 'Down' || event.key === 'ArrowDown') {
-			builder.callback('drawingarea', 'keypress', container, UNOKey.DOWN | modifier, builder);
+			callback('drawingarea', 'keypress', container, UNOKey.DOWN | modifier, builder);
 			event.preventDefault();
 		} else if (event.key === 'Home') {
-			builder.callback('drawingarea', 'keypress', container, UNOKey.HOME | modifier, builder);
+			callback('drawingarea', 'keypress', container, UNOKey.HOME | modifier, builder);
 			event.preventDefault();
 		} else if (event.key === 'End') {
-			builder.callback('drawingarea', 'keypress', container, UNOKey.END | modifier, builder);
+			callback('drawingarea', 'keypress', container, UNOKey.END | modifier, builder);
 			event.preventDefault();
 		} else if (event.key === 'Backspace') {
-			builder.callback('drawingarea', 'keypress', container, UNOKey.BACKSPACE | modifier, builder);
+			callback('drawingarea', 'keypress', container, UNOKey.BACKSPACE | modifier, builder);
 			event.preventDefault();
 		} else if (event.key === 'Delete') {
-			builder.callback('drawingarea', 'keypress', container, UNOKey.DELETE | modifier, builder);
+			callback('drawingarea', 'keypress', container, UNOKey.DELETE | modifier, builder);
 			event.preventDefault();
 		} else if (event.key === 'Space') {
-			builder.callback('drawingarea', 'keypress', container, UNOKey.SPACE | modifier, builder);
+			callback('drawingarea', 'keypress', container, UNOKey.SPACE | modifier, builder);
 			event.preventDefault();
 		} else if (event.key === 'Tab') {
-			builder.callback('drawingarea', 'keypress', container, UNOKey.TAB | modifier, builder);
+			callback('drawingarea', 'keypress', container, UNOKey.TAB | modifier, builder);
 		} else if (event.key === 'Shift') {
 			modifier = modifier | app.UNOModifier.SHIFT;
 			event.preventDefault();
@@ -204,7 +206,7 @@ function _drawingAreaControl (parentContainer, data, builder) {
 			modifier = modifier | app.UNOModifier.CTRL;
 			event.preventDefault();
 		} else if (event.key === 'a' && event.ctrlKey) {
-			builder.callback('drawingarea', 'keypress', container, UNOKey.A | app.UNOModifier.CTRL, builder);
+			callback('drawingarea', 'keypress', container, UNOKey.A | app.UNOModifier.CTRL, builder);
 		}
 	});
 
@@ -249,11 +251,24 @@ function _drawingAreaControl (parentContainer, data, builder) {
 				keyCode |= app.UNOModifier.CTRL;
 			}
 
-			builder.callback('drawingarea', 'keypress', container, keyCode, builder);
+			callback('drawingarea', 'keypress', container, keyCode, builder);
 		}
 
 		event.preventDefault();
 	});
+
+	// Fix for LibreOfficeKit crash: "sendDialogEvent: no widget id set"
+	// Problem: During rapid mouse interactions on drawing areas (Writer->Format->Page Style->Area->Pattern->Pattern Editor),
+	// the JSDialog system's _updateWidgetImpl function can clear container.id (set to '') during
+	// widget updates, creating a race condition. When event handlers then call builder.callback()
+	// with the container object, it has an empty ID, causing dialog events to be sent with
+	// empty widget IDs to the core, which triggers an assertion failure.
+	// This wrapper ensures container.id is restored from the original data.id before
+	// any callback is made, preventing empty widget IDs from being sent in dialog events.
+	function callback(...args) {
+		if(!container.id) container.id = data.id; // Ensure the container has a valid Id
+		builder.callback(...args);
+	}
 
 	return false;
 }


### PR DESCRIPTION
Fixes a race condition where container IDs could be cleared during widget updates, causing dialog events with empty widget IDs to trigger assertion failures in LibreOfficeKit.

Ensures container IDs are restored before invoking callbacks, improving stability during rapid mouse interactions in drawing areas. Addresses a crash in the pattern editor of Writer's page style dialog.

Change-Id: Ie44e74a200d2e7f12a0087e8c9ec7d25d43b6fb8

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

