### PR TITLE
Feat: Add more button in notebookbar groups

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -26,6 +26,7 @@
 .hasnotebookbar .ui-content.unotoolbutton.inline,
 .hasnotebookbar .ui-content.unotoolbutton:not(.has-label):not(.inline),
 .sidebar.unotoolbutton,
+.ui-overflow-group-more.unotoolbutton,
 .jsdialog.unotoolbutton,
 .notebookbar.unotoolbutton,
 #closebutton {
@@ -75,6 +76,7 @@
 .hasnotebookbar .ui-content.unotoolbutton.selected:hover,
 .hasnotebookbar .ui-content.unotoolbutton.selected:not(.has-label):not(.inline):hover,
 .sidebar.unotoolbutton.selected:hover,
+.ui-overflow-group-more.unotoolbutton:hover,
 .notebookbar.unotoolbutton.selected:hover,
 .jsdialog.unotoolbutton.selected:hover {
 	color: var(--color-text-darker);

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -65,7 +65,8 @@ img.sidebar.ui-image {
 	display: flex;
 }
 
-.ui-expander-icon-right .sidebar.unotoolbutton {
+.ui-expander-icon-right .sidebar.unotoolbutton,
+.ui-expander-icon-right .ui-overflow-group-more.unotoolbutton {
 	margin: 0px !important;
 }
 
@@ -74,7 +75,9 @@ img.sidebar.ui-image {
 }
 
 .ui-expander-icon-right.jsdialog.sidebar .sidebar.unotoolbutton button,
-.ui-expander-icon-right.jsdialog.sidebar .sidebar.unotoolbutton button img {
+.ui-expander-icon-right.jsdialog.sidebar .ui-overflow-group-more.unotoolbutton button,
+.ui-expander-icon-right.jsdialog.sidebar .sidebar.unotoolbutton button img,
+.ui-expander-icon-right.jsdialog.sidebar .ui-overflow-group-more.unotoolbutton button img {
 	width: 10px;
 	height: 10px;
 	padding: 0;
@@ -168,7 +171,8 @@ div.sidebar.ui-grid .checkbutton.sidebar,
 .sidebar.ui-grid-cell .sidebar.ui-pushbutton {
 	margin: 0;
 }
-.sidebar.unotoolbutton {
+.sidebar.unotoolbutton,
+.ui-overflow-group-more.unotoolbutton {
 	margin-right: 3px;
 	padding: 0 !important;
 }

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -455,6 +455,9 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'id': 'home-font',
 				'name': 'Font',
 				'accessibility': { focusBack: true,	combination: 'FF', de: null },
+				'more': {
+					'command':'.uno:CellTextDlg'
+				},
 				'children': [
 				{
 					'id': 'Home-Section-Format',
@@ -598,6 +601,9 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'id': 'home-alignment',
 				'name': 'Alignment',
 				'accessibility': { focusBack: true,	combination: 'AT', de: null },
+				'more': {
+					'command':'.uno:Hyphenate'
+				},
 				'children' : [
 				{
 					'id': 'Home-Section-Align',
@@ -731,6 +737,9 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'id': 'home-number-format',
 				'name': 'Number',
 				'accessibility': { focusBack: true,	combination: 'N', de: null },
+				'more': {
+					'command':'.uno:FormatCellDialog'
+				},
 				'children' : [
 				{
 					'id': 'Home-Section-Number',
@@ -3144,7 +3153,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				]
 			},
 			{ type: 'separator', id: 'picture-wrapright-break', orientation: 'vertical' },
-						{
+				{
 				'type': 'overflowgroup',
 				'id': 'picture-align',
 				'name':_('Align'),
@@ -3211,7 +3220,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				]
 			},
 			{ type: 'separator', id: 'picture-aligndown-break', orientation: 'vertical' },
-						{
+				{
 				'type': 'overflowgroup',
 				'id': 'picture-arrange',
 				'name':_('Arrange'),

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -653,6 +653,9 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				'id': 'home-font',
 				'name':_('Font'),
 				'accessibility': { focusBack: true, combination: 'FN', de: null },
+				'more': {
+					'command':'.uno:FontDialog'
+				},
 				'children' : [					
 					{
 						'type': 'container',
@@ -877,6 +880,9 @@ L.Control.NotebookbarDraw = L.Control.NotebookbarImpress.extend({
 				'id': 'home-paragraph',
 				'name':_('Paragraph'),
 				'accessibility': { focusBack: true, combination: 'BD', de: null },
+				'more': {
+					'command':'.uno:ParagraphDialog'
+				},
 				'children' : [
 					{
 						'type': 'container',

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -768,6 +768,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'id': 'home-slide-layout',
 				'name':_('Slide Layout'),
 				'accessibility': { focusBack: true, combination: 'CS', de: null },
+				'more': {
+					'command':'.uno:PageSetup'
+				},
 				'children' : [
 					{
 						'id': 'home-create-slide:NewSlideLayoutMenu',
@@ -808,6 +811,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'id': 'home-character',
 				'name':_('Character'),
 				'accessibility': { focusBack: true, combination: 'FN', de: null },
+				'more': {
+					'command':'.uno:FontDialog'
+				},
 				'children' : [
 					{
 						'type': 'container',
@@ -943,6 +949,9 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'home-paragraph',
+				'more': {
+					'command':'.uno:ParagraphDialog'
+				},
 				'name':_('Paragraph'),
 				'accessibility': { focusBack: true, combination: 'DB', de: null },
 				'children' : [

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -646,6 +646,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'type': 'overflowgroup',
 				'id': 'home-font',
 				'name': 'Font',
+				'more': {
+					'command':'.uno:FontDialog'
+				},
 				'accessibility': { focusBack: false,	combination: 'FF',	de: null },
 				'children': [
 			{
@@ -788,6 +791,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'id': 'home-paragraph',
 				'name': 'Paragraph',
 				'accessibility': { focusBack: false, 	combination: 'U',	de: 'AA' },
+				'more': {
+					'command':'.uno:ParagraphDialog'
+				},
 				'children': [
 					{
 						'type': 'container',
@@ -945,8 +951,8 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			},
 			{
 				'type': 'overflowgroup',
-				'id': 'home-insert-element',
-				'name': _('Insert Control'),
+				'id': 'home-illustrations',
+				'name':_('Illustrations'),
 				'accessibility': { focusBack: false,	combination: 'IT',	de:	null },
 				'children': [
 					{
@@ -2018,6 +2024,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'id': 'layout-align',
 				'name':_('Align'),
 				'accessibility': { focusBack: false,	combination: 'OL', de: null },
+				'more': {
+					'command':'.uno:TransformDialog'
+				},
 				'children' : [
 					{
 						'type': 'container',
@@ -2085,6 +2094,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'id': 'layout-arrange',
 				'name':_('Arrange'),
 				'accessibility': { focusBack: false,	combination: 'OF', de: null },
+				'more': {
+					'command':'.uno:TransformDialog'
+				},
 				'children' : [
 					{
 						'type': 'container',
@@ -3222,6 +3234,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'id': 'shape-align',
 				'name':_('Align'),
 				'accessibility': { focusBack: false, combination: 'SA', de: null },
+				'more': {
+					'command':'.uno:TransformDialog'
+				},
 				'children' : [
 					{
 						'type': 'container',
@@ -3277,6 +3292,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'id': 'shape-arrange',
 				'name':_('Arrange'),
 				'accessibility': { focusBack: false, combination: 'AR', de: null },
+				'more': {
+					'command':'.uno:TransformDialog'
+				},
 				'children' : [
 					{
 						'type': 'container',
@@ -3368,6 +3386,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'id': 'picture-adjustments',
 				'name':_('Image Controls'),
 				'accessibility': { focusBack: false, combination: 'BN', de: null },
+				'more': {
+					'command':'.uno:GraphicDialog'
+				},
 				'children' : [
 					{
 						'type': 'container',
@@ -3533,6 +3554,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'id': 'picture-align',
 				'name':_('Align'),
 				'accessibility': { focusBack: false, combination: 'BP', de: null },
+				'more': {
+					'command':'.uno:GraphicDialog'
+				},
 				'children' : [
 					{
 						'type': 'container',
@@ -3588,6 +3612,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'id': 'picture-arrange',
 				'name':_('Arrange'),
 				'accessibility': { focusBack: false, combination: 'AB', de: null },
+				'more': {
+					'command':'.uno:GraphicDialog'
+				},
 				'children' : [
 					{
 						'type': 'container',

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -171,8 +171,11 @@ interface ContainerWidgetJSON extends WidgetJSON {
 interface OverflowGroupWidgetJSON extends ContainerWidgetJSON {
 	name: string; // visible name of a group
 	icon?: string; // Optional icon name. Otherwise it will be guessed.
+	more?: MoreOptions;
 }
-
+interface MoreOptions {
+	command: string;
+}
 interface OverflowGroupContainer extends Element {
 	foldGroup?: () => void;
 	isCollapsed?: () => boolean;

--- a/browser/src/control/jsdialog/Widget.OverflowGroup.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowGroup.ts
@@ -30,10 +30,49 @@ function migrateItems(from: HTMLElement, to: HTMLElement) {
 	});
 }
 
+function createMoreButton(
+	id: string,
+	more: MoreOptions,
+	groupLabel: HTMLElement,
+): HTMLElement {
+	const moreOptionsButton = document.createElement('button');
+	moreOptionsButton.className = 'ui-content unobutton';
+	moreOptionsButton.id = `${id}-more-button`;
+	moreOptionsButton.setAttribute('aria-label', `More options for ${id}`);
+	moreOptionsButton.setAttribute('aria-pressed', 'false');
+
+	const img = document.createElement('img');
+	app.LOUtil.setImage(img, 'lc_morebutton.svg', app.map);
+	moreOptionsButton.appendChild(img);
+
+	const unoToolButtonDiv = document.createElement('div');
+	unoToolButtonDiv.className = 'unotoolbutton ui-overflow-group-more';
+	unoToolButtonDiv.tabIndex = -1;
+	unoToolButtonDiv.setAttribute('data-cooltip', `More options for ${id}`);
+	unoToolButtonDiv.appendChild(moreOptionsButton);
+
+	const expanderIconRightDiv = document.createElement('div');
+	expanderIconRightDiv.className = 'ui-expander-icon-right jsdialog sidebar';
+	expanderIconRightDiv.appendChild(unoToolButtonDiv);
+
+	if (groupLabel.parentElement) {
+		groupLabel.parentElement.appendChild(expanderIconRightDiv);
+	}
+
+	moreOptionsButton.addEventListener('click', (e) => {
+		e.stopPropagation();
+		e.preventDefault();
+		app.map.sendUnoCommand(more.command);
+	});
+
+	return expanderIconRightDiv;
+}
+
 function setupOverflowMenu(
 	parentContainer: HTMLElement,
 	overflowMenu: HTMLElement,
 	id: string,
+	more: MoreOptions | undefined,
 ) {
 	const overflowMenuButton = parentContainer.querySelector(
 		'[id^="overflow-button"]',
@@ -43,6 +82,12 @@ function setupOverflowMenu(
 	const groupLabel = parentContainer.querySelector(
 		'.ui-overflow-group-label',
 	) as HTMLElement;
+
+	let expanderIconRightDiv: HTMLElement | undefined;
+
+	if (more) {
+		expanderIconRightDiv = createMoreButton(id, more, groupLabel);
+	}
 
 	// keeps hidden items
 	const hiddenItems = L.DomUtil.create(
@@ -79,6 +124,9 @@ function setupOverflowMenu(
 
 		overflowMenuHandler(true);
 		groupLabel.style.display = 'none';
+		if (expanderIconRightDiv) {
+			expanderIconRightDiv.style.display = 'none';
+		}
 		overflowMenuButton.style.display = '';
 		isCollapsed = true;
 	};
@@ -90,6 +138,9 @@ function setupOverflowMenu(
 		JSDialog.CloseDropdown(dropdownId);
 
 		groupLabel.style.display = '';
+		if (expanderIconRightDiv) {
+			expanderIconRightDiv.style.display = '';
+		}
 		overflowMenuButton.style.display = 'none';
 		overflowMenuHandler(false);
 		isCollapsed = false;
@@ -250,7 +301,7 @@ JSDialog.OverflowGroup = function (
 		false,
 	);
 
-	setupOverflowMenu(container, contentContainer, data.id);
+	setupOverflowMenu(container, contentContainer, data.id, data.more);
 
 	return false;
 } as JSWidgetHandler;


### PR DESCRIPTION
- We have introduce a new button "more"
- it works same as we have more button on sidebar for some categories
- This more button will shown after the label of group at very end
- user can easily open the respected dialog of that related group to change many other properties.


Change-Id: I3dcae849176c63e222acd62dd5281d327eca2b2b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

