### PR TITLE
Set Cell cursor and Selection color's to doc-type color

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -1092,7 +1092,7 @@ body {
 	border-style: solid; /* required for ie11 */
 	display: none; /* prevent cypress failure */
 
-	border-top-color: var(--cell-cursor-selection-border-color); /* color */
+	border-top-color: rgba(var(--doc-type), 1); /* color */
 	border-top-width: 2px; /* weight */
 }
 
@@ -1100,7 +1100,7 @@ body {
 	border-style: solid; /* required for ie11 */
 	display: none; /* prevent cypress failure */
 
-	background-color: var(--cell-cursor-selection-border-color); /* fill color */
+	background-color: rgba(var(--doc-type), 1); /* fill color */
 	opacity: 0.25; /* opacity */
 	border-top-width: 1px; /* weight */
 }


### PR DESCRIPTION
Change-Id: I2310d854991cc93e118f15726f0e7a28bf477c29


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Previously, the cell cursor and selection were always shown in blue across all document types, regardless of whether it  was a writer, calc, or impress.

- This change  helps drive the color-coded experience further by making sure the cursor and selection match the document's assigned color.


### PREVIEWS

#### Writer
<img width="837" height="289" alt="image" src="https://github.com/user-attachments/assets/5943ecee-e364-4536-8857-25e6fae100ab" />

#### Calc
<img width="536" height="364" alt="image" src="https://github.com/user-attachments/assets/ba8a8874-02d8-48c6-9f6c-a20904b66d6a" />

#### Impress
<img width="1096" height="593" alt="image" src="https://github.com/user-attachments/assets/869152dc-50cf-47b1-97c9-e73df9c0a7e5" />




- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

