### PR TITLE
[Backport] slideshow: Fix 2D context detection across iframe boundaries

### DIFF
--- a/browser/src/slideshow/RenderContext.ts
+++ b/browser/src/slideshow/RenderContext.ts
@@ -30,8 +30,12 @@ abstract class RenderContext {
 		return this.gl as WebGL2RenderingContext;
 	}
 
-	public get2dGl(): CanvasRenderingContext2D {
-		return this.gl instanceof CanvasRenderingContext2D ? this.gl : null;
+	public get2dGl(): CanvasRenderingContext2D | null {
+		return this.gl &&
+			(this.gl instanceof CanvasRenderingContext2D ||
+				this.gl.constructor?.name === 'CanvasRenderingContext2D')
+			? (this.gl as CanvasRenderingContext2D)
+			: null;
 	}
 
 	public get2dOffscreen(): OffscreenCanvasRenderingContext2D {


### PR DESCRIPTION
Handle cross-window CanvasRenderingContext2D instanceof failures in windowed presentations by adding constructor name fallback check for iframe contexts.


Change-Id: Ib215ba2dede4ca4e763ffeba8cc325cb727d95ab


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

