### PR TITLE
perf: add compressed slide prefetching for slideshow responsiveness

### DIFF
--- a/browser/src/app/SlideshowMiddleware.ts
+++ b/browser/src/app/SlideshowMiddleware.ts
@@ -14,8 +14,15 @@
 
 // SlideBitmapManager handles the layers for the slideshow
 // It provides utility to decompress the row data from zstd and then make bitmaps from it
+interface CompressedSlideLayer {
+	json: any;
+	imgRawData: Uint8Array;
+}
+
 class SlideBitmapManager {
 	public static pendingLayers: Promise<ImageBitmap>[] = [];
+	private static compressedSlideCache: Map<string, CompressedSlideLayer[]> =
+		new Map();
 
 	public static decompressAndCreateImageData(
 		imgRawData: Uint8Array,
@@ -27,9 +34,58 @@ class SlideBitmapManager {
 		return new ImageData(clampedArray, width, height);
 	}
 
+	public static renderCachedCompressSlide(layers: CompressedSlideLayer[]) {
+		const pendingLayers: Promise<void>[] = [];
+
+		for (const layer of layers) {
+			const { json, imgRawData } = layer;
+			if (json?.width && json?.height) {
+				const imgData = this.decompressAndCreateImageData(
+					imgRawData,
+					json.width,
+					json.height,
+				);
+
+				console.debug(
+					'CompressedCache: fetching layers from compressed cache',
+					layer,
+				);
+				pendingLayers.push(
+					createImageBitmap(imgData).then((img) => {
+						app.map.fire('slidelayer', {
+							message: json,
+							image: img,
+						});
+					}),
+				);
+			}
+		}
+
+		Promise.all(pendingLayers)
+			.then(() => {
+				console.debug('CompressedCache: Complete Slide rendering');
+
+				app.map.fire('sliderenderingcomplete', {
+					success: 'success',
+					compressedLayers: false,
+				});
+			})
+			.catch((err) => {
+				app.map.fire('sliderenderingcomplete', {
+					success: 'fail',
+					compressedLayers: false,
+				});
+				console.error('Something Went wrong while preparing layers', err);
+			});
+	}
+
 	public static handleRenderSlideEvent(e: any) {
 		if (!e.textMsg.startsWith('slidelayer:')) return;
 		var json = JSON.parse(e.textMsg.substring('slidelayer: '.length));
+		if (json.isCompressed) {
+			this.cacheCompressedLayer(json, e.imgBytes.subarray(e.imgIndex));
+			return;
+		}
 		if (json.width && json.height) {
 			var imgData = this.decompressAndCreateImageData(
 				e.imgBytes.subarray(e.imgIndex),
@@ -53,13 +109,42 @@ class SlideBitmapManager {
 	public static handleSlideRenderingComplete(e: any) {
 		if (!e.textMsg.startsWith('sliderenderingcomplete:')) return;
 
-		// make sure all bitmaps are created before firing the complete event
+		var json = JSON.parse(
+			e.textMsg.substring('sliderenderingcomplete: '.length),
+		);
+
+		if (
+			json.compressedLayers &&
+			this.compressedSlideCache.get(json.slidehash) != null
+		) {
+			const layers = this.compressedSlideCache.get(json.slidehash);
+			if (json.status === 'success') {
+				app.map.fire('compressedslide', {
+					slideHash: json.slidehash,
+					layers: layers,
+				});
+			}
+			this.compressedSlideCache.delete(json.slidehash);
+			app.map.fire('sliderenderingcomplete', {
+				success: json.status === 'success',
+				compressedLayers: json.compressedLayers,
+			});
+			return;
+		}
+
 		Promise.all(this.pendingLayers).then(() => {
 			this.pendingLayers = [];
-			const status = e.textMsg.substring('sliderenderingcomplete: '.length);
 			app.map.fire('sliderenderingcomplete', {
-				success: status === 'success',
+				success: json.status === 'success',
+				compressedLayers: json.compressedLayers,
 			});
 		});
+	}
+
+	private static cacheCompressedLayer(json: any, imgRawData: Uint8Array) {
+		if (!this.compressedSlideCache.has(json.slideHash)) {
+			this.compressedSlideCache.set(json.slideHash, []);
+		}
+		this.compressedSlideCache.get(json.slideHash).push({ json, imgRawData });
 	}
 }

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -198,7 +198,7 @@ private:
     bool selectGraphic(const StringVector& tokens);
     bool renderNextSlideLayer(SlideCompressor &scomp,
                               unsigned width, unsigned height,
-                              double dDevicePixelRatio, bool& done);
+                              double dDevicePixelRatio, bool& done, bool isCompressed);
     bool renderSlide(const StringVector& tokens);
     bool renderWindow(const StringVector& tokens);
     bool resizeWindow(const StringVector& tokens);


### PR DESCRIPTION
Change-Id: I05e65e83fe47a2b5c00fb3c78b89ca35d43fbf9a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Prefetch compressed slides in advance so we don’t need to request them from the server each time. This currently works only in Experimental mode. to enable it, change ENABLE_EXPERIMENTAL from false to true in configure.ac. 
follow up task: Cache only the next 5/6 slides to avoid over-fetching.