### PR TITLE
Impress slideshow: Check if dark mode is active before start.

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -133,6 +133,7 @@ class SlideShowPresenter {
 	private _onImpressModeChanged: any = null;
 	private _startingPresentation: boolean = false;
 	private _hammer: HammerManager;
+	private _wasInDarkMode: boolean = false;
 
 	constructor(map: any) {
 		this._cypressSVGPresentationTest =
@@ -514,6 +515,8 @@ class SlideShowPresenter {
 	}
 
 	endPresentation(force: boolean) {
+		this.checkDarkMode(false);
+
 		console.debug('SlideShowPresenter.endPresentation');
 		if (this._pauseTimer) this._pauseTimer.stopTimer();
 
@@ -837,12 +840,29 @@ class SlideShowPresenter {
 		);
 	}
 
+	// We want to present the slides in default mode. So we check the state here and change when needed.
+	private checkDarkMode(starting: boolean) {
+		if (starting) {
+			const isDarkMode = window.prefs.getBoolean('darkTheme');
+			if (isDarkMode) {
+				this._wasInDarkMode = true;
+				app.map.uiManager.toggleDarkMode();
+			}
+		} else if (this._wasInDarkMode) {
+			app.map.uiManager.toggleDarkMode();
+			this._wasInDarkMode = false;
+		}
+	}
+
 	/// called when user triggers the presentation using UI
 	_onStart(that: any) {
 		this._startSlide = that?.startSlideNumber ?? 0;
 		if (!this._onPrepareScreen(false))
 			// opens full screen, has to be on user interaction
 			return;
+
+		this.checkDarkMode(true);
+
 		// disable slide sorter or it will receive key events
 		this._map._docLayer._preview.partsFocused = false;
 		this._startingPresentation = true;
@@ -855,6 +875,9 @@ class SlideShowPresenter {
 		if (!this._onPrepareScreen(true))
 			// opens full screen, has to be on user interaction
 			return;
+
+		this.checkDarkMode(true);
+
 		// disable present in console onStartInWindow
 		this._enablePresenterConsole(true);
 		this._startingPresentation = true;


### PR DESCRIPTION
Issue:
* Auto color and background color is not working in dark mode.
* So the slides may have invisible text.
* Thinking that slides should have their own background colors and color scheme, dark mode switch may not be good in terms of design.
* So we set the dark mode off before start and set it back to on after user ends the slide show.


Change-Id: I36e47d6867abecbecd0977e558347a8aea6e39e0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

