### PR TITLE
Context toolbar: Fix color picker borders

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -34,6 +34,7 @@
 	--color-border: #121212;
 	--color-border-dark: #1E1E1E; /* select */
 	--color-border-darker: #000;  /* hover */
+	--color-border-dark-63: #5e5e5e;
 	--color-border-lighter: #303030; /* disabled */
 
 	--color-btn-border: #b6b6b6;

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -35,6 +35,7 @@
 	--color-border: #b6b6b6;
 	--color-border-dark: #cecece; /* select */
 	--color-border-darker: #c0bfbc;  /* hover */
+	--color-border-dark-63: #a1a1a1;
 	--color-border-lighter: #f1f1f1; /* disabled */
 
 	--color-btn-border: #b6b6b6;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1633,6 +1633,9 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	border-radius: 7px;
 	outline: 1px solid var(--color-background-lighter);
 }
+#context-toolbar .unotoolbutton .selected-color {
+	outline: 1px solid var(--color-border-dark-63);
+}
 
 /* dropdown arrow */
 .unoarrow, .menubutton .arrow {


### PR DESCRIPTION
Before this commit the border around the color pill was white on white
background.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I1a814b77921137879c498f0cdd914c7a88af5280
