### PR TITLE
Only use linux-only thread and fd-counter on linux

### DIFF
--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -61,6 +61,11 @@ extern "C"
 #define THREAD_UNSAFE_DUMP_END
 #endif
 
+#ifdef __linux__
+#define THREADCOUNTER_USABLE 1
+#define FDCOUNT_USABLE 1
+#endif
+
 /// Format minutes with the units suffix until we migrate to C++20.
 inline std::ostream& operator<<(std::ostream& os, const std::chrono::minutes& s)
 {

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -1012,8 +1012,10 @@ int forkit_main(int argc, char** argv)
         Util::forcedExit(EX_SOFTWARE);
     }
 
+#ifdef THREADCOUNT_USABLE
     if (Util::ThreadCounter().count() != 1)
         LOG_ERR("forkit has more than a single thread after pre-init" << Util::ThreadCounter().count());
+#endif
 
     // Link the network and system files in sysTemplate, if possible.
     JailUtil::SysTemplate::setupDynamicFiles(sysTemplate);

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3366,10 +3366,14 @@ void lokit_main(
         const std::string jailPathStr = jailPath.toString();
         JailUtil::createJailPath(jailPathStr);
 
+#ifdef THREADCOUNT_USABLE
         // initialize while we have access to /proc/self/task
         threadCounter.reset(new Util::ThreadCounter());
+#endif
+#ifdef FDCOUNT_USABLE
         // initialize while we have access to /proc/self/fd
         fdCounter.reset(new Util::FDCounter());
+#endif
 
         if (!ChildSession::NoCapsForKit)
         {


### PR DESCRIPTION
Change-Id: I38ea00278c1d595291b23715551e513423602f09


* Resolves: none
* Target version: master 

### Summary

These are linux only types that should not be used on othersystems. In the future a new implementation should be used for FreeBSD/others, however the only downside I can think of is the stats not working? That does not sound like a major issue.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

Cannot run `make check`, but works on freebsd