### PR TITLE
context toolbar: initialize notebookbar in core if needed

### DIFF
--- a/browser/src/control/Control.ContextToolbar.ts
+++ b/browser/src/control/Control.ContextToolbar.ts
@@ -53,6 +53,11 @@ class ContextToolbar {
 		this.pendingShow = false;
 		if (!this.initialized) {
 			this.builder.build(this.container, this.getWriterTextContext(), false);
+			if (
+				!this.builder.map.uiManager.notebookbar ||
+				!this.builder.map.uiManager.notebookbar.isInitializedInCore()
+			)
+				this.builder.map.uiManager.initializeNotebookbarInCore();
 			this.initialized = true;
 		}
 

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -75,7 +75,7 @@ L.Control.Notebookbar = L.Control.extend({
 			this.map.on('toggleslidehide', this.onSlideHideToggle, this);
 		}
 
-		this.initializeInCore();
+		this.map.uiManager.initializeNotebookbarInCore();
 
 		$('#toolbar-wrapper').addClass('hasnotebookbar');
 		$('.main-nav').addClass('hasnotebookbar');
@@ -117,7 +117,7 @@ L.Control.Notebookbar = L.Control.extend({
 			if (!that.isInitializedInCore()) {
 				// if notebookbar doesn't have any welded controls it can trigger false alarm here
 				window.app.console.warn('notebookbar might be not initialized, retrying');
-				that.initializeInCore();
+				that.map.uiManager.initializeNotebookbarInCore();
 				that.retry = setTimeout(retryNotebookbarInit, 3000);
 			}
 		};
@@ -144,10 +144,6 @@ L.Control.Notebookbar = L.Control.extend({
 
 	isInitializedInCore: function() {
 		return this._isNotebookbarLoadedOnCore;
-	},
-
-	initializeInCore: function() {
-		this.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=notebookbar_online.ui');
 	},
 
 	resetInCore: function() {

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1174,6 +1174,10 @@ class UIManager extends L.Control {
 
 	// Notebookbar helpers
 
+	initializeNotebookbarInCore(): void {
+		this.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=notebookbar_online.ui');
+	}
+
 	/**
 	 * Returns whether the notebookbar is currently shown.
 	 */

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1626,7 +1626,7 @@ app.definitions.Socket = L.Class.extend({
 			var uiMode = this._map.uiManager.getCurrentMode();
 			if (uiMode === 'notebookbar' && this._map.uiManager.notebookbar) {
 				this._map.uiManager.notebookbar.resetInCore();
-				this._map.uiManager.notebookbar.initializeInCore();
+				this._map.uiManager.initializeNotebookbarInCore();
 			}
 			// close all the popups otherwise document textArea will not get focus
 			this._map.uiManager.closeAll();


### PR DESCRIPTION
problem:
in compact view mode notebookbar is not initialized this causes font box(s) to not work and render fonts


Change-Id: Ifc87e31a0e576100cd68d1f19680e2041d1a3df4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

