### PR TITLE
Calc: Disable contextual toolbar

### DIFF
--- a/browser/src/control/Control.ContextToolbar.ts
+++ b/browser/src/control/Control.ContextToolbar.ts
@@ -47,7 +47,13 @@ class ContextToolbar {
 	}
 
 	showContextToolbar(): void {
-		if (this.builder.map.isReadOnlyMode() || !window.mode.isDesktop()) return;
+		const map = this.builder.map;
+		if (
+			map.isReadOnlyMode() ||
+			!window.mode.isDesktop() ||
+			map.getDocType() === 'spreadsheet'
+		)
+			return;
 		if (this.lastIinputEvent.input === 'mouse') this.pendingShow = true;
 		if (this.lastIinputEvent.type !== 'buttonup') return;
 


### PR DESCRIPTION
- For now we need to disable contextual toolbar in calc.
-  When working with spreadsheets there are more things at play here that appear/respond to mouse cursor changes
    - autocomplete formula and its variations, drag to fill copy or fill series, editing formula by selecting other cells
- Thus, it's important to don't add more friction to any of these actions.


Change-Id: I2b95a7d28215184ecea1aa3f6e988ef5f69909d1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

