### PR TITLE
Revert "dump coolwsd console log on failure"

### DIFF
--- a/cypress_test/Makefile.am
+++ b/cypress_test/Makefile.am
@@ -753,9 +753,7 @@ define run_test_parallel
 		--spec $(3) \
 		--type $(4) \
 		--log-file $(5) \
-		--config-file $(CYPRESS_CONFIG) \
-		|| (echo ==dump coolwsd console output== && cat $(COOLWSD_OUTPUT) &&\
-		    false)
+		--config-file $(CYPRESS_CONFIG)
 endef
 
 # Run one test \ tests in headless mode.
@@ -773,8 +771,7 @@ define run_test_headless
 		--config $(1) \
 		--env $(2) \
 		$(if $(3),--spec=$(3)) \
-		|| (echo ==dump coolwsd console output== && cat $(COOLWSD_OUTPUT) && \
-		    $(KILL_COMMAND) && false)
+		|| ($(KILL_COMMAND) && false)
 endef
 
 # Checks whether the given spec file exists.


### PR DESCRIPTION
This reverts commit ab3bd72c5fcb7c3b0c21cfa228a63266e8bdfc72.

There's too much noise for now. Lets revisit by either silencing the warnings in core, or merging duplicate lines.


Change-Id: I313c4690b22ca30c5d1d02ea2265715d79b2a60c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

