### PR TITLE
Simplify Status bar

### DIFF
--- a/browser/src/control/Control.NavigatorPanel.ts
+++ b/browser/src/control/Control.NavigatorPanel.ts
@@ -23,6 +23,7 @@ class NavigatorPanel extends SidebarBase {
 	closeNavButton: HTMLElement;
 
 	highlightTerm: string;
+	focusQuickFind: boolean;
 
 	constructor(map: any) {
 		super(map, SidebarType.Navigator);
@@ -32,6 +33,7 @@ class NavigatorPanel extends SidebarBase {
 		super.onAdd(map);
 		this.map.on('navigator', this.onNavigator, this);
 		this.map.on('doclayerinit', this.onDocLayerInit, this);
+		this.map.on('focussearch', this.focusSearch, this);
 		this.navigationPanel = document.getElementById(`navigation-sidebar`);
 		this.floatingNavIcon = document.getElementById(`navigator-floating-icon`);
 		this.presentationControlsWrapper = this.navigationPanel.querySelector(
@@ -272,6 +274,11 @@ class NavigatorPanel extends SidebarBase {
 			} else {
 				this.switchNavigationTab('tab-navigator');
 			}
+			if (this.focusQuickFind) {
+				this.switchNavigationTab('tab-quick-find');
+				this.focusSearch();
+				this.focusQuickFind = false;
+			}
 		} else {
 			this.closeSidebar();
 		}
@@ -343,6 +350,18 @@ class NavigatorPanel extends SidebarBase {
 			this.navigationPanel.classList.remove('visible');
 			this.floatingNavIcon.classList.add('visible');
 			this.handleFloatingButtonVisibilityOnZoomChange(); // on close panel we should check if we can display nav icon or not based on zoom level
+		});
+	}
+
+	preFocusQuickFind() {
+		this.focusQuickFind = true;
+	}
+
+	focusSearch() {
+		app.layoutingService.appendLayoutingTask(() => {
+			(
+				document.getElementById('navigator-search-input') as HTMLInputElement
+			).focus();
 		});
 	}
 

--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -311,6 +311,7 @@ class StatusBar extends JSDialog.Toolbar {
 				this.showItem('permissionmode-container', true);
 				this.showItem('showcomments-container', true);
 				this.showItem('documentstatus-container', true);
+				this.showItem('search', false);
 			}
 			break;
 

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1268,6 +1268,10 @@ class UIManager extends L.Control {
 		this.map.fire('statusbarchanged');
 	}
 
+	showNavigator(): void {
+		app.socket.sendMessage('uno .uno:Navigator');
+	}
+
 	/**
 	 * Hides the status bar.
 	 * @param firstStart - Optional flag indicating if this is the initial call.
@@ -1298,7 +1302,13 @@ class UIManager extends L.Control {
 	 * Focuses the search functionality.
 	 */
 	focusSearch(): void {
-		this.showStatusBar();
+		if (this.map.isText() && !app.showNavigator) {
+			this.map.navigator.preFocusQuickFind();
+			this.showNavigator();
+		}
+		else {
+			this.showStatusBar();
+		}
 		this.map.fire('focussearch');
 	}
 

--- a/cypress_test/integration_tests/common/writer_helper.js
+++ b/cypress_test/integration_tests/common/writer_helper.js
@@ -39,5 +39,48 @@ function openFileProperties() {
 	cy.log('<< openFileProperties - end');
 }
 
+// QuickFind Related functions
+
+function openQuickFind() {
+	cy.log('>> openQuickFind - start');
+
+	cy.cGet('#quickfind-dock-wrapper').should('not.be.visible');
+
+	cy.cGet('#floating-navigator').click();
+
+	// wait for navigator to load
+	cy.cGet('#navigator-dock-wrapper').find('#contenttree').should('be.visible');
+
+	cy.cGet('#tab-quick-find').click();
+
+	cy.cGet('#quickfind-dock-wrapper').should('be.visible');
+
+	cy.log('<< openQuickFind - end');
+}
+
+function searchInQuickFind(text) {
+	cy.log('>> searchInQuickFind - start');
+
+	cy.cGet('input#navigator-search-input').clear().type(text);
+	cy.cGet('input#navigator-search-input').should('have.prop', 'value', text);
+
+	cy.cGet('#navigator-search-button').click();
+
+	cy.cGet('#numberofsearchfinds').should('not.be.empty');
+
+	cy.log('<< searchInQuickFind - end');
+}
+
+function assertQuickFindMatches(expectedCount) {
+	cy.log('>> assertQuickFindMatches - start');
+
+	cy.cGet('#numberofsearchfinds').should('have.text', expectedCount + ' results');
+
+	cy.log('<< assertQuickFindMatches - end');
+}
+
 module.exports.selectAllTextOfDoc = selectAllTextOfDoc;
 module.exports.openFileProperties = openFileProperties;
+module.exports.openQuickFind = openQuickFind;
+module.exports.searchInQuickFind = searchInQuickFind;
+module.exports.assertQuickFindMatches = assertQuickFindMatches;

--- a/cypress_test/integration_tests/desktop/writer/focus_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/focus_spec.js
@@ -15,7 +15,7 @@ describe(['tagdesktop', 'tagproxy'], 'Focus tests', function() {
 		helper.assertFocus('className', 'clipboard');
 	});
 
-	it('Search for non existing word.', function() {
+	it.skip('Search for non existing word.', function() {
 		// Move focus to the search field
 		cy.cGet('#search-input').click();
 
@@ -30,7 +30,7 @@ describe(['tagdesktop', 'tagproxy'], 'Focus tests', function() {
 		cy.cGet('#search-input').should('have.prop', 'value', text);
 	});
 
-	it('Search for existing word (with bold font).', function() {
+	it.skip('Search for existing word (with bold font).', function() {
 		// Move focus to the search field
 		cy.cGet('#search-input').click();
 
@@ -45,7 +45,7 @@ describe(['tagdesktop', 'tagproxy'], 'Focus tests', function() {
 		cy.cGet('#search-input').should('have.prop', 'value', text);
 	});
 
-	it('Search for existing word (in table).', function() {
+	it.skip('Search for existing word (in table).', function() {
 		// Move focus to the search field
 		cy.cGet('#search-input').click();
 
@@ -60,7 +60,7 @@ describe(['tagdesktop', 'tagproxy'], 'Focus tests', function() {
 		cy.cGet('#search-input').should('have.prop', 'value', text);
 	});
 
-	it('Search with fast typing.', function() {
+	it.skip('Search with fast typing.', function() {
 		// Move focus to the search field
 		cy.cGet('#search-input').click();
 

--- a/cypress_test/integration_tests/desktop/writer/quickfind_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/quickfind_spec.js
@@ -1,0 +1,57 @@
+/* global describe it cy beforeEach require */
+
+var helper = require('../../common/helper');
+var writerHelper = require('../../common/writer_helper');
+
+describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via quickfind in navigation panel' ,function() {
+
+    beforeEach(function() {
+        helper.setupAndLoadDocument('writer/search_bar.odt');
+    });
+
+    it('Search existing word.', function() {
+        writerHelper.openQuickFind();
+        writerHelper.searchInQuickFind('a');
+
+        // Highlight the first hit
+        helper.textSelectionShouldExist();
+
+        writerHelper.assertQuickFindMatches(2);
+    });
+
+    it('Search not existing word.', function() {
+        writerHelper.selectAllTextOfDoc();
+        writerHelper.openQuickFind();
+        writerHelper.searchInQuickFind('q');
+        helper.textSelectionShouldNotExist();
+    });
+
+    it('Search existing word in table.', function() {
+        writerHelper.openQuickFind();
+        writerHelper.searchInQuickFind('b'); // check character inside table
+
+        // Part of the text should be selected
+        helper.textSelectionShouldExist();
+
+        writerHelper.assertQuickFindMatches(5);
+
+    });
+
+    it('Search input should keep the focus after a part change', function() {
+        helper.typeIntoDocument('{ctrl}f');
+
+        cy.cGet('body').type('Off');
+        cy.wait(1000);
+        helper.assertFocus('id', 'navigator-search-input');
+
+        cy.cGet('body').type('i');
+        cy.wait(1000);
+        helper.assertFocus('id', 'navigator-search-input');
+    });
+
+    it('Ctrl F should open and focus quickfind', function() {
+        helper.typeIntoDocument('{ctrl}f');
+        cy.cGet('#quickfind-dock-wrapper').should('be.visible');
+        helper.assertFocus('id', 'navigator-search-input');
+    });
+});

--- a/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/searchbar_spec.js
@@ -5,7 +5,8 @@ var desktopHelper = require('../../common/desktop_helper');
 var searchHelper = require('../../common/search_helper');
 var writerHelper = require('../../common/writer_helper');
 
-describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar' ,function() {
+// TODO: no longer needed after we remove searchbar in favour of quickfind in https://github.com/CollaboraOnline/online/pull/12581
+describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar' ,function() {
 
 	beforeEach(function() {
 		helper.setupAndLoadDocument('writer/search_bar.odt');

--- a/cypress_test/integration_tests/multiuser/writer/cursor_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/cursor_spec.js
@@ -2,7 +2,7 @@
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
-var searchHelper = require('../../common/search_helper.js');
+var writerHelper = require('../../common/writer_helper.js');
 
 describe(['tagmultiuser'], 'Check cursor and view behavior', function() {
 
@@ -21,8 +21,8 @@ describe(['tagmultiuser'], 'Check cursor and view behavior', function() {
 
 		// first view goes somewhere down
 		cy.cSetActiveFrame('#iframe1');
-		searchHelper.typeIntoSearchField('P'); // avoid focus loss
-		searchHelper.typeIntoSearchField('Pellentesque porttitor');
+		writerHelper.openQuickFind();
+		writerHelper.searchInQuickFind('Pellentesque porttitor');
 		desktopHelper.assertScrollbarPosition('vertical', 380, 390);
 
 		// verify that second view is scrolled to the editor


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Once #12511 is merged, use the unified search bar on `Ctrl+F` and `Home > Search` rather than the (current) status bar search. 

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

