### PR TITLE
Fix usage of waitid

### DIFF
--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -355,8 +355,12 @@ static void cleanupChildren(const std::string& childRoot)
                 }
                 else
                 {
-                    LOG_ERR("Child " << exitedChildPid << " has exited, with status " << status);
+                    LOG_ERR("Child " << exitedChildPid << " has terminated, with signal " << status);
                 }
+            }
+            else if (info.si_code == CLD_EXITED && status != 0)
+            {
+                LOG_ERR("Child " << exitedChildPid << " has exited, with status " << status);
             }
 
             LOG_INF("Child " << exitedChildPid << " has exited, will remove its jail [" << it->second << "].");

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -309,7 +309,7 @@ static void cleanupChildren(const std::string& childRoot)
     memset(&info, 0, sizeof(info)); // Make sure no stale fields remain
 
     // Reap quickly without doing slow cleanup so WSD can spawn more rapidly.
-    while (waitid(P_ALL, -1, &info, WEXITED | WUNTRACED | WNOHANG) == 0)
+    while (waitid(P_ALL, -1, &info, WEXITED | WNOHANG) == 0)
     {
         if (info.si_pid == 0)
         {
@@ -319,13 +319,12 @@ static void cleanupChildren(const std::string& childRoot)
 
         exitedChildPid = info.si_pid;
         status = info.si_status;
-
         if (const auto it = childJails.find(exitedChildPid); it != childJails.end())
         {
-            if (WIFSIGNALED(status))
+            if (info.si_code == CLD_KILLED || info.si_code == CLD_DUMPED)
             {
-                if (WTERMSIG(status) == SIGSEGV || WTERMSIG(status) == SIGBUS ||
-                    WTERMSIG(status) == SIGABRT)
+                if (status == SIGSEGV || status == SIGBUS ||
+                    status == SIGABRT)
                 {
                     ++segFaultCount;
 
@@ -338,7 +337,7 @@ static void cleanupChildren(const std::string& childRoot)
                     else
                         close(noteCrashFD);
                 }
-                else if (WTERMSIG(status) == SIGKILL)
+                else if (status == SIGKILL)
                 {
                     // TODO differentiate with docker
                     if (info.si_code == SI_KERNEL)


### PR DESCRIPTION
6f4eeaa75d27cfb5dee8d70335757545dce1cc18 "ForKit: log killed child processes by users & oom" (replacing a use of waitpid with a use of waitid) broke it in three regards:

For one, waitid (unlike waitpid) doesn't take WUNTRACED ("The status of any child processes specified by pid that are stopped [...] shall also be reported to the requesting process", POSIX.1-2024).  It would take a corresponding WSTOPPED ("Status shall be returned for any child that has stopped upon receipt of a signal [...]", POSIX.1-2024), but why should we be interested in SIGSTOP/SIGTSTP here, anyway (and treat that as if the child had terminated)? WUNTRACED had been added in de7cda7891fff43992df61a1b2702608ed579549 "loolwsd: improve child cleanup and forking", for unclear reasons.  So just drop it unconditionally.

For another, waitid reports the waited-for event in si_code (CLD_EXITED, etc.) rather than via WIFEXITED etc. (as waitpid does).  And when si_code is CLD_KILLED or CLD_DUMPED, si_status is the signal that caused the child to terminated, and must not be operated on with the WTERMSIG macro.

For a third, I doubt that the

>                     if (info.si_code == SI_KERNEL)

check (introduced in 6f4eeaa75d27cfb5dee8d70335757545dce1cc18 "ForKit: log killed child processes by users & oom") works as intended.  si_code necessarily is CLD_KILLED or CLD_DUMPED here, so it can't be SI_KILLED.  But lets leave that dubious check alone for now.


Change-Id: I5748f700d552485cd5db7387fa4d7dc16c7db4d5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

