### PR TITLE
Add more button support in overflow popup (Backport)

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1319,6 +1319,8 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .notebookbar.ui-overflow-group-bottom {
 	display: flex;
 	padding: 0 5px;
+	width: 100%;
+	box-sizing: border-box;
 }
 
 .notebookbar .ui-overflow-group-inner {

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -116,11 +116,15 @@
 	margin: 0px;
 }
 
+.ui-overflow-group-popup > .top-row-overflow-group {
+	display: flex;
+}
 /* overflow menu */
 .ui-overflow-group-popup {
+	display: flex;
+	flex-direction: column;
 	position: absolute;
 	z-index: 12;
-	display: flex;
 	background-color: var(--color-background-lighter);
 	border: 1px solid var(--color-toolbar-border);
 	align-items: center;

--- a/browser/src/control/jsdialog/Widget.OverflowGroup.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowGroup.ts
@@ -83,10 +83,8 @@ function setupOverflowMenu(
 		'.ui-overflow-group-label',
 	) as HTMLElement;
 
-	let expanderIconRightDiv: HTMLElement | undefined;
-
 	if (more) {
-		expanderIconRightDiv = createMoreButton(id, more, groupLabel);
+		createMoreButton(id, more, groupLabel);
 	}
 
 	// keeps hidden items
@@ -100,14 +98,31 @@ function setupOverflowMenu(
 
 	// keeps original content
 	const originalTopbar = overflowMenu.querySelectorAll(':scope > *');
-
+	const bottomGroup = parentContainer.querySelector(
+		'.ui-overflow-group-bottom',
+	) as HTMLElement;
 	// hide/show content on resize
 	const overflowMenuHandler = (hideContent: boolean) => {
 		overflowMenu.replaceChildren();
+		hiddenItems.replaceChildren();
+
+		// Create a new container for the top row
+		const topRow = document.createElement('div');
+		topRow.classList.add('top-row-overflow-group');
+
 		originalTopbar.forEach((element: Element) => {
-			overflowMenu.append(element);
+			topRow.append(element);
 		});
 
+		overflowMenu.append(topRow);
+
+		if (bottomGroup && hideContent) {
+			overflowMenu.append(bottomGroup);
+		} else {
+			const parent = overflowMenu.parentNode as HTMLElement;
+			const grandParent = parent?.parentNode as HTMLElement;
+			grandParent?.insertBefore(bottomGroup, parent.nextSibling);
+		}
 		if (hideContent) migrateItems(overflowMenu, hiddenItems);
 	};
 
@@ -124,10 +139,6 @@ function setupOverflowMenu(
 		JSDialog.CloseDropdown(dropdownId);
 
 		overflowMenuHandler(true);
-		groupLabel.style.display = 'none';
-		if (expanderIconRightDiv) {
-			expanderIconRightDiv.style.display = 'none';
-		}
 		parentContainer.classList.remove('ui-overflow-group-container-with-label');
 		overflowMenuButton.style.display = '';
 		isCollapsed = true;
@@ -139,10 +150,6 @@ function setupOverflowMenu(
 		app.console.debug('overflow manager: unfold group: ' + id);
 		JSDialog.CloseDropdown(dropdownId);
 
-		groupLabel.style.display = '';
-		if (expanderIconRightDiv) {
-			expanderIconRightDiv.style.display = '';
-		}
 		overflowMenuButton.style.display = 'none';
 		parentContainer.classList.add('ui-overflow-group-container-with-label');
 		overflowMenuHandler(false);


### PR DESCRIPTION
Bbackport: https://github.com/CollaboraOnline/online/pull/12693


- this patch will add more button option inside overflow popup
- we will replace bottom-bar differently on fold and on unfold
- added common logic for bottom-bar addition to overflow popup in overflowMenuHandler
- To position bottom-bar appropriately with the group options we have wrapped the overflow-group-options in `top-row-overflow-group`


Change-Id: Icd582e0c0d009b2c679d4106660806d9de2870b3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

