### PR TITLE
Fix reset slide layout option not working

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -783,7 +783,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 								'noLabel': true,
 								'text': _('Change Layout'),
 								'icon': 'lc_changelayout.svg',
-								'command': _UNO('.uno:AssignLayout'),
+								'command': '.uno:AssignLayout',
 								'accessibility': { focusBack: true, combination: 'CL', de: null }
 							},
 							{
@@ -791,7 +791,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 								'noLabel': true,
 								'text': _('Reset Layout'),
 								'type': 'toolitem',
-								'command': _UNO('.uno:AssignLayout'),
+								'command': '.uno:AssignLayout',
 								'accessibility': { focusBack: true, combination: 'RS', de: null }
 							}
 						],


### PR DESCRIPTION

- before this patch `Reset layout` option was not working
- Reason: We accidentally added `_UNO`  prefix for `command` property  in json this cause issue to send uno command to CORE
- this patch will fix this _UNO prefix issue

Regression commit: https://github.com/CollaboraOnline/online/pull/12479/commits/dfd4a7733e96602e052340563128c59ebad5f0d7

Change-Id: I39d7fb709ef0c120bb28a77b5c2752880312cef1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

