### PR TITLE
Calc: Pre-selection of sheet name in rename modal

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -372,10 +372,16 @@ L.Control.JSDialog = L.Control.extend({
 	addFocusHandler: function(instance) {
 		if (!instance.canHaveFocus)
 			return;
+		
+		const elementToFocus = document.getElementById(instance.init_focus_id);
+
+		if (instance.init_focus_id === 'input-modal-input' && elementToFocus) {
+			elementToFocus.select();
+		}
 
 		const failedToFindFocus = () => {
-			if (document.getElementById(instance.init_focus_id))
-				document.getElementById(instance.init_focus_id).focus();
+			if (elementToFocus)
+				elementToFocus.focus();
 			else {
 				app.console.error('There is no focusable element in the modal. Either focusId should be given or modal should have a response button.');
 				instance.that.close(instance.id, true);


### PR DESCRIPTION
Change-Id: I1b9d423204fb936db893707cf9d054908ae4f71f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Ensures the sheet name is automatically pre-selected in the input field when the rename modal is opened by double clicking a sheet tab.


### PREVIEW

https://github.com/user-attachments/assets/aeae94c3-261d-4c5a-9974-8f7f081da733



- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

