### PR TITLE
fix: remove unnecessary hyperlink from copy, paste and cut buttons

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2023,13 +2023,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 
 		var controls = {};
 
-		var div;
-		if (data.command === '.uno:Paste' || data.command === '.uno:Cut' || data.command === '.uno:Copy') {
-			var hyperlink = L.DomUtil.create('a', '', parentContainer);
-			div = this._createIdentifiable('div', 'unotoolbutton ' + builder.options.cssClass + ' ui-content unospan', hyperlink, data);
-		} else {
-			div = this._createIdentifiable('div', 'unotoolbutton ' + builder.options.cssClass + ' ui-content unospan', parentContainer, data);
-		}
+		let div = this._createIdentifiable('div', 'unotoolbutton ' + builder.options.cssClass + ' ui-content unospan', parentContainer, data);
 
 		controls['container'] = div;
 		div.tabIndex = -1;


### PR DESCRIPTION
Change-Id: I88ec0cb24d24b172ed85aa3fc8ebed2a06bfc173

* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

