### PR TITLE
app.activeDocument seen as undefined:

### DIFF
--- a/browser/src/canvas/sections/CellCursorSection.ts
+++ b/browser/src/canvas/sections/CellCursorSection.ts
@@ -37,7 +37,7 @@ class CellCursorSection extends CanvasSectionObject {
 	public static adjustSizePos(defaultSizePos: number[]): number[] {
 		const splitPos = app.map._docLayer._splitPanesContext ? app.map._docLayer._splitPanesContext.getSplitPos() : null;
 
-		if (!splitPos || (splitPos.x === 0 && splitPos.y === 0) || (app.activeDocument.activeView.viewedRectangle.pX1 === 0 && app.activeDocument.activeView.viewedRectangle.pY1 === 0)) return defaultSizePos;
+		if (!splitPos || (splitPos.x === 0 && splitPos.y === 0) || !app.activeDocument || (app.activeDocument.activeView.viewedRectangle.pX1 === 0 && app.activeDocument.activeView.viewedRectangle.pY1 === 0)) return defaultSizePos;
 
 		if (defaultSizePos[0] < splitPos.x && defaultSizePos[0] + defaultSizePos[2] > splitPos.x)
 			defaultSizePos[2] = Math.max(splitPos.x - defaultSizePos[0], defaultSizePos[2] - app.activeDocument.activeView.viewedRectangle.pX1);


### PR DESCRIPTION
 CellCursorSection.adjustSizePos (CellCursorSection.ts:40)
 CellCursorSection.onDraw (CellCursorSection.ts:69)
 CanvasSectionContainer.drawSections (CanvasSectionContainer.ts:1796)
 CanvasSectionContainer.redrawCallback (CanvasSectionContainer.ts:662)
 requestAnimationFrame
 CanvasSectionContainer.requestReDraw (CanvasSectionContainer.ts:670)
 Header._updateCanvas (Control.Header.ts:145)
 Evented.fire (Events.ts:280)
 fire (Events.js:25)
 SplitPanesContext.setSplitPos (SplitPanesContext.ts:73)
 CalcSplitPanesContext.setSplitPosFromCell (CalcSplitPanesContext.ts:47)
 setSplitPosFromCell (CalcTileLayer.js:833)
 _onSplitStateChanged (CalcTileLayer.js:961)
 _onCommandStateChanged (CalcTileLayer.js:897)
 Evented.fire (Events.ts:280)
 fire (Events.js:25)
 _onStateChangedMsg (CanvasTileLayer.js:2201)
 _onMessage (CanvasTileLayer.js:1051)
 _onMessage (CalcTileLayer.js:137)
 _onMessage (Socket.js:1424)
 _emitSlurpedEvents (Socket.js:425)


Change-Id: I15aaead19b947834ff718af8218d11202541f533


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

