### PR TITLE
Formulas tab: keep active in spreadsheets on context change

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -19,11 +19,13 @@ L.Control.Notebookbar = L.Control.extend({
 	_showNotebookbar: false,
 	_RTL: false,
 	_lastContext: null,
+	_lastSelectedTabName: null,
 
 	container: null,
 	builder: null,
 
 	HOME_TAB_ID: 'Home-tab-label',
+	FORMULAS_TAB_ID: 'Formula-tab-label',
 
 	additionalShortcutButtons: [],
 
@@ -263,8 +265,13 @@ L.Control.Notebookbar = L.Control.extend({
 		this.createShortcutsBar();
 	},
 
-	selectedTab: function() {
+	selectedTab: function(tabName) {
 		// implement in child classes
+		this._lastSelectedTabName = tabName;
+	},
+
+	isTabSelected: function(tabName) {
+		return this._lastSelectedTabName === tabName;
 	},
 
 	getTabs: function() {
@@ -517,11 +524,17 @@ L.Control.Notebookbar = L.Control.extend({
 			return;
 		}
 
+		const docType = this._map.getDocType();
+		
+		if (docType === 'spreadsheet' && this.isTabSelected('Formulas')) {
+			this.updateButtonVisibilityForContext(requestedContext, this.FORMULAS_TAB_ID);
+			return;
+		}
+
 		if (contextTab) {
 			// Switch to the tab of the context, unless we currently show the review tab
 			// for text documents, where jumping to the next change would possibly
 			// switch to the Home or Table tabs, which is not wanted.
-			var docType = this._map.getDocType();
 			if (docType !== 'text' || currentlySelectedTabName !== 'Review') {
 				contextTab.click();
 			}


### PR DESCRIPTION
Change-Id: I1cb0809abd7838776e9d66cb7ea8abfb4ade4c88


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- In Calc, selecting a pre-canned function or double-clicking a cell caused a context change that switched the UI away from the Formulas tab.

- This prevents unexpected formula tab switching and keeps the user workflow stable while editing formulas.

### PREVIEW

https://github.com/user-attachments/assets/96e1ac5c-a799-45ec-9d5a-66233d9b8aad



- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

