### PR TITLE
Private/pedro/add outline btn selected

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -55,8 +55,8 @@
 .sidebar.unotoolbutton.selected,
 .notebookbar.unotoolbutton.selected,
 .jsdialog.unotoolbutton.selected {
-	background-color: var(--color-background-dark);
-	border: 1px solid var(--color-border-dark);
+	background-color: rgba(var(--doc-type), 0.1);
+	border: 1px solid rgb(var(--doc-type));
 	color: var(--color-text-dark);
 	border-radius: var(--border-radius);
 }

--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -39,13 +39,12 @@
 .hasnotebookbar .ui-content.unotoolbutton.has-label:hover,
 .hasnotebookbar .ui-content.unotoolbutton.inline:hover,
 .hasnotebookbar .ui-content.unotoolbutton:not(.has-label):not(.inline):hover,
-.sidebar.unotoolbutton:hover,
-.jsdialog.unotoolbutton:hover,
-.notebookbar.unotoolbutton:hover,
+.unotoolbutton:hover,
 .close-navigation-wrapper:hover {
 	border: 1px solid var(--color-btn-border);
 	color: var(--color-text-darker);
 	border-radius: var(--border-radius);
+	background-color: var(--color-background-tabs-group);
 }
 
 /* toolbuttons selected */
@@ -71,17 +70,16 @@
 }
 
 /* toolbuttons selected hover */
+/* toolbuttons have .unobuttons as children */
 .hasnotebookbar .ui-content.unotoolbutton.has-label:hover,
 .hasnotebookbar .ui-content.unotoolbutton.selected:hover,
-.unotoolbutton.notebookbar:hover,
-.unotoolbutton.jsdialog:hover,
 .hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline):hover,
 .sidebar.unotoolbutton.selected:hover,
 .notebookbar.unotoolbutton.selected:hover,
 .jsdialog.unotoolbutton.selected:hover {
-	border: 1px solid var(--color-border-darker);
 	color: var(--color-text-darker);
 	border-radius: var(--border-radius);
+	background-color: var(--color-background-tabs-group);
 }
 
 /*limit icon to button height*/

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1997,8 +1997,9 @@ button.menubutton.sidebar > span {
 	left: var(--click-increment);
 }
 
-.notebookbar .ui-content.unobutton:hover,
-.jsdialog .ui-content.unobutton:hover {
+/* targetting buttons inside of split button */
+.notebookbar .splitbutton > .ui-content.unobutton:hover,
+.jsdialog .splitbutton > .ui-content.unobutton:hover {
 	background-color: var(--color-background-darker);
 }
 

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -169,7 +169,6 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 	margin: 0;
 }
 .sidebar.unotoolbutton {
-	border: 1px solid transparent;
 	margin-right: 3px;
 	padding: 0 !important;
 }

--- a/browser/src/control/jsdialog/Widget.MenuButton.js
+++ b/browser/src/control/jsdialog/Widget.MenuButton.js
@@ -71,8 +71,9 @@ function _menubuttonControl (parentContainer, data, builder) {
 
 		var options = {hasDropdownArrow: menuEntries.length > 1};
 		var control = builder._unoToolButton(parentContainer, data, builder, options);
+		var isSplitButton = data.applyCallback;
 
-		$(control.container).addClass('menubutton');
+		$(control.container).addClass('menubutton' + (isSplitButton ? ' splitbutton' : ''));
 
 		$(control.button).unbind('click');
 		$(control.label).unbind('click');
@@ -122,8 +123,6 @@ function _menubuttonControl (parentContainer, data, builder) {
 				JSDialog.OpenDropdown(dropdownId, control.container, freshMenu, callback);
 			}
 		};
-
-		var isSplitButton = data.applyCallback;
 
 		// make it possible to setup separate callbacks for split button
 		if (isSplitButton) {


### PR DESCRIPTION
commit e6c4fcd03c1b7bfcf70167f8368d2819fccc1695 (HEAD -> private/pedro/add-outline-btn-selected, origin/private/pedro/add-outline-btn-selected, origin/private/elliot/add-outline-btn-selected, private/elliot/add-outline-btn-selected)
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Tue Aug 12 17:16:24 2025 +0200

    unotoolbutton: remove unused css, fix hover state on non selected btns
    
    it also removes duplicity and the fact that i the sidebar
    unotoolbuttons were having transparent border
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Idbe15448ec6dadb7916a00b3cc95b0a1a8ec6f51

commit 7c59c4b76bf50d77fccebbddd4d01ff512377f60
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Tue Aug 12 16:53:12 2025 +0200

    Menu button: only add sub btns hover if it's the menu is a split btn
    
    - It fixes the double hover effect on unobutton (div and in btn
    which causes flickering in some cases)
    - It makes a visual distinction between Dropdown menu buttons and
    Split buttons
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Ia53442a2615f4a516d663d17412ad4fbe78734d5

commit 7f095e43b9024aa68b39af2b44c71cb2c26a2a28
Author: elliotfreebairn <elliot.freebairn@collabora.com>
Date:   Mon Aug 11 16:21:06 2025 +0100

    Add outline to btn in selected state
    
    Co-authored-by: elliotfreebairn <elliot.freebairn@collabora.com>
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Id3bfa3c5c85eeb1d2fce83324371b22dfe9c203e
