### PR TITLE
pre-commit: suppress 'which: no gmake' stderr output

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -133,8 +133,8 @@ sub check_prettier()
 {
     my $red = "\033[0;31m";
     my $reset = "\033[0m";
-    my $hasmake = system("which make > /dev/null") == 0;
-    my $hasgmake = system("which gmake > /dev/null") == 0;
+    my $hasmake = system("which make > /dev/null 2>&1") == 0;
+    my $hasgmake = system("which gmake > /dev/null 2>&1") == 0;
 
     my $make = $hasgmake? "gmake" : $hasmake? "make" : die  $red .
                 "\n===============================================\n" .


### PR DESCRIPTION
I have `make` not `gmake` so everytime I try to commit, it prints the annoying `which: no gmake` message.


Change-Id: Ib49af5cf5d13d5e884df97e361e80cb277149073


* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

