### PR TITLE
Insert Image button was broken without WOPI

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1409,6 +1409,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'type': 'overflowgroup',
 				'id': 'insert-illustrations',
 				'name':_('Illustrations'),
+				'icon': 'lc_insertgraphic.svg',
 				'accessibility': { focusBack: true, combination: 'IG', de: null },
 				'children' : [
 										{
@@ -1433,7 +1434,8 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 								!window.ThisIsAMobileApp ?
 									{
 										'id': 'insert-insert-multimedia:InsertMultimediaMenu',
-										'type': 'toolitem',
+										'type': 'menubutton',
+										'noLabel': true,
 										'text': _UNO('.uno:InsertAVMedia'),
 										'command': 'insertmultimedia',
 										'accessibility': { focusBack: true, combination: 'MM', de: null }, // IM was already taken, so 'MM' for MultiMedia

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -1152,11 +1152,15 @@ menuDefinitions.set('LanguageMenu', [
 ] as Array<MenuDefinition>);
 
 menuDefinitions.set('InsertImageMenu', [
-	// local and remote entries added in Map.WOPI
+	{ action: 'localgraphic', text: _('Insert Local Image') },
+	// local entry may be removed
+	// remote entries added in Map.WOPI
 ] as Array<MenuDefinition>);
 
 menuDefinitions.set('InsertMultimediaMenu', [
-	// local and remote entries added in Map.WOPI
+	{ action: 'insertmultimedia', text: _('Insert Local Multimedia') },
+	// local entry may be removed
+	// remote entries added in Map.WOPI
 ] as Array<MenuDefinition>);
 
 menuDefinitions.set('CharSpacingMenu', [

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -185,13 +185,13 @@ L.Map.WOPI = L.Handler.extend({
 			return;
 		}
 
+		if (this.DisableInsertLocalImage) {
+			JSDialog.MenuDefinitions.set('InsertImageMenu', []);
+			JSDialog.MenuDefinitions.set('InsertMultimediaMenu', []);
+		}
+
 		var menuEntriesImage = JSDialog.MenuDefinitions.get('InsertImageMenu');
 		var menuEntriesMultimedia = JSDialog.MenuDefinitions.get('InsertMultimediaMenu');
-
-		if (!this.DisableInsertLocalImage) {
-			menuEntriesImage.push({ action: 'localgraphic', text: _('Insert Local Image') });
-			menuEntriesMultimedia.push({ action: 'insertmultimedia', text: _('Insert Local Multimedia') });
-		}
 
 		if (this.EnableInsertRemoteImage) {
 			menuEntriesImage.push({action: 'remotegraphic', text: _UNO('.uno:InsertGraphic', '', true)});


### PR DESCRIPTION
Also the InsertMedia button needed a similar fix
as in commit af317e4130583e29038fd9f45f3a750b11b0cbe5 ie being a menubutton.


Change-Id: I64ed638a6179bb5f274b11729c5681f3e1ac54fb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

