### PR TITLE
Shape Scaling: Reverse the scaling shortcut function for images.

### DIFF
--- a/browser/src/canvas/sections/ShapeHandleScalingSubSection.ts
+++ b/browser/src/canvas/sections/ShapeHandleScalingSubSection.ts
@@ -216,12 +216,23 @@ class ShapeHandleScalingSubSection extends CanvasSectionObject {
 		return [handle.id, handle.x, handle.y];
 	}
 
+	private doWeKeepRatio(e: MouseEvent) {
+		let keep = e.ctrlKey && e.shiftKey;
+
+		// For images, the keepRatio shortcut works the opposite way.
+		if (app.map.context.context === 'Graphic')
+			keep = !keep;
+
+		return keep;
+	}
+
 	onMouseUp(point: cool.SimplePoint, e: MouseEvent): void {
 		if (this.containerObject.isDraggingSomething()) {
 			this.stopPropagating();
 			e.stopPropagation();
 
-			const keepRatio = e.ctrlKey && e.shiftKey;
+			const keepRatio = this.doWeKeepRatio(e);
+
 			let handleId = this.sectionProperties.ownInfo.id;
 			const parentHandlerSection = this.sectionProperties.parentHandlerSection;
 
@@ -290,7 +301,7 @@ class ShapeHandleScalingSubSection extends CanvasSectionObject {
 
 	calculateNewShapeRectangleProperties(point: number[], e: MouseEvent) {
 		const shapeRecProps: any = JSON.parse(JSON.stringify(this.sectionProperties.parentHandlerSection.sectionProperties.shapeRectangleProperties));
-		const keepRatio = e.ctrlKey && e.shiftKey;
+		const keepRatio = this.doWeKeepRatio(e);
 
 		if (keepRatio) {
 			point = this.calculateRatioPoint(point, shapeRecProps);

--- a/cypress_test/integration_tests/desktop/calc/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/image_operation_spec.js
@@ -43,7 +43,7 @@ describe(['tagdesktop'], 'Image Operation Tests', function() {
 		});
 
 		cy.wait(1000);
-		helper.assertImageSize(660, 63);
+		helper.assertImageSize(205, 45);
 	});
 
 	it.skip('Resize image when keep ratio option enabled and disabled', function() {

--- a/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/image_operation_spec.js
@@ -45,7 +45,7 @@ describe(['tagdesktop'], 'Image Operation Tests', function() {
 		});
 
 		cy.wait(1000);
-		helper.assertImageSize(43, 63);
+		helper.assertImageSize(232, 51);
 	});
 
 	it('Resize image when keep ratio option enabled and disabled', function() {

--- a/cypress_test/integration_tests/mobile/calc/image_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/image_operation_spec.js
@@ -57,6 +57,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Image Operation Tests', fun
 		});
 
 		cy.wait(1000);
-		helper.assertImageSize(494, 130);
+		helper.assertImageSize(494, 115);
 	});
 });

--- a/cypress_test/integration_tests/mobile/impress/image_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/image_operation_spec.js
@@ -43,6 +43,6 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Image Operation Tests', fun
 		});
 
 		cy.wait(1000);
-		helper.assertImageSize(284, 77);
+		helper.assertImageSize(284, 63);
 	});
 });

--- a/cypress_test/integration_tests/mobile/writer/image_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/writer/image_operation_spec.js
@@ -40,6 +40,6 @@ describe(['tagmobile'],'Image Operation Tests', function() {
 		});
 
 		cy.wait(1000);
-		helper.assertImageSize(492, 130);
+		helper.assertImageSize(492, 115);
 	});
 });


### PR DESCRIPTION
Issue:
When a user is scaling a shape using shape scaling handles at the corners:
* They can break the width / height ratio.
* To keep the ratio, they can press and hold shift & ctrl keys.

For images:
* **the opposite functionality should be default**.
* When scaling images, if user doesn't press any keys, image should keep the ratio.
* If user presses shift & ctrl keys, they can break the width & height ratio.

Fix: Reverse the keepRatio variable for images.