### PR TITLE
notebookbar: fix scroll range inside icon views (backport)

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -349,6 +349,11 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	height: 82px;
 	align-content: center;
 }
+
+.ui-overflow-manager > .notebookbar.ui-iconview {
+	align-content: initial; /* fixes scrolling range, for example in #stylesview */
+}
+
 .ui-overflow-manager > .notebookbar:not(.ui-separator):not(.ui-overflow-group):not(:has(.ui-overflow-group-container-with-label)) {
 	height: 49px;
 	/* 14px extra margin for containers without label */


### PR DESCRIPTION
fixes regression from commit 625a2370d6493bd83903d6aab07d20c2946c296d Tabbed: overflow: Align buttons without overflow label

Bug was visible in some window sizes when styles previews scrolling was not possible to the very top

Backport of: https://github.com/CollaboraOnline/online/pull/12679