### PR TITLE
Drop Emscripten Module.print and Module.printErr overrides

### DIFF
--- a/browser/src/main.js
+++ b/browser/src/main.js
@@ -107,14 +107,6 @@ if (window.ThisIsTheEmscriptenApp) {
 		onRuntimeInitialized: function() {
 			map.loadDocument(global.socket);
 		},
-		print: function (text) {
-			if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
-			console.warn(text);
-		},
-		printErr: function (text) {
-			if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
-			console.error(text);
-		},
 		arguments: [docURL, encodedWOPI, isWopi ? 'true' : 'false'],
 	};
 	createOnlineModule(globalThis.Module);


### PR DESCRIPTION
...which had been added with a7d6d1debc46f618733e180bd1b8ff87e7303ab7 "wasm: pass the docURL to the wasm app" for unclear reasons, as the defaults of calling console.log and console.error, respectively, should work just fine


Change-Id: Idbcc67279613560f4e75b680ca0a06ad92864ccf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

