### PR TITLE
Layout Tab: Writer and Calc: add additional DE accessKeys

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1076,9 +1076,10 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 				'type': 'overflowgroup',
 				'id': 'layout-page',
 				'name':_('Page Setup'),
-				'accessibility': { focusBack: true,	combination: 'PS', de: null },
+				'accessibility': { focusBack: true,	combination: 'PS', de: 'K' },
 				'more': {
-					'command':'.uno:PageFormatDialog'
+					'command':'.uno:PageFormatDialog',
+					'accessibility': { focusBack: true,	combination: 'PS', de: 'K' },
 				},
 				'children' : [
 					{
@@ -1086,27 +1087,28 @@ L.Control.NotebookbarCalc = L.Control.NotebookbarWriter.extend({
 						'type': 'menubutton',
 						'text': _('Margin'),
 						'enabled': 'true',
+						'accessibility': { focusBack: true,	combination: 'M', de: '8' }
 					},
 					{
 						'id': 'Layout-SizeMenu:MenuPageSizesCalc',
 						'type': 'menubutton',
 						'text': _('Size'),
 						'enabled': 'true',
-						'accessibility': { focusBack: true,	combination: 'PS', de: null }
+						'accessibility': { focusBack: true,	combination: 'SZ', de: 'R' }
 					},
 					{
 						'id': 'Layout-OrientationMenu:MenuOrientation',
 						'type': 'menubutton',
 						'text': _UNO('.uno:Orientation'),
 						'enabled': 'true',
-						'accessibility': { focusBack: true,	combination: 'PO', de: null }
+						'accessibility': { focusBack: true,	combination: 'O', de: '4' }
 					},
 					{
 						'id': 'Layout-PrintRangesMenu:MenuPrintRanges',
 						'type': 'menubutton',
 						'text': _UNO('.uno:PrintRangesMenu', 'spreadsheet'),
 						'enabled': 'true',
-						'accessibility': { focusBack: true,	combination: 'PR', de: null }
+						'accessibility': { focusBack: true,	combination: 'R', de: 'H' }
 					},
 				]
 			},

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1804,9 +1804,10 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'type': 'overflowgroup',
 				'id': 'layout-page',
 				'name': 'Page Setup',
+				'accessibility': { focusBack: true,	combination: 'SP', de: 'T' },
 				'more': {
 					'command':'.uno:PageDialog',
-					'accessibility': { focusBack: false, combination: 'MP', de: '8' }
+					'accessibility': { focusBack: false, combination: 'SP', de: 'T' }
 				},
 				'children' : [
 					{
@@ -1883,7 +1884,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 								'type': 'toolitem',
 								'text':  _UNO('.uno:Hyphenate', 'text'),
 								'command': '.uno:Hyphenate',
-								'accessibility': { focusBack: true,	combination: 'H', de: null }
+								'accessibility': { focusBack: true,	combination: 'H', de: 'I' }
 							}
 						]
 					},


### PR DESCRIPTION
with 167afe17f0ed722f434bc0b39cd2c5139bc725e6 merged, overflow groups
can now have accesskeys. Add them to first overflow group in layout
tab both in Calc and Writer and update default and DE Accesskeys.

Note: the PS accessKey in the case of Calc or SP in the case of writer
are intentionally duplicated in the file but they will not be
duplicated for the user. the first instance is for when the overflow
group is folded (press that accessKey will change the focus to the
very first element)

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ide694daa84711771c14559446349ad43d61a932b
