### PR TITLE
Navigation: Style Page dividers

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -579,9 +579,8 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 }
 
 #QuickFindPanel .ui-treeview-cell-text-content.page-divider {
-	/*TODO: style however we want*/
-	font-weight: bold;
-	font-size: large;
+	/* TODO The treeview entry should have disabled listenners for these items */
+	color: var(--color-text-lighter);
 }
 
 /* search field box */


### PR DESCRIPTION
Inherit font size and family from existing styles and set the color to gray

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ifbb75e883979d6001c87bce1ffd44bad0dfbeebd
