### PR TITLE
Backport: Pre-selection of sheet name in rename modal

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -373,9 +373,15 @@ L.Control.JSDialog = L.Control.extend({
 		if (!instance.canHaveFocus)
 			return;
 
+		const elementToFocus = document.getElementById(instance.init_focus_id);
+
+		if (instance.init_focus_id === 'input-modal-input' && elementToFocus) {
+			elementToFocus.select();
+		}
+		
 		const failedToFindFocus = () => {
-			if (document.getElementById(instance.init_focus_id))
-				document.getElementById(instance.init_focus_id).focus();
+			if (elementToFocus)
+				elementToFocus.focus();
 			else {
 				app.console.error('There is no focusable element in the modal. Either focusId should be given or modal should have a response button.');
 				instance.that.close(instance.id, true);


### PR DESCRIPTION
Change-Id: I35d4c6c509b48bb9afd15b8604a08cdf0c641f03


* Backport PR: #12729
* Target version: master 

### Summary
- Ensures the sheet name is automatically pre-selected in the input field when the rename modal is opened by double clicking a sheet tab.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

