### PR TITLE
QuickFind: Highlight matched text in results tab

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -573,6 +573,11 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	height: inherit;
 }
 
+#QuickFindPanel .ui-treeview-cell-text-content .highlighted {
+	background-color: var(--color-treeview-highlight);
+	color: var(--color-treeview-highlight-text);
+}
+
 /* search field box */
 #navigator-search {
 	padding: 8px 16px;

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -578,6 +578,12 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	color: var(--color-treeview-highlight-text);
 }
 
+#QuickFindPanel .ui-treeview-cell-text-content.page-divider {
+	/*TODO: style however we want*/
+	font-weight: bold;
+	font-size: large;
+}
+
 /* search field box */
 #navigator-search {
 	padding: 8px 16px;

--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -478,6 +478,9 @@ class TreeViewControl {
 		index: any,
 		builder: JSBuilder,
 	) {
+		const PAGE_ENTRY_PREFIX = '-$#~';
+		const PAGE_ENTRY_SUFFIX = '~#$-';
+
 		const text =
 			builder._cleanText(entry.columns[index].text) ||
 			builder._cleanText(entry.text);
@@ -500,7 +503,19 @@ class TreeViewControl {
 			img.alt = text;
 		} else {
 			let cell;
-			if (treeViewData.highlightTerm !== undefined) {
+			if (this.isPageDivider(entry, PAGE_ENTRY_PREFIX, PAGE_ENTRY_SUFFIX)) {
+				cell = L.DomUtil.create(
+					'span',
+					builder.options.cssClass +
+						` ui-treeview-cell-text-content page-divider`,
+					parent,
+				);
+				cell.innerText = this.getPageEntryText(
+					entry.text,
+					PAGE_ENTRY_PREFIX,
+					PAGE_ENTRY_SUFFIX,
+				);
+			} else if (treeViewData.highlightTerm !== undefined) {
 				cell = this.createHighlightedCell(
 					parent,
 					entry,
@@ -582,6 +597,30 @@ class TreeViewControl {
 		}
 
 		return mainSpan;
+	}
+
+	isPageDivider(
+		entry: TreeEntryJSON,
+		pageEntryPrefix: string,
+		pageEntrySuffix: string,
+	): boolean {
+		// Matches page divider prefix and suffix: -$#~ PAGE ~#$- as set in core: QuickFindPanel::FillSearchFindsList() (QuickFindPanel.cxx)
+		return (
+			entry.text &&
+			entry.text.startsWith(pageEntryPrefix) &&
+			entry.text.endsWith(pageEntrySuffix)
+		);
+	}
+
+	getPageEntryText(
+		text: string,
+		pageEntryPrefix: string,
+		pageEntrySuffix: string,
+	): string {
+		return text.substring(
+			pageEntryPrefix.length,
+			text.length - pageEntrySuffix.length,
+		);
 	}
 
 	caseInsensitiveSplit(text: string, delimeter: string) {

--- a/cypress_test/integration_tests/desktop/writer/navigator_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/navigator_spec.js
@@ -8,7 +8,6 @@ describe(['tagdesktop'], 'Scroll through document, modify heading', function() {
 	function expandSecion(name) {
 		cy.cGet('#contenttree')
 			.contains('.jsdialog.sidebar.ui-treeview-cell-text', name)
-			.parent() // .ui-treeview-cell-text
 			.parent() // .ui-treeview-cell
 			.parent() // div - column
 			.parent() // .ui-treeview-entry

--- a/cypress_test/integration_tests/desktop/writer/navigator_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/navigator_spec.js
@@ -5,7 +5,7 @@ var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'Scroll through document, modify heading', function() {
 
-	function expandSecion(name) {
+	function expandSection(name) {
 		cy.cGet('#contenttree')
 			.contains('.jsdialog.sidebar.ui-treeview-cell-text', name)
 			.parent() // .ui-treeview-cell
@@ -30,9 +30,9 @@ describe(['tagdesktop'], 'Scroll through document, modify heading', function() {
 	it('Jump to element. Navigator -> Document', function() {
 		// Expand Tables, Frames, Images
 		// Note click()/dblclick() scrolls the contenttree even if it would be not needed to click
-		expandSecion('Tables');
-		expandSecion('Frames');
-		expandSecion('Images');
+		expandSection('Tables');
+		expandSection('Frames');
+		expandSection('Images');
 
 		cy.wait(500);
 
@@ -69,9 +69,9 @@ describe(['tagdesktop'], 'Scroll through document, modify heading', function() {
 	it('Jump to element even when cursor not visible', function() {
 		// Expand Tables, Frames, Images
 		// Note click()/dblclick() scrolls the contenttree even if it would be not needed to click
-		expandSecion('Tables');
-		expandSecion('Frames');
-		expandSecion('Images');
+		expandSection('Tables');
+		expandSection('Frames');
+		expandSection('Images');
 
 		//Scroll back to Top
 		cy.cGet('#navigator-dock-wrapper').scrollTo(0,0, { ensureScrollable: false });


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Highlight matched text in search results.
e.g. searching for `prod` used to yield results like
`Collabora [Prod]uctivity` now we get: 
<img width="248" height="68" alt="image" src="https://github.com/user-attachments/assets/66543d2e-9d1b-4892-be0d-621df415a4ae" />

<details>
<summary>Outdated: Original issue with square brackets</summary>

~~However to continue with this approach we need to deal with cases where the user has placed square brackets in the document which is currently breaking it:~~
<img width="659" height="482" alt="image" src="https://github.com/user-attachments/assets/9b188f0c-586d-4ec4-9ecc-1cc1688a577f" />

</details>
Fixed by searching for search term inbetween brackets


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

