### PR TITLE
configure: use header Poco/SAX/SAXParser.h which also exists in 1.14

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1528,14 +1528,15 @@ AS_IF([test "$ENABLE_IOSAPP" != "true" -a "$ENABLE_ANDROIDAPP" != "true" -a "$ho
                          [AC_MSG_ERROR([The POCO version is too old])])
 
        # Poco headers from distro packages may need -DPOCO_UNBUNDLED
-       AC_CHECK_HEADERS([Poco/XML/ParserEngine.h])
-       if test "x$ac_cv_header_Poco_XML_ParserEngine_h" != xyes; then
-            unset ac_cv_header_Poco_XML_ParserEngine_h
+       # (the actual problem was in 1.13 Poco/XML/ParserEngine.h)
+       AC_CHECK_HEADERS([Poco/SAX/SAXParser.h])
+       if test "x$ac_cv_header_Poco_SAX_SAXParser_h" != xyes; then
+            unset ac_cv_header_Poco_SAX_SAXParser_h
             CXXFLAGS="$CXXFLAGS -DPOCO_UNBUNDLED"
             CPPFLAGS="$CPPFLAGS -DPOCO_UNBUNDLED"
-            AC_CHECK_HEADERS([Poco/XML/ParserEngine.h],
-                                        [AC_MSG_RESULT([... with POCO_UNBUNDLED])],
-                                        [AC_MSG_ERROR([header Poco/XML/ParserEngine.h not found, perhaps you want to use --with-poco-includes])])
+            AC_CHECK_HEADERS([Poco/SAX/SAXParser.h],
+                [AC_MSG_RESULT([... with POCO_UNBUNDLED])],
+                [AC_MSG_ERROR([header Poco/SAX/SAXParser.h not found, perhaps you want to use --with-poco-includes])])
        fi
 
        # If poco is built with --unbundled, it uses the system pcre library


### PR DESCRIPTION
Unclear if the POCO_UNBUNDLED is actually required with version 1.14 but the header Poco/XML/ParserEngine.h definitely doesn't exist in 1.14.


Change-Id: I02045bb825c1026024e0712e7d01c85054c5fa94


* Resolves: regression from previous PR
* Target version: master 

### Summary

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

