### PR TITLE
Prevent gap to left of hyperlink dialog mail fields

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2359,6 +2359,11 @@ kbd,
 	display: none;
 }
 
+/* Third column has nothing to display */
+#HyperlinkMailPage #grid1 {
+	grid-template-columns: repeat(2, auto) 0px !important;
+}
+
 /* feature_lock */
 #modal-dialog-unlock-features-popup {
 	width: 652px;


### PR DESCRIPTION
In CORE, there is an address book after the 'URL' field. We hide this in online, but this causes a third column to be added, which is then given a third of the spare width due to the auto property. This leaves a gap, which is solved by adding css to set the width to 0px.

Change-Id: I6a6a696433cf8f324005ead68104f39d98e17d88


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

