### PR TITLE
silence 'expecting three or four values per ContextList entry' spam

### DIFF
--- a/coolkitconfig-mobile.xcu
+++ b/coolkitconfig-mobile.xcu
@@ -40,7 +40,7 @@
 <item oor:path="/org.openoffice.Office.UI/ColorScheme/ColorSchemes/org.openoffice.Office.UI:ColorScheme['LibreOfficeDev']/DocBoundaries"><prop oor:name="IsVisible" oor:op="fuse"><value>false</value></prop></item>
 
 <!-- Hide MediaPlaybackPanel on sidebar. It does not work in Online. Video playback controls are implemented by the browser.  -->
-<item oor:path="/org.openoffice.Office.UI.Sidebar/Content/PanelList/org.openoffice.Office.UI.Sidebar:Panel['MediaPlaybackPanel']"><prop oor:name="ContextList" oor:op="fuse"><value><it>any</it><it>default</it><it>hidden</it></value></prop></item>
+<item oor:path="/org.openoffice.Office.UI.Sidebar/Content/PanelList/org.openoffice.Office.UI.Sidebar:Panel['MediaPlaybackPanel']"><prop oor:name="ContextList" oor:op="fuse"><value><it>any, default, hidden</it></value></prop></item>
 
 <!-- Hyperlink insertion in MS fileformats, should behave like in excel: hyperlinks inserted into the whole cell, not only for textfields.  -->
 <item oor:path="/org.openoffice.Office.Calc/Compatibility"><prop oor:name="Links" oor:op="fuse"><value>true</value></prop></item>

--- a/coolkitconfig.xcu.in
+++ b/coolkitconfig.xcu.in
@@ -59,7 +59,7 @@
 <item oor:path="/org.openoffice.Office.Linguistic/ServiceManager/GrammarCheckerList"><prop oor:name="ro-RO" oor:op="fuse" oor:type="oor:string-list"><value><it>org.openoffice.lingu.LanguageToolGrammarChecker</it></value></prop></item>
 
 <!-- Hide MediaPlaybackPanel on sidebar. It does not work in Online. Video playback controls are implemented by the browser.  -->
-<item oor:path="/org.openoffice.Office.UI.Sidebar/Content/PanelList/org.openoffice.Office.UI.Sidebar:Panel['MediaPlaybackPanel']"><prop oor:name="ContextList" oor:op="fuse"><value><it>any</it><it>default</it><it>hidden</it></value></prop></item>
+<item oor:path="/org.openoffice.Office.UI.Sidebar/Content/PanelList/org.openoffice.Office.UI.Sidebar:Panel['MediaPlaybackPanel']"><prop oor:name="ContextList" oor:op="fuse"><value><it>any, default, hidden</it></value></prop></item>
 
 <!-- CJK/CTL settings -->
 <item oor:path="/org.openoffice.Office.Common/I18N/CJK"><prop oor:name="VerticalText" oor:op="fuse"><value>true</value></prop></item>


### PR DESCRIPTION
There is (debug) log spam of:

 warn:sfx.sidebar ... sfx2/source/sidebar/ResourceManager.cxx:537:
   expecting three or four values per ContextList entry, separated by comma, entries: any, default, hidden

This suppreses that by using the correct format for this entry. The original in officecfg/registry/data/org/openoffice/Office/UI/Sidebar.xcu is "any, Media,  visible"


Change-Id: I863a401558028a9e145d13d72189c677049b6093


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

