### PR TITLE
Cypress: Fix open help dialog test

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
@@ -97,7 +97,7 @@ describe(['tagdesktop'], 'JSDialog unit test', function() {
 
 	it('Open hybrid help dialog', function() {
 		cy.cGet('#Help-tab-label').click();
-		cy.cGet('#Help').click();
+		cy.cGet('#online-help').click();
 		cy.cGet('#online-help-content').should('exist');
 	});
 


### PR DESCRIPTION
Before this commit when running
make -C cypress_test run-desktop spec=calc/jsdialog_spec.js
we were getting the following:

Error:
cy:command ✔  cGet	#Help-tab-label
cy:command ✔  click
cy:command ✔  cGet	#Help
cy:command ✔  click
cy:command ✔  cGet	#online-help-content
cy:command ✘  assert	expected **#online-help-content** to exist in
the DOM

Because the button is not called #Help but instead #online-help

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ic8bceab543b40f871e8eff1478af94805074a41f
