### PR TITLE
fix richdocuments code

### DIFF
--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -814,7 +814,8 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
     const bool canStreamToFile =
         request.getMethod() == Poco::Net::HTTPRequest::HTTP_POST &&
         request.getContentLength() != Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH &&
-        !request.getChunkedTransferEncoding(); // ignore chunked transfer for now
+        !request.getChunkedTransferEncoding() && // ignore chunked transfer for now
+        request.find("ProxyPrefix") == request.end(); // proxy mode assumes nothing consumed
 
     if (canStreamToFile && request.getContentLength() > 0)
     {


### PR DESCRIPTION
since:

commit f1fe0ba405965e1f7ec8ac01b702631726471729
Date:   Wed Apr 30 20:19:40 2025 +0100

    accumulate POST messages in a temp stream before dispatching

the consumer assumes nothing was consumed yet and the socket can be passed to another handler and has full contents of message so far still available


Change-Id: I7132a4b8dcb41bfad5330546c8a88e5514a9ab69


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

