### PR TITLE
wordbook: upload standard.dic

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4224,7 +4224,17 @@ void DocumentBroker::uploadPresetsToWopiHost()
         fileJailPath.append(fileName);
         std::filesystem::file_time_type currentTimestamp =
             std::filesystem::last_write_time(fileJailPath, ec);
-        if (ec || currentTimestamp <= _presetTimestamp[fileName])
+
+        auto it = _presetTimestamp.find(fileName);
+        bool skipUpload = false;
+        if (ec)
+            skipUpload = true;
+        else if (it != _presetTimestamp.end())
+            skipUpload = (currentTimestamp <= it->second);
+        else if (fileName != "standard.dic")
+            skipUpload = true;
+
+        if (skipUpload)
         {
             LOG_TRC("Skip uploading preset file [" << fileName << "] to wopiHost["
                                                    << uriObject.toString() << "], "


### PR DESCRIPTION
- now always have option to add words to custom dictionary even if they have not added a custom dictionary using adminIntegrationSettings.


Change-Id: Ia8e57cd4c33629e984df816fe6f6180aa7c1fe73

* 
* Target version: master 

### Summary
Corresponding core change: https://gerrit.libreoffice.org/c/core/+/189359