### PR TITLE
Tabbed view: Make it horizontally scrollable if there is not space

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -1,7 +1,9 @@
 
 .notebookbar-scroll-wrapper {
-	height: 72px;
+	height: 82px;
 	display: flex;
+	overflow-x: auto;
+	overflow-y: hidden;
 }
 
 /* stretch the fields */


### PR DESCRIPTION
With the introduction of groups and the overflow button we have now
dorpdowns that appear with other buttons inside when there is no space
to show them all. Nevertheless, there will be still cases where the
window is even narrower. So, let's make it scrollable.

Also updates the scroll-wrapper height that was missing from
9efe7c23533fae8def368a9e3bb884012969de19 where the following was also
changed:

```javascript
 .hasnotebookbar > #toolbar-row {
-       height: 74px;
+       height: 82px;
 }
```

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I7818067d1830552142b4743f1fb549aa3f74bdcc
