### PR TITLE
Writer: Home tab: Reduce number of buttons 

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -30,6 +30,7 @@
 
 	--tooltip-font-size: 0.875rem;
 	--default-font-size: 0.75rem;
+	--overflow-group-font-size: 0.7rem;
 	--medium-font-size: 0.875rem;
 	--header-font-size: 1rem;
 	/* tab min font-size */

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1306,7 +1306,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 .ui-overflow-group-label {
 	font-family: var(--jquery-ui-font);
-	font-size: var(--default-font-size);
+	font-size: var(--overflow-group-font-size);
 	color: var(--color-text-lighter);
 	flex-grow: 1;
 	text-align: center;

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -782,14 +782,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			},
 			{ type: 'separator', id: 'home-fontcombobox-break', orientation: 'vertical' },
 			{
-				'id': 'home-insert-annotation',
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:InsertAnnotation'),
-				'command': '.uno:InsertAnnotation',
-				'accessibility': { focusBack: false, combination: 'ZC', de: 'ZC' }
-			},
-			{ type: 'separator', id: 'home-insertannotation-break', orientation: 'vertical' },
-			{
 				'type': 'overflowgroup',
 				'id': 'home-paragraph',
 				'name': 'Paragraph',
@@ -948,7 +940,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				],
 				'vertical': 'true'
 			},
-			{ type: 'separator', id: 'home-stylesview-break', orientation: 'vertical' },
 			{
 				'type': 'overflowgroup',
 				'id': 'home-insert-element',


### PR DESCRIPTION
commit 127c86f48a528d44efc0923f3abeffb4037e3405 (HEAD -> master, origin/private/pedro/writer-home-tab-reduce-btns, private/pedro/writer-home-tab-reduce-btns)
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Thu Aug 14 13:02:24 2025 +0200

    Tabbed view: Overflow group labels: reduce font size
    
    These labels are there just for extra help and thus they shouldn't be
    at the same size as the default button labels etc
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I243f96c8c124c7557d2c3de9dba69e137c29ff07

commit df6f40cbec5f501aea7d8799cce844beea0212ac
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Thu Aug 14 13:00:06 2025 +0200

    Writer: Home tab: Reduce number of buttons
    
    - Remove insert comment: this button is already present in multiple
    places (Insert tab; review tab; contextual toolbar; right click menu)
    - Remove unnecessary separators (the stylesview is already contained
    within a rectangle)
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I3d1a7313c21141da7cf4a10ed4ebde02ced3ea2a
