### PR TITLE
Prevent JS dialog buttons being selected twice durign tab navigation

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2882,6 +2882,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 			&& data.type !== 'spacer'
 			&& data.type !== 'edit'
 			&& data.type !== 'deck'
+			&& data.type !== 'pushbutton'
 			)
 			control.setAttribute('tabIndex', '0');
 	},


### PR DESCRIPTION
Prevent the wrapper of the JS dialog button being given the 'tabIndex: 0' property

Change-Id: I6a6a69646dce8ab29c90059806ad51062ebe4309

* Target version: master 

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

