### PR TITLE
Enable logging for the Wasm build

### DIFF
--- a/common/Log.hpp
+++ b/common/Log.hpp
@@ -24,6 +24,10 @@
 #include <android/log.h>
 #endif
 
+#if defined __EMSCRIPTEN__
+#include <emscripten/console.h>
+#endif
+
 #include "Util.hpp"
 #include "StateEnum.hpp"
 
@@ -194,6 +198,16 @@ static constexpr std::size_t skipPathPrefix(const char (&s)[N], std::size_t n = 
 #define LOG_LOG(LVL, STR) \
     ((void)__android_log_print(ANDROID_LOG_DEBUG, \
                                "coolwsd", "%s %s", #LVL, STR.c_str()))
+#elif defined __EMSCRIPTEN__
+
+// emscripten/console.h does not have emscripten_console_info (corresponding to JS console.info) nor
+// emsripten_console_debug (corresponding to JS console.debug), so use emscripten_console_log
+// (corresponding to JS console.log) instead:
+#define LOG_LOG(LVL, STR) ( \
+    Log::LVL <= Log::ERR ? emscripten_console_error((STR).c_str()) : \
+    Log::LVL <= Log::WRN ? emscripten_console_warn((STR).c_str()) : \
+                           emscripten_console_log((STR).c_str()))
+
 #else
 
 #define LOG_LOG(LVL, STR)  Log::log(Log::LVL, STR)

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3824,6 +3824,12 @@ int COOLWSD::innerMain()
     {
         LOG_DBG("No remote_font_config");
     }
+
+#elif defined __EMSCRIPTEN__
+
+    // Hard-code a somewhat random log level:
+    Log::setLevel("information");
+
 #endif
 
     // URI with /contents are public and we don't need to anonymize them.


### PR DESCRIPTION
...redirecting output to the browser console instead of to the underlying Poco facilities, and hard-coding a somewhat random "information" log level for now


Change-Id: Idcb2da6b6128cd20fcce49e96a33768d1b0203cc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

