### PR TITLE
accessbility: add id to titlebar

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -316,7 +316,8 @@ L.Control.JSDialog = L.Control.extend({
 
 		if (instance.haveTitlebar) {
 			instance.titlebar = L.DomUtil.create('div', 'ui-dialog-titlebar ui-corner-all ui-widget-header ui-helper-clearfix', instance.form);
-			var title = L.DomUtil.create('h2', 'ui-dialog-title', instance.titlebar);
+			let title = L.DomUtil.create('h2', 'ui-dialog-title', instance.titlebar);
+			title.setAttribute('id', instance.title);
 			title.innerText = instance.title;
 			instance.titleCloseButton = L.DomUtil.create('button', 'ui-button ui-corner-all ui-widget ui-button-icon-only ui-dialog-titlebar-close', instance.titlebar);
 			const titleCloseButtonText = _('Close dialog');


### PR DESCRIPTION
The `<form>` element with role="dialog" uses in this case aria-labelledby="Character" to associate a label with the dialog, but there is no element with the ID Character. Although a heading `<h2 class="ui-dialog-title">Character</h2>` exists, it does not have an id="Character", so assistive technologies like screen readers cannot correctly associate the dialog with its label.

Change-Id: I4f540631313460c5fcef1b2420bd1d1e18d11c3d

* Target version: master 


