### PR TITLE
iconview: adjusted grid layout and alignment in column page

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2036,7 +2036,7 @@ button.menubutton.sidebar > span {
 
 /* Writer - Table of Contents, Index or Bibliography dialog, Columns tab */
 [data-theme='dark'] #ColumnPage #pageexample-img,
-[data-theme='dark'] #ColumnPage #valueset-img {
+[data-theme='dark'] #ColumnPage #column-iconview img {
 	filter: invert(.9)
 }
 
@@ -2581,11 +2581,11 @@ kbd,
 #CharacterPropertiesDialog #fonteffects #FontColor,
 #CharacterPropertiesDialog #fonteffects #TextDecoration,
 #CharacterPropertiesDialog #fonteffects #Effects,
-#TemplateDialog8 #Footnote #FootnoteAreaPage {
+[id^='TemplateDialog'] #Footnote #FootnoteAreaPage {
 	width: fit-content;
 }
 
-#TemplateDialog8 #Footnote #FootnoteAreaPage .menubutton {
+[id^='TemplateDialog'] #Footnote #FootnoteAreaPage .menubutton {
 	margin: 0;
 }
 
@@ -2617,4 +2617,15 @@ kbd,
 /* Writer - Format - Paragraph - Area - Color */
 #ColorPage.jsdialog #rgbpreset {
 	width: max-content;
+}
+
+/* Writer - Format - Page Style - Columns - Settings */
+
+#ColumnPage.jsdialog #grid4 {
+	align-items: center;
+}
+
+#ColumnPage.jsdialog #column-iconview.ui-iconview {
+	grid-template-columns: repeat(5, 1fr);
+	overflow: visible;
 }


### PR DESCRIPTION
- keeps all column icon-views in single row
- align items center for grid layout

core patch(requires): https://gerrit.libreoffice.org/c/core/+/188954

Change-Id: Id7384614b5aecfa3b1ea113c59304e0cc1a66e84

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

