### PR TITLE
Autofilter and validity dropdown popups: Consider frozen panes.

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -372,7 +372,7 @@ L.Control.JSDialog = L.Control.extend({
 	addFocusHandler: function(instance) {
 		if (!instance.canHaveFocus)
 			return;
-		
+
 		const elementToFocus = document.getElementById(instance.init_focus_id);
 
 		if (instance.init_focus_id === 'input-modal-input' && elementToFocus) {
@@ -671,12 +671,20 @@ L.Control.JSDialog = L.Control.extend({
 		}
 		else {
 			// This is a Cell DropDown. We will use current cell's rectangle.
-			cellRectangle = app.calc.cellCursorRectangle;
+			cellRectangle = app.calc.cellCursorRectangle.clone();
 		}
 
 		const documentAnchor = app.sectionContainer.getDocumentAnchor();
-		cellRectangle.pX1 += documentAnchor[0] - app.activeDocument.activeView.viewedRectangle.pX1;
-		cellRectangle.pY1 += documentAnchor[1] - app.activeDocument.activeView.viewedRectangle.pY1;
+
+		if (!app.isXOrdinateInFrozenPane(cellRectangle.pX1))
+			cellRectangle.pX1 += documentAnchor[0] - app.activeDocument.activeView.viewedRectangle.pX1;
+		else
+			cellRectangle.pX1 += documentAnchor[0];
+
+		if (!app.isYOrdinateInFrozenPane(cellRectangle.pY1))
+			cellRectangle.pY1 += documentAnchor[1] - app.activeDocument.activeView.viewedRectangle.pY1;
+		else
+			cellRectangle.pY1 += documentAnchor[1];
 
 		app.calc.autoFilterCell = null; // Set to null after using to ensure it doesn't confuse consequent calls.
 		app.calc.pivotTableFilterCell = null;


### PR DESCRIPTION
Issue: Extracting the scrolled amount from the position leads to wrong position if an ordinate is in frozen pane.


Change-Id: I6ca15acb3027aba18ef060393e5d5eb56b904f76


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

