### PR TITLE
slideshow: Enable video control from presenter console

### DIFF
--- a/browser/src/slideshow/PresenterConsole.js
+++ b/browser/src/slideshow/PresenterConsole.js
@@ -151,6 +151,10 @@ class PresenterConsole {
 		if (!currentPresentationCanvas) return;
 		this._computeCanvas(currentPresentationCanvas);
 
+		currentPresentationCanvas.addEventListener(
+			'click',
+			this._onPresenterCanvasClick.bind(this),
+		);
 		this._timer = this._proxyPresenter.setInterval(
 			L.bind(this._onTimer, this),
 			1000,
@@ -185,6 +189,19 @@ class PresenterConsole {
 				elem.append(img);
 			}
 		}
+	}
+
+	_onPresenterCanvasClick(event) {
+		const canvas = event.target;
+		const rect = canvas.getBoundingClientRect();
+		const relativeX = (event.clientX - rect.left) / canvas.clientWidth;
+		const relativeY = (event.clientY - rect.top) / canvas.clientHeight;
+
+		this._map.fire('presentercanvasclick', {
+			relativeX: relativeX,
+			relativeY: relativeY,
+			originalEvent: event,
+		});
 	}
 
 	_onImpressModeChanged(e) {

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -153,6 +153,11 @@ class SlideShowPresenter {
 			this.handleSlideShowProgressBar,
 			this,
 		);
+		this._map.on(
+			'presentercanvasclick',
+			this._handlePresenterCanvasClick,
+			this,
+		);
 	}
 
 	removeHooks() {
@@ -170,6 +175,54 @@ class SlideShowPresenter {
 			'handleslideshowprogressbar',
 			this.handleSlideShowProgressBar,
 			this,
+		);
+		this._map.off(
+			'presentercanvasclick',
+			this._handlePresenterCanvasClick,
+			this,
+		);
+	}
+
+	private _handlePresenterCanvasClick(event: any) {
+		const navigator = this._slideShowNavigator;
+		if (!navigator) return;
+
+		const currentSlideIndex = navigator.currentSlideIndex;
+		if (currentSlideIndex === undefined) return;
+
+		const slideInfo =
+			this._metaPresentation.getSlideInfoByIndex(currentSlideIndex);
+		if (!slideInfo || !slideInfo.videos || slideInfo.videos.length === 0) {
+			return;
+		}
+
+		if (event.relativeX !== undefined && event.relativeY !== undefined) {
+			const x = event.relativeX * this._metaPresentation.slideWidth;
+			const y = event.relativeY * this._metaPresentation.slideHeight;
+
+			const clickedVideo = slideInfo.videos.find((videoInfo) =>
+				this.isPointInVideoArea(videoInfo, x, y),
+			);
+
+			if (clickedVideo) {
+				const videoRenderer = this.getVideoRenderer(
+					slideInfo.hash,
+					clickedVideo,
+				);
+				if (videoRenderer) {
+					videoRenderer.handleClick();
+					return;
+				}
+			}
+		}
+	}
+
+	private isPointInVideoArea(bounds: VideoInfo, x: number, y: number): boolean {
+		return (
+			x >= bounds.x &&
+			x <= bounds.x + bounds.width &&
+			y >= bounds.y &&
+			y <= bounds.y + bounds.height
 		);
 	}
 


### PR DESCRIPTION
slideshow: Enable video control from presenter console

Add click event handling to the presenter console canvas to allow video playback control from the presenter view. Previously, video controls only worked from the main slideshow canvas.

The coordinate normalization ensures clicks work regardless of canvas size differences between presenter console and main slideshow window.


Change-Id: I4235c217515269ceb8fee2bb8f380261682ef453


* Resolves: # <!-- related github issue -->
* Target version: master 



https://github.com/user-attachments/assets/615529a8-a2da-49ef-82a9-b6c1a2f2df58

