### PR TITLE
Fix: Sidebar color icons now update when changed via jsdialog

### DIFF
--- a/browser/src/control/jsdialog/Widget.ColorPickerButton.js
+++ b/browser/src/control/jsdialog/Widget.ColorPickerButton.js
@@ -222,7 +222,12 @@ JSDialog.colorPickerButton = function (parentContainer, data, builder) {
 			builder.map.on(
 				'commandstatechanged',
 				function (e) {
-					if (e.commandName === data.command) updateFunction();
+					if (e.commandName === data.command) {
+						app.colorLastSelection[data.command] = toHexColor(
+							parseInt(e.state),
+						);
+						updateFunction();
+					}
 				},
 				this,
 			);


### PR DESCRIPTION
- Previously, changing a color (e.g., border color in Calc) from its properties dialog did not update the corresponding color icon in the sidebar.
- This patch updates the `colorLastSelection` document state property based on incoming UNO command values, ensuring the sidebar reflects color changes made via jsdialog.
- A simple change that resolves all cases where sidebar colors failed to update after being changed from jsdialog.


Change-Id: I7eb011b58120bef2cbb29a8f53027094b76503e3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

