### PR TITLE
Always use core dialog for sethyperlinkdialog

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -1075,14 +1075,6 @@ body {
 	border-radius: 50%;
 }
 
-#hyperlink-text-box:not(.mobile-wizard) {
-	width: 100% !important;
-	margin-bottom: 10px;
-	resize: none;
-	height: 32px;
-	box-sizing: border-box;
-}
-
 .functiontooltip {
 	white-space: nowrap;
 	max-width: fit-content !important;
@@ -1346,4 +1338,3 @@ body {
 	background-color: var(--color-insert-marker-background-dark) !important;
 	background: url('images/insert-plus-marker-hover.svg') no-repeat center center /20px;
 }
-

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -840,7 +840,7 @@ img.context-menu-icon {
 	outline-offset: -2px;
 }
 
-.jsdialog.ui-edit, #hyperlink-text-box:not(.mobile-wizard) {
+.jsdialog.ui-edit {
 	color: var(--color-text-dark);
 	background-color: var(--color-background-dark);
 	line-height: 28px;

--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -585,8 +585,7 @@ input.spinfield:disabled ~ .spinfieldcontrols *:active, input.spinfield:disabled
 	font-weight: normal;
 }
 
-input.ui-edit.mobile-wizard,
-#hyperlink-text-box.mobile-wizard {
+input.ui-edit.mobile-wizard {
 	background-color: var(--color-background-lighter);
 	color: var(--color-text-lighter);
 	border: 1px solid var(--color-border-dark);

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -346,8 +346,7 @@ L.Map.include({
 
 	messageNeedsToBeRedirected: function(command) {
 		if (command === '.uno:EditHyperlink') {
-			var that = this;
-			setTimeout(function () { that.showHyperlinkDialog(); }, 500);
+			this.sendUnoCommand('.uno:HyperlinkDialog');
 			return true;
 		}
 		else {
@@ -796,90 +795,6 @@ L.Map.include({
 		return str;
 	},
 
-	_createAndRunHyperlinkDialog: function(defaultText, defaultLink) {
-		var map = this;
-		var id = 'hyperlink';
-		var title = _('Insert hyperlink');
-
-		let focusId = 'hyperlink-link-box-input';
-		if (defaultText === '') {
-			focusId = 'hyperlink-text-box';
-		}
-
-		var dialogId = 'modal-dialog-' + id;
-		var json = map.uiManager._modalDialogJSON(id, title, true, [
-			{
-				id: 'hyperlink-text-box-label',
-				type: 'fixedtext',
-				text: _('Text'),
-				labelFor: 'hyperlink-text-box'
-			},
-			{
-				id: 'hyperlink-text-box',
-				type: 'multilineedit',
-				text: defaultText,
-				labelledBy: 'hyperlink-text-box-label'
-			},
-			{
-				id: 'hyperlink-link-box-label',
-				type: 'fixedtext',
-				text: _('Link'),
-				labelFor: 'hyperlink-link-box'
-			},
-			{
-				id: 'hyperlink-link-box',
-				type: 'edit',
-				text: defaultLink,
-				labelledBy: 'hyperlink-link-box-label'
-			},
-			{
-				type: 'buttonbox',
-				enabled: true,
-				children: [
-					{
-						id: 'response-cancel',
-						type: 'pushbutton',
-						text: _('Cancel'),
-					},
-					{
-						id: 'response-ok',
-						type: 'pushbutton',
-						text: _('OK'),
-						'has_default': true,
-					}
-				],
-				vertical: false,
-				layoutstyle: 'end'
-			},
-		], focusId);
-
-		map.uiManager.showModal(json, [
-			{id: 'response-ok', func: function() {
-				var text = document.getElementById('hyperlink-text-box');
-				var link = document.getElementById('hyperlink-link-box-input');
-
-				if (link.value != '') {
-					if (!text.value || text.value === '')
-						text.value = link.value;
-
-					var command = {
-						'Hyperlink.Text': {
-							type: 'string',
-							value: text.value
-						},
-						'Hyperlink.URL': {
-							type: 'string',
-							value: map.makeURLFromStr(link.value)
-						}
-					};
-					map.sendUnoCommand('.uno:SetHyperlink', command, true);
-				}
-
-				map.uiManager.closeModal(dialogId);
-			}}
-		]);
-	},
-
 	getTextForLink: function() {
 		var map = this;
 		var text = '';
@@ -898,22 +813,6 @@ L.Map.include({
 			text = this.extractContent(this._docLayer._selectedTextContent);
 		}
 		return text;
-	},
-
-	showHyperlinkDialog: function() {
-		if (this.getDocType() === 'spreadsheet') {
-			// show native core dialog
-			// in case we try to edit email EditHyperlink doesn't work
-			this.sendUnoCommand('.uno:HyperlinkDialog');
-			return;
-		}
-
-		var text = this.getTextForLink();
-		var link = '';
-		if (this.hyperlinkUnderCursor && this.hyperlinkUnderCursor.link)
-			link = this.hyperlinkUnderCursor.link;
-
-		this._createAndRunHyperlinkDialog(text ? text.replace(/^[\n\r]+|[\n\r]+$/g, '') : '', link);
 	},
 
 	cancelSearch: function() {

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -97,12 +97,10 @@ class Dispatcher {
 		};
 		// TODO: deduplicate
 		this.actionsMap['hyperlinkdialog'] = function () {
-			app.map.showHyperlinkDialog();
+			app.map.sendUnoCommand('.uno:HyperlinkDialog');
 		};
 		this.actionsMap['inserthyperlink'] = () => {
-			if (app.map.getDocType() == 'spreadsheet')
-				app.map.sendUnoCommand('.uno:HyperlinkDialog');
-			else app.map.showHyperlinkDialog();
+			app.map.sendUnoCommand('.uno:HyperlinkDialog');
 		};
 		this.actionsMap['rev-history'] = function () {
 			app.map.openRevisionHistory();

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1078,18 +1078,8 @@ L.CanvasTileLayer = L.Layer.extend({
 				// Single format: as-is.
 				textMsgHtml = textMsgContent;
 			}
-			const hyperlinkTextBox = document.getElementById('hyperlink-text-box');
-			if (hyperlinkTextBox) {
-				// Hyperlink dialog is open, the text selection is for the link text
-				// widget.
-				const extracted = this._map.extractContent(textMsgHtml);
-				hyperlinkTextBox.value = extracted.trim();
 
-				const hyperlinkLinkBoxInput = document.getElementById('hyperlink-link-box-input');
-				if (extracted !== '' && hyperlinkLinkBoxInput) {
-					hyperlinkLinkBoxInput.focus();
-				}
-			} else if (this._map._clip) {
+			if (this._map._clip) {
 				this._map._clip.setTextSelectionHTML(textMsgHtml, textMsgPlainText);
 			} else
 				// hack for ios and android to get selected text into hyperlink insertion dialog

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -734,7 +734,7 @@ L.Map.Keyboard = L.Handler.extend({
 		}
 
 		if (this._isCtrlKey(e) && !e.shiftKey && e.keyCode === this.keyCodes.K) {
-			this._map.showHyperlinkDialog();
+			this._map.sendUnoCommand('.uno:HyperlinkDialog');
 			e.preventDefault();
 			return true;
 		}

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -250,7 +250,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		cy.cGet('#document-container svg g.Graphic').should('exist');
 	});
 
-	it.skip('Insert hyperlink.', function() {
+	it('Insert hyperlink.', function() {
 		helper.setDummyClipboardForCopy();
 		helper.copy();
 		cy.wait(1000);
@@ -258,10 +258,10 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 
 		cy.cGet('#Insert-tab-label').click();
 		cy.cGet('#Insert-container .hyperlinkdialog button').click();
-		cy.cGet('#hyperlink-link-box-input').should('exist');
-		cy.cGet('#hyperlink-text-box').type('link');
-		cy.cGet('#hyperlink-link-box-input').type('www.something.com');
-		cy.cGet('#response-ok').click();
+		cy.cGet('#target-input').should('exist');
+		cy.cGet('#indication-input').type('link');
+		cy.cGet('#target-input').type('www.something.com');
+		cy.cGet('#ok').click();
 
 		writerHelper.selectAllTextOfDoc();
 		helper.copy();

--- a/cypress_test/integration_tests/mobile/impress/insertion_wizard_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/insertion_wizard_spec.js
@@ -109,18 +109,22 @@ describe(['tagmobile', 'tagnextcloud'], 'Impress insertion wizard.', function() 
 	});
 
 	it('Insert hyperlink.', function() {
+		helper.setDummyClipboardForCopy();
 		mobileHelper.openInsertionWizard();
 		// Open hyperlink dialog
 		cy.cGet('body').contains('.menu-entry-with-icon', 'Hyperlink...').click();
 		// Dialog is opened
-		cy.cGet('#hyperlink-link-box-input').should('exist');
+		cy.cGet('#target-input').should('exist');
 		// Type text and link
-		cy.cGet('#hyperlink-text-box').type('some text');
-		cy.cGet('#hyperlink-link-box-input').type('www.something.com');
+		cy.cGet('#indication-input').type('some text');
+		cy.cGet('#target-input').type('www.something.com');
 		// Insert
-		cy.cGet('#response-ok').click();
-		// TODO: we have some weird shape here instead of a text shape with the link
-		cy.cGet('#document-container svg g').should('exist');
+		cy.cGet('#ok').click();
+
+		impressHelper.selectTextOfShape();
+		helper.copy();
+		helper.expectTextForClipboard('some text');
+		cy.cGet('.hyperlink-pop-up-container a').should('have.text', 'http://www.something.com/');
 	});
 
 	it('Insert shape.', function() {
@@ -260,17 +264,17 @@ describe(['tagmobile', 'tagnextcloud'], 'Impress insertion wizard.', function() 
 		// Open hyperlink dialog
 		cy.cGet('body').contains('.menu-entry-with-icon', 'Hyperlink...').click();
 		// Dialog is opened
-		cy.cGet('#hyperlink-link-box-input').should('exist');
+		cy.cGet('#target-input').should('exist');
 		// Type text and link
-		cy.cGet('#hyperlink-text-box').type('some text');
-		cy.cGet('#hyperlink-link-box-input').type('www.something.com');
+		cy.cGet('#indication-input').type('some text');
+		cy.cGet('#target-input').type('www.something.com');
 		// Insert
-		cy.cGet('#response-ok').click();
+		cy.cGet('#ok').click();
 		// Check the text
 		impressHelper.selectTextOfShape();
 		helper.copy();
 		helper.expectTextForClipboard('some text');
-		cy.cGet('.hyperlink-pop-up-container a').should('have.text', 'http://www.something.com');
+		cy.cGet('.hyperlink-pop-up-container a').should('have.text', 'http://www.something.com/');
 	});
 
 	it('Insert date field (fixed) inside existing text shape.', function() {

--- a/cypress_test/integration_tests/mobile/writer/insert_object_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/insert_object_spec.js
@@ -189,12 +189,12 @@ describe(['tagmobile', 'tagnextcloud'], 'Insert objects via insertion wizard.', 
 		// Open hyperlink dialog
 		cy.cGet('body').contains('.menu-entry-with-icon', 'Hyperlink...').click();
 		// Dialog is opened
-		cy.cGet('#hyperlink-link-box-input').should('exist');
+		cy.cGet('#target-input').should('exist');
 		// Type text and link
-		cy.cGet('#hyperlink-text-box').type('some text');
-		cy.cGet('#hyperlink-link-box-input').type('www.something.com');
+		cy.cGet('#indication-input').type('some text');
+		cy.cGet('#target-input').type('www.something.com');
 		// Insert
-		cy.cGet('#response-ok').click();
+		cy.cGet('#ok').click();
 		writerHelper.selectAllTextOfDoc();
 		helper.copy();
 		helper.expectTextForClipboard('some text');
@@ -206,15 +206,15 @@ describe(['tagmobile', 'tagnextcloud'], 'Insert objects via insertion wizard.', 
 		// Open hyperlink dialog
 		cy.cGet('body').contains('.menu-entry-with-icon', 'Hyperlink...').click();
 		// Dialog is opened
-		cy.cGet('#hyperlink-link-box-input').should('exist');
+		cy.cGet('#target-input').should('exist');
 		// Type text and link
-		cy.cGet('#hyperlink-text-box').type('some text');
-		cy.cGet('#hyperlink-link-box-input').type('www.something.com');
+		cy.cGet('#indication-input').type('some text');
+		cy.cGet('#target-input').type('www.something.com');
 		// Insert
-		cy.cGet('#response-ok').click();
+		cy.cGet('#ok').click();
 		helper.typeIntoDocument('{leftArrow}');
 		cy.cGet('#hyperlink-pop-up').click();
-		cy.cGet('#info-modal-label2').should('have.text', 'http://www.something.com');
+		cy.cGet('#info-modal-label2').should('have.text', 'http://www.something.com/');
 	});
 
 	it('Insert shape.', function() {


### PR DESCRIPTION
Change-Id: I6774fa507ec1e51e9c94894337b35c2604b665b8

Use the CORE dialog for creating hyperlinks in all cases; previously, it was only used for calc and when right clicking on text. The CORE dialog has a few benefits, such as allowing mail links and having a name field (which so only works on writer text). It also removes a bug where a race condition causes the hyperlink text box to not receive any text.

### Summary
Replace calls to showHyperlinkDialog() with sendUnoCommand('.uno:HyperlinkDialog').

### TODO
Change CORE to allow image links to be added to draw/impress
Change CORE to make dialog only show relevant fields (e.g. no name or text fields for images)
Allow image links to be clickable in draw/impress online (without this, they can only be used after exporting)

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

