### PR TITLE
Static content rendering using span instead of Label

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -465,6 +465,7 @@ COOL_JS_LST =\
 	src/control/jsdialog/Widget.ScrolledWindow.js \
 	src/control/jsdialog/Widget.SearchEdit.ts \
 	src/control/jsdialog/Widget.SidebarContainers.ts \
+	src/control/jsdialog/Widget.Text.ts \
 	src/control/jsdialog/Widget.Timefield.js \
 	src/control/jsdialog/Widget.TreeView.ts \
 	src/control/Control.JSDialog.js \

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2307,10 +2307,24 @@ button.menubutton.sidebar > span {
 	display: grid;
 	min-width: 400px;
 }
+
 #FormulaDialog .ui-tabs-content.jsdialog {
 	grid-auto-columns: 250px;
 	margin-right: 0.2em;
 	margin-top: 0px;
+}
+
+#FormulaDialog #ParameterPage :is(#editdesc, #pardesc),
+#FormulaDialog #ALTBOX #funcdesc {
+	margin: auto 0px;
+	color: var(--color-main-text);
+	font-size: var(--default-font-size);
+	line-height: var(--default-height);
+	padding-left: inherit;
+}
+
+#FormulaDialog #ALTBOX #headline {
+	font-weight: bold;
 }
 
 div [id^='TemplateDialog'] {

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2314,6 +2314,10 @@ button.menubutton.sidebar > span {
 	margin-top: 0px;
 }
 
+#FormulaDialog #box3 :is(#grid2, #grid3) {
+	align-items: center;
+}
+
 #FormulaDialog #ParameterPage :is(#editdesc, #pardesc),
 #FormulaDialog #ALTBOX #funcdesc {
 	margin: auto 0px;

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1755,6 +1755,11 @@ L.Control.JSDialogBuilder = L.Control.extend({
 	},
 
 	_fixedtextControl: function(parentContainer, data, builder) {
+		// Check if this label should render as static content(i.e. span) instead of interactive label
+		// This property is set by LibreOffice Kit when accessible-role="static" is detected
+		if(data.renderAsStatic)
+			return JSDialog.StaticText(parentContainer, data, builder);
+
 		var fixedtext = L.DomUtil.create('label', builder.options.cssClass, parentContainer);
 
 		if (data.labelFor)

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -219,7 +219,11 @@ type ExpanderWidgetJSON = any;
 // type: 'fixedtext'
 interface TextWidget extends WidgetJSON {
 	text: string;
+	html?: string;
 	labelFor?: string;
+	style?: string;
+	hidden?: boolean;
+	renderAsStatic?: boolean;
 }
 
 // type: 'pushbutton'

--- a/browser/src/control/jsdialog/Widget.Text.ts
+++ b/browser/src/control/jsdialog/Widget.Text.ts
@@ -1,0 +1,50 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * JSDialog.StaticText - static text rendering with span
+ */
+
+declare var JSDialog: any;
+
+function staticTextControl(
+	parentContainer: HTMLElement,
+	data: TextWidget,
+	builder: JSBuilder,
+) {
+	var statictext = L.DomUtil.create(
+		'span',
+		builder.options.cssClass,
+		parentContainer,
+	);
+
+	if (data.text) statictext.textContent = builder._cleanText(data.text);
+	else if (data.html) statictext.innerHTML = data.html;
+
+	statictext.id = data.id;
+	if (data.style && data.style.length) {
+		L.DomUtil.addClass(statictext, data.style);
+	} else {
+		L.DomUtil.addClass(statictext, 'ui-text');
+	}
+
+	if (data.hidden) $(statictext).hide();
+
+	return false;
+}
+
+JSDialog.StaticText = function (
+	parentContainer: HTMLElement,
+	data: TextWidget,
+	builder: JSBuilder,
+) {
+	return staticTextControl(parentContainer, data, builder);
+};


### PR DESCRIPTION
Requires core patch: https://gerrit.libreoffice.org/c/core/+/190558

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

