### PR TITLE
Add missing localization strings

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -392,7 +392,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'home-clipboard',
-				'name': 'Clipboard',
+				'name': _('Clipboard'),
 				'accessibility': { focusBack: true,	combination: 'V', de: null },
 				'children' :
 				[
@@ -453,7 +453,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'home-font',
-				'name': 'Font',
+				'name': _('Font'),
 				'accessibility': { focusBack: true,	combination: 'FF', de: null },
 				'more': {
 					'command':'.uno:CellTextDlg'
@@ -599,7 +599,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'home-alignment',
-				'name': 'Alignment',
+				'name': _('Alignment'),
 				'accessibility': { focusBack: true,	combination: 'AT', de: null },
 				'more': {
 					'command':'.uno:Hyphenate'
@@ -735,7 +735,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'home-number-format',
-				'name': 'Number',
+				'name': _('Number'),
 				'accessibility': { focusBack: true,	combination: 'N', de: null },
 				'more': {
 					'command':'.uno:FormatCellDialog'
@@ -836,7 +836,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'home-insert-table',
-				'name': 'Cells',
+				'name': _('Cells'),
 				'accessibility': { focusBack: true,	combination: 'RB', de: null },
 				'children' : [
 				{
@@ -917,7 +917,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'home-style',
-				'name': 'Style',
+				'name': _('Style'),
 				'accessibility': { focusBack: true,	combination: 'L', de: null },
 				'children' : [
 				{
@@ -994,7 +994,7 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'home-find-n-filter',
-				'name': 'Editing',
+				'name': _('Editing'),
 				'accessibility': { focusBack: true,	combination: 'SS', de: null },
 				'children' : [
 				{

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -580,7 +580,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'home-clipboard',
-				'name': 'Clipboard',
+				'name': _('Clipboard'),
 				'accessibility': { focusBack: false,	combination: 'V',	de: null },
 				'children' : [
 				{
@@ -639,7 +639,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'home-font',
-				'name': 'Font',
+				'name': _('Font'),
 				'more': {
 					'command':'.uno:FontDialog'
 				},
@@ -783,7 +783,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'home-paragraph',
-				'name': 'Paragraph',
+				'name': _('Paragraph'),
 				'accessibility': { focusBack: false, 	combination: 'U',	de: 'AA' },
 				'more': {
 					'command':'.uno:ParagraphDialog'
@@ -997,7 +997,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 			{
 				'type': 'overflowgroup',
 				'id': 'home-search',
-				'name': 'Search',
+				'name': _('Search'),
 				'accessibility': { focusBack: false,	combination: 'SS',	de: 'SS' },
 				'children': [
 					{


### PR DESCRIPTION
- In few cases we missed to add _ for name property in overflow groups
- this patch will fix that issue so no localization get missed out


Change-Id: I96670607a9f557f3524a963894b74ac688926c77


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

