### PR TITLE
fix(canvas): requestAnimationFrame after resizing

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -589,24 +589,32 @@ class CanvasSectionContainer {
 	private redrawCallback(timestamp: number) {
 		this.drawRequest = null;
 
-		if (this.needsResize) {
-			this.needsResize = false;
-			this.canvas.width = this.width;
-			this.canvas.height = this.height;
+		const doRedraw = () => {
+			this.drawSections();
+			this.flushLayoutingTasks();
+			this.canvas.style.visibility = 'unset';
+		};
 
-			// CSS pixels can be fractional, but need to round to the same real pixels
-			var cssWidth: number = this.width / app.dpiScale; // NB. beware
-			var cssHeight: number = this.height / app.dpiScale;
-			this.canvas.style.width = cssWidth.toFixed(4) + 'px';
-			this.canvas.style.height = cssHeight.toFixed(4) + 'px';
-
-			// Avoid black default background.
-			this.clearCanvas();
+		if (!this.needsResize) {
+			doRedraw();
+			return;
 		}
 
-		this.drawSections();
-		this.flushLayoutingTasks();
-		this.canvas.style.visibility = 'unset';
+		this.needsResize = false;
+		this.canvas.width = this.width;
+		this.canvas.height = this.height;
+
+		// CSS pixels can be fractional, but need to round to the same real pixels
+		var cssWidth: number = this.width / app.dpiScale; // NB. beware
+		var cssHeight: number = this.height / app.dpiScale;
+		this.canvas.style.width = cssWidth.toFixed(4) + 'px';
+		this.canvas.style.height = cssHeight.toFixed(4) + 'px';
+
+		requestAnimationFrame(() => {
+			// Avoid black default background.
+			this.clearCanvas();
+			doRedraw();
+		});
 	}
 
 	public requestReDraw() {


### PR DESCRIPTION
When we resize the canvas (and set styles on it for HiDPI screens) we can't immediately draw on it at the new size, instead we need to wait until the next animation frame. Not waiting was causing us to draw blurry things on the canvas.


Change-Id: I6a6a69646f7c4fa0b5af9ba2f8c63ddf41c03632


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

