### PR TITLE
backport(co-25.04): fix(teardrop): correct non-desktop hiding

### DIFF
--- a/browser/css/device-desktop.css
+++ b/browser/css/device-desktop.css
@@ -1,13 +1,5 @@
 /* CSS specific for desktop browsers. */
 
-/* Hide text droplets if accurate pointing device such as a mouse is detected */
-@media (pointer: fine) {
-	.text-selection-handle-start,
-	.text-selection-handle-end {
-		display: none;
-	}
-}
-
 #coolwsd-version span:before,
 #lokit-version > span:before {
 	content: ' (';

--- a/browser/src/canvas/sections/TextSelectionHandleSection.ts
+++ b/browser/src/canvas/sections/TextSelectionHandleSection.ts
@@ -11,8 +11,20 @@
 */
 
 class TextSelectionHandle extends HTMLObjectSection {
+	_showSection: boolean = true; // Store the internal show/hide section through forced non-touchscreen hides...
+	super_setShowSection: (show: boolean) => void; // HACK: used when dealing with CanvasSectionContainer only having setShowSection via addSectionFunctions
+
 	constructor (sectionName: string, objectWidth: number, objectHeight: number, documentPosition: cool.SimplePoint,  extraClass: string = "", showSection: boolean = false) {
 		super(sectionName, objectWidth, objectHeight, documentPosition, extraClass, showSection);
+	}
+
+	onInitialize() {
+		// HACK: used when dealing with CanvasSectionContainer only having setShowSection via addSectionFunctions
+		// we need to rename the property otherwise
+		// (1) we will not be able to call it again via super, since as it's not a real superclass function
+		// (2) we will not be able to call our own setShowSection as, since as it's set directly on the object, it'll override everything in the prototype...
+		this.super_setShowSection = this.setShowSection;
+		delete this.setShowSection;
 	}
 
 	onDrag(point: number[]) {
@@ -24,6 +36,16 @@ class TextSelectionHandle extends HTMLObjectSection {
 		this.sectionProperties.objectDiv.style.top = candidateY + 'px';
 
 		app.map.fire('handleautoscroll', {pos: { x: candidateX, y: candidateY }, map: app.map});
+	}
+
+	setShowSection(show: boolean) {
+		this._showSection = show;
+
+		if (!window.touch.currentlyUsingTouchscreen()) {
+			this.super_setShowSection(false);
+		} else {
+			this.super_setShowSection(this._showSection);
+		}
 	}
 
 	setOpacity(value: number) {

--- a/cypress_test/integration_tests/desktop/writer/copy_paste_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/copy_paste_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy require expect */
+/* global describe it cy require */
 
 var helper = require('../../common/helper');
 
@@ -9,14 +9,10 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Clipboard operations.', fu
 		// Select some text
 		helper.selectAllText();
 
-		cy.cGet('.html-object-section')
-			.then(function(marker) {
-				expect(marker).to.have.lengthOf(2);
-				var XPos =  (marker[0].getBoundingClientRect().right + marker[1].getBoundingClientRect().left) / 2;
-				var YPos = marker[0].getBoundingClientRect().top - 5;
-
-				cy.cGet('body').rightclick(XPos, YPos);
-			});
+		cy.getFrameWindow().then(win => {
+			const selectionStart = win.TextSelections.getStartRectangle();
+			cy.cGet('#map').rightclick(selectionStart.pX1, selectionStart.pY1);
+		});
 
 		helper.setDummyClipboardForCopy();
 


### PR DESCRIPTION
This is a **nontrivial** backport of #12508: since as #12508 depended on #12455 (which is not getting backported) I have adapted the code to work with the code that is currently in distro/collabora/co-25.04

This reimplements the I6544845526c2e70bee7d6e3b193e9fb4931422c6's intent but using the existing system to show/hide the teardrop

I do this in a similar way to my recent work hiding uninteractible elements from #12422, albeit without an event to switch over when we change from mouse to touch or vice-versa time. The lack of an event is because the selection handles aren't properly moved into place when they are hidden and there are some finnicky events (where sometimes we end up detecting touch events as having some mouse events too) on the mouse -> touch switch. We may change this behavior in a followup.

This fixes a regression from I6544845526c2e70bee7d6e3b193e9fb4931422c6 where the cursor droplets were incorrectly hidden such that:

- They would never show if we started using a touchscreen
- Some parts of them remained active so selections worked differently


Change-Id: I6a6a696452b13d46eb9fd364def2ba3e92b2c9dc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

