### PR TITLE
wsd: take DocBrokersMutex in dumpState

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3362,7 +3362,6 @@ public:
            << "\n  OutstandingForks: " << TotalOutstandingForks
            << "\n  NumPreSpawnedChildren: " << COOLWSD::NumPreSpawnedChildren
            << "\n  ChildSpawnTimeoutMs: " << ChildSpawnTimeoutMs.load()
-           << "\n  Document Brokers: " << DocBrokers.size()
 #if !MOBILEAPP
            << "\n  of which ConvertTo: " << ConvertToBroker::getInstanceCount()
 #endif
@@ -3435,9 +3434,12 @@ public:
         COOLWSD::FileRequestHandler->dumpState(os);
 #endif
 
-        os << "\nDocument Broker polls " << "[ " << DocBrokers.size() << " ]:\n";
-        for (auto &i : DocBrokers)
-            i.second->dumpState(os);
+        {
+            std::lock_guard<std::mutex> docBrokerLock(DocBrokersMutex);
+            os << "\nDocument Broker polls " << "[ " << DocBrokers.size() << " ]:\n";
+            for (auto& i : DocBrokers)
+                i.second->dumpState(os);
+        }
 
 #if !MOBILEAPP
         os << "\nConverter count: " << ConvertToBroker::getInstanceCount() << '\n';


### PR DESCRIPTION
This should fix the race on DocBrokers
which is accessed from both cleanupDocBrokers()
and dumpState(), where it wasn't protected.

Change-Id: I1bb87a11ea12fb73dbfa23c6135cf8af7cabfa28
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
