### PR TITLE
Navigator: add placeholder text for empty quick find search (backport)

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -581,7 +581,8 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 }
 
 /* matched count on top */
-#quickfind-dock-wrapper #box .ui-text {
+#quickfind-dock-wrapper #box .ui-text,
+#quickfind-dock-wrapper #quickfind-placeholder.ui-text {
 	grid-row: 1;
 	height: min-content;
 	font-size: var(--default-font-size);
@@ -623,6 +624,12 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 
 #quickfind-dock-wrapper .ui-treeview.empty {
 	border: none;
+}
+
+#quickfind-dock-wrapper #quickfind-container > [id='0'] {
+	display: grid !important;
+	grid-auto-flow: row !important;
+	grid-template-columns: 1fr;
 }
 
 #navigation-sidebar.visible {

--- a/browser/src/control/Control.QuickFindPanel.ts
+++ b/browser/src/control/Control.QuickFindPanel.ts
@@ -36,29 +36,23 @@ class QuickFindPanel extends SidebarBase {
 	onJSUpdate(e: FireEvent): void {
 		var data = e.data;
 
-		if (data.jsontype !== this.type) return;
-		if (!this.container) return;
-		if (!this.builder) return;
+		super.onJSUpdate(e);
 
-		if (data.control.id === 'addonimage') {
-			window.app.console.log('Ignored update for control: ' + data.control.id);
-			return;
-		}
+		// handle placeholder text visibility
+		app.layoutingService.appendLayoutingTask(() => {
+			const placeholder = document.getElementById('quickfind-placeholder');
 
-		const placeholder = document.getElementById('quickfind-placeholder');
-
-		if (data.control.id === 'numberofsearchfinds') {
-			const resultsText = data.control.text.trim().length > 0;
-			if (placeholder) placeholder.classList.toggle('hidden', resultsText);
-		} else if (
-			data.control.id === 'searchfinds' &&
-			data.control.type === 'treelistbox'
-		) {
-			const isEmpty = data.control.entries.length === 0;
-			if (placeholder) placeholder.classList.toggle('hidden', !isEmpty);
-		}
-
-		this.builder.updateWidget(this.container, data.control);
+			if (data.control.id === 'numberofsearchfinds') {
+				const resultsText = data.control.text.trim().length > 0;
+				if (placeholder) placeholder.classList.toggle('hidden', resultsText);
+			} else if (
+				data.control.id === 'searchfinds' &&
+				data.control.type === 'treelistbox'
+			) {
+				const isEmpty = data.control.entries.length === 0;
+				if (placeholder) placeholder.classList.toggle('hidden', !isEmpty);
+			}
+		});
 	}
 
 	addPlaceholderIfEmpty(quickFindData: any): any {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Backport #12668

>### Summary
>-Show "Type in the search box to find anything in your document" when search is empty
>-Hide placeholder label when user types search terms
>
>### PREVIEW
>
>https://github.com/user-attachments/assets/efa911c2-6807-4077-8977-737086f2b62a

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

