### PR TITLE
Navigator: Results tab: add up/down arrows for search navigation

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -325,7 +325,16 @@ body {
 	height: 100%;
 }
 
-#sidebar-dock-wrapper, #navigator-dock-wrapper, #quickfind-dock-wrapper {
+#quickfind-dock-wrapper {
+	display: none;
+	background: var(--color-background-lighter);
+	position: relative;
+	z-index: 990;
+	max-width: 350px;
+	height: 100%;
+}
+
+#sidebar-dock-wrapper, #navigator-dock-wrapper {
 	display: none;
 	background: var(--color-background-lighter);
 	position: relative;

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -628,6 +628,7 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	overflow-y: auto;
 	scrollbar-width: thin;
 	scrollbar-color: var(--color-border) transparent;
+	max-height: calc(100vh - 350px);
 }
 
 /* results */

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -671,6 +671,27 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	grid-template-columns: 1fr;
 }
 
+#quickfind-container #quickfindcontrols {
+	position: absolute;
+	top: 0;
+	right: 0;		
+}
+
+#quickfind-container #quickfindcontrols button img {
+	width: var(--btn-img-size-m);
+	height: var(--btn-img-size-m);
+}
+
+#quickfind-container #quickfindcontrols button {
+	width: var(--btn-size-m);
+	height: var(--btn-size-m);
+	background-color: var(--color-background-lighter) !important;
+}
+
+#quickfind-container #quickfindcontrols button:hover {
+	background-color: var(--color-background-dark) !important;
+}
+
 #navigation-sidebar.visible {
 	display: flex;
 	flex-direction: column;

--- a/browser/src/control/Control.QuickFindPanel.ts
+++ b/browser/src/control/Control.QuickFindPanel.ts
@@ -36,21 +36,36 @@ class QuickFindPanel extends SidebarBase {
 
 		super.onJSUpdate(e);
 
-		// handle placeholder text visibility
+		// handle placeholder text and quickfind controls visibility
 		app.layoutingService.appendLayoutingTask(() => {
-			const placeholder = document.getElementById('quickfind-placeholder');
-
 			if (data.control.id === 'numberofsearchfinds') {
-				const resultsText = data.control.text.trim().length > 0;
-				if (placeholder) placeholder.classList.toggle('hidden', resultsText);
+				this.handleNumberOfSearchFinds(data.control);
 			} else if (
 				data.control.id === 'searchfinds' &&
 				data.control.type === 'treelistbox'
 			) {
-				const isEmpty = data.control.entries.length === 0;
-				if (placeholder) placeholder.classList.toggle('hidden', !isEmpty);
+				this.handleSearchFindsTreelistbox(data.control);
 			}
 		});
+	}
+
+	handleNumberOfSearchFinds(control: any): void {
+		const placeholder = document.getElementById('quickfind-placeholder');
+
+		const hasText = (control.text ?? '').trim().length > 0;
+		if (placeholder) placeholder.classList.toggle('hidden', hasText);
+	}
+
+	handleSearchFindsTreelistbox(control: any): void {
+		const placeholder = document.getElementById('quickfind-placeholder');
+		const quickFindControls = document.getElementById('quickfind-controls');
+
+		const isEmpty =
+			!Array.isArray(control.entries) || control.entries.length === 0;
+
+		if (placeholder) placeholder.classList.toggle('hidden', !isEmpty);
+		if (quickFindControls)
+			quickFindControls.classList.toggle('hidden', isEmpty);
 	}
 
 	addPlaceholderIfEmpty(quickFindData: any): any {
@@ -88,6 +103,7 @@ class QuickFindPanel extends SidebarBase {
 		else console.error('QuickFind: no container');
 
 		const modifiedData = this.addPlaceholderIfEmpty(quickFindData);
+
 		this.builder.build(this.container, [modifiedData], false);
 
 		app.showQuickFind = true;

--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -922,6 +922,25 @@ class TreeViewControl {
 		if (checkbox) checkbox.removeAttribute('tabindex');
 	}
 
+	selectEntryByRow(row: number) {
+		const rowElement = this._rows.get(String(row));
+		if (!rowElement) {
+			console.warn('TreeView onSelect: row "' + row + '" not found');
+			return;
+		}
+
+		// Clear existing selections
+		this._container
+			.querySelectorAll('.ui-treeview-entry.selected')
+			.forEach((item: HTMLElement) => {
+				this.unselectEntry(item);
+			});
+
+		// Select the target row
+		const checkbox = rowElement.querySelector('input') as HTMLInputElement;
+		this.selectEntry(rowElement, checkbox);
+	}
+
 	unselectEntry(item: HTMLElement) {
 		L.DomUtil.removeClass(item, 'selected');
 		item.removeAttribute('aria-selected');
@@ -1626,6 +1645,9 @@ class TreeViewControl {
 		this._singleClickActivate = TreeViewControl.isSingleClickActivate(data);
 
 		this._tbody = this._container;
+		(this._container as any).onSelect = (position: number) => {
+			this.selectEntryByRow(position);
+		};
 		(this._container as any).filterEntries = this.filterEntries.bind(this);
 		(this._container as any).highlightEntries =
 			this.highlightEntries.bind(this);


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Adds prev/next buttons that appear when search finds matches and hide when the results list is empty.

### PREVIEW

https://github.com/user-attachments/assets/151cb66c-78a5-42f5-a174-571274a2ed64



- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

