### PR TITLE
Issue: When the cell cursor drawing overlaps with the split panes, th…

### DIFF
--- a/browser/src/canvas/sections/CellCursorSection.ts
+++ b/browser/src/canvas/sections/CellCursorSection.ts
@@ -33,6 +33,31 @@ class CellCursorSection extends CanvasSectionObject {
 		this.sectionProperties.viewId = viewId;
 	}
 
+	// If the split panes are active and the cell cursor overlaps with the split pane, we adjust the size and position.
+	public static adjustSizePos(defaultSizePos: number[]): number[] {
+		const splitPos = app.map._docLayer._splitPanesContext ? app.map._docLayer._splitPanesContext.getSplitPos() : null;
+
+		if (!splitPos || (splitPos.x === 0 && splitPos.y === 0) || (app.activeDocument.activeView.viewedRectangle.pX1 === 0 && app.activeDocument.activeView.viewedRectangle.pY1 === 0)) return defaultSizePos;
+
+		if (defaultSizePos[0] < splitPos.x && defaultSizePos[0] + defaultSizePos[2] > splitPos.x)
+			defaultSizePos[2] = Math.max(splitPos.x - defaultSizePos[0], defaultSizePos[2] - app.activeDocument.activeView.viewedRectangle.pX1);
+
+		if (defaultSizePos[0] >= splitPos.x && app.activeDocument.activeView.viewedRectangle.pX1 + splitPos.x > defaultSizePos[0]) {
+			defaultSizePos[2] = (defaultSizePos[0] + defaultSizePos[2]) - (app.activeDocument.activeView.viewedRectangle.pX1 + splitPos.x);
+			defaultSizePos[0] = splitPos.x + app.activeDocument.activeView.viewedRectangle.pX1;
+		}
+
+		if (defaultSizePos[1] < splitPos.y && defaultSizePos[1] + defaultSizePos[3] > splitPos.y)
+			defaultSizePos[3] = Math.max(splitPos.y - defaultSizePos[1], defaultSizePos[3] - app.activeDocument.activeView.viewedRectangle.pY1);
+
+		if (defaultSizePos[1] >= splitPos.y && app.activeDocument.activeView.viewedRectangle.pY1 + splitPos.y > defaultSizePos[1]) {
+			defaultSizePos[3] = (defaultSizePos[1] + defaultSizePos[3]) - (app.activeDocument.activeView.viewedRectangle.pY1 + splitPos.y);
+			defaultSizePos[1] = splitPos.y + app.activeDocument.activeView.viewedRectangle.pY1;
+		}
+
+		return defaultSizePos;
+	}
+
 	public onDraw() {
 		if (app.calc.cellCursorVisible) {
 			this.context.lineJoin = 'miter';
@@ -41,23 +66,24 @@ class CellCursorSection extends CanvasSectionObject {
 
 			this.context.strokeStyle = this.sectionProperties.color;
 
-			let x: number = 0;
+			const tempSizePos = CellCursorSection.adjustSizePos([this.position[0], this.position[1], this.size[0], this.size[1]]);
+
+			let x: number = (tempSizePos[0] - this.position[0]);
+			const y: number = (tempSizePos[1] - this.position[1]);
 			if (app.calc.isRTL()) {
 				const rightMost = this.containerObject.getDocumentAnchor()[0] + this.containerObject.getDocumentAnchorSection().size[0];
-				x = rightMost - this.size[0];
+				x = rightMost - tempSizePos[2] + (tempSizePos[0] - this.position[0]);
 			}
 
 			for (let i: number = 0; i < this.sectionProperties.weight; i++)
-				this.context.strokeRect(x + -0.5 - i, -0.5 - i, this.size[0] + i * 2, this.size[1] + i * 2);
+				this.context.strokeRect(x + -0.5 - i, y - 0.5 - i, tempSizePos[2] + i * 2, tempSizePos[3] + i * 2);
 
 			if (window.prefs.getBoolean('darkTheme')) {
 				this.context.strokeStyle = 'white';
 				const diff = 1;
-				this.context.strokeRect(x + -0.5 + diff, -0.5 + diff, this.size[0] - 2 * diff, this.size[1] - 2 * diff);
-				this.context.strokeRect(x + -0.5 + diff, -0.5 + diff, this.size[0] - 2 * diff, this.size[1] - 2 * diff);
+				this.context.strokeRect(x + -0.5 + diff, y - 0.5 + diff, tempSizePos[2] - 2 * diff, tempSizePos[3] - 2 * diff);
+				this.context.strokeRect(x + -0.5 + diff, y - 0.5 + diff, tempSizePos[2] - 2 * diff, tempSizePos[3] - 2 * diff);
 			}
 		}
 	}
 }
-
-app.definitions.cellCursorSection = CellCursorSection;

--- a/browser/src/canvas/sections/OtherViewCellCursorSection.ts
+++ b/browser/src/canvas/sections/OtherViewCellCursorSection.ts
@@ -47,9 +47,14 @@ class OtherViewCellCursorSection extends CanvasSectionObject {
 
         this.adjustPopUpPosition();
 
+        const tempSizePos = CellCursorSection.adjustSizePos([this.position[0], this.position[1], this.size[0], this.size[1]]);
+
+        const x: number = (tempSizePos[0] - this.position[0]);
+        const y: number = (tempSizePos[1] - this.position[1]);
+
         this.context.strokeStyle = this.sectionProperties.color;
         this.context.lineWidth = 2;
-        this.context.strokeRect(-0.5, -0.5, this.size[0], this.size[1]);
+        this.context.strokeRect(x - 0.5, y - 0.5, tempSizePos[2], tempSizePos[3]);
     }
 
     checkMyVisibility() {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3,7 +3,7 @@
  * L.CanvasTileLayer is a layer with canvas based rendering.
  */
 
-/* global app L JSDialog CanvasSectionContainer GraphicSelection CanvasOverlay CDarkOverlay CursorHeaderSection $ _ CPointSet CPolyUtil CPolygon Cursor CCellSelection PathGroupType UNOKey UNOModifier cool OtherViewCellCursorSection TileManager MultiPageViewLayout SplitSection TextSelections CellSelectionMarkers URLPopUpSection CalcValidityDropDown */
+/* global app L JSDialog CanvasSectionContainer GraphicSelection CanvasOverlay CDarkOverlay CursorHeaderSection $ _ CPointSet CPolyUtil CPolygon Cursor CCellSelection PathGroupType UNOKey UNOModifier cool OtherViewCellCursorSection TileManager MultiPageViewLayout SplitSection TextSelections CellSelectionMarkers URLPopUpSection CalcValidityDropDown CellCursorSection */
 
 function clamp(num, min, max)
 {
@@ -3748,7 +3748,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			var cursorStyle = new CStyleData(this._cursorDataDiv);
 			var weight = cursorStyle.getFloatPropWithoutUnit('border-top-width') * app.dpiScale;
 			var color = cursorStyle.getPropValue('border-top-color');
-			this._cellCursorSection = new app.definitions.cellCursorSection(color, weight);
+			this._cellCursorSection = new CellCursorSection(color, weight);
 			app.sectionContainer.addSection(this._cellCursorSection);
 		}
 


### PR DESCRIPTION
…e cursor drawing overlaps with the other cells.

To reproduce, set split panes. Click on an edge cell that is not frozen. Scroll the view slightly to the right.

Fix: Check if cursor drawing overlaps with other cells.


Change-Id: If902b7660cc9fadb4cf06603be0d1322486d6789


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

