### PR TITLE
Refactor/Admin: Replace jQuery ID Selectors with getElementById

### DIFF
--- a/browser/admin/src/AdminClusterOverviewAbout.js
+++ b/browser/admin/src/AdminClusterOverviewAbout.js
@@ -1,5 +1,5 @@
 /* -*- js-indent-level: 8 -*- */
-/* global AdminSocketBase Admin $ */
+/* global AdminSocketBase Admin */
 
 var AdminClusterOverviewAbout = AdminSocketBase.extend({
     constructor: function(host, routeToken) {

--- a/browser/admin/src/AdminClusterOverviewAbout.js
+++ b/browser/admin/src/AdminClusterOverviewAbout.js
@@ -8,7 +8,7 @@ var AdminClusterOverviewAbout = AdminSocketBase.extend({
     },
 
     onSocketMessage: function(e) {
-        var textMsg;
+        let textMsg;
         if (typeof e.data === 'string') {
             textMsg = e.data;
         }
@@ -16,8 +16,13 @@ var AdminClusterOverviewAbout = AdminSocketBase.extend({
             textMsg = '';
         }
         if (textMsg.startsWith('license')) {
-            $('#license-content').html(textMsg.substring('license: '.length));
-        }
+            const licenseContentEl = document.getElementById('license-content');
+            if (licenseContentEl) {
+                licenseContentEl.innerHTML = textMsg.substring('license: '.length);
+            } else {
+                console.warn('Element #license-content not found');
+            }
+         }
     },
 
     onSocketOpen: function() {

--- a/browser/admin/src/AdminSocketAnalytics.js
+++ b/browser/admin/src/AdminSocketAnalytics.js
@@ -13,7 +13,7 @@
  * containing various graphs to show to the user on specified interval
  */
 
-/* global _ d3 Util AdminSocketBase $ Admin */
+/* global _ d3 Util AdminSocketBase Admin */
 var AdminSocketAnalytics = AdminSocketBase.extend({
 	constructor: function(host) {
 		this.base(host);
@@ -530,8 +530,13 @@ var AdminSocketAnalytics = AdminSocketBase.extend({
 		else if (textMsg.startsWith('sent_activity')) {
 			var data = Util.consumeDataText(textMsg, this._sentStatsData);
 			if (data === undefined) {
-				if ($('#NetVisualisation').html() === '')
-					this._createGraph('net');
+				const netVisEl = document.getElementById('NetVisualisation');
+				if (netVisEl) {
+					if (netVisEl.innerHTML === '')
+						this._createGraph('net');
+				} else {
+					console.warn('Element #NetVisualisation not found');
+				}
 			} else {
 				this._addNewData(this._sentStatsData, parseInt(data), 'sent');
 				this._updateNetGraph();
@@ -540,8 +545,13 @@ var AdminSocketAnalytics = AdminSocketBase.extend({
 		else if (textMsg.startsWith('recv_activity')) {
 			var data = Util.consumeDataText(textMsg, this._recvStatsData);
 			if (data === undefined) {
-				if ($('#NetVisualisation').html() === '')
-					this._createGraph('net');
+				const netVisEl = document.getElementById('NetVisualisation');
+				if (netVisEl) {
+					if (netVisEl.innerHTML === '')
+						this._createGraph('net');
+				} else {
+					console.warn('Element #NetVisualisation not found');
+				}
 			} else {
 				this._addNewData(this._recvStatsData, parseInt(data), 'recv');
 				this._updateNetGraph();
@@ -550,8 +560,13 @@ var AdminSocketAnalytics = AdminSocketBase.extend({
 		else if (textMsg.startsWith('connection_activity')) {
 			var data = Util.consumeDataText(textMsg, this._connStatsData);
 			if (data === undefined) {
-				if ($('#NetVisualisation').html() === '')
-					this._createGraph('net');
+				const netVisEl = document.getElementById('NetVisualisation');
+				if (netVisEl) {
+					if (netVisEl.innerHTML === '')
+						this._createGraph('net');
+				} else {
+					console.warn('Element #NetVisualisation not found');
+				}
 			} else {
 				this._addNewData(this._connStatsData, parseInt(data), 'connect');
 				this._updateNetGraph();

--- a/browser/admin/src/AdminSocketHistory.js
+++ b/browser/admin/src/AdminSocketHistory.js
@@ -28,9 +28,14 @@ var AdminSocketHistory = AdminSocketBase.extend({
 		this.base.call(this);
 
 		var socketHistory = this;
-		$('#refreshHistory').on('click', function () {
-			return socketHistory.refreshHistory();
-		});
+		const refreshHistoryBtn = document.getElementById('refreshHistory');
+		if (refreshHistoryBtn) {
+			refreshHistoryBtn.addEventListener('click', function () {
+				return socketHistory.refreshHistory();
+			});
+		} else {
+			console.warn('Element #refreshHistory not found');
+		}
 		this.refreshHistory();
 	},
 
@@ -44,8 +49,20 @@ var AdminSocketHistory = AdminSocketBase.extend({
 			jsonObj = JSON.parse(e.data);
 			var doc = jsonObj['History']['documents'];
 			var exdoc = jsonObj['History']['expiredDocuments'];
-			$('#json-doc').find('textarea').text(JSON.stringify(doc));
-			$('#json-ex-doc').find('textarea').text(JSON.stringify(exdoc));
+				const jsonDocEl = document.getElementById('json-doc');
+				if (jsonDocEl) {
+					const ta = jsonDocEl.querySelector('textarea');
+					if (ta) ta.textContent = JSON.stringify(doc);
+				} else {
+					console.warn('Element #json-doc not found');
+				}
+				const jsonExDocEl = document.getElementById('json-ex-doc');
+				if (jsonExDocEl) {
+					const ta2 = jsonExDocEl.querySelector('textarea');
+					if (ta2) ta2.textContent = JSON.stringify(exdoc);
+				} else {
+					console.warn('Element #json-ex-doc not found');
+				}
 		} catch (e) {
 			$('document').alert(e.message);
 		}

--- a/browser/admin/src/AdminSocketLog.js
+++ b/browser/admin/src/AdminSocketLog.js
@@ -12,15 +12,15 @@
  * Socket to be intialized on opening the log page in Admin console
  */
 
-/* global Admin $ AdminSocketBase */
+/* global Admin AdminSocketBase */
 
 var AdminSocketLog = AdminSocketBase.extend({
 	_logLines: '',
 
 	constructor: function(host) {
 		this.base(host);
-		// There is a "$" is never used error. Let's get rid of this. This is vanilla script and has not more lines than the one with JQuery.
-		$('#form-channel-list').id;
+		// There was a "$" is never used error; replace the id-based jQuery lookup with a native DOM access.
+		document.getElementById('form-channel-list');
 	},
 
 	refreshLog: function() {

--- a/browser/admin/src/AdminSocketOverview.js
+++ b/browser/admin/src/AdminSocketOverview.js
@@ -273,7 +273,6 @@ var AdminSocketOverview = AdminSocketBase.extend({
 			textMsg = '';
 		}
 
-		var $doc, $a;
 		var nTotalViews;
 		var docProps, sPid, sName;
 		if (textMsg.startsWith('documents')) {
@@ -337,7 +336,10 @@ var AdminSocketOverview = AdminSocketBase.extend({
 			else if (sCommand === 'uptime') {
 				nData = Util.humanizeSecs(nData);
 			}
-			$(document.getElementById(sCommand)).text(nData);
+			{
+				const cmdEl = document.getElementById(sCommand);
+				if (cmdEl) cmdEl.textContent = nData;
+			}
 		}
 		else if (textMsg.startsWith('rmdoc')) {
 			textMsg = textMsg.substring('rmdoc'.length);
@@ -347,19 +349,20 @@ var AdminSocketOverview = AdminSocketBase.extend({
 
 			var doc = document.getElementById('doc' + sPid);
 			if (doc !== undefined && doc !== null) {
-				var $user = $(document.getElementById('user' + sessionid));
-				$user.remove();
+				var userEl = document.getElementById('user' + sessionid);
+				if (userEl) userEl.remove();
 				var collapsable = getCollapsibleClass('ucontainer' + sPid);
 				var viewerCount = parseInt(collapsable.getText().split(' ')[0]) - 1;
 				if (viewerCount === 0) {
 					document.getElementById('docview').deleteRow(doc.rowIndex);
-				}
-				else {
+				} else {
 					collapsable.setText(String(viewerCount) + _(' user(s).'));
 				}
-				$a = $(document.getElementById('active_users_count'));
-				nTotalViews = parseInt($a.text());
-				$a.text(nTotalViews - 1);
+				var aEl = document.getElementById('active_users_count');
+				if (aEl) {
+					nTotalViews = parseInt(aEl.textContent) || 0;
+					aEl.textContent = String(nTotalViews - 1);
+				}
 			}
 
 			var docEntry = document.getElementById(sessionid + '_' + sPid);
@@ -382,11 +385,11 @@ var AdminSocketOverview = AdminSocketBase.extend({
 			var sProp = docProps[1];
 			var sValue = docProps[2];
 
-			$doc = $('#doc' + sPid);
-			if ($doc.length !== 0) {
+			var docEl2 = document.getElementById('doc' + sPid);
+			if (docEl2) {
 				if (sProp == 'mem') {
-					var $mem = $('#docmem' + sPid);
-					$mem.text(Util.humanizeMem(parseInt(sValue)));
+					var memEl = document.getElementById('docmem' + sPid);
+					if (memEl) memEl.textContent = Util.humanizeMem(parseInt(sValue));
 				}
 			}
 		}
@@ -396,8 +399,8 @@ var AdminSocketOverview = AdminSocketBase.extend({
 			sPid = docProps[0];
 			var value = docProps[1];
 
-			var $mod = $(document.getElementById('mod' + sPid));
-			$mod.text(value);
+			var modEl = document.getElementById('mod' + sPid);
+			if (modEl) modEl.textContent = value;
 		}
 		else if (textMsg.startsWith('uploaded')) {
 			textMsg = textMsg.substring('uploaded'.length);
@@ -406,10 +409,8 @@ var AdminSocketOverview = AdminSocketBase.extend({
 				sPid = docProps[0];
 				var value = docProps[1];
 
-				var up = $(document.getElementById('up' + sPid));
-				if (up !== undefined) {
-					up.text(value);
-				}
+				var upEl = document.getElementById('up' + sPid);
+				if (upEl) upEl.textContent = value;
 			}
 		}
 		else if (e.data == 'InvalidAuthToken' || e.data == 'NotAuthenticated') {

--- a/browser/admin/src/AdminSocketSettings.js
+++ b/browser/admin/src/AdminSocketSettings.js
@@ -23,22 +23,31 @@ var AdminSocketSettings = AdminSocketBase.extend({
 	_init: function() {
 		var socketSettings = this.socket;
 		$(document).ready(function() {
-			$('#admin_settings').on('submit', function(e) {
-				e.preventDefault();
-				var memStatsSize = $('#mem_stats_size').val();
-				var memStatsInterval = $('#mem_stats_interval').val();
-				var cpuStatsSize = $('#cpu_stats_size').val();
-				var cpuStatsInterval = $('#cpu_stats_interval').val();
-				var command = 'set';
-				command += ' mem_stats_size=' + memStatsSize;
-				command += ' mem_stats_interval=' + memStatsInterval;
-				command += ' cpu_stats_size=' + cpuStatsSize;
-				command += ' cpu_stats_interval=' + cpuStatsInterval;
-				command += ' limit_virt_mem_mb=' + $('#limit_virt_mem_mb').val();
-				command += ' limit_stack_mem_kb=' + $('#limit_stack_mem_kb').val();
-				command += ' limit_file_size_mb=' + $('#limit_file_size_mb').val();
-				socketSettings.send(command);
-			});
+			const adminForm = document.getElementById('admin_settings');
+			if (adminForm) {
+				adminForm.addEventListener('submit', function(e) {
+					e.preventDefault();
+					const memStatsSizeEl = document.getElementById('mem_stats_size');
+					const memStatsIntervalEl = document.getElementById('mem_stats_interval');
+					const cpuStatsSizeEl = document.getElementById('cpu_stats_size');
+					const cpuStatsIntervalEl = document.getElementById('cpu_stats_interval');
+					var memStatsSize = memStatsSizeEl ? memStatsSizeEl.value : '';
+					var memStatsInterval = memStatsIntervalEl ? memStatsIntervalEl.value : '';
+					var cpuStatsSize = cpuStatsSizeEl ? cpuStatsSizeEl.value : '';
+					var cpuStatsInterval = cpuStatsIntervalEl ? cpuStatsIntervalEl.value : '';
+					var command = 'set';
+					command += ' mem_stats_size=' + memStatsSize;
+					command += ' mem_stats_interval=' + memStatsInterval;
+					command += ' cpu_stats_size=' + cpuStatsSize;
+					command += ' cpu_stats_interval=' + cpuStatsInterval;
+					command += ' limit_virt_mem_mb=' + (document.getElementById('limit_virt_mem_mb') ? document.getElementById('limit_virt_mem_mb').value : '');
+					command += ' limit_stack_mem_kb=' + (document.getElementById('limit_stack_mem_kb') ? document.getElementById('limit_stack_mem_kb').value : '');
+					command += ' limit_file_size_mb=' + (document.getElementById('limit_file_size_mb') ? document.getElementById('limit_file_size_mb').value : '');
+					socketSettings.send(command);
+				});
+			} else {
+				console.warn('Element #admin_settings not found');
+			}
 
 			document.getElementById('btnShutdown').onclick = function() {
 				var dialog = (new DlgYesNo())
@@ -50,8 +59,8 @@ var AdminSocketSettings = AdminSocketBase.extend({
 					.yesFunction(function() {
 						socketSettings.send('shutdown maintenance');
 					});
-				dialog.open();
-			};
+					dialog.open();
+				};
 		});
 	},
 
@@ -91,16 +100,28 @@ var AdminSocketSettings = AdminSocketBase.extend({
 			var h = coolwsdVersionObj.Hash;
 			if (parseInt(h,16).toString(16) === h.toLowerCase().replace(/^0+/, '')) {
 				h = '<a target="_blank" href="https://github.com/CollaboraOnline/online/commits/' + h + '">' + h + '</a>';
-				$('#coolwsd-version').html(coolwsdVersionObj.Version + ' (git hash: ' + h + ')');
+					{
+						const el = document.getElementById('coolwsd-version');
+						if (el) el.innerHTML = coolwsdVersionObj.Version + ' (git hash: ' + h + ')';
+						else console.warn('Element #coolwsd-version not found');
+					}
 			}
 			else {
-				$('#coolwsd-version').text(coolwsdVersionObj.Version);
+					{
+						const el = document.getElementById('coolwsd-version');
+						if (el) el.textContent = coolwsdVersionObj.Version;
+						else console.warn('Element #coolwsd-version not found');
+					}
 			}
 			let buildConfig = coolwsdVersionObj.BuildConfig;
 			if (coolwsdVersionObj.PocoVersion !== undefined) {
 				buildConfig += ' (poco version: ' + coolwsdVersionObj.PocoVersion + ')';
 			}
-			$('#coolwsd-buildconfig').html(buildConfig);
+				{
+					const el = document.getElementById('coolwsd-buildconfig');
+					if (el) el.innerHTML = buildConfig;
+					else console.warn('Element #coolwsd-buildconfig not found');
+				}
 		}
 		else if (textMsg.startsWith('lokitversion ')) {
 			var lokitVersionObj = JSON.parse(textMsg.substring(textMsg.indexOf('{')));
@@ -108,10 +129,18 @@ var AdminSocketSettings = AdminSocketBase.extend({
 			if (parseInt(h,16).toString(16) === h.toLowerCase().replace(/^0+/, '')) {
 				h = '<a target="_blank" href="https://git.libreoffice.org/core/+log/' + lokitVersionObj.BuildId + '/">' + h + '</a>';
 			}
-			$('#lokit-version').html(lokitVersionObj.ProductName + ' ' +
-			                         lokitVersionObj.ProductVersion + lokitVersionObj.ProductExtension +
-			                         ' (git hash: ' + h + ')');
-			$('#lokit-buildconfig').html(lokitVersionObj.BuildConfig);
+			{
+				const el = document.getElementById('lokit-version');
+				if (el) el.innerHTML = lokitVersionObj.ProductName + ' ' +
+				                         lokitVersionObj.ProductVersion + lokitVersionObj.ProductExtension +
+				                         ' (git hash: ' + h + ')';
+				else console.warn('Element #lokit-version not found');
+			}
+			{
+				const el2 = document.getElementById('lokit-buildconfig');
+				if (el2) el2.innerHTML = lokitVersionObj.BuildConfig;
+				else console.warn('Element #lokit-buildconfig not found');
+			}
 		}
 	},
 


### PR DESCRIPTION
* Resolves: #11754
* Target version: master 

### Summary
This PR is part of the effort to remove jQuery from the codebase. Specifically, it focuses on admin-related files by replacing jQuery selectors that target elements by ID (e.g., $('#element-id')) with the native JavaScript method document.getElementById('element-id').


### TODO

- [ ] ...

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

