### PR TITLE
Overflow icons: compact mode

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1278,7 +1278,6 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 .ui-overflow-manager {
 	display: flex !important;
-	overflow-x: hidden;
 }
 
 .ui-overflow-group {

--- a/browser/css/override-smartmenus.css
+++ b/browser/css/override-smartmenus.css
@@ -48,7 +48,7 @@
 	}
 }
 
-@media (max-width: 752px) {
+@media (max-width: 988px) {
 	#menu-last-mod {
 		display: none;
 	}

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -590,6 +590,7 @@ button.leaflet-control-search-next
 }
 #toolbar-up #fontsizecombobox .select2-container {
 	min-width: 55px !important;
+	margin: 0px 4px;
 }
 #fontsizecombobox-input-notebookbar,
 #fontsizecombobox-input-sidebar,

--- a/browser/src/control/Control.TopToolbar.js
+++ b/browser/src/control/Control.TopToolbar.js
@@ -112,12 +112,10 @@ class TopToolbar extends JSDialog.Toolbar {
 			}
 		];
 		var undoGroup = [
-			{type: 'separator', orientation: 'vertical', id: 'savebreak', mobile: false},
 			{type: 'toolitem',  id: 'undo', text: _UNO('.uno:Undo'), command: '.uno:Undo', mobile: false},
 			{type: 'toolitem',  id: 'redo', text: _UNO('.uno:Redo'), command: '.uno:Redo', mobile: false}
 		];
 		var fontGroup = [
-			{type: 'separator', orientation: 'vertical', id: 'redobreak', mobile: false, tablet: false,},
 			{type: 'toolitem',  id: 'formatpaintbrush', text: _UNO('.uno:FormatPaintbrush'), command: '.uno:FormatPaintbrush', mobile: false},
 			{type: 'toolitem',  id: 'reset', text: _UNO('.uno:ResetAttributes', 'text'), visible: false, command: '.uno:ResetAttributes', mobile: false},
 			{type: 'toolitem',  id: 'resetimpress', class: 'unoResetAttributes', text: _UNO('.uno:SetDefault', 'presentation', 'true'), visible: false, command: '.uno:SetDefault', mobile: false},
@@ -127,21 +125,18 @@ class TopToolbar extends JSDialog.Toolbar {
 			{type: 'listbox', id: 'fontsizecombobox', text: '12 pt', command: '.uno:FontHeight', mobile: false,}
 		];
 		var formatGroup = [
-			{type: 'separator', orientation: 'vertical', id: 'breakfontsizes', invisible: true, mobile: false, tablet: false},
 			{type: 'toolitem',  id: 'bold', text: _UNO('.uno:Bold'), command: '.uno:Bold'},
 			{type: 'toolitem',  id: 'italic', text: _UNO('.uno:Italic'), command: '.uno:Italic'},
 			{type: 'toolitem',  id: 'underline', text: _UNO('.uno:Underline'), command: '.uno:Underline'},
 			{type: 'toolitem',  id: 'strikeout', text: _UNO('.uno:Strikeout'), command: '.uno:Strikeout'},
 		];
 		const fontColorGroup = [
-			{type: 'separator', orientation: 'vertical', id: 'breakformatting'},
 			{type: 'colorlistbox',  id: 'fontcolorwriter:ColorPickerMenu', command: '.uno:FontColor', text: _UNO('.uno:FontColor'), visible: false, lockUno: '.uno:FontColor'},
 			{type: 'colorlistbox',  id: 'fontcolor:ColorPickerMenu', command: '.uno:Color', text: _UNO('.uno:FontColor'), lockUno: '.uno:FontColor'},
 			{type: 'colorlistbox',  id: 'backcolor:ColorPickerMenu', command: '.uno:CharBackColor', text: _UNO('.uno:CharBackColor', 'text'), visible: false, lockUno: '.uno:CharBackColor'},
 			{type: 'colorlistbox',  id: 'backgroundcolor:ColorPickerMenu', command: '.uno:BackgroundColor', text: _UNO('.uno:BackgroundColor'), visible: false, lockUno: '.uno:BackgroundColor'},
 		];
 		const indentGroup = [
-			{type: 'separator', orientation: 'vertical' , id: 'breakcolor', mobile:false},
 			{type: 'toolitem',  id: 'leftpara',  command: '.uno:LeftPara', text: _UNO('.uno:LeftPara', '', true), visible: false},
 			{type: 'toolitem',  id: 'centerpara',  command: '.uno:CenterPara', text: _UNO('.uno:CenterPara', '', true), visible: false},
 			{type: 'toolitem',  id: 'rightpara',  command: '.uno:RightPara', text: _UNO('.uno:RightPara', '', true), visible: false},
@@ -174,7 +169,6 @@ class TopToolbar extends JSDialog.Toolbar {
 			{type: 'toolitem',  id: 'wraptextbutton', text: _UNO('.uno:WrapText', 'spreadsheet', true), visible: false, command: '.uno:WrapText'}
 		];
 		var otherGroup = [
-			{type: 'separator', orientation: 'vertical', id: 'breakspacing', visible: false},
 			{type: 'toolitem',  id: 'defaultnumbering', text: _UNO('.uno:DefaultNumbering', '', true), visible: false, command: '.uno:DefaultNumbering'},
 			{type: 'toolitem',  id: 'defaultbullet', text: _UNO('.uno:DefaultBullet', '', true), visible: false, command: '.uno:DefaultBullet'},
 			{type: 'separator', orientation: 'vertical', id: 'breakbullet', visible: false},
@@ -208,11 +202,17 @@ class TopToolbar extends JSDialog.Toolbar {
 		var items = [
 			{type: 'overflowmanager', id: 'overflow-manager-toptoolbar', children: [
 				{type: 'overflowgroup', id: 'save-toptoolbar', children: saveGroup},
+				{type: 'separator', orientation: 'vertical', id: 'savebreak', mobile: false},
 				{type: 'overflowgroup', id: 'undo-toptoolbar', children: undoGroup},
+				{type: 'separator', orientation: 'vertical', id: 'redobreak', mobile: false, tablet: false,},
 				{type: 'overflowgroup', id: 'font-toptoolbar', children: fontGroup},
+				{type: 'separator', orientation: 'vertical', id: 'breakfontsizes', invisible: true, mobile: false, tablet: false},
 				{type: 'overflowgroup', id: 'format-toptoolbar', children: formatGroup},
+				{type: 'separator', orientation: 'vertical', id: 'breakformatting'},
 				{type: 'overflowgroup', id: 'fontcolor-toptoolbar', children: fontColorGroup},
+				{type: 'separator', orientation: 'vertical' , id: 'breakcolor', mobile:false},
 				{type: 'overflowgroup', id: 'indent-toptoolbar', children: indentGroup},
+				{type: 'separator', orientation: 'vertical', id: 'breakspacing', visible: false},
 				{type: 'overflowgroup', id: 'other-toptoolbar', children: otherGroup},
 			]},
 			{type: 'spacer', id: 'topspacer'},

--- a/cypress_test/integration_tests/desktop/calc/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/top_toolbar_spec.js
@@ -90,9 +90,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 
 		// Turn text wrap on
 		calcHelper.clickOnFirstCell();
-		cy.cGet('#toolbar-up #overflow-button-indent-toptoolbar .arrowbackground').click();
 		cy.cGet('.ui-toolbar .unoWrapText').click();
-		cy.cGet('.jsdialog-overlay').click();
 
 		// Leave cell
 		helper.typeIntoDocument('{enter}');
@@ -266,11 +264,9 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 
 	it('Apply left/right alignment', function() {
 		helper.setDummyClipboardForCopy();
-		cy.cGet('#toolbar-up #overflow-button-indent-toptoolbar .arrowbackground').click();
 		// Set right alignment first
 		cy.cGet('#textalign .arrowbackground').click();
 		cy.cGet('body').contains('.ui-combobox-entry', 'Align Right').click();
-		cy.cGet('.jsdialog-overlay').click();
 		calcHelper.selectEntireSheet();
 		helper.copy();
 		cy.cGet('#copy-paste-container table td').should('have.attr', 'align', 'right');
@@ -278,10 +274,8 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		// Change alignment back
 		calcHelper.clickOnFirstCell();
 
-		cy.cGet('#toolbar-up #overflow-button-indent-toptoolbar .arrowbackground').click();
 		cy.cGet('#textalign .arrowbackground').click();
 		cy.cGet('body').contains('.ui-combobox-entry', 'Align Left').click();
-		cy.cGet('.jsdialog-overlay').click();
 
 		calcHelper.selectEntireSheet();
 		helper.copy();

--- a/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
@@ -22,7 +22,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply bold on text shape.', function() {
-		cy.cGet('#toolbar-up #overflow-button-format-toptoolbar .arrowbackground').click();
 		cy.cGet('#bold').click();
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
@@ -31,7 +30,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply italic on text shape.', function() {
-		cy.cGet('#toolbar-up #overflow-button-format-toptoolbar .arrowbackground').click();
 		cy.cGet('#italic').click();
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
@@ -40,7 +38,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply underline on text shape.', function() {
-		cy.cGet('#toolbar-up #overflow-button-format-toptoolbar .arrowbackground').click();
 		cy.cGet('#underline').click();
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
@@ -49,7 +46,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply strikethrough on text shape.', function() {
-		cy.cGet('#toolbar-up #overflow-button-format-toptoolbar .arrowbackground').click();
 		cy.cGet('#strikeout').click();
 
 		impressHelper.triggerNewSVGForShapeInTheCenter();
@@ -58,7 +54,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply font color on text shape.', function() {
-		cy.cGet('#toolbar-up #overflow-button-fontcolor-toptoolbar .arrowbackground').click();
 		cy.cGet('#fontcolor .arrowbackground').click();
 		desktopHelper.selectColorFromPalette('FFFF00');
 
@@ -68,7 +63,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply highlight color on text shape.', function() {
-		cy.cGet('#toolbar-up #overflow-button-fontcolor-toptoolbar .arrowbackground').click();
 		cy.cGet('#backcolor .arrowbackground').click();
 		desktopHelper.selectColorFromPalette('FFBF00');
 


### PR DESCRIPTION
1. Compact mode: Move out separator out of the overflow manager div

- Instead of adding separator inside group we should separate it out side the manager div
- this will fix issue when we do resize of screen
    - on resize screen before this patch it was including the separator within other options in dropdown which is not needed in that compact view
    
2. Add some breathing space after fontsizecombobox for compact mode

- Before this change fontsizecombobox and the next element which in this case is separator glued with each other on high zoom
- so by adding minor margin will fix the breathing issues

<img width="449" height="161" alt="image" src="https://github.com/user-attachments/assets/1382a143-1efc-42c0-8631-93e7a2ece5f2" />

3. On zoom 200% the last updated status time in navigation shifted to next row.

- In compact mode when we do 200% zoom in the navigation bar the last updated time jumps to next line and make navigation bar ugly
- this will fix the issue as on 200% zoom we will hide that status
- user can check that status in status-bar down anytime

Before: 

<img width="1434" height="155" alt="image" src="https://github.com/user-attachments/assets/16702ff6-8f99-4672-88cf-7792ab750e1e" />


After: 

<img width="1824" height="302" alt="image" src="https://github.com/user-attachments/assets/faffbd11-4988-4e3e-8e84-c92f15dbd9ae" />

4. Make scroll overflow hidden for overflow manager class

- Because of `overflow-x:hidden` on high zoom in compact mode user can see the vertical scroll bar next to orderlist group option
- this patch fix that visible vertical scroll issue

Issue: <img width="1185" height="373" alt="image" src="https://github.com/user-attachments/assets/db2769dd-9ef4-4d87-b9d1-21dbddb93ea9" />


