### PR TITLE
'File not found' should be a warning, not an error

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1166,7 +1166,7 @@ bool FileServerRequestHandler::handleRequest(const HTTPRequest& request,
     }
     catch (const Poco::FileNotFoundException& exc)
     {
-        LOG_ERR("FileServerRequestHandler: " << exc.displayText());
+        LOG_WRN("FileServerRequestHandler: " << exc.displayText());
         sendError(http::StatusCode::NotFound, getRequestPath(request), socket, "404 - file not found!",
                   "There seems to be a problem locating");
     }


### PR DESCRIPTION
e.g. "ERR FileServerRequestHandler: File not found: Invalid URI request (hash): [/browser/aeb4eab5fa/branding.js]" is quite common and associated with not having branding installed. Also UI tries to load icons that are not for display, just artifacts of JSDialog creation.


Change-Id: Ia23b96082fc912b8ec0470bd08f399e84828d85e
