### PR TITLE
[FreeBSD(?)] Rework the casting for the header size

### DIFF
--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -1621,7 +1621,7 @@ ssize_t StreamSocket::readHeader(const std::string_view clientName, std::istream
     }
 
     // Skip the marker.
-    ssize_t headerSize = message.tellg() + static_cast<std::streamsize>(marker.size());
+    ssize_t headerSize = static_cast<ssize_t>(message.tellg()) + marker.size();
     message.seekg(0, std::ios_base::beg);
 
     try


### PR DESCRIPTION
Change-Id: I378e70541e46a4aa4fb9c198233a8ab7f09e077f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

This just precasts the LHS to ssize_t, as that is the correct type.

The compile error this fixes is:

```
:1624:42: error: use of overloaded operator '+' is ambiguous (with operand types 'pos_type' (aka 'fpos<__mbstate_t>') and 'std::streamsize' (aka 'long'))
 1624 |     ssize_t headerSize = message.tellg() + static_cast<std::streamsize>(marker.size());
      |                          ~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

with compiler FreeBSD clang version 19.1.7

not sure if this has anything to do with FreeBSD or specific compiler settings (sigh).


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

Can confirm this results in a working setup on FreeBSD, no make check