### PR TITLE
Set jsdialog label text even when hidden

### DIFF
--- a/browser/src/control/jsdialog/Widget.Frame.js
+++ b/browser/src/control/jsdialog/Widget.Frame.js
@@ -27,8 +27,8 @@
 /* global JSDialog $ */
 
 function _extractLabelText(data) {
-	if (data.type === 'fixedtext') {
-		return data.visible != false ? data.text : ''; // visible can be undefined too, in that case it means its visible
+	if (data.type === 'fixedtext' && data.text !== undefined) {
+		return data.text;
 	}
 
 	for (var i = 0; i < data.children.length; i++) {


### PR DESCRIPTION
Set label text even when the object is hidden in jsdialogs. This has a benefit in the hyperlink dialog, where we can change which labels show when the selection changes (e.g. a different object type is clicked with the dialog still open). Also triggers in other places, such as format>page style>headers, but this legend seems to not appear anyway, making this change have no effect here.


Change-Id: I6a6a696480a926a05c07b71b7d5d261e6102ca9a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

