### PR TITLE
Calc: apply doc type theme color to sheet buttons

### DIFF
--- a/browser/css/spreadsheet.css
+++ b/browser/css/spreadsheet.css
@@ -51,7 +51,7 @@
 }
 
 .spreadsheet-tab.spreadsheet-tab-selected {
-	background-color: var(--color-primary) !important;
+	background-color: rgba(var(--doc-type)) !important;
 	color: var(--color-primary-text) !important;
 	border: 1px solid var(--color-border-dark);
 }
@@ -64,7 +64,7 @@
 }
 
 #spreadsheet-tab-scroll button.spreadsheet-tab-selected:hover {
-	background-color: var(--color-primary-dark) !important;
+	background-color: rgba(var(--doc-type)) !important;
 	color: var(--color-primary-text) !important;
 }
 


### PR DESCRIPTION
Change-Id: I95abcfb786741d10ce5230b9344366ede2cdd5ac


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Updated the sheet tab buttons to use the document type color defined in the theme.

### PREVIEW
<img width="717" height="69" alt="Screenshot from 2025-08-21 14-02-20" src="https://github.com/user-attachments/assets/889fef47-829b-4173-aab3-ae4b02ad9d07" />

<img width="717" height="69" alt="image" src="https://github.com/user-attachments/assets/a70ef053-6eb3-4afe-955e-4e792ae5586c" />

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

