### PR TITLE
cypress: disable failing test in impress/jsdialog_spec.js

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/jsdialog_spec.js
@@ -8,7 +8,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'JSDialog Tests', function(
 		helper.setupAndLoadDocument('impress/jsdialog.odp');
 	});
 
-	it('Check disabled state in animation sidebar', function() {
+	// fails on Panel6
+	it.skip('Check disabled state in animation sidebar', function() {
 		// open animation deck
 		cy.cGet('#options-custom-animation-button').should('not.have.class', 'selected');
 		cy.cGet('#options-custom-animation-button').click();


### PR DESCRIPTION
- after incompatible core change related to sidebar
for c++ tests requires core change: https://gerrit.libreoffice.org/c/core/+/189034