### PR TITLE
WIP: Find Dialog: search on enter

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -314,9 +314,23 @@ L.Control.JSDialog = L.Control.extend({
 		defaultButton.style.display = 'none';
 		defaultButton.onclick = function() {
 			if (instance.defaultButtonId) {
-				var button = instance.form.querySelector('#' + instance.defaultButtonId);
-				if (button)
-					button.click();
+				var buttonContainer = instance.form.querySelector('#' + instance.defaultButtonId);
+				if(!buttonContainer) return;
+
+				// Check if the buttonContainer is a button
+				if (buttonContainer.tagName.toLowerCase() === 'button') {
+					buttonContainer.click();
+					return;
+				}
+
+				const button = buttonContainer.querySelector('button:not([disabled]):not(.hidden)');
+				if (button) {
+					if (button.onclick) {
+						button.onclick();
+					} else {
+						button.click();
+					}
+				}
 			}
 		};
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Issue was we were clicking the button container again, as the container has the `id` for the button see:
```html
                                                                          \/ here \/
<div class="d-flex justify-content-center ui-pushbutton-wrapper jsdialog" id="search" disabled="disabled" aria-disabled="true">
    <button class="ui-pushbutton jsdialog button-primary" accesskey="x" aria-label="Find Next">
        Find Ne<u class="access-key">x</u>t
    </button>
</div>
```
Fix is to go inside container and try find a button to click.

Seems to be working in calc, impress is a bit buggy for me: after the first hit we lose the selection on the hit. May be unrelated. More testing needed

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

