### PR TITLE
Restrict core comphelper threadpool MAX_CONCURRENCY in the Wasm build

### DIFF
--- a/wasm/Makefile.am
+++ b/wasm/Makefile.am
@@ -65,6 +65,7 @@ online_DEPENDENCIES = \
 	soffice.data.js.metadata \
 	@LOBUILDDIR@/workdir/CustomTarget/static/emscripten_fs_image/soffice.data.js.link \
 	@LOBUILDDIR@/workdir/CustomTarget/static/unoembind/bindings_uno.js \
+	@LOSOURCEDIR@/static/emscripten/environment.js \
 	@LOSOURCEDIR@/static/emscripten/uno.js
 
 # note cannot add content of .linkdeps to DEPENDENCIES because it contains -lFoo
@@ -83,6 +84,7 @@ online_LDADD = \
 # TODO these are just copypasta from core
 online_LDFLAGS = \
 	-pthread -s MODULARIZE -s EXPORT_NAME=createOnlineModule -s USE_PTHREADS=1 -s TOTAL_MEMORY=1GB -s PTHREAD_POOL_SIZE_STRICT=0 --bind -s FORCE_FILESYSTEM=1 -s WASM_BIGINT=1 -s ERROR_ON_UNDEFINED_SYMBOLS=1 -s FETCH=1 -s ASSERTIONS=1 -s EXIT_RUNTIME=0 -s EXPORTED_RUNTIME_METHODS=["UTF16ToString","stringToUTF16","UTF8ToString","stringToNewUTF8","ccall","cwrap","FS","registerType","ClassHandle","HEAPU16","HEAPU32"] -pthread -s USE_PTHREADS=1 -fwasm-exceptions -s EXPORTED_FUNCTIONS=@exports \
+	--pre-js @LOSOURCEDIR@/static/emscripten/environment.js \
 	--pre-js @LOBUILDDIR@/workdir/CustomTarget/static/emscripten_fs_image/soffice.data.js.link \
 	--post-js @LOBUILDDIR@/workdir/CustomTarget/static/unoembind/bindings_uno.js \
 	--post-js @LOSOURCEDIR@/static/emscripten/uno.js


### PR DESCRIPTION
...just as core itself does too (cf.
<https://git.libreoffice.org/core/+/b84ef4d67eaf9f9fd7fd700ca05339cb0cdff742%5E%21> "Adapt comphelper::ThreadPool to Emscripten's threading needs" and <https://git.libreoffice.org/core/+/6e6451ce96f47e0ef5e8ecf1750f394ff3fb48e4%5E%21> "Emscripten: Move the Qt event loop off the JS main thread")


Change-Id: Iba1655e1d7a85ba0a09ac0ad7e8f16d7c29d2e60


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

