### PR TITLE
Context toolbar: Fix button sizes

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -706,3 +706,8 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	opacity: 0;
 	transition: all 0.25s allow-discrete;
 }
+
+#context-toolbar .unobutton > img {
+	width: var(--btn-img-size);
+	height: var(--btn-img-size);
+}


### PR DESCRIPTION
Set Height and Width for icon to make sure the ratio is kept 1:1 and
that they are properly rendered in different browsers.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I1ecfa9e55eacdf99bcd2082db126edc3c518c1df
