### PR TITLE
Fix backport command when backport branch already exists

### DIFF
--- a/g
+++ b/g
@@ -133,7 +133,7 @@ query($owner: String!, $repo: String!)
 
     # Create local branch if needed.
     BRANCH_CREATED=
-    if git rev-parse --quiet --verify master2 >/dev/null; then
+    if git rev-parse --quiet --verify $BACKPORT_BRANCH >/dev/null; then
         git checkout $BACKPORT_BRANCH
     else
         git checkout --track $REMOTE/$BACKPORT_BRANCH


### PR DESCRIPTION
Backport would fail if the branch was already checked out locally.

Signed-off-by: Samuel Mehrbrodt <samuel.mehrbrodt@collabora.com>
Change-Id: I246b52e1a826d89576685ee1c4deb7e545aa3add
