### PR TITLE
cool#12608: Check windowId when calling removeTextContext.

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -1176,11 +1176,12 @@ L.TextInput = L.Layer.extend({
 
 		this._followMyCursor();
 
+		const windowId = app.map._docLayer._formID !== null ? app.map._docLayer._formID : this._map.getWinId();
+
 		/// TODO: rename the event to 'removetextcontent' as soon as coolwsd supports it
 		/// TODO: Ask Marco about it
 		app.socket.sendMessage(
-			'removetextcontext id=' +
-			this._map.getWinId() +
+			'removetextcontext id=' + windowId +
 			' before=' + before +
 			' after=' + after
 		);

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1871,6 +1871,11 @@ L.CanvasTileLayer = L.Layer.extend({
 
 		this._cursorAtMispelledWord = obj.mispelledWord ? Boolean(parseInt(obj.mispelledWord)).valueOf() : false;
 
+		if (obj.controlEvent === true)
+			this._formID = obj.windowId;
+		else
+			this._formID = null;
+
 		// Remember the last position of the caret (in core pixels).
 		this._cursorPreviousPositionCorePixels = app.file.textCursor.rectangle.clone();
 
@@ -3763,6 +3768,12 @@ L.CanvasTileLayer = L.Layer.extend({
 
 	onAdd: function (map) {
 		this._initContainer();
+
+		/*
+			Because of special handling of delete and backspace chars, we need to know which Writer form is focused.
+			When sending removeTextContext event to core side, we send the formID instead of the map id.
+		*/
+		this._formID = null;
 
 		// Initiate selection handles.
 		TextSelections.initiate();


### PR DESCRIPTION
Issue:
When calling the function, if a form control in Writer is focused, the command works on the wrong window. It deletes text from the document. It should delete the content from the form control, which has a different window id.


Change-Id: I0371d3ea24b8b4ffdf8201df7fcc0c152470404f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

