### PR TITLE
Calc: Layout tab: remove Page button, add more button and label

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1072,7 +1072,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'layout-page',
-				'name':_('Format'),
+				'name':_('Page Setup'),
 				'accessibility': { focusBack: true,	combination: 'PS', de: null },
 				'children' : [
 					{

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1074,6 +1074,9 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'id': 'layout-page',
 				'name':_('Page Setup'),
 				'accessibility': { focusBack: true,	combination: 'PS', de: null },
+				'more': {
+					'command':'.uno:PageFormatDialog'
+				},
 				'children' : [
 					{
 						'id': 'Layout-MarginMenu:MenuMargins',
@@ -1101,13 +1104,6 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'text': _UNO('.uno:PrintRangesMenu', 'spreadsheet'),
 						'enabled': 'true',
 						'accessibility': { focusBack: true,	combination: 'PR', de: null }
-					},
-					{
-						'id': 'layout-page-format-dialog',
-						'type': 'bigtoolitem',
-						'text': _UNO('.uno:PageFormatDialog', 'spreadsheet', true),
-						'command': '.uno:PageFormatDialog',
-						'accessibility': { focusBack: true,	combination: 'FD', de: null }
 					},
 				]
 			},

--- a/cypress_test/integration_tests/desktop/calc/focus_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/focus_spec.js
@@ -63,7 +63,7 @@ describe(['tagdesktop'], 'Calc focus tests', function() {
 
 	it('On Tabcontrol dialog open', function() {
 		cy.cGet('#Layout-tab-label').click();
-		cy.cGet('#Layout-container .unoPageFormatDialog').filter(':visible').click();
+		cy.cGet('#layout-page-more-button').filter(':visible').click();
 		// focus should be on selected tab if current dialog is tabcontrol dialog
 		cy.cGet('.ui-tab.jsdialog.selected').should('have.focus');
 	});


### PR DESCRIPTION
commit e110727e11a3d7d940b68259c7a1461c34409397 (HEAD -> master, origin/private/pedro/Calc-Layout-tab-remove-Page-button, origin/private/pedro/Calc, private/pedro/Calc-Layout-tab-remove-Page-button, private/pedro/Calc)
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Aug 22 10:28:38 2025 +0200

    Calc: Layout tab: remove Page button, add more button and label
    
    With the new pre-canned menu items recently added  we can now remove
    the bigtoolitem that we have and add a label and a more button that opens the dialog.
    
    - Add group label: makes it easier to conceptually group them and
    understand their functionality
    - Add more button that opens the "Page Style" (.uno:PageDialog)
    dialog: which makes it evident that all those options can be also
    found with further control in that dialog
      - Remove the now unnecessary Page with cogwheel bigtoolitem so we
    can also delete the big button: frees precious screen space
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I16b940bc103a3ab36d62b4b6788629ade1b74cf8

commit bee0138fb1e228c2d071998d3be2fceb1a02ebfe
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Aug 22 10:26:50 2025 +0200

    Calc: Layout tab: Page Setup: group label from generic to specific
    
    Prefer something that starts with the keyword Page so it's easier for
    user to find/eye scan. It's also a bit more semantic and specific
    which also helps space memory.
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Id19c230d87d03953acfab8385f14600da479d575
