### PR TITLE
Do not hide hyperlink dialog components in css

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2389,16 +2389,6 @@ kbd,
 	min-height: 300px;
 }
 
-/* Insert hyperlink dialog */
-
-#HyperlinkInternetPage #grid2,
-#HyperlinkInternetPage #label2,
-#HyperlinkInternetPage #lbProtocol,
-#HyperlinkInternetPage #linktyp_ftp,
-#HyperlinkInternetPage #linktyp_internet {
-	display: none;
-}
-
 /* Third column has nothing to display */
 #HyperlinkMailPage #grid1 {
 	grid-template-columns: repeat(2, auto) 0px !important;


### PR DESCRIPTION
Now that there are more fields in hyperlink dialog, I have a slight preference to show the titles to split the text fields up into different sections. However, if we decide to hide them, could we please do it:
a) For both the internet and mail tabs
b) On CORE where other elements are hidden


Change-Id: I6a6a6964bfee19751c5a00f5977a49047b6d9ae2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

