### PR TITLE
IframeSettings: Parse settings, use semantic labels and make it localized

### DIFF
--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -813,6 +813,9 @@ class SettingIframe {
 	): HTMLFieldSetElement {
 		const fieldset = document.createElement('fieldset');
 		fieldset.classList.add('xcu-settings-fieldset');
+		if (uniqueId.startsWith('Grid-')) {
+			fieldset.classList.add('grid-options-fieldset');
+		}
 		const legend = document.createElement('legend');
 		legend.textContent = _(this.settingLabels[key] || key);
 		fieldset.appendChild(legend);
@@ -850,6 +853,7 @@ class SettingIframe {
 	): HTMLSpanElement {
 		const checkboxWrapper = document.createElement('span');
 		checkboxWrapper.className = `checkbox-radio-switch checkbox-radio-switch-checkbox ${isChecked ? '' : 'checkbox-radio-switch--checked'} checkbox-wrapper`;
+		id = id.replace(/\s/g, '');
 		checkboxWrapper.id = id + '-container';
 
 		// Use the new helper here
@@ -890,7 +894,14 @@ class SettingIframe {
 		if (!isDisabled) {
 			checkboxWrapper.addEventListener('click', () => {
 				onClickHandler(inputCheckbox, checkboxWrapper, materialIconContainer);
+				if (checkboxWrapper.id === 'Grid-ShowGrid-container') {
+					this.toggleGridOptionsVisibility(checkboxWrapper);
+				}
 			});
+			if (checkboxWrapper.id === 'Grid-ShowGrid-container') {
+				// Set the initial state of Grid fieldsets' visibility
+				setTimeout(() => this.toggleGridOptionsVisibility(checkboxWrapper), 0);
+			}
 		} else {
 			checkboxWrapper.classList.add('checkbox-radio-switch--disabled');
 		}
@@ -1545,6 +1556,20 @@ class SettingIframe {
 			filename = filename.replace(/\.[^.]+$/, '');
 		}
 		return filename;
+	}
+
+	private toggleGridOptionsVisibility(checkbox: HTMLElement): void {
+		const gridFieldset = checkbox.closest('.xcu-settings-fieldset');
+		const childFieldsets = gridFieldset?.querySelectorAll(
+			'.grid-options-fieldset',
+		) as NodeListOf<HTMLElement>;
+		childFieldsets?.forEach((fieldset) => {
+			if (checkbox.classList.contains('checkbox-radio-switch--checked')) {
+				fieldset.style.display = 'none';
+			} else {
+				fieldset.style.display = 'block';
+			}
+		});
 	}
 }
 

--- a/browser/admin/src/integrator/Xcu.ts
+++ b/browser/admin/src/integrator/Xcu.ts
@@ -203,11 +203,17 @@ class Xcu {
 			const keys = path.split('/').filter((key) => key.trim() !== '');
 
 			let currentLevel = result;
+			let gridLevel;
 			keys.forEach((key) => {
 				if (!(key in currentLevel)) {
 					currentLevel[key] = {};
 				}
 				currentLevel = currentLevel[key];
+
+				if (key === 'Grid') {
+					gridLevel = currentLevel;
+					gridLevel['Show Grid'] = false;
+				}
 			});
 
 			const props = item.getElementsByTagName('prop');
@@ -231,7 +237,11 @@ class Xcu {
 				}
 
 				if (typeof value === 'boolean') {
-					currentLevel[propName] = value;
+					if (propName === 'Visible grid') {
+						gridLevel['Show Grid'] = value;
+					} else {
+						currentLevel[propName] = value;
+					}
 				}
 			});
 		});
@@ -240,12 +250,24 @@ class Xcu {
 	}
 
 	private generate(xcu: XcuObject): string {
+		function format(key: string): string {
+			let result = key[0];
+			for (let i = 1; i < key.length; i++) {
+				if (key[i] === ' ' && i < key.length - 1) {
+					result += key[i + 1].toUpperCase();
+					i++;
+				} else {
+					result += key[i];
+				}
+			}
+			return result;
+		}
 		function generateItemNodes(node: any, path: string[]): string[] {
 			const items: string[] = [];
 			const leafProps: { [key: string]: string | boolean } = {};
 			const nestedKeys: string[] = [];
 
-			for (const key in node) {
+			for (let key in node) {
 				if (Object.prototype.hasOwnProperty.call(node, key)) {
 					const value = node[key];
 					if (
@@ -255,16 +277,23 @@ class Xcu {
 					) {
 						nestedKeys.push(key);
 					} else {
+						key = format(key);
 						leafProps[key] = value;
 					}
 				}
 			}
+
+			let visibleGrid;
 
 			if (Object.keys(leafProps).length > 0) {
 				const oorPath = '/org.openoffice.Office.' + path.join('/');
 				let propsXml = '';
 				for (const propName in leafProps) {
 					if (Object.prototype.hasOwnProperty.call(leafProps, propName)) {
+						if (propName === 'ShowGrid') {
+							visibleGrid = leafProps[propName];
+							continue;
+						}
 						const value = leafProps[propName];
 						let valueStr = '';
 						if (typeof value === 'boolean') {
@@ -282,6 +311,9 @@ class Xcu {
 
 			for (const key of nestedKeys) {
 				const child = node[key];
+				if (typeof visibleGrid === 'boolean') {
+					child['VisibleGrid'] = visibleGrid;
+				}
 				const newPath = path.concat(key);
 				items.push(...generateItemNodes(child, newPath));
 			}


### PR DESCRIPTION
Change-Id: I177d10403b7d6a1a3556557d7cfa1bd14b5f3267

* Target version: master

## Summary
- Capitalize few strings to use available translations
- Parse the checkbox label strings to add spaces between them & make them l10n friendly
- Parse it again while uploading xcu file
- Add "Show Grid" checkbox which will hide/show other settings related to Grid

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

