### PR TITLE
Impress: Add slide layout controls to the Design tab

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1771,6 +1771,34 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			},
 			{ type: 'separator', id: 'design-themedialog-break', orientation: 'vertical' },
 			{
+				'type': 'overflowgroup',
+				'id': 'design-slide-layout',
+				'name':_('Slide Layout'),
+				'accessibility': { focusBack: true, combination: 'CS', de: null },
+				'more': {
+					'command':'.uno:PageSetup',
+					'accessibility': { focusBack: true, combination: 'ML', de: null }
+				},
+				'children': [
+					{
+						'id': 'home-change-layout:ChangeSlideLayoutMenu',
+						'type': 'menubutton',
+						'text': _('Change Layout'),
+						'icon': 'lc_changelayout.svg',
+						'command': '.uno:AssignLayout',
+						'accessibility': { focusBack: true, combination: 'CL', de: null }
+					},
+					{
+						'id': 'home-assign-layout',
+						'text': _('Reset Layout'),
+						'type': 'bigtoolitem',
+						'command': '.uno:AssignLayout',
+						'accessibility': { focusBack: true, combination: 'RS', de: null }
+					}
+				]
+			},
+			{ type: 'separator', id: 'design-slidelayout-break', orientation: 'vertical' },
+			{
 				'id': 'design-slide-size:SlideSizeMenu',
 				'class': 'unoSlideSize',
 				'type': 'menubutton',


### PR DESCRIPTION
Change-Id: Ib9ba488651f05a12ba8886ff7cb9cc8902fcccdf


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Moved the two slide layout controls from the Home tab to the Design tab and present them as prominent buttons.
- Matches user expectations: slide layout is a design decision, so keeping these controls in Design aligns with the mental model and common workflows.


### PREVIEW
<img width="408" height="136" alt="image" src="https://github.com/user-attachments/assets/f3a79de3-1490-4598-a3d3-d58e2e80ba70" />

<img width="450" height="425" alt="image" src="https://github.com/user-attachments/assets/0eae2554-4f55-4198-9de4-fb3399df45bf" />

<img width="491" height="156" alt="image" src="https://github.com/user-attachments/assets/11b1b1f9-1047-4495-96f6-aed1a3030872" />

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

