### PR TITLE
browser/Control.Header: separate row and column resize are calculation

### DIFF
--- a/browser/src/control/Control.ColumnHeader.ts
+++ b/browser/src/control/Control.ColumnHeader.ts
@@ -96,6 +96,16 @@ export class ColumnHeader extends Header {
 		this._headerInfo = new cool.HeaderInfo(this._map, true /* isCol */);
 	}
 
+	isMouseOverResizeArea(start: number, end:number, position: number, entryIsCurrent: boolean) : boolean {
+		const isRTL = this.isCalcRTL();
+		// NOTE: From a geometric perspective resizeAreaStart is really "resizeAreaEnd" in RTL case.
+		let resizeAreaStart = isRTL ? Math.min(start + this.borderResizeHandle * app.dpiScale, end) : Math.max(start, end - this.borderResizeHandle * app.dpiScale);
+		if (entryIsCurrent || (window as any).mode.isMobile()) {
+			resizeAreaStart = isRTL ? start + this.resizeHandleSize : end - this.resizeHandleSize;
+		}
+		return isRTL ? (position < resizeAreaStart) : (position > resizeAreaStart);
+	}
+
 	drawHeaderEntry (entry: HeaderEntryData): void {
 		if (!entry)
 			return;

--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -49,6 +49,7 @@ export class Header extends CanvasSectionObject {
 	_isColumn: boolean;
 	cursor: string;
 	resizeHandleSize: number;
+	borderResizeHandle = 3;
 
 	getFont: () => string;
 
@@ -69,6 +70,8 @@ export class Header extends CanvasSectionObject {
 	_handleStatusUpdated(): void {
 		this._reInitRowColumnHeaderStylesAfterModeChange();
 	}
+
+	isMouseOverResizeArea(start: number, end:number, position: number, entryIsCurrent: boolean): boolean {return false;}
 
 	_initHeaderEntryStyles (className: string): void {
 		const baseElem = document.getElementsByTagName('body')[0];
@@ -490,14 +493,7 @@ export class Header extends CanvasSectionObject {
 			const end = isRTL ? this.size[0] - entry.pos + entry.size : entry.pos;
 			const start = end - entry.size;
 			if (position >= start && position < end) {
-				// NOTE: From a geometric perspective resizeAreaStart is really "resizeAreaEnd" in RTL case.
-				const borderResizeHandle = 3;
-				let resizeAreaStart = isRTL ? Math.min(start + borderResizeHandle * app.dpiScale, end) : Math.max(start, end - borderResizeHandle * app.dpiScale);
-				if (this._isColumn && (entry.isCurrent || (window as any).mode.isMobile())) {
-					resizeAreaStart = isRTL ? start + this.resizeHandleSize : end - this.resizeHandleSize;
-				}
-				const isMouseOverResizeArea = isRTL ? (position < resizeAreaStart) : (position > resizeAreaStart);
-				result = {entry: entry, hit: isMouseOverResizeArea};
+				result = {entry: entry, hit: this.isMouseOverResizeArea(start, end, position, entry.isCurrent)};
 				return true;
 			}
 		}.bind(this));

--- a/browser/src/control/Control.RowHeader.ts
+++ b/browser/src/control/Control.RowHeader.ts
@@ -99,6 +99,14 @@ export class RowHeader extends cool.Header {
 		this._headerInfo = new cool.HeaderInfo(this._map, false /* isCol */);
 	}
 
+	isMouseOverResizeArea(start: number, end:number, position: number, entryIsCurrent: boolean) : boolean {
+		let resizeAreaStart = Math.max(start, end - this.borderResizeHandle * app.dpiScale);
+		if (entryIsCurrent || (window as any).mode.isMobile()) {
+			resizeAreaStart =  end - this.resizeHandleSize;
+		}
+		return position > resizeAreaStart;
+	}
+
 	drawHeaderEntry (entry: HeaderEntryData): void {
 		if (!entry)
 			return;


### PR DESCRIPTION

Change-Id: I28e91f940f16f60103e7c1535904f5fd0a16c006


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Previously for the current row, the same code was run for the column and row header when the header/row was current, i.e correspond to the currently selected cell.

Separate the row and column calculation.

This address the regression introduced by:
https://github.com/CollaboraOnline/online/pull/12452

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

