### PR TITLE
Search: Remove search box and use Find dialog instead

### DIFF
--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -225,11 +225,6 @@ class StatusBar extends JSDialog.Toolbar {
 
 	getToolItems() {
 		return [
-			{type: 'searchedit',  id: 'search', placeholder: _('Search'), text: ''},
-			{type: 'customtoolitem',  id: 'searchprev', command: 'searchprev', text: _UNO('.uno:UpSearch'), enabled: false, pressAndHold: true},
-			{type: 'customtoolitem',  id: 'searchnext', command: 'searchnext', text: _UNO('.uno:DownSearch'), enabled: false, pressAndHold: true},
-			{type: 'customtoolitem',  id: 'cancelsearch', command: 'cancelsearch', text: _('Cancel the search'), visible: false},
-			{type: 'separator', id: 'searchbreak', orientation: 'vertical'},
 			this._generateHtmlItem('statusdocpos'), 					// spreadsheet
 			this._generateHtmlItem('rowcolselcount', 1), 					// spreadsheet
 			this._generateHtmlItem('statepagenumber'), 					// text
@@ -311,7 +306,6 @@ class StatusBar extends JSDialog.Toolbar {
 				this.showItem('permissionmode-container', true);
 				this.showItem('showcomments-container', true);
 				this.showItem('documentstatus-container', true);
-				this.showItem('search', false);
 			}
 			break;
 

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -1111,12 +1111,6 @@ $(document).ready(function() {
 function setupToolbar(e) {
 	map = e;
 
-	map.on('focussearch', function () {
-		var entry = L.DomUtil.get('search-input');
-		entry.focus();
-		entry.select();
-	});
-
 	map.on('search', function (e) {
 		var searchInput = L.DomUtil.get('search-input');
 		var toolbar = window.mode.isMobile() ? app.map.mobileSearchBar: app.map.statusBar;

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1310,7 +1310,7 @@ class UIManager extends L.Control {
 			this.showNavigator();
 		}
 		else {
-			this.showStatusBar();
+			app.socket.sendMessage('uno .uno:SearchDialog');
 		}
 		this.map.fire('focussearch');
 	}

--- a/cypress_test/integration_tests/common/find_helper.js
+++ b/cypress_test/integration_tests/common/find_helper.js
@@ -1,0 +1,75 @@
+/* global cy require */
+
+// Find dialog related helper methods
+var helper = require('./helper');
+
+// Open the find dialog
+function openFindDialog() {
+    cy.log('>> openFindDialog - start');
+
+    cy.cGet('.jsdialog-window').should('not.exist');
+
+    helper.typeIntoDocument('{ctrl}f');
+
+    cy.cGet('.jsdialog-window').should('exist');
+    cy.cGet('#FindReplaceDialog').should('exist');
+
+    cy.log('<< openFindDialog - end');
+}
+
+// Type some text into the search field, which will
+// trigger searching automatically.
+// Parameters:
+// text - the text to type in
+function typeIntoSearchField(text) {
+    cy.log('>> typeIntoSearchField - start');
+
+    cy.cGet('input#searchterm-input-dialog').clear().type(text);
+    cy.cGet('input#searchterm-input-dialog').should('have.prop', 'value', text);
+
+    cy.cGet('#search').should('not.be.disabled');
+    cy.cGet('#searchall').should('not.be.disabled'); //doesnt seem to exist in impress
+    cy.cGet('#backsearch').should('not.be.disabled');
+
+    cy.log('<< typeIntoSearchField - end');
+}
+
+// Move to the next search result in the document.
+function findNext() {
+    cy.log('>> findNext - start');
+
+    cy.cGet('#search').should('not.have.attr', 'disabled');
+    cy.cGet('#search').click();
+
+    cy.log('<< findNext - end');
+}
+
+// Move to the previous search result in the document.
+function findPrev() {
+    cy.log('>> findPrev - start');
+
+    cy.cGet('#backsearch').should('not.have.attr', 'disabled');
+    cy.cGet('#backsearch').click();
+
+    cy.log('<< findPrev - end');
+}
+
+function closeFindDialog() {
+    cy.log('>> closeFindDialog - start');
+
+    cy.cGet('.jsdialog-window').should('exist');
+    cy.cGet('#FindReplaceDialog').should('exist');
+
+    cy.cGet('.ui-dialog-titlebar-close').click();
+
+    cy.cGet('.jsdialog-window').should('not.exist');
+    cy.cGet('#FindReplaceDialog').should('not.exist');
+
+    cy.log('<< closeFindDialog - end');
+}
+
+module.exports.openFindDialog = openFindDialog;
+module.exports.typeIntoSearchField = typeIntoSearchField;
+module.exports.findNext = findNext;
+module.exports.findPrev = findPrev;
+module.exports.closeFindDialog = closeFindDialog;

--- a/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
@@ -31,7 +31,9 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell
 		cy.cGet(helper.addressInputSelector).should('have.value', 'Z11');
 
 		desktopHelper.assertScrollbarPosition('horizontal', 205, 330);
-		cy.cGet('input#search-input').clear().type('FIRST{enter}');
+		helper.typeIntoDocument('{ctrl}f');
+		cy.cGet('input#searchterm-input-dialog').clear().type('FIRST');
+		cy.cGet('#search').find('button').click();
 
 		cy.cGet(helper.addressInputSelector).should('have.value', 'A10');
 		desktopHelper.assertScrollbarPosition('horizontal', 40, 60);

--- a/cypress_test/integration_tests/desktop/calc/find_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/find_dialog_spec.js
@@ -2,9 +2,9 @@
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
-var searchHelper = require('../../common/search_helper');
+var findHelper = require('../../common/find_helper');
 
-describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar.', function() {
+describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via find dialog.', function() {
 
 	beforeEach(function() {
 		helper.setupAndLoadDocument('calc/search_bar.ods');
@@ -14,25 +14,26 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar.'
 
 	it('Search existing word.', function() {
 		helper.setDummyClipboardForCopy();
-		searchHelper.typeIntoSearchField('a');
+		findHelper.openFindDialog();
+		findHelper.typeIntoSearchField('a');
 
-		searchHelper.searchNext();
+		findHelper.findNext();
 
 		// First cell should be selected
 		cy.cGet(helper.addressInputSelector).should('have.value', 'A1');
 		helper.copy();
 		cy.cGet('#copy-paste-container table td').should('have.text', 'a');
 
-		searchHelper.searchNext();
+		findHelper.findNext();
 		cy.cGet(helper.addressInputSelector).should('have.value', 'B1');
 
-		searchHelper.typeIntoSearchField('c');
-		searchHelper.searchNext();
+		findHelper.typeIntoSearchField('c');
+		findHelper.findNext();
 
 		helper.copy();
 		cy.cGet('#copy-paste-container table td').should('have.text', 'c');
 
-		searchHelper.searchNext();
+		findHelper.findNext();
 		cy.cGet(helper.addressInputSelector).should('have.value', 'A301');
 	});
 
@@ -52,24 +53,26 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar.'
 		});
 
 		helper.setDummyClipboardForCopy();
-		searchHelper.typeIntoSearchField('a');
+		findHelper.openFindDialog();
+		findHelper.typeIntoSearchField('a');
 
-		searchHelper.searchNext();
+		findHelper.findNext();
 
 		cy.cGet(helper.addressInputSelector).should('have.value', 'A1');
 		desktopHelper.assertScrollbarPosition('vertical', 10, 30);
 
 		desktopHelper.scrollViewDown();
 
-		searchHelper.typeIntoSearchField('c');
-		searchHelper.searchNext();
+		findHelper.typeIntoSearchField('c');
+		findHelper.findNext();
 
 		cy.cGet(helper.addressInputSelector).should('have.value', 'C1');
 		desktopHelper.assertScrollbarPosition('vertical', 10, 30);
 	});
 
 	it('Search not existing word.', function() {
-		searchHelper.typeIntoSearchField('q');
+		findHelper.openFindDialog();
+		findHelper.typeIntoSearchField('q');
 
 		// Should be no new selection
 		cy.cGet(helper.addressInputSelector).should('have.value', 'A2');
@@ -77,22 +80,23 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar.'
 
 	it('Search next / prev instance.', function() {
 		helper.setDummyClipboardForCopy();
-		searchHelper.typeIntoSearchField('d');
-		searchHelper.searchNext();
+		findHelper.openFindDialog();
+		findHelper.typeIntoSearchField('d');
+		findHelper.findNext();
 
 		cy.cGet(helper.addressInputSelector).should('have.value', 'A472');
 		helper.copy();
 		cy.cGet('#copy-paste-container table td').should('have.text', 'd');
 
 		// Search next instance
-		searchHelper.searchNext();
+		findHelper.findNext();
 
 		cy.cGet(helper.addressInputSelector).should('have.value', 'D1');
 		helper.copy();
 		cy.cGet('#copy-paste-container table td').should('have.text', 'd');
 
 		// Search prev instance
-		searchHelper.searchPrev();
+		findHelper.findPrev();
 
 		cy.cGet(helper.addressInputSelector).should('have.value', 'A472');
 		helper.copy();
@@ -101,43 +105,27 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Searching via search bar.'
 
 	it('Search wrap at document end', function() {
 		helper.setDummyClipboardForCopy();
-		searchHelper.typeIntoSearchField('a');
+		findHelper.openFindDialog();
+		findHelper.typeIntoSearchField('a');
 
-		searchHelper.searchNext();
+		findHelper.findNext();
 
 		cy.cGet(helper.addressInputSelector).should('have.value', 'A1');
 		helper.copy();
 		cy.cGet('#copy-paste-container table td').should('have.text', 'a');
 
 		// Search next instance
-		searchHelper.searchNext();
+		findHelper.findNext();
 
 		cy.cGet(helper.addressInputSelector).should('have.value', 'B1');
 		helper.copy();
 		cy.cGet('#copy-paste-container table td').should('have.text', 'a');
 
 		// Search next instance, which is in the beginning of the document.
-		searchHelper.searchNext();
+		findHelper.findNext();
 
 		cy.cGet(helper.addressInputSelector).should('have.value', 'A1');
 		helper.copy();
 		cy.cGet('#copy-paste-container table td').should('have.text', 'a');
 	});
-
-	it('Cancel search.', function() {
-		helper.setDummyClipboardForCopy();
-		searchHelper.typeIntoSearchField('a');
-
-		searchHelper.searchNext();
-
-		cy.cGet(helper.addressInputSelector).should('have.value', 'A1');
-		helper.copy();
-		cy.cGet('#copy-paste-container table td').should('have.text', 'a');
-
-		// Cancel search -> selection removed
-		searchHelper.cancelSearch();
-
-		cy.cGet('input#search-input').should('be.visible');
-	});
-
 });

--- a/cypress_test/integration_tests/desktop/impress/find_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/find_dialog_spec.js
@@ -1,57 +1,71 @@
 /* global describe it cy expect beforeEach require */
 
 var helper = require('../../common/helper');
-var searchHelper = require('../../common/search_helper');
+var findHelper = require('../../common/find_helper');
 
-describe.skip(['tagdesktop'], 'Searching via search bar' ,function() {
+describe(['tagdesktop'], 'Searching via find dialog' ,function() {
 
 	beforeEach(function() {
 		helper.setupAndLoadDocument('impress/search_bar.odp');
 	});
 
 	it('Search existing word.', function() {
-		searchHelper.typeIntoSearchField('a');
-		searchHelper.searchNext();
+		helper.setDummyClipboardForCopy();
+		findHelper.openFindDialog();
+		findHelper.typeIntoSearchField('a');
+
+		findHelper.findNext();
+		findHelper.closeFindDialog(); // we cant copy the document text while the dialog is still open
 		// A shape and some text should be selected
 		//cy.get('.transform-handler--rotate')
 		//	.should('be.not.visible');
+
 		helper.textSelectionShouldExist();
 
+		helper.copy();
 		helper.expectTextForClipboard('a');
 	});
 
 	it('Search not existing word.', function() {
 		cy.cGet('.leaflet-layer').dblclick('center');
-		cy.wait(2000);
 		helper.selectAllText();
-		cy.wait(2000);
 		helper.textSelectionShouldExist();
-		searchHelper.typeIntoSearchField('q');
-		searchHelper.searchNext();
+
+		findHelper.openFindDialog();
+		findHelper.typeIntoSearchField('q');
+		findHelper.findNext();
+
 		helper.textSelectionShouldNotExist();
 	});
 
 	it('Search next / prev instance.', function() {
-		searchHelper.typeIntoSearchField('a');
+		helper.setDummyClipboardForCopy();
+		findHelper.openFindDialog();
+		findHelper.typeIntoSearchField('a');
 
-		searchHelper.searchNext();
+		findHelper.findNext();
+		findHelper.closeFindDialog();
 
 		// A shape and some text should be selected
 		//cy.get('.transform-handler--rotate')
 		//	.should('be.not.visible');
-		cy.cGet('.text-selection-handle-start').should('be.visible');
 
 		helper.getCursorPos('left', 'cursorOrigLeft');
 
+		helper.textSelectionShouldExist();
+		helper.copy();
 		helper.expectTextForClipboard('a');
 
 		// Search next instance
-		searchHelper.searchNext();
+		findHelper.openFindDialog();
+		findHelper.findNext();
+		findHelper.closeFindDialog();
 
 		//cy.get('.transform-handler--rotate')
 		//	.should('be.not.visible');
-		cy.cGet('.text-selection-handle-start').should('be.visible');
 
+		helper.textSelectionShouldExist();
+		helper.copy();
 		helper.expectTextForClipboard('a');
 
 		cy.get('@cursorOrigLeft')
@@ -63,13 +77,15 @@ describe.skip(['tagdesktop'], 'Searching via search bar' ,function() {
 			});
 
 		// Search prev instance
-		searchHelper.searchPrev();
+		findHelper.openFindDialog();
+		findHelper.findPrev();
+		findHelper.closeFindDialog();
 
 		//cy.get('.transform-handler--rotate')
 		//	.should('be.not.visible');
-		cy.cGet('.text-selection-handle-start')
-			.should('be.visible');
 
+		helper.textSelectionShouldExist();
+		helper.copy();
 		helper.expectTextForClipboard('a');
 
 		cy.get('@cursorOrigLeft')
@@ -82,31 +98,34 @@ describe.skip(['tagdesktop'], 'Searching via search bar' ,function() {
 	});
 
 	it('Search wrap at the document end.', function() {
-		searchHelper.typeIntoSearchField('a');
+		helper.setDummyClipboardForCopy();
+		findHelper.openFindDialog();
+		findHelper.typeIntoSearchField('a');
 
-		searchHelper.searchNext();
+		findHelper.findNext();
+		findHelper.closeFindDialog();
 
 		// A shape and some text should be selected
 		//cy.get('.transform-handler--rotate')
 		//	.should('be.not.visible');
-		cy.cGet('.text-selection-handle-start')
-			.should('be.visible');
-
+		helper.textSelectionShouldExist();
+		helper.copy();
 		helper.expectTextForClipboard('a');
 
 		helper.getCursorPos('left', 'cursorOrigLeft');
 
 		// Search next instance
-		searchHelper.searchNext();
+		findHelper.openFindDialog();
+		findHelper.findNext();
+		findHelper.closeFindDialog();
 
 		//cy.get('.transform-handler--rotate')
 		//	.should('be.not.visible');
-		cy.cGet('.text-selection-handle-start')
-			.should('be.visible');
-
+		helper.textSelectionShouldExist();
+		helper.copy();
 		helper.expectTextForClipboard('a');
 
-		cy.cGet('@cursorOrigLeft')
+		cy.get('@cursorOrigLeft')
 			.then(function(cursorOrigLeft) {
 				cy.cGet('.blinking-cursor')
 					.should(function(cursor) {
@@ -115,44 +134,22 @@ describe.skip(['tagdesktop'], 'Searching via search bar' ,function() {
 			});
 
 		// Search next instance, which is in the beginning of the document.
-		searchHelper.searchNext();
+		findHelper.openFindDialog();
+		findHelper.findNext();
+		findHelper.closeFindDialog();
 
 		//cy.get('.transform-handler--rotate')
 		//	.should('be.not.visible');
-		cy.cGet('.text-selection-handle-start')
-			.should('be.visible');
-
+		helper.textSelectionShouldExist();
+		helper.copy();
 		helper.expectTextForClipboard('a');
 
-		cy.cGet('@cursorOrigLeft')
+		cy.get('@cursorOrigLeft')
 			.then(function(cursorOrigLeft) {
 				cy.cGet('.blinking-cursor')
 					.should(function(cursor) {
 						expect(cursor.offset().left).to.be.equal(cursorOrigLeft);
 					});
 			});
-	});
-	it('Cancel search.', function() {
-		searchHelper.typeIntoSearchField('a');
-
-		searchHelper.searchNext();
-
-		//cy.get('.transform-handler--rotate')
-		//	.should('be.not.visible');
-		cy.cGet('.text-selection-handle-start')
-			.should('be.visible');
-
-		helper.expectTextForClipboard('a');
-
-		// Cancel search -> selection removed
-		searchHelper.cancelSearch();
-
-		cy.cGet('.transform-handler--rotate')
-			.should('not.exist');
-		cy.cGet('.text-selection-handle-start')
-			.should('not.exist');
-
-		cy.cGet('input#search-input')
-			.should('be.visible');
 	});
 });


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Remove search box from the status bar, route `Ctrl+F` to the find and replace dialog (find tab is open first by default).

### TODO

- [ ] Focus search the search field in the dialog on `Ctrl+F`
- [ ] On enter, perform search (core change)

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

