### PR TITLE
Private/pedro/tabbed overflow alignments

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -384,7 +384,7 @@ body {
 	flex-direction: column;
 }
 #toolbar-wrapper:not(.mobile) {
-	padding: 3px 0;
+	padding: 2px 0;
 }
 /* Remove bottom padding in calc as it affects formulabar*/
 #toolbar-wrapper.spreadsheet:not(.mobile) {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1301,7 +1301,6 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .notebookbar.ui-overflow-group-bottom {
 	display: flex;
 	padding: 0 5px;
-	margin-top: 4px;
 }
 
 .notebookbar .ui-overflow-group-inner {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -342,6 +342,19 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	height: 100%;
 }
 
+.ui-overflow-manager > .notebookbar:not(.ui-separator),
+.ui-overflow-manager:not(:has(.ui-overflow-group)) {
+	box-sizing: border-box;
+	/* same height as .hasnotebookbar > #toolbar-row */
+	height: 82px;
+	align-content: center;
+}
+.ui-overflow-manager > .notebookbar:not(.ui-separator):not(.ui-overflow-group):not(:has(.ui-overflow-group-container-with-label)) {
+	height: 49px;
+	/* 14px extra margin for containers without label */
+	margin-bottom: 14px;
+}
+
 .ui-toggle button,
 .ui-tab.jsdialog {
 	float: left !important;

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -417,143 +417,137 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 		var hasServerAudit = !!this.map.serverAuditDialog;
 
 		var content = [
-			{
-				'type': 'container',
-				'id': helpTabName + '-container',
-				'children': [
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'id': 'forum',
-								'type': 'bigtoolitem',
-								'text': _('Forum'),
-								'command': '.uno:ForumHelp',
-								'accessibility': { focusBack: true, combination: 'C', de: null }
-							}
-						]
-					},
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'id': 'online-help',
-								'type': 'bigtoolitem',
-								'text': _('Online Help'),
-								'command': '.uno:OnlineHelp',
-								'accessibility': { focusBack: false, combination: 'H', de: null }
-							}
-						]
-					},
-					{ type: 'separator', id: 'help-onlinehelp-break', orientation: 'vertical' },
-					{
-						'type': 'toolbox',
-						'children': [
-							{
-								'id': 'keyboard-shortcuts',
-								'type': 'bigtoolitem',
-								'text': _('Keyboard shortcuts'),
-								'command': '.uno:KeyboardShortcuts',
-								'accessibility': { focusBack: false, combination: 'S', de: null }
-							}
-						]
-					},
-					{ type: 'separator', id: 'help-keyboardshortcuts-break', orientation: 'vertical' },
-					hasAccessibilitySupport ?
+				{
+					'type': 'toolbox',
+					'children': [
 						{
-							'id':'togglea11ystate',
-							'type': 'bigcustomtoolitem',
-							'text': _('Screen Reading'),
-							'accessibility': { focusBack: true,	combination: 'SR', de: null }
-						} : {},
-					hasAccessibilityCheck ?
-						{
-							'id': 'accessibility-check',
-							'class': 'unoAccessibilityCheck',
+							'id': 'forum',
 							'type': 'bigtoolitem',
-							'text': _UNO('.uno:AccessibilityCheck', 'text'),
-							'command': '.uno:SidebarDeck.A11yCheckDeck',
-							'accessibility': { focusBack: false, combination: 'A', de: null }
-						} : {},
-					hasAccessibilitySupport || hasAccessibilityCheck ?
+							'text': _('Forum'),
+							'command': '.uno:ForumHelp',
+							'accessibility': { focusBack: true, combination: 'C', de: null }
+						}
+					]
+				},
+				{
+					'type': 'toolbox',
+					'children': [
 						{
-							'id': 'help-accessibility-break',
+							'id': 'online-help',
+							'type': 'bigtoolitem',
+							'text': _('Online Help'),
+							'command': '.uno:OnlineHelp',
+							'accessibility': { focusBack: false, combination: 'H', de: null }
+						}
+					]
+				},
+				{ type: 'separator', id: 'help-onlinehelp-break', orientation: 'vertical' },
+				{
+					'type': 'toolbox',
+					'children': [
+						{
+							'id': 'keyboard-shortcuts',
+							'type': 'bigtoolitem',
+							'text': _('Keyboard shortcuts'),
+							'command': '.uno:KeyboardShortcuts',
+							'accessibility': { focusBack: false, combination: 'S', de: null }
+						}
+					]
+				},
+				{ type: 'separator', id: 'help-keyboardshortcuts-break', orientation: 'vertical' },
+				hasAccessibilitySupport ?
+					{
+						'id':'togglea11ystate',
+						'type': 'bigcustomtoolitem',
+						'text': _('Screen Reading'),
+						'accessibility': { focusBack: true,	combination: 'SR', de: null }
+					} : {},
+				hasAccessibilityCheck ?
+					{
+						'id': 'accessibility-check',
+						'class': 'unoAccessibilityCheck',
+						'type': 'bigtoolitem',
+						'text': _UNO('.uno:AccessibilityCheck', 'text'),
+						'command': '.uno:SidebarDeck.A11yCheckDeck',
+						'accessibility': { focusBack: false, combination: 'A', de: null }
+					} : {},
+				hasAccessibilitySupport || hasAccessibilityCheck ?
+					{
+						'id': 'help-accessibility-break',
+						'type': 'separator',
+						'orientation': 'vertical'
+					} : {},
+				hasServerAudit ?
+				{
+					'type': 'toolbox',
+					'children': [
+						{
+							'id': 'server-audit',
+							'type': 'bigcustomtoolitem',
+							'text': _('Server audit'),
+							'command': 'serveraudit',
+							'accessibility': { focusBack: false, combination: 'SA', de: null }
+						},
+						{
+							'id': 'help-serveraudit-break',
 							'type': 'separator',
 							'orientation': 'vertical'
-						} : {},
-					hasServerAudit ?
+						}
+					]
+				} : {},
+				{
+					'type': 'toolbox',
+					'children': [
+						{
+							'id': 'report-an-issue',
+							'type': 'bigtoolitem',
+							'text': _('Report an issue'),
+							'command': '.uno:ReportIssue',
+							'accessibility': { focusBack: true, combination: 'K', de: null }
+						},
+						{ 'type': 'separator', 'id': 'help-reportissue-break', 'orientation': 'vertical' },
+					]
+				},
+				hasLatestUpdates ?
 					{
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'server-audit',
-								'type': 'bigcustomtoolitem',
-								'text': _('Server audit'),
-								'command': 'serveraudit',
-								'accessibility': { focusBack: false, combination: 'SA', de: null }
-							},
-							{
-								'id': 'help-serveraudit-break',
-								'type': 'separator',
-								'orientation': 'vertical'
+								'id': 'latestupdates',
+								'type': 'bigtoolitem',
+								'text': _('Latest Updates'),
+								'command': '.uno:LatestUpdates',
+								'accessibility': { focusBack: true,	combination: 'LU', de: null }
+
 							}
 						]
 					} : {},
+				hasFeedback ?
 					{
 						'type': 'toolbox',
 						'children': [
 							{
-								'id': 'report-an-issue',
+								'id': 'feedback',
 								'type': 'bigtoolitem',
-								'text': _('Report an issue'),
-								'command': '.uno:ReportIssue',
-								'accessibility': { focusBack: true, combination: 'K', de: null }
-							},
-							{ 'type': 'separator', 'id': 'help-reportissue-break', 'orientation': 'vertical' },
+								'text': _('Send Feedback'),
+								'command': '.uno:Feedback',
+								'accessibility': { focusBack: true,	combination: 'SF', de: null }
+							}
 						]
-					},
-					hasLatestUpdates ?
-						{
-							'type': 'toolbox',
-							'children': [
-								{
-									'id': 'latestupdates',
-									'type': 'bigtoolitem',
-									'text': _('Latest Updates'),
-									'command': '.uno:LatestUpdates',
-									'accessibility': { focusBack: true,	combination: 'LU', de: null }
-
-								}
-							]
-						} : {},
-					hasFeedback ?
-						{
-							'type': 'toolbox',
-							'children': [
-								{
-									'id': 'feedback',
-									'type': 'bigtoolitem',
-									'text': _('Send Feedback'),
-									'command': '.uno:Feedback',
-									'accessibility': { focusBack: true,	combination: 'SF', de: null }
-								}
-							]
-						} : {},
-					hasAbout ?
-						{
-							'type': 'toolbox',
-							'children': [
-								{
-									'id': 'about',
-									'type': 'bigtoolitem',
-									'text': _('About'),
-									'command': '.uno:About',
-									'accessibility': { focusBack: false, combination: 'W', de: null }
-								}
-							]
-						} : {}
-				]
-			}
+					} : {},
+				hasAbout ?
+					{
+						'type': 'toolbox',
+						'children': [
+							{
+								'id': 'about',
+								'type': 'bigtoolitem',
+								'text': _('About'),
+								'command': '.uno:About',
+								'accessibility': { focusBack: false, combination: 'W', de: null }
+							}
+						]
+					} : {}
 		];
 
 		return this.getTabPage(helpTabName, content);

--- a/browser/src/control/jsdialog/Widget.OverflowGroup.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowGroup.ts
@@ -96,6 +96,7 @@ function setupOverflowMenu(
 		parentContainer,
 	);
 	hiddenItems.style.display = 'none';
+	parentContainer.classList.add('ui-overflow-group-container-with-label');
 
 	// keeps original content
 	const originalTopbar = overflowMenu.querySelectorAll(':scope > *');
@@ -127,6 +128,7 @@ function setupOverflowMenu(
 		if (expanderIconRightDiv) {
 			expanderIconRightDiv.style.display = 'none';
 		}
+		parentContainer.classList.remove('ui-overflow-group-container-with-label');
 		overflowMenuButton.style.display = '';
 		isCollapsed = true;
 	};
@@ -142,6 +144,7 @@ function setupOverflowMenu(
 			expanderIconRightDiv.style.display = '';
 		}
 		overflowMenuButton.style.display = 'none';
+		parentContainer.classList.add('ui-overflow-group-container-with-label');
 		overflowMenuHandler(false);
 		isCollapsed = false;
 	};


### PR DESCRIPTION
commit 624550562bf9d27629455b2d61903585edfc614d (HEAD -> private/pedro/tabbed-overflow-alignments, upstream/private/pedro/tabbed-overflow-alignments)
Author: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
Date:   Thu Aug 21 23:59:50 2025 +0530

    Remove unnecessary container around Help tab options
    
    - Previously, the Help tab options were built one level deeper than other tabs
      due to the extra top-level `container` type with `children`.
    - This caused issues when adding the `overflow-manager` class, as it was applied
      at the top level instead of within the correct tab scope (`gettingstarted`).
    - This patch removes the redundant container, aligning the Help tab structure
      with other tabs and fixing the class scope issue.
    
    Signed-off-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
    Change-Id: Ib89a61327ceaa6f6f5b5568561116e652f46d842


commit 1fb8e592a469d26cb71a6263afe08e4eaedbf195 (HEAD -> master, origin/private/pedro/tabbed-overflow-alignments, private/pedro/tabbed-overflow-alignments)
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Thu Aug 21 11:00:39 2025 +0200

    Tabbed: overflow: Align buttons without overflow label
    
    TODO: THIS IS A WIP COMMIT AS THE
    ui-overflow-group-container-with-label SHOULD BE ADDED/REMOVED
    DYNAMICALLY -> Assigning this to Darshan now
    
    Before this, every button that was now an overflow group or was a
    overflow group **folded** was misaligned. Make sure we account for the
    label space in other elements and that the flex layout is always
    centered.
    
    Co-authored-by: Darshan-upadhyay1110 <darshan.upadhyay@collabora.com>
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I6342d574fc88a9dd73673fa1ccce68dca8915e44

commit 6ba66616ea2b8cfbbe50be8c2eee9d2fa2e00864
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Thu Aug 21 10:59:14 2025 +0200

    Tabbed: overflow: Fix some buttons being cropped
    
    Remove the margin-top from the overflow group buttons as it was
    affecting the flex box layout and making other elements being cropped
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I18294975223ff9ff11ca3e0163ca49735ef5fefc

commit 610267c06e4851fcd1d56faed6b63b6c17f2cba2
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Thu Aug 21 10:58:18 2025 +0200

    Tabbed: reduce tab's container padding
    
    So, we can utilize better the space for content
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I040549ddba7a2a26b43a53bc00687d9b21ea0012