### PR TITLE
fix(canvas): always resize when it is needed

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -586,23 +586,29 @@ class CanvasSectionContainer {
 		while (layoutingService.runTheTopTask());
 	}
 
+	private resizeCanvas() {
+		if (!this.needsResize) {
+			return;
+		}
+
+		this.needsResize = false;
+		this.canvas.width = this.width;
+		this.canvas.height = this.height;
+
+		// CSS pixels can be fractional, but need to round to the same real pixels
+		var cssWidth: number = this.width / app.dpiScale; // NB. beware
+		var cssHeight: number = this.height / app.dpiScale;
+		this.canvas.style.width = cssWidth.toFixed(4) + 'px';
+		this.canvas.style.height = cssHeight.toFixed(4) + 'px';
+
+		// Avoid black default background.
+		this.clearCanvas();
+	}
+
 	private redrawCallback(timestamp: number) {
 		this.drawRequest = null;
 
-		if (this.needsResize) {
-			this.needsResize = false;
-			this.canvas.width = this.width;
-			this.canvas.height = this.height;
-
-			// CSS pixels can be fractional, but need to round to the same real pixels
-			var cssWidth: number = this.width / app.dpiScale; // NB. beware
-			var cssHeight: number = this.height / app.dpiScale;
-			this.canvas.style.width = cssWidth.toFixed(4) + 'px';
-			this.canvas.style.height = cssHeight.toFixed(4) + 'px';
-
-			// Avoid black default background.
-			this.clearCanvas();
-		}
+		this.resizeCanvas();
 
 		this.drawSections();
 		this.flushLayoutingTasks();
@@ -1506,6 +1512,8 @@ class CanvasSectionContainer {
 			this.createUpdateDivElements();
 		if (redraw && this.drawingAllowed())
 			this.requestReDraw();
+		else
+			this.resizeCanvas();
 	}
 
 	private roundPositionAndSize(section: CanvasSectionObject) {


### PR DESCRIPTION
Previously if we were not able to redraw we also would not resize the canvas. Unfortunately this can cause issues where the canvas is in an uninitialized size when we do get to drawing on it, leaving our drawing blurry until the next resize.

Resizing the canvas if we can't actually draw fixes this.


Change-Id: I6a6a696419ae3fcf3605d3d93c7ba30e16087a3c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

