### PR TITLE
Fix overflow popup width to display full content

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -382,7 +382,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 
 .unotoolbutton.notebookbar.has-label > *:not(.arrowbackground) { /*so they stay side by side*/
 	display: table-cell;
-	width: 100%;
+	width: max-content;
 	height: 100%;
 }
 

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -118,6 +118,7 @@
 
 .top-row-overflow-group {
 	display: flex;
+	max-width: 498px;
 }
 /* overflow menu */
 .ui-overflow-group-popup {


### PR DESCRIPTION
- before this patch because of the fixed width of popup some level of big content items or you can say elements gets hiddedn on screen
- this will fix the issue and make sure all the content gets visible and for overflow condition we will add scroll bar


Before:
<img width="736" height="228" alt="image" src="https://github.com/user-attachments/assets/7663d2a8-2d90-4d62-8b04-3c74c8a51cc0" />

After:
<img width="736" height="228" alt="image" src="https://github.com/user-attachments/assets/bba896d1-dc9f-45c5-8db3-44ef7075bf5c" />


Change-Id: I0d746433848d5f7d77a3256635ca3206a1fd5966


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

