### PR TITLE
Cool#12606 Remove extra condition of textSelectionMsg.

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2262,7 +2262,7 @@ L.CanvasTileLayer = L.Layer.extend({
 	_onTextSelectionMsg: function (textMsg) {
 		var rectArray = this._getTextSelectionRectangles(textMsg);
 
-		if (rectArray.length && !this._cellSelectionArea) {
+		if (rectArray.length) {
 			TextSelections.activate();
 
 			var rectangles = rectArray.map(function (rect) {


### PR DESCRIPTION
It assumes that text selection and cell selection cannot exist simultaneously.

But they can exist simultaneously:
* Select a range of cells.
* Start editing one of the selected cells with F2 (still keeping the cell selection set).
* Select a portion of the text from currently edited cell.
* So text selection and cell selection exist at the same time.

This issue also causes copy & paste operation to not work on some systems.


Change-Id: I022d4a9354c658b92b181e128a8f6aa40d16709d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

