### PR TITLE
fix(ui): make "New slide" act as split button in Tabbed view

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -731,6 +731,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			{
 				'id': 'home-create-slide:NewSlideLayoutMenu',
 				'type': 'menubutton',
+				'applyCallback':function () {
+					app.map.sendUnoCommand('.uno:InsertPage') // this will make this as split button
+				},
 				'text': _('New'),
 				'command': '.uno:InsertPage',
 				'accessibility': { focusBack: true, combination: 'CS', de: null }


### PR DESCRIPTION
- Add applyCallback to NewSlideLayoutMenu to call app.map.sendUnoCommand('.uno:InsertPage') so clicking the icon inserts a new slide with the default layout.
- Ensures the New button visually and functionally behaves as a split button in tabbed view.


Change-Id: I70f3edab78111005e429f1cad85487cec6785af7


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

