### PR TITLE
Calc splitter lines: Multiply gradient width with dpiScale.

### DIFF
--- a/browser/src/canvas/sections/SplitterLinesSection.ts
+++ b/browser/src/canvas/sections/SplitterLinesSection.ts
@@ -45,8 +45,10 @@ class SplitterLinesSection extends CanvasSectionObject {
 		if (splittersDataDiv) {
 			this.sectionProperties.fillColor =
 				getComputedStyle(splittersDataDiv).getPropertyValue('color');
+
 			this.sectionProperties.fillOpacity =
 				getComputedStyle(splittersDataDiv).getPropertyValue('opacity');
+
 			this.sectionProperties.thickness =
 				parseFloat(
 					getComputedStyle(splittersDataDiv)
@@ -67,10 +69,13 @@ class SplitterLinesSection extends CanvasSectionObject {
 		// Create a linear gradient based on the extracted color stops
 		// get raw data from sheet geometry. use index = 1
 		const deafultRowSize = rowData.data.sizecore;
-		// gradient width should be half a default row hight.
+
+		// Gradient width should be half of the default row height.
 		const gradientWidth: number = Math.ceil(deafultRowSize / 2);
-		//adjust horizontal position for RTL mode
+
+		// Adjust horizontal position for RTL mode.
 		splitPos.x = this.isCalcRTL() ? this.size[0] - splitPos.x : splitPos.x;
+
 		// Create a linear gradient based on the extracted color stops
 		selectionBackgroundGradient = this.createSplitLineGradient(
 			splitPos,
@@ -86,6 +91,9 @@ class SplitterLinesSection extends CanvasSectionObject {
 		gradientWidth: number,
 		isVertSplitter: boolean,
 	) {
+		const sPx = splitPos.x * app.dpiScale;
+		const sPy = splitPos.y * app.dpiScale;
+
 		let linearGradient = null;
 		const colorStops = [
 			{ colorCode: this.sectionProperties.fillColor, offset: 0 },
@@ -95,16 +103,16 @@ class SplitterLinesSection extends CanvasSectionObject {
 		if (isVertSplitter) {
 			linearGradient = this.context.createLinearGradient(
 				0,
-				splitPos.y,
+				sPy,
 				0,
-				splitPos.y + gradientWidth,
+				sPy + gradientWidth,
 			);
 		} else {
-			let x0 = splitPos.x;
-			let x1 = splitPos.x + gradientWidth;
+			let x0 = sPx;
+			let x1 = sPx + gradientWidth;
 			if (this.isCalcRTL()) {
-				x0 = splitPos.x - gradientWidth;
-				x1 = splitPos.x;
+				x0 = sPx - gradientWidth;
+				x1 = sPx;
 			}
 			linearGradient = this.context.createLinearGradient(x0, 0, x1, 0);
 		}


### PR DESCRIPTION
Issue: When browser zoom is at a higher level, gradient becomes invisible. Because its width is not multiplied with dpiScale and is very tiny.


Change-Id: I08f8951ad954268c3b7d0e6a57234ed20c5e90c5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

