### PR TITLE
Remove usage of ulong type

### DIFF
--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1441,7 +1441,7 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(
     }
 
     http::Session::Protocol protocol = http::Session::Protocol::HttpSsl;
-    ulong port = 443;
+    unsigned long port = 443;
     if (scheme == "https://" || scheme.empty()) {
         // empty scheme assumes https
     } else if (scheme == "http://") {


### PR DESCRIPTION



Change-Id: I4e497d0f3a4e985ced7cafb0cf0e7ddc70f91075


* Resolves: #-
* Target version: master 

### Summary

This type does not exist in C, and only in some gnu headers for compatibility. I see no reason to keep using it. The usage also causes issues on FreeBSD.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

I cannot run `make check` as I need to compile with `--without-system-nss`, which I need to compile in freeBSD atm.

I have more small patches incoming to allow running collabora-online on freebsd! I also have a patch which I don't think you want to include, I am working on a proper fix to upstream later.
