### PR TITLE
Use MAX_SAFE_INTEGER to make sure that all tiles are invalidated

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1456,8 +1456,8 @@ L.CanvasTileLayer = L.Layer.extend({
 					+ ' ';
 			}
 			msg += 'x=0 y=0 ';
-			msg += 'width=' + app.activeDocument.fileSize.x + ' ';
-			msg += 'height=' + app.activeDocument.fileSize.y;
+			msg += 'width=' + Number.MAX_SAFE_INTEGER + ' ';
+			msg += 'height=' + Number.MAX_SAFE_INTEGER;
 			if (wireIdToken !== undefined)
 				msg += ' ' + wireIdToken;
 			this._onInvalidateTilesMsg(msg);


### PR DESCRIPTION
In some cases, a tile may be requested at the end of a document, when
layout isn't finished, and current size of the document is loo small.
This may happen e.g. when renaming a long document, when the current
position is near its end.

In this case, an empty tile would be returned. Later, when the layout
finishes, 'invalidatetiles: EMPTY' message would arrive, requesting
to flush all cached tiles. This makes handleInvalidateTilesMsg create
a new 'invalidatetiles' message with a rectangle, and then pass it to
_onInvalidateTilesMsg, which checks if cached tiles are in the area,
and then drops them.

The old code used document size as the size of the rectangle. But it
is the old size of the document at this point; and the empty tiles
requested initially turn out to be outside of the bounds calculated
for the 'invalidatetiles' message, so they are kept, and not fetched
again.

This change uses Number.MAX_SAFE_INTEGER constant here, which will
guarantee that all tiles are covered by it. I don't know if we can
ever have tiles with negative coordinates; but if so, then 'x=0 y=0'
can be replaced using respective Number.MIN_VALUE. This shouldn't
affect performance.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I89992b4911872d2aa8397eed98e55823c2f4d059
