### PR TITLE
Allow JSdialog tab navigation to loop

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1523,6 +1523,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		var wrapper = L.DomUtil.create('div', wrapperClass + ' ui-pushbutton-wrapper ' + builder.options.cssClass, parentContainer); // need for locking overlay
 		wrapper.id = data.id;
 		var pushbutton = L.DomUtil.create('button', 'ui-pushbutton ' + builder.options.cssClass, wrapper);
+		pushbutton.setAttribute('tabindex', '0');
 		builder._setAccessKey(pushbutton, builder._getAccessKeyFromText(data.text));
 		var pushbuttonText = builder._customPushButtonTextForId(data.id) !== '' ? builder._customPushButtonTextForId(data.id) : builder._cleanText(data.text);
 		var image;


### PR DESCRIPTION
While using tab to navigate would loop through each option in the JSdialog, using shift tab would only swap between the exit button and the first item. Adding tabindex: 0 to the final button fixes this, and seems to have no other effect. 

Change-Id: I6a6a6964e020244c6d36fc9d5bc430dab1cdff7d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

