### PR TITLE
wsd: use unique_ptr in FakeSocket

### DIFF
--- a/net/FakeSocket.cpp
+++ b/net/FakeSocket.cpp
@@ -82,7 +82,7 @@ static int fakeSocketLogLevel = -1;
 
 static void fakeSocketDumpStateImpl();
 
-static std::vector<FakeSocketPair*> fds;
+static std::vector<std::unique_ptr<FakeSocketPair>> fds;
 
 static std::string flush()
 {
@@ -129,7 +129,7 @@ static FakeSocketPair& fakeSocketAllocate()
     const int i = fds.size();
     fds.resize(i + 1);
 
-    fds[i] = new FakeSocketPair();
+    fds[i] = std::make_unique<FakeSocketPair>();
     fds[i]->fd[0] = i*2;
 
     return *(fds[i]);


### PR DESCRIPTION
Leak Sanitizer complains of the leaked
FakeSocketPair instances. By using
unique_ptr the leak is plugged.

Change-Id: Iacdbf0d5dd86212aff5806c369e25e869080a9f5
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
