### PR TITLE
When InsertLocalImage is false, disable the feature

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1403,7 +1403,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 								'children': [
 									{
 									'id': 'insert-insert-graphic:InsertImageMenu',
-									'type': 'toolitem',
+									'type': 'menubutton',
+									'noLabel': true,
 									'text': _UNO('.uno:InsertGraphic'),
 									'command': '.uno:InsertGraphic',
 									'accessibility': { focusBack: true, combination: 'IG', de: null }

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1231,7 +1231,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'insert-illustrations',
-				'name':_('Illustrations'),
+				'name': _('Illustrations'),
+				'icon': 'lc_insertgraphic.svg',
 				'children' : [
 					{
 						'type': 'container',
@@ -1241,12 +1242,12 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'children': [
 									{
 										'id': 'insert-insert-graphic:InsertImageMenu',
-										'type': 'toolitem',
+										'type': 'menubutton',
+										'noLabel': true,
 										'text': _UNO('.uno:InsertGraphic'),
 										'command': '.uno:InsertGraphic',
 										'accessibility': { focusBack: true,	combination: 'P',	de:	'BI' }
 									},
-		
 								]
 							},
 							{

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -1117,13 +1117,11 @@ menuDefinitions.set('LanguageMenu', [
 ] as Array<MenuDefinition>);
 
 menuDefinitions.set('InsertImageMenu', [
-	{ action: 'localgraphic', text: _('Insert Local Image') },
-	// remote entry added in Map.WOPI
+	// local and remote entries added in Map.WOPI
 ] as Array<MenuDefinition>);
 
 menuDefinitions.set('InsertMultimediaMenu', [
-	{ action: 'insertmultimedia', text: _('Insert Local Multimedia') },
-	// remote entry added in Map.WOPI
+	// local and remote entries added in Map.WOPI
 ] as Array<MenuDefinition>);
 
 menuDefinitions.set('CharSpacingMenu', [

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -169,6 +169,7 @@ interface ContainerWidgetJSON extends WidgetJSON {
 
 interface OverflowGroupWidgetJSON extends ContainerWidgetJSON {
 	name: string; // visible name of a group
+	icon?: string; // Optional icon name. Otherwise it will be guessed.
 }
 
 interface OverflowGroupContainer extends Element {

--- a/browser/src/control/jsdialog/Widget.MenuButton.js
+++ b/browser/src/control/jsdialog/Widget.MenuButton.js
@@ -73,6 +73,10 @@ function _menubuttonControl (parentContainer, data, builder) {
 		var control = builder._unoToolButton(parentContainer, data, builder, options);
 		var isSplitButton = data.applyCallback;
 
+		if (menuEntries.length == 0) {
+			control.container.setAttribute('disabled', true);
+		}
+
 		$(control.container).addClass('menubutton' + (isSplitButton ? ' splitbutton' : ''));
 
 		$(control.button).unbind('click');

--- a/browser/src/control/jsdialog/Widget.OverflowGroup.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowGroup.ts
@@ -200,7 +200,7 @@ JSDialog.OverflowGroup = function (
 				type: 'menubutton',
 				id: id,
 				text: data.name ? data.name : firstItem ? (firstItem as any).text : '',
-				icon: getToolitemIcon(firstItem),
+				icon: data.icon ? data.icon : getToolitemIcon(firstItem),
 				command: firstItem ? (firstItem as any).command : '',
 				noLabel: !data.name,
 				menu: builtMenu,

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -188,9 +188,9 @@ L.Map.WOPI = L.Handler.extend({
 		var menuEntriesImage = JSDialog.MenuDefinitions.get('InsertImageMenu');
 		var menuEntriesMultimedia = JSDialog.MenuDefinitions.get('InsertMultimediaMenu');
 
-		if (this.DisableInsertLocalImage) {
-			menuEntriesImage = [];
-			menuEntriesMultimedia = [];
+		if (!this.DisableInsertLocalImage) {
+			menuEntriesImage.push({ action: 'localgraphic', text: _('Insert Local Image') });
+			menuEntriesMultimedia.push({ action: 'insertmultimedia', text: _('Insert Local Multimedia') });
 		}
 
 		if (this.EnableInsertRemoteImage) {

--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -249,7 +249,7 @@ function insertVideo() {
 	selectZoomLevel('50', false);
 
 	cy.cGet('#Insert-tab-label').click();
-	cy.cGet('#Insert-container .insertmultimedia').click();
+	cy.cGet('#Insert-container .inline.insertmultimedia').click();
 
 	cy.cGet('#insertmultimedia[type=file]').attachFile(
 		'/desktop/impress/video_to_insert.mp4'


### PR DESCRIPTION
- The InsertImage buttons are of type menubutton.
- Overflow group icon can be definied statically with `icon`.
- Disable menu button that have no menu entries
- This fixes a regression introduced when refactoring the UI code and further when relayouting UI.


Change-Id: I97fd063f66c3edda1c2e311a4c3d6c1fb5c71452


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

