### PR TITLE
QuickFind: scroll only in results

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -618,6 +618,12 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	padding-inline-start: 0;
 }
 
+#quickfind-dock-wrapper #searchfinds {
+	overflow-y: auto;
+	scrollbar-width: thin;
+	scrollbar-color: var(--color-border) transparent;
+}
+
 /* results */
 #quickfind-dock-wrapper .ui-treeview {
 	grid-row: 2;


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Avoid scrolling the whole wrapper, thus leaving the 'numberofsearchfinds' static in the layout.
<details>
<summary>Before:</summary>

![290825_scrollingBefore](https://github.com/user-attachments/assets/0b171a84-676a-4852-afc8-9638e4df4aac)
</details>
<details>
<summary>After:</summary>

![290825_scrollingAfter](https://github.com/user-attachments/assets/5eb42ca4-3523-4a64-bb60-03f3b641b9c6)

</details>

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

