### PR TITLE
Navigator: dont register to 'focussearch' in non-writer

### DIFF
--- a/browser/src/control/Control.NavigatorPanel.ts
+++ b/browser/src/control/Control.NavigatorPanel.ts
@@ -360,10 +360,13 @@ class NavigatorPanel extends SidebarBase {
 	}
 
 	focusSearch() {
+		const searchInput = document.getElementById(
+			'navigator-search-input',
+		) as HTMLInputElement;
+		if (!searchInput) return;
+
 		app.layoutingService.appendLayoutingTask(() => {
-			(
-				document.getElementById('navigator-search-input') as HTMLInputElement
-			).focus();
+			searchInput.focus();
 		});
 	}
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

QuickFind only exists in writer so trying to focus the search bar causes an error in non-writer.
Fix this:
<img width="1289" height="466" alt="Pasted image 20250827133213" src="https://github.com/user-attachments/assets/f2d5d719-675f-45c9-878e-b9f7f26f839b" />


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

