### PR TITLE
QuickFind: scroll only in results

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -618,6 +618,12 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	padding-inline-start: 0;
 }
 
+#quickfind-dock-wrapper #searchfinds {
+	overflow-y: auto;
+	scrollbar-width: thin;
+	scrollbar-color: var(--color-border) transparent;
+}
+
 /* results */
 #quickfind-dock-wrapper .ui-treeview {
 	grid-row: 2;


### PR DESCRIPTION
Avoid scrolling the whole wrapper, thus leaving
the 'numberofsearchfinds' static in the layout.

backport of: https://github.com/CollaboraOnline/online/pull/12734