### PR TITLE
Writer: Insert tab: Fix separator typo, regression

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1355,7 +1355,7 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 				'accessibility': { focusBack: true, combination: 'RL', de: null }
 			} : {},
 			(this.map['wopi'].EnableRemoteAIContent) ? {
-				'type': 'bigcustomtoolitem',
+				'type': 'separator',
 				'id': 'insert-remoteaicontent-break',
 				'orientation': 'vertical'
 			} : {},


### PR DESCRIPTION
Regression from ab2d4c2bd19c27a2cae5be7b32ebac788ea39f3f

this in turn was rendering a "ghost" button and an error was appearing
in the console about a missing lc_insert-remoteaicontent-break.svg

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I8eeeaac01615cf681b414eff9d6c5ac2fb168cee
