### PR TITLE
feat: improve NixOS support

### DIFF
--- a/coolwsd-systemplate-setup
+++ b/coolwsd-systemplate-setup
@@ -157,4 +157,9 @@ if test "z$ENABLE_DEBUG" != "z" -a "z$HOME" != "z"; then
     test -d $HOME/.fonts && ${CP} -r -p -L $HOME/.fonts $CHROOT/$HOME
 fi
 
+# Create a mount point for /nix/store if we will need to mount it
+if test -d /nix/store; then
+    mkdir -p $CHROOT/nix/store
+fi
+
 exit 0

--- a/coolwsd-systemplate-setup
+++ b/coolwsd-systemplate-setup
@@ -20,9 +20,9 @@ mkdir -p $CHROOT || exit 1
 # while INSTDIR is the physical one. Both will most likely be the same,
 # except on systems that have symlinks in the path. We must create
 # both paths (if they are different) inside the jail, hence we need both.
-CHROOT=`cd $CHROOT && /bin/pwd`
-INSTDIR_LOGICAL=`cd $INSTDIR && /bin/pwd -L`
-INSTDIR=`cd $INSTDIR && /bin/pwd -P`
+CHROOT=`cd $CHROOT && pwd`
+INSTDIR_LOGICAL=`cd $INSTDIR && pwd -L`
+INSTDIR=`cd $INSTDIR && pwd -P`
 
 if [ ! `uname -s` = "FreeBSD" ]; then
     CP=cp

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3459,6 +3459,17 @@ void lokit_main(
                     return false;
                 }
 
+                if (FileUtil::Stat("/nix/store").exists()) {
+                    // Bind-mount /nix/store to the jail as otherwise we will likely get missing fonts/etc.
+                    // We won't quit if we fail (e.g. the non-nixos case could work) but unless we're doing something special COOLWSD is unlikely to work without this on nixos
+                    const std::string jailNixDir = Poco::Path(jailPath, "nix/store").toString();
+                    if (!JailUtil::bind("/nix/store", jailNixDir)
+                        || !JailUtil::remountReadonly("/nix/store", jailNixDir))
+                    {
+                        LOG_WRN("Failed to mount [/nix/store] -> [" << jailNixDir
+                                                    << "], ignoring. If you have used nix for dependencies COOLWSD is likely to fail");
+                    }
+                }
 
                 if (!configId.empty())
                 {


### PR DESCRIPTION
I've previously been having to use [this patch from CollaboraOnline/nix-build-support](https://github.com/CollaboraOnline/nix-build-support/blob/main/patches/online/0001-build-add-nix-build-support.patch) and the command `sudo mount --bind /nix systemplate/nix` to make Collabora run

I would like to not have to do that anymore.

I'm expecting these changes to do very little outside of NixOS, but drastically improve the experience for anyone trying to develop Collabora Online on NixOS