### PR TITLE
Fix Transition tab options label color in dark mode (Backport)

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -248,6 +248,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	align-items: center;
 	justify-items: center;
 	width: max-content;
+	color: var(--color-main-text);
 }
 
 /* unobuttons */


### PR DESCRIPTION
Backport : https://github.com/CollaboraOnline/online/pull/12692

- button label color seems to be not set before this patch
- this patch will fix the label visibility problem in dark mode


Change-Id: Icbfd1ef8cb63478e00febe06644a2e65f3c7f9fe


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

