### PR TITLE
fix(teardrop): correct non-desktop hiding

### DIFF
--- a/browser/css/device-desktop.css
+++ b/browser/css/device-desktop.css
@@ -1,13 +1,5 @@
 /* CSS specific for desktop browsers. */
 
-/* Hide text droplets if accurate pointing device such as a mouse is detected */
-@media (pointer: fine) {
-	.text-selection-handle-start,
-	.text-selection-handle-end {
-		display: none;
-	}
-}
-
 #coolwsd-version span:before,
 #lokit-version > span:before {
 	content: ' (';

--- a/browser/src/canvas/sections/TextSelectionHandleSection.ts
+++ b/browser/src/canvas/sections/TextSelectionHandleSection.ts
@@ -11,6 +11,8 @@
 */
 
 class TextSelectionHandle extends HTMLObjectSection {
+	_showSection: boolean = true; // Store the internal show/hide section through forced non-touchscreen hides...
+
 	constructor (sectionName: string, objectWidth: number, objectHeight: number, documentPosition: cool.SimplePoint,  extraClass: string = "", showSection: boolean = false) {
 		super(sectionName, objectWidth, objectHeight, documentPosition, extraClass, showSection);
 	}
@@ -24,6 +26,16 @@ class TextSelectionHandle extends HTMLObjectSection {
 		this.sectionProperties.objectDiv.style.top = candidateY + 'px';
 
 		app.map.fire('handleautoscroll', {pos: { x: candidateX, y: candidateY }, map: app.map});
+	}
+
+	setShowSection(show: boolean) {
+		this._showSection = show;
+
+		if (!window.touch.currentlyUsingTouchscreen()) {
+			super.setShowSection(false);
+		} else {
+			super.setShowSection(this._showSection);
+		}
 	}
 
 	setOpacity(value: number) {

--- a/cypress_test/integration_tests/desktop/writer/copy_paste_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/copy_paste_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require expect */
+/* global describe it cy require */
 
 var helper = require('../../common/helper');
 
@@ -9,14 +9,10 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Clipboard operations.', fu
 		// Select some text
 		helper.selectAllText();
 
-		cy.cGet('.html-object-section')
-			.then(function(marker) {
-				expect(marker).to.have.lengthOf(2);
-				var XPos =  (marker[0].getBoundingClientRect().right + marker[1].getBoundingClientRect().left) / 2;
-				var YPos = marker[0].getBoundingClientRect().top - 5;
-
-				cy.cGet('body').rightclick(XPos, YPos);
-			});
+		cy.getFrameWindow().then(win => {
+			const selectionStart = win.TextSelections.getStartRectangle();
+			cy.cGet('#map').rightclick(selectionStart.pX1, selectionStart.pY1);
+		});
 
 		helper.setDummyClipboardForCopy();
 


### PR DESCRIPTION
This reimplements the I6544845526c2e70bee7d6e3b193e9fb4931422c6's intent but using the existing system to show/hide the teardrop

I do this by changing the default of currentlyUsingTouchscreen as before if any touchscreen were detected on your system the droplet would show on joining the document but this is undesirable

We need the new initial parameter as this is the only visual effect of currentlyUsingTouchscreen: the rest are to do with hit detection which I don't want to mess up

This fixes a regression from I6544845526c2e70bee7d6e3b193e9fb4931422c6 where the cursor droplets were incorrectly hidden such that:

- They would never show if we started using a touchscreen
- Some parts of them remained active so selections worked differently


Change-Id: I6a6a696452b13d46eb9fd364def2ba3e92b2c9dc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

