### PR TITLE
notebookbar: single initialization

### DIFF
--- a/browser/src/control/Control.ContextToolbar.ts
+++ b/browser/src/control/Control.ContextToolbar.ts
@@ -73,12 +73,6 @@ class ContextToolbar {
 
 			this.builder.build(this.container, contextToolbarItems, false);
 
-			if (
-				!this.builder.map.uiManager.notebookbar ||
-				!this.builder.map.uiManager.notebookbar.isInitializedInCore()
-			)
-				this.builder.map.uiManager.initializeNotebookbarInCore();
-
 			this.initialized = true;
 		}
 

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -73,8 +73,6 @@ L.Control.Notebookbar = L.Control.extend({
 			this.map.on('toggleslidehide', this.onSlideHideToggle, this);
 		}
 
-		this.map.uiManager.initializeNotebookbarInCore();
-
 		$('#toolbar-wrapper').addClass('hasnotebookbar');
 		$('.main-nav').addClass('hasnotebookbar');
 		this.floatingNavIcon = document.querySelector('.navigator-btn-wrapper');
@@ -109,23 +107,10 @@ L.Control.Notebookbar = L.Control.extend({
 		var isDarkMode = window.prefs.getBoolean('darkTheme');
 		if (!isDarkMode)
 			$('#invertbackground').hide();
-
-		var that = this;
-		var retryNotebookbarInit = function() {
-			if (!that.isInitializedInCore()) {
-				// if notebookbar doesn't have any welded controls it can trigger false alarm here
-				window.app.console.warn('notebookbar might be not initialized, retrying');
-				that.map.uiManager.initializeNotebookbarInCore();
-				that.retry = setTimeout(retryNotebookbarInit, 3000);
-			}
-		};
-
-		this.retry = setTimeout(retryNotebookbarInit, 3000);
 	},
 
 	onRemove: function() {
 		clearTimeout(this.retry);
-		this.resetInCore();
 		this.map.off('commandstatechanged', this.builder.onCommandStateChanged, this.builder);
 		this.map.off('notebookbar');
 		this.map.off('jsdialogupdate', this.onJSUpdate, this);
@@ -138,15 +123,6 @@ L.Control.Notebookbar = L.Control.extend({
 			this.floatingNavIcon.classList.remove('hasnotebookbar');
 		$('.main-nav #document-header').remove();
 		this.clearNotebookbar();
-	},
-
-	isInitializedInCore: function() {
-		return this._isNotebookbarLoadedOnCore;
-	},
-
-	resetInCore: function() {
-		this._isNotebookbarLoadedOnCore = false;
-		this.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=Default');
 	},
 
 	onJSUpdate: function (e) {

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -552,6 +552,9 @@ class UIManager extends L.Control {
 			}
 		});
 		this.map.contextToolbar = L.control.ContextToolbar(this.map);
+
+		// do it always as we need it for contextual toolbar
+		if (!window.mode.isMobile()) this.initializeNotebookbarInCore();
 	}
 
 	/**

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1626,11 +1626,9 @@ app.definitions.Socket = L.Class.extend({
 			this._map.uiManager.applyInvert();
 			this._map.uiManager.setCanvasColorAfterModeChange();
 
-			var uiMode = this._map.uiManager.getCurrentMode();
-			if (uiMode === 'notebookbar' && this._map.uiManager.notebookbar) {
-				this._map.uiManager.notebookbar.resetInCore();
+			if (!window.mode.isMobile())
 				this._map.uiManager.initializeNotebookbarInCore();
-			}
+
 			// close all the popups otherwise document textArea will not get focus
 			this._map.uiManager.closeAll();
 			this._map.setPermission(app.file.permission);


### PR DESCRIPTION
- notebookbar is needed for few components
- even if no acctual notebookbar is visible in online we need to initialize it in the core
- examples: contextual toolbar
- in the future we might remove that and use notebookbar in core always