### PR TITLE
Fix QuickFind overflow (backport)

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -325,7 +325,7 @@ body {
 	height: 100%;
 }
 
-#sidebar-dock-wrapper, #navigator-dock-wrapper {
+#sidebar-dock-wrapper, #navigator-dock-wrapper, #quickfind-dock-wrapper {
 	display: none;
 	background: var(--color-background-lighter);
 	position: relative;

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -604,6 +604,7 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 
 #quickfind-dock-wrapper .ui-treeview-entry {
 	text-wrap: balance;
+	word-break: break-word;
 	border-bottom: 1px solid var(--color-quickfind-border);
 }
 #quickfind-dock-wrapper .ui-treeview-entry.selected {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: distro/collabora/co-25.04

### Summary
backport of #12716

dont push view up when we have many results, additionally wrap results that were previously out of bounds.

<details>
<summary>Before:</summary>
<img width="471" height="1018" alt="image" src="https://github.com/user-attachments/assets/19a9a04e-59c1-4b30-b1f8-9f32920ca6c4" />
</details>

<details>
<summary>After:</summary>
<img width="528" height="884" alt="image" src="https://github.com/user-attachments/assets/7b84bff5-8f4b-4d54-9211-2ba2375f6210" />
</details>

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

