### PR TITLE
browser: fix changes to numeric values

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -424,7 +424,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 	},
 
 	listenNumericChanges: function (data, builder, controls, customCallback) {
-		controls.spinfield.addEventListener('change', function() {
+		controls.spinfield.addEventListener('input', function() {
 			if (!this.checkValidity())
 				return;
 


### PR DESCRIPTION
"The 'input' event listener fires after the user inputs a valid number.

Change-Id: I3c50010a22de1f8abb1ac54875a3dc6d1b4f3662
Signed-off-by: Henry Castro <hcastro@collabora.com>
