### PR TITLE
Initialize core components after first tiles request

### DIFF
--- a/browser/src/control/Control.QuickFindPanel.ts
+++ b/browser/src/control/Control.QuickFindPanel.ts
@@ -16,8 +16,6 @@
 const QUICKFIND_WINDOW_ID = -5;
 class QuickFindPanel extends SidebarBase {
 	constructor(map: any) {
-		// Initialize QuickFindPanel in core
-		app.socket.sendMessage('uno .uno:QuickFind');
 		super(map, SidebarType.QuickFind);
 	}
 

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -565,11 +565,12 @@ class UIManager extends L.Control {
 		if (window.mode.isDesktop() && !window.ThisIsAMobileApp) {
 			var showSidebar = this.getBooleanDocTypePref('ShowSidebar', true);
 
-			if (this.getBooleanDocTypePref('PropertyDeck', true)) {
+			if (showSidebar && this.getBooleanDocTypePref('PropertyDeck', true)) {
 				app.socket.sendMessage('uno .uno:SidebarShow');
+				this.map.sidebar.setAsInitialized();
 			}
 
-			if (this.map.getDocType() === 'presentation') {
+			if (showSidebar && this.map.getDocType() === 'presentation') {
 				if (this.getBooleanDocTypePref('SdSlideTransitionDeck', false)) {
 					app.socket.sendMessage('uno .uno:SidebarShow');
 					app.socket.sendMessage('uno .uno:SlideChangeWindow');
@@ -579,7 +580,7 @@ class UIManager extends L.Control {
 					app.socket.sendMessage('uno .uno:CustomAnimation');
 					this.map.sidebar.setupTargetDeck('.uno:CustomAnimation');
 				}
-			} else if (this.getBooleanDocTypePref('StyleListDeck', false)) {
+			} else if (showSidebar && this.getBooleanDocTypePref('StyleListDeck', false)) {
 				app.socket.sendMessage('uno .uno:SidebarShow');
 				app.socket.sendMessage('uno .uno:SidebarDeck.StyleListDeck');
 				this.map.sidebar.setupTargetDeck('.uno:SidebarDeck.StyleListDeck');

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -552,9 +552,6 @@ class UIManager extends L.Control {
 			}
 		});
 		this.map.contextToolbar = L.control.ContextToolbar(this.map);
-
-		// do it always as we need it for contextual toolbar
-		if (!window.mode.isMobile()) this.initializeNotebookbarInCore();
 	}
 
 	/**
@@ -1181,6 +1178,9 @@ class UIManager extends L.Control {
 	// Notebookbar helpers
 
 	initializeNotebookbarInCore(): void {
+		// do it always apart of mobile as we need it for contextual toolbar
+		if (window.mode.isMobile()) return;
+
 		this.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=notebookbar_online.ui');
 	}
 

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1184,6 +1184,15 @@ class UIManager extends L.Control {
 		this.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=notebookbar_online.ui');
 	}
 
+	// QuickFindPanel
+
+	initializeQuickFindInCore(): void {
+		if (!this.map.quickFindPanel) return;
+
+		// Initialize QuickFindPanel in core
+		app.socket.sendMessage('uno .uno:QuickFind');
+	}
+
 	/**
 	 * Returns whether the notebookbar is currently shown.
 	 */

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -555,6 +555,17 @@ class UIManager extends L.Control {
 	}
 
 	/**
+	 * Initializes the heavy components which require core side to work.
+	 * Scheduled to be executed after we do first tiles requests to not
+	 * block the document content rendering on a load.
+	 */
+	initializeLateComponents(): void {
+		this.initializeNotebookbarInCore();
+		this.initializeSidebar();
+		this.initializeQuickFindInCore();
+	}
+
+	/**
 	 * Initializes the sidebar based on saved state and preferences.
 	 */
 	initializeSidebar(): void {

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -304,8 +304,8 @@ L.Map = L.Evented.extend({
 
 			if (this._docLayer && !this._docLoadedOnce) {
 				// Let the first page finish loading then request core ui components
-				// TODO: make it deterministic by using the signal for first tiles received
-				setTimeout(this.uiManager.initializeLateComponents.bind(this.uiManager), 200);
+				TileManager.appendAfterFirstTileTask(
+					this.uiManager.initializeLateComponents.bind(this.uiManager));
 			}
 
 			// We have loaded.

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -302,12 +302,10 @@ L.Map = L.Evented.extend({
 			if (!window.mode.isMobile())
 				this.initializeModificationIndicator();
 
-			// Show sidebar.
 			if (this._docLayer && !this._docLoadedOnce) {
-				// Let the first page finish loading then load the sidebar and notebookbar
-				setTimeout(this.uiManager.initializeSidebar.bind(this.uiManager), 200);
-				setTimeout(this.uiManager.initializeNotebookbarInCore.bind(this.uiManager), 200);
-				setTimeout(this.uiManager.initializeQuickFindInCore.bind(this.uiManager), 400);
+				// Let the first page finish loading then request core ui components
+				// TODO: make it deterministic by using the signal for first tiles received
+				setTimeout(this.uiManager.initializeLateComponents.bind(this.uiManager), 200);
 			}
 
 			// We have loaded.

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -304,8 +304,9 @@ L.Map = L.Evented.extend({
 
 			// Show sidebar.
 			if (this._docLayer && !this._docLoadedOnce) {
-				// Let the first page finish loading then load the sidebar.
+				// Let the first page finish loading then load the sidebar and notebookbar
 				setTimeout(this.uiManager.initializeSidebar.bind(this.uiManager), 200);
+				setTimeout(this.uiManager.initializeNotebookbarInCore.bind(this.uiManager), 200);
 			}
 
 			// We have loaded.

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -307,6 +307,7 @@ L.Map = L.Evented.extend({
 				// Let the first page finish loading then load the sidebar and notebookbar
 				setTimeout(this.uiManager.initializeSidebar.bind(this.uiManager), 200);
 				setTimeout(this.uiManager.initializeNotebookbarInCore.bind(this.uiManager), 200);
+				setTimeout(this.uiManager.initializeQuickFindInCore.bind(this.uiManager), 400);
 			}
 
 			// We have loaded.

--- a/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
@@ -20,6 +20,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Invalidation tests.', func
 		helper.setupAndLoadDocument('writer/invalidations.odt');
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('div.clipboard').as('clipboard');
+		cy.cGet('#stylesview .ui-iconview-entry img').should('exist');
+		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '0 words, 0 characters');
 
 		// Add some main body text of X
 		ceHelper.type('X');
@@ -47,6 +49,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Invalidation tests.', func
 		helper.setupAndLoadDocument('writer/invalidations_headers.odt');
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('div.clipboard').as('clipboard');
+		cy.cGet('#stylesview .ui-iconview-entry img').should('exist');
+		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '2 words, 3 characters');
 
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#toolbar-down #StateWordCount').should('have.text', 'Selected: 1 word, 1 character');
@@ -89,6 +93,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Invalidation tests.', func
 		helper.setupAndLoadDocument('writer/invalidations.odt');
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('div.clipboard').as('clipboard');
+		cy.cGet('#stylesview .ui-iconview-entry img').should('exist');
+		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '0 words, 0 characters');
 
 		// Add some main body text of X and bullet
 		ceHelper.type('XX');


### PR DESCRIPTION
BEFORE:
```
INCOMING: status: ...
OUTGOING: uno .uno:ChangeTheme {"NewTheme":{"type":"string","value":"Dark"}}
OUTGOING: uno .uno:InvertBackground {"NewTheme":{"type":"string","value":"Dark"}}
OUTGOING: uno .uno:ToolbarMode?Mode:string=notebookbar_online.ui
OUTGOING: uno .uno:SidebarShow
OUTGOING: uno .uno:SidebarHide 

... Creating CanvasTileWorker
```

AFTER:
```
INCOMING: status: ...
OUTGOING: a11ystate false
Creating CanvasTileWorker
OUTGOING: clientzoom
OUTGOING: tilecombine

... delay ...

sidebar, notebookbar, quick find
```