### PR TITLE
accessibility: add role attribute to tree view rows for improved accessibility

### DIFF
--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -353,6 +353,7 @@ class TreeViewControl {
 		);
 		this._rows.set(String(entry.row), tr);
 		tr.setAttribute('level', String(level));
+		tr.setAttribute('role', 'row');
 
 		let dummyColumns = 0;
 		if (this._hasState) dummyColumns++;


### PR DESCRIPTION
Change-Id: I36619e09d3683865cd1ae0da776a8931f8bbd5e4

In treeview, the container with role="grid" (e.g., id="charttype" and id="shape") does not contain elements with role="row". According to the WAI-ARIA specification, a grid must contain direct children with role="row", and each row must in turn contain children with role="gridcell". This semantic structure is essential for screen readers and other assistive technologies to correctly interpret the layout and enable keyboard navigation.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

