### PR TITLE
[FreeBSD/correctness]  Include unistd.h and declare environ

### DIFF
--- a/common/Util-server.cpp
+++ b/common/Util-server.cpp
@@ -20,6 +20,8 @@
 #include <sys/resource.h>
 #elif defined __FreeBSD__
 #include <sys/resource.h>
+#include <unistd.h>
+extern char** environ;
 #endif
 
 #include <dirent.h>

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -33,6 +33,7 @@
 #include <cstddef>
 #include <fstream>
 #include <sstream>
+#include <unistd.h>
 
 /// WhiteBox unit-tests.
 class WhiteBoxTests : public CPPUNIT_NS::TestFixture

--- a/tools/KitClient.cpp
+++ b/tools/KitClient.cpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <memory>
 #include <sysexits.h>
+#include <unistd.h>
 
 #define LOK_USE_UNSTABLE_API
 #include <LibreOfficeKit/LibreOfficeKitInit.h>


### PR DESCRIPTION
Change-Id: Ic706155750f906bbecec7d57b437a99fd998a6b0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

unistd.h is probably included indirectly on linux, but should be included direclty for good measure. The include is absolutely needed on FreeBSD. E.G.:
https://man7.org/linux/man-pages/man2/getpagesize.2.html https://man.freebsd.org/cgi/man.cgi?getpid(2)

Environ is sometimes non-standard conventionally maybe included mayhaps in unistd.h, but not always. See:
https://man.freebsd.org/cgi/man.cgi?environ(7)
https://man7.org/linux/man-pages/man7/environ.7.html


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

Cannot run make check, can confirm results in working setup on FreeBSD