### PR TITLE
backport(co-25.04): fix(dark): make hyperlink preview readable

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -1281,6 +1281,7 @@ body {
 }
 
 #hyperlink-pop-up-preview p {
+	color: var(--color-main-text);
 	text-overflow: ellipsis;
 	overflow: hidden;
 	font-size: 14px;


### PR DESCRIPTION
This is a trivial backport of #12580

Previously the hyperlink preview text wouldn't change color in dark mode which led to black text on a dark background. If we make it dependent on our CSS variables then we will be able to read it in any theme


Change-Id: I6a6a6964154cd34c3c1fe15577b4c1bcf83d4656


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

