### PR TITLE
Writer layout tab remove page button and add accesskeys

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1802,7 +1802,6 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'type': 'overflowgroup',
 				'id': 'layout-page',
 				'name': 'Page Setup',
-				'accessibility': { focusBack: true, combination: 'PS', de: null },
 				'more': {
 					'command':'.uno:PageDialog'
 				},
@@ -1812,20 +1811,21 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 						'type': 'menubutton',
 						'text': _('Margin'),
 						'enabled': 'true',
+						'accessibility': { focusBack: true,	combination: 'M', de: '8' },
 					},
 					{
 						'id': 'Layout-SizeMenu:MenuPageSizesWriter',
 						'type': 'menubutton',
 						'text': _('Size'),
 						'enabled': 'true',
-						'accessibility': { focusBack: true, combination: 'PS', de: null }
+						'accessibility': { focusBack: true, combination: 'SZ', de: 'R' }
 					},
 					{
 						'id': 'Layout-OrientationMenu:MenuOrientation',
 						'type': 'menubutton',
 						'text': _UNO('.uno:Orientation'),
 						'enabled': 'true',
-						'accessibility': { focusBack: true, combination: 'PO', de: null }
+						'accessibility': { focusBack: true, combination: 'O', de: '4' }
 					}
 				]
 			},
@@ -1835,7 +1835,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'type': 'bigtoolitem',
 				'text': _UNO('.uno:FormatColumns', 'text'),
 				'command': '.uno:FormatColumns',
-				'accessibility': { focusBack: false, combination: 'J', de: 'R' }
+				'accessibility': { focusBack: false, combination: 'J', de: 'HS' }
 			},
 			{ type: 'separator', id: 'layout-formatcolumns-break', orientation: 'vertical' },
 			{


### PR DESCRIPTION
commit 3e4e68aeddf0991502be6cd240416d99ba44c7d0 (HEAD -> master, origin/private/pedro/writer-Layout-tab-remove-Page-button-and-accesskeys, private/pedro/writer-Layout-tab-remove-Page-button-and-accesskeys)
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Aug 22 11:03:14 2025 +0200

    Writer: Layout tab: Page setup group: fix accessKeys
    
    Update acesskeys and add missing ones for DE
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I0b3ac3b1108a8d519ecc1196bc681fcf202fd614

commit a67931d5084f1655bdb08db0fecaf629008cced7
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Fri Aug 22 10:48:47 2025 +0200

    Writer: Layout tab: remove Page button, add more button and label
    
    With the new pre-canned menu items recently added  we can now remove
    the bigtoolitem that we have and add a label and a more button that opens the dialog.
    
    - Add group label: makes it easier to conceptually group them and
    understand their functionality
    - Add more button that opens the "Page Style" (.uno:PageDialog)
    dialog: which makes it evident that all those options can be also
    found with further control in that dialog
      - Remove the now unnecessary Page with cogwheel bigtoolitem so we
    can also delete the big button: frees precious screen space
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Ifbfc9d0556e8ae703e0ee449870e1a6db7e77845
