### PR TITLE
common: improve getWidth()/getHeight() in Rectangle

### DIFF
--- a/common/Rectangle.hpp
+++ b/common/Rectangle.hpp
@@ -104,9 +104,29 @@ public:
 
     int getBottom() const { return _y2; }
 
-    int getWidth() const { return _x2 - _x1; }
+    int getWidth() const
+    {
+        if (static_cast<long>(_x2) - _x1 > std::numeric_limits<int>::min())
+        {
+            return _x2 - _x1;
+        }
+        else
+        {
+            return std::numeric_limits<int>::min();
+        }
+    }
 
-    int getHeight() const { return _y2 - _y1; }
+    int getHeight() const
+    {
+        if (static_cast<long>(_y2) - _y1 > std::numeric_limits<int>::min())
+        {
+            return _y2 - _y1;
+        }
+        else
+        {
+            return std::numeric_limits<int>::min();
+        }
+    }
 
     bool isValid() const { return _x1 <= _x2 && _y1 <= _y2; }
 


### PR DESCRIPTION
Seen:
common/Rectangle.hpp:107:39: runtime error: signed integer overflow: -2147483648 - 2147483647 cannot be represented in type 'int'
in an -fsanitize=undefined build while running unit-perf.

Probably the exact large negative value is not interesting at this
point, so just limit it, similar to what the Rectangle ctor does
already.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I53def2537731eb2ca2d12c63dd61fc395a8aac28
