### PR TITLE
HTTP Chunking and Multipart/Data Support

### DIFF
--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -1132,8 +1132,13 @@ public:
     }
 
     /// Append a chunk to the body. Must have Transfer-Encoding: chunked.
-    void appendChunk(const std::string& chunk)
+    void appendChunk(std::string_view chunk)
     {
+        assert(get("transfer-encoding").find("chunked") != std::string::npos &&
+               "Expected to have chunked transfer-encoding header");
+        assert(!_header.has("content-length") &&
+               "Unexpected to have content-length header with transfer-encoding defined");
+
         _body.reserve(_body.size() + chunk.size() + 32);
 
         std::stringstream ss;

--- a/test/HttpWhiteBoxTests.cpp
+++ b/test/HttpWhiteBoxTests.cpp
@@ -20,6 +20,14 @@
 
 #include <cppunit/extensions/HelperMacros.h>
 
+#include <Poco/Net/MultipartReader.h>
+#include <Poco/MemoryStream.h>
+#include <Poco/Net/HTMLForm.h>
+#include <Poco/Net/HTTPRequest.h>
+
+#include <cstdint>
+#include <string>
+
 /// HTTP WhiteBox unit-tests.
 class HttpWhiteBoxTests : public CPPUNIT_NS::TestFixture
 {
@@ -39,6 +47,8 @@ class HttpWhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testRequestParserValidPostIncomplete);
     CPPUNIT_TEST(testRequestParserChunkedPostComplete);
     CPPUNIT_TEST(testClipboardIsOwnFormat);
+    CPPUNIT_TEST(testMultiPartDataParser);
+    CPPUNIT_TEST(testInsertFile);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -54,6 +64,8 @@ class HttpWhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testRequestParserValidPostIncomplete();
     void testRequestParserChunkedPostComplete();
     void testClipboardIsOwnFormat();
+    void testMultiPartDataParser();
+    void testInsertFile();
 };
 
 void HttpWhiteBoxTests::testStatusLineParserValidComplete()
@@ -439,6 +451,310 @@ PK)x";
         // is not a hex size.
         LOK_ASSERT_EQUAL(ClipboardData::isOwnFormat(stream), false);
     }
+}
+static inline void comparePostContent(const std::string_view testname, const std::string_view data)
+{
+    Poco::MemoryInputStream message(data.data(), data.size());
+    Poco::Net::HTTPRequest request;
+    request.read(message);
+
+    http::RequestParser req;
+    LOK_ASSERT(req.readData(data.data(), data.size()) > 0);
+
+    LOK_ASSERT_EQUAL_STR(request.getMethod(), req.getVerb());
+    LOK_ASSERT_EQUAL_STR(request.getURI(), req.getUrl());
+    LOK_ASSERT_EQUAL_STR(request.getVersion(), req.getVersion());
+    LOK_ASSERT_EQUAL_STR(request.getHost(), req.get("Host"));
+
+    std::size_t headerCount = 0;
+    for (const auto& header : request)
+    {
+        ++headerCount;
+        LOK_ASSERT_EQUAL_STR(header.second, req.get(header.first));
+    }
+
+    LOK_ASSERT_EQUAL(headerCount, req.header().size());
+
+    // LOK_ASSERT_EQUAL_STR(std::string(), req.getBody());
+
+    // ConvertToPartHandler handler;
+    // Poco::Net::HTMLForm form(request, message, handler);
+    Poco::MemoryInputStream messageForm(req.getBody().data(), req.getBody().size());
+    Poco::Net::HTMLForm form(request, messageForm);
+    std::size_t fieldCount = 0;
+    for (const auto& field : form)
+    {
+        ++fieldCount;
+        LOK_ASSERT(!field.first.empty());
+        LOK_ASSERT(!field.second.empty());
+        // LOK_ASSERT_EQUAL_STR(field.second, req.get(field.first));
+    }
+
+    LOK_ASSERT(fieldCount > 0);
+    // LOK_ASSERT_EQUAL(fieldCount, req.header().size());
+
+    // LOK_ASSERT_EQUAL_STR(form.(), req.boundary());
+    // LOK_ASSERT_EQUAL_STR(form.boundary(), req.boundary());
+    // LOK_ASSERT_EQUAL_STR(form.getEncoding(), req.getEncoding());
+}
+
+static std::string getStreamData(std::istream& stream)
+{
+    int ch = stream.get();
+    std::string data;
+    while (ch >= 0)
+    {
+        data += (char)ch;
+        ch = stream.get();
+    }
+
+    return data;
+}
+
+void HttpWhiteBoxTests::testMultiPartDataParser()
+{
+    constexpr std::string_view testname = __func__;
+
+    const std::string header = "POST / HTTP/1.1\r\n"
+                               "Content-type: multipart/mixed; boundary=\"simple boundary\"\r\n"
+                               "\r\n";
+    const std::string body =
+        "This is the preamble.  It is to be ignored, though it\r\n"
+        "is a handy place for composition agents to include an\r\n"
+        "explanatory note to non-MIME conformant readers.\r\n"
+        "\r\n"
+        "--simple boundary\r\n"
+        "Content-Disposition: file; name=\"attachment1\"; filename=\"att1.txt\"\r\n"
+        "Content-Type: text/plain\r\n"
+        "\r\n"
+        "This is implicitly typed plain US-ASCII text.\r\n"
+        "It does NOT end with a linebreak.\r\n"
+        "--simple boundary\r\n"
+        "Content-Disposition: file; name=\"attachment2\"; filename=\"att2.txt\"\r\n"
+        "Content-type: text/plain; charset=us-ascii\r\n"
+        "\r\n"
+        "This is explicitly typed plain US-ASCII text.\r\n"
+        "It DOES end with a linebreak.\r\n"
+        "\r\n"
+        "--simple boundary--\r\n"
+        "\r\n"
+        "This is the epilogue.  It is also to be ignored.\r\n"
+        "\r\n";
+    const std::string data = header + body;
+
+    const std::string boundary = "simple boundary";
+
+    const std::string firstContentDisposition = "file; name=\"attachment1\"; filename=\"att1.txt\"";
+    const std::string firstContentType = "text/plain";
+    const std::string firstPartData = "This is implicitly typed plain US-ASCII text.\r\n"
+                                      "It does NOT end with a linebreak.";
+
+    const std::string secondContentDisposition =
+        "file; name=\"attachment2\"; filename=\"att2.txt\"";
+    const std::string secondContentType = "text/plain; charset=us-ascii";
+    const std::string secondPartData = "This is explicitly typed plain US-ASCII text.\r\n"
+                                       "It DOES end with a linebreak.\r\n";
+
+    std::istringstream istr(body);
+    Poco::Net::MultipartReader r(istr, boundary);
+    LOK_ASSERT(r.hasNextPart());
+    Poco::Net::MessageHeader h;
+    r.nextPart(h);
+    LOK_ASSERT(h.size() == 2);
+    LOK_ASSERT(h["Content-Disposition"] == firstContentDisposition);
+    LOK_ASSERT(h["Content-Type"] == firstContentType);
+    LOK_ASSERT_EQUAL_STR(firstPartData, getStreamData(r.stream()));
+
+    LOK_ASSERT(r.hasNextPart());
+    r.nextPart(h);
+    LOK_ASSERT(h.size() == 2);
+    LOK_ASSERT(h["Content-Disposition"] == secondContentDisposition);
+    LOK_ASSERT(h["Content-Type"] == secondContentType);
+    LOK_ASSERT_EQUAL_STR(secondPartData, getStreamData(r.stream()));
+
+    http::MultipartDataParser multipart(boundary);
+    LOK_ASSERT_EQUAL_STR(boundary, multipart.boundary());
+
+    // Incomplete until we reach the beginning of the *second* part.
+    for (std::size_t i = 0; i < 456; ++i)
+    {
+        http::Header multipartHeader;
+        std::string_view multipartBody;
+        std::string fragment = data.substr(0, i);
+        LOK_ASSERT_EQUAL_MESSAGE("At " << i << ": " << fragment
+                                       << "\n----\nPart: " << multipartBody,
+                                 0L, multipart.readPart(fragment, multipartHeader, multipartBody));
+    }
+
+    constexpr int64_t firstPartOffset = 435;
+    constexpr int64_t secondPartOffset = 213;
+
+    // Parse the first part.
+    for (std::size_t i = 456; i < data.size(); ++i)
+    {
+        http::Header multipartHeader;
+        std::string_view multipartBody;
+        LOK_ASSERT_EQUAL(firstPartOffset,
+                         multipart.readPart(data.substr(0, i), multipartHeader, multipartBody));
+        LOK_ASSERT_EQUAL(2UL, multipartHeader.size());
+        LOK_ASSERT_EQUAL_STR(firstContentDisposition, multipartHeader.get("Content-Disposition"));
+        LOK_ASSERT_EQUAL_STR(firstContentType, multipartHeader.getContentType());
+        LOK_ASSERT_EQUAL_STR(firstPartData, multipartBody);
+    }
+
+    // Incomplete until we reach the beginning of the *last* part.
+    for (std::size_t i = 0; i < 236; ++i)
+    {
+        http::Header multipartHeader;
+        std::string_view multipartBody;
+        std::string fragment = data.substr(firstPartOffset, i);
+        LOK_ASSERT_EQUAL_MESSAGE("At " << i << ": " << fragment
+                                       << "\n----\nPart: " << multipartBody,
+                                 0L, multipart.readPart(fragment, multipartHeader, multipartBody));
+    }
+
+    // Parse the second part.
+    {
+        http::Header multipartHeader;
+        std::string_view multipartBody;
+        LOK_ASSERT_EQUAL_MESSAGE(
+            "At " << 236, secondPartOffset,
+            multipart.readPart(data.substr(firstPartOffset, 236), multipartHeader, multipartBody));
+        LOK_ASSERT_EQUAL(2UL, multipartHeader.size());
+        LOK_ASSERT_EQUAL_STR(secondContentDisposition, multipartHeader.get("Content-Disposition"));
+        LOK_ASSERT_EQUAL_STR(secondContentType, multipartHeader.getContentType());
+        LOK_ASSERT_EQUAL_STR(secondPartData, multipartBody);
+        LOK_ASSERT(multipart.isLast());
+    }
+
+    // After the last part, everything is disposable.
+    for (std::size_t i = 0; i < data.size(); ++i)
+    {
+        http::Header multipartHeader;
+        std::string_view multipartBody;
+        std::string fragment = data.substr(firstPartOffset + secondPartOffset, i);
+        LOK_ASSERT_EQUAL_MESSAGE("At " << i << ": " << fragment
+                                       << "\n----\nPart: " << multipartBody,
+                                 static_cast<int64_t>(fragment.size()),
+                                 multipart.readPart(fragment, multipartHeader, multipartBody));
+        LOK_ASSERT_EQUAL(0UL, multipartHeader.size());
+        LOK_ASSERT_EQUAL_STR(std::string(), multipartBody);
+        LOK_ASSERT(multipart.isLast());
+    }
+}
+
+void HttpWhiteBoxTests::testInsertFile()
+{
+    constexpr std::string_view testname = __func__;
+
+    using namespace std::string_literals;
+
+    const std::string header =
+        "POST "
+        "/cool/"
+        "http%3A%2F%2Flocalhost%2Fnextcloud%2Findex.php%2Fapps%2Frichdocuments%2Fwopi%2Ffiles%"
+        "2F6734_ocqiesh0cngs/"
+        "insertfile?WOPISrc=http%3A%2F%2Flocalhost%2Fnextcloud%2Findex.php%2Fapps%2Frichdocuments%"
+        "2Fwopi%2Ffiles%2F6734_ocqiesh0cngs&compat=/ws HTTP/1.1\r\n"
+        "Host: localhost:9980\r\n"
+        "Connection: keep-alive\r\n"
+        "Content-Length: 2237\r\n"
+        "sec-ch-ua-platform: \"Linux\"\r\n"
+        "User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/132.0.0.0 Safari/537.36\r\n"
+        "sec-ch-ua: \"Not A(Brand\";v=\"8\", \"Chromium\";v=\"132\", \"Google "
+        "Chrome\";v=\"132\"\r\n"
+        "Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryVNBIDV9swREloOQh\r\n"
+        "sec-ch-ua-mobile: ?0\r\n"
+        "Accept: */*\r\n"
+        "Origin: http://localhost:9980\r\n"
+        "Sec-Fetch-Site: same-origin\r\n"
+        "Sec-Fetch-Mode: cors\r\n"
+        "Sec-Fetch-Dest: empty\r\n"
+        "Accept-Encoding: gzip, deflate, br, zstd\r\n"
+        "Accept-Language: en-US,en;q=0.9\r\n"
+        "\r\n";
+
+    const std::string body =
+        "------WebKitFormBoundaryVNBIDV9swREloOQh\r\n"
+        "Content-Disposition: form-data; name=\"name\"\r\n"
+        "\r\n"
+        "1755424155510\r\n"
+        "------WebKitFormBoundaryVNBIDV9swREloOQh\r\n"
+        "Content-Disposition: form-data; name=\"childid\"\r\n"
+        "\r\n"
+        "OyQKcYniZdMUeuDl\r\n"
+        "------WebKitFormBoundaryVNBIDV9swREloOQh\r\n"
+        "Content-Disposition: form-data; name=\"file\"; filename=\"Screenshot from 2024-01-30 "
+        "06-57-17.png\"\r\n"
+        "Content-Type: image/png\r\n"
+        "\r\n"
+        "\211PNG\r\n"
+        "\32\n"
+        "\0\0\0\rIHDR\0\0\2\26\0\0\1~\10\2\0\0\0Qj\304."
+        "\0\0\0\3sBIT\10\10\10\333\341O\340\0\0\0\31tEXtSoftware\0gnome-screenshot\357\3\277>"
+        "\0\0\6\246IDATx\234\355\334\241\256\34U\34\300\341\273\313\205V "
+        "\20\204'\300\21\34\10\22\236\1\203 "
+        "\200F\3624H$\340\220<"
+        "A\r\242\26Q\211\303\220\220\220\24\350\335\2313\210\206\252\222\206\337\356\236\345\336~"
+        "\237\235\3159\1775\277\234\231\314\356\376zrs\5\0\377\335\376\322\3\0p["
+        "I\10\0\221\204\0\20I\10\0\221\204\0\20I\10\0\221\204\0\20I\10\0\221\204\0\20I\10\0\221\204"
+        "\0\20I\10\0\221\204\0\20I\10\0\221\204\0\20I\10\0\221\204\0\20I\10\0\221\204\0\20I\10\0"
+        "\221\204\0\20I\10\0\221\204\0\20]_v\3731\306\30c\333\266\313\216\1@"
+        "p\231\204\2141\226e\31c\254\353\272\375\343\"\223\0\220\315N\310\266m\313\262\34\16\207eY"
+        "\306\272\216\355\351!D?\0n\237y\11\371\356\333o\246\355\5\300\4SO!\237~\366\371\277]"
+        "\332\357\275\330\7\270e&%\344\331\243\252{\257\275\372\334\37H\10\300\2553\351\306}ss3g#"
+        "\0\246\231\221\220eY\226e\231\260\21\03\315J\310\3410a#\0f:{B\326u]"
+        "\327uY\235B\0\356\232I\11Y\327q\356\215\0\230\354\354\11\31c\214u\35CB\0\356\232\263'"
+        "d\333\266\355j\223\20\200\273\347\274\337\205<"
+        "\373\377\253\247\11\331\357\367\276\377\0\2703\334\320\1\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\204\27\330\355v\227\36\1\370\237\222\20\0\"\11\1 \222\20\0\"\11\1 \222\20\0\"\11\1 "
+        "\222\20\0\242\353K\17\300K\341\317\337\36mc9~\235\373o\274\275\177\345\376\361\353\0'!!"
+        "\314\360\323\367\37\216\345\217\253\335Q\247\336qx\374\356'\17_"
+        "\177\353\275SM\5\34IB\230\344\235\217\37\34y\367\177\370\365\233\247\32\68\11\357B\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200\350\372\322\3\360\2628<"
+        "\376\345\311\357?\37\265\3046N3\n"
+        "p\"\22\302$\217~\370\350\322#\0'&!\314\360\376\27\277^z\4\340\364\274\13\1 "
+        "\222\20\0\"\17\2628\273\37\277\332\235p\265\17\276\334N\270\32p\14\247\20\0\"\247\20\316"
+        "\316\271\1\356*\247\20\0\"\11\1 "
+        "\222\20^`\333<\206\2\236OB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210$"
+        "\4\200HB\0\210$\4\200HB\0\210$\4\200HB\0\210\376\6\332E\243\373\267\206)"
+        "\r\0\0\0\0IEND\256B`\202\r\n"
+        "------WebKitFormBoundaryVNBIDV9swREloOQh--\r\n"s;
+
+    const std::string data = header + body;
+
+    http::RequestParser req;
+    LOK_ASSERT(req.readData(data.data(), data.size()) > 0);
+    LOK_ASSERT_EQUAL_STR(body, req.getBody());
+    LOK_ASSERT_EQUAL(body.size(), req.getBody().size());
+
+    comparePostContent(testname, data);
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(HttpWhiteBoxTests);


### PR DESCRIPTION
Adds support for parsing chunks and multipart/data in POST requests.

Since we never supported parsing POST requests, the new code is only used in tests, and therefore is safe.

- **wsd: http: support chunked POST in RequestParser**
- **wsd: http: Request supports chunk writing**
- **wsd: http: MultipartDataParser and test**
