### PR TITLE
[FreeBSD/non-gnu linux] Allow gmake in the git pre-commit hook

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -133,14 +133,24 @@ sub check_prettier()
 {
     my $red = "\033[0;31m";
     my $reset = "\033[0m";
+    my $hasmake = system("which make > /dev/null") == 0;
+    my $hasgmake = system("which gmake > /dev/null") == 0;
 
-    system("make prettier >/dev/null 2>&1") == 0
+    my $make = $hasgmake? "gmake" : $hasmake? "make" : die  $red .
+                "\n===============================================\n" .
+                "  ERROR: Code formatting check failed\n" .
+                "===============================================\n" .
+                "Please install (gnu) make as `gmake` or `make`\n" .
+                "===============================================\n" .
+                $reset . "\n";
+
+    system("$make prettier >/dev/null 2>&1") == 0
         or die $red .
                 "\n===============================================\n" .
                 "  ERROR: Code formatting check failed\n" .
                 "===============================================\n" .
                 "Your code is not properly formatted.\n" .
-                "Please run 'make prettier-write' before committing.\n" .
+                "Please run '$make prettier-write' before committing.\n" .
                 "===============================================\n" .
                 $reset . "\n";
 }


### PR DESCRIPTION
Change-Id: I0c1d5472efc0d05281c031f45adf99227a6279bc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
This checks for gmake, and make as fallback

This allows for the hook to work on FreeBSD/systems where gmake is not the standard

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

Unable to run make check