### PR TITLE
Calc: Home tab: Reduce number of buttons

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -448,8 +448,8 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{ type: 'separator', id: 'home-resertattributes-break', orientation: 'vertical' },
 			{
 				'type': 'overflowgroup',
-				'id': 'home-character',
-				'name': 'Character',
+				'id': 'home-font',
+				'name': 'Font',
 				'children': [
 				{
 					'id': 'Home-Section-Format',
@@ -706,6 +706,13 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						}
 					],
 					'vertical': 'true'
+				},
+				{
+					'id': 'home-merge-cells',
+					'type': 'bigtoolitem',
+					'text': _('Merge & Center'),
+					'command': '.uno:ToggleMergeCells',
+					'accessibility': { focusBack: true, combination: 'M', de: null }
 				}
 			]
 		},
@@ -713,7 +720,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'home-number-format',
-				'name': 'Number Format',
+				'name': 'Number',
 				'children' : [
 				{
 					'id': 'Home-Section-Number',
@@ -808,17 +815,9 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 		},
 			{ type: 'separator', id: 'home-numberformatdecrementdecimals-break', orientation: 'vertical' },
 			{
-				'id': 'home-merge-cells',
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:MergeCells', 'spreadsheet'),
-				'command': '.uno:ToggleMergeCells',
-				'accessibility': { focusBack: true,	combination: 'M', de: null }
-			},
-			{ type: 'separator', id: 'home-mergecells-break', orientation: 'vertical' },
-			{
 				'type': 'overflowgroup',
 				'id': 'home-insert-table',
-				'name': 'Insert',
+				'name': 'Cells',
 				'children' : [
 				{
 					'id': 'Home-Section-Cell1',
@@ -896,18 +895,17 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 		},
 			{ type: 'separator', id: 'home-columnoperations-break', orientation: 'vertical' },
 			{
-				'id': 'home-conditional-format-menu:ConditionalFormatMenu',
-				'type': 'menubutton',
-				'text': _UNO('.uno:ConditionalFormatMenu', 'spreadsheet'),
-				'command': '.uno:ConditionalFormatMenu',
-				'accessibility': { focusBack: true,	combination: 'L', de: null }
-			},
-			{ type: 'separator', id: 'home-conditionalformatmenu-break', orientation: 'vertical' },
-			{
 				'type': 'overflowgroup',
 				'id': 'home-style',
 				'name': 'Style',
 				'children' : [
+				{
+					'id': 'home-conditional-format-menu:ConditionalFormatMenu',
+					'type': 'menubutton',
+					'text': _UNO('.uno:ConditionalFormatMenu', 'spreadsheet'),
+					'command': '.uno:ConditionalFormatMenu',
+					'accessibility': { focusBack: true, combination: 'L', de: null }
+				},
 				{
 					'id': 'Home-Section-Style2',
 					'type': 'container',
@@ -974,8 +972,8 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{ type: 'separator', id: 'home-styleapplybad-break', orientation: 'vertical' },
 			{
 				'type': 'overflowgroup',
-				'id': 'home-search',
-				'name': 'Search',
+				'id': 'home-find-n-filter',
+				'name': 'Editing',
 				'children' : [
 				{
 					'type': 'container',
@@ -1007,14 +1005,6 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						],
 					'vertical': 'true'
 				},
-			]
-		},
-			{ type: 'separator', id: 'home-replace-break', orientation: 'vertical' },
-			{
-				'type': 'overflowgroup',
-				'id': 'home-filter',
-				'name': 'Filter',
-				'children' : [
 				{
 					'id': 'Home-Section-Find',
 					'type': 'container',
@@ -1062,7 +1052,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'id': 'layout-page',
 				'name':_('Format'),
 				'children' : [
-					{	
+					{
 						'id': 'Layout-MarginMenu:MenuMargins',
 						'type': 'menubutton',
 						'text': _('Margin'),

--- a/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
@@ -7,6 +7,7 @@ describe(['tagdesktop'], 'JSDialog unit test', function() {
 
 	beforeEach(function() {
 		helper.setupAndLoadDocument('calc/help_dialog.ods');
+		cy.viewport(1920,1080);
 	});
 
 	it('JSDialog popup dialog', function() {


### PR DESCRIPTION
- Rename Character group to Font as it seems easier on the user both
in terms of understanding but more crucial when eye scanning
- Rename Merge Cells to what the buttons actually does: "Merge &
Center"
  - Place it under alignment group
- Shorten "Number Format" to "Number" to save space
- Rename generic "Insert" group to a more semantic one "Cells" as the
actions in it are not just for inserting
- Move Conditional format button into the existing Style group to save
space and to help user understand that conditional formatting is
change the style according to conditionals
- Move Search related buttons into a more generic group with the sort
and filter called "Editing" as it seems to be what the users search
when looking and it also saves space

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I517c5e1daa3cf92a4dbaa5eca644c134f44f6f00
