### PR TITLE
Add border tool to Writer Notebookbar

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2815,6 +2815,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'type': 'toolitem',
 								'text': _UNO('.uno:NumberFormatDate', 'text'),
 								'command': '.uno:NumberFormatDate'
+							},
+							{
+								'type': 'toolitem',
+								'text': _UNO('.uno:NumberFormatPercent', 'text'),
+								'command': '.uno:NumberFormatPercent'
 							}
 						]
 					},
@@ -2827,9 +2832,11 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'command': '.uno:TableCellBackgroundColor',
 							},
 							{
-								'type': 'toolitem',
-								'text': _UNO('.uno:NumberFormatPercent', 'text'),
-								'command': '.uno:NumberFormatPercent'
+								'id': 'set-border-style:BorderStyleMenuWriter',
+								'type': 'menubutton',
+								'noLabel': true,
+								'text': _UNO('.uno:SetBorderStyle', 'text'),
+								'command': '.uno:SetBorderStyle'
 							}
 						]
 					}

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -421,6 +421,13 @@ menuDefinitions.set('BorderStyleMenu', [
 	{ type: 'separator' }, // required to show dropdown arrow
 ] as Array<MenuDefinition>);
 
+menuDefinitions.set(
+	'BorderStyleMenuWriter',
+	(menuDefinitions.get('BorderStyleMenu') || []).filter(
+		(item) => item.uno !== '.uno:FormatCellBorders',
+	),
+);
+
 menuDefinitions.set('InsertShapesMenu', [
 	{ type: 'html', htmlId: 'insertshapespopup' },
 	{ type: 'separator' }, // required to show dropdown arrow


### PR DESCRIPTION
Re-use the widget from Calc, minus the button which opens
the 'format cell' dialog

Signed-off-by: Samuel Mehrbrodt <samuel.mehrbrodt@collabora.com>
Change-Id: I6aed0f31c75eb550a34266b42535416f2339544a
