### PR TITLE
Backport: Calc: Add “Page Sizes” dropdown with sticky "More Paper Sizes…"

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -444,6 +444,7 @@ COOL_JS_LST =\
 	src/control/jsdialog/Widget.ColorPickerButton.js \
 	src/control/jsdialog/Widget.ColorPicker.ts \
 	src/control/jsdialog/Widget.PageMarginEntry.ts \
+	src/control/jsdialog/Widget.PageSizeEntry.ts \
 	src/control/jsdialog/Widget.Combobox.js \
 	src/control/jsdialog/Widget.Containers.ts \
 	src/control/jsdialog/Widget.DropDown.ts \
@@ -1089,6 +1090,7 @@ pot:
 		src/control/jsdialog/Util.SnackbarController.ts \
 		src/control/jsdialog/Widget.ColorPicker.ts \
 		src/control/jsdialog/Widget.PageMarginEntry.ts \
+		src/control/jsdialog/Widget.PageSizeEntry.ts \
 		src/control/jsdialog/Widget.HTMLContent.ts \
 		src/control/jsdialog/Widget.MobileBorderSelector.js \
 		src/control/jsdialog/Widget.RadioButton.ts \

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -79,6 +79,12 @@
 	font-size: var(--default-font-size);
 }
 
+.pagesize-list {
+	max-height: clamp(12rem, 45vh, 24rem);
+	overflow-y: auto;
+	overflow-x: hidden;
+}
+
 @keyframes moveIndicator {
 	from { left: -25%; }
 	to { left: 100%; }

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -93,6 +93,7 @@ L.Control.JSDialogBuilder = L.Control.extend({
 		this._controlHandlers['radiobutton'] = JSDialog.RadioButton;
 		this._controlHandlers['progressbar'] = JSDialog.progressbar;
 		this._controlHandlers['pagemarginentry'] = JSDialog.pageMarginEntry;
+		this._controlHandlers['pagesizeentry'] = JSDialog.pageSizeEntry;
 		this._controlHandlers['checkbox'] = this._checkboxControl;
 		this._controlHandlers['basespinfield'] = this.baseSpinField;
 		this._controlHandlers['spinfield'] = this._spinfieldControl;

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -916,14 +916,21 @@ const pageSizes = [
 	},
 ];
 
-menuDefinitions.set(
-	'MenuPageSizesCalc',
-	pageSizes.map((item) => ({
-		id: item.id,
-		text: item.text,
-		uno: '.uno:CalcPageSize?PaperFormat:long=' + item.paper,
-	})) as Array<MenuDefinition>,
-);
+menuDefinitions.set('MenuPageSizesCalc', [
+	{
+		type: 'json',
+		content: {
+			id: 'Layout-PageSizeMenu',
+			type: 'pagesizeentry',
+			options: pageSizes.map((item) => ({
+				id: item.id,
+				text: item.text,
+				uno: '.uno:CalcPageSize?PaperFormat:long=' + item.paper,
+			})),
+		},
+	},
+	{ type: 'separator' },
+] as Array<MenuDefinition>);
 
 menuDefinitions.set(
 	'MenuPageSizesWriter',

--- a/browser/src/control/jsdialog/Widget.PageSizeEntry.ts
+++ b/browser/src/control/jsdialog/Widget.PageSizeEntry.ts
@@ -1,0 +1,83 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Widget.PageSizeEntry.ts
+ *
+ * A JSDialog "json" widget for rendering the page sizes
+ */
+
+declare var JSDialog: any;
+
+interface PageSizeOption {
+	id: string;
+	text: string;
+	uno: string;
+}
+
+function createPageSizeEntryWidget(data: any, builder: any): HTMLElement {
+	const sizes: PageSizeOption[] = data.options || [];
+	const container = document.createElement('div');
+	container.className = 'jsdialog ui-grid';
+
+	const list = document.createElement('div');
+	list.className = 'jsdialog pagesize-list';
+	container.appendChild(list);
+
+	const map = builder.map;
+
+	sizes.forEach((opt) => {
+		const item = document.createElement('div');
+		item.className = 'ui-combobox-entry jsdialog ui-grid-cell';
+		item.id = opt.id;
+
+		item.addEventListener('click', (evt: MouseEvent) => {
+			map.sendUnoCommand(opt.uno);
+			builder.callback('dialog', 'close', { id: data.id }, null);
+		});
+
+		const text = document.createElement('span');
+		text.textContent = opt.text;
+
+		item.appendChild(text);
+		list.appendChild(item);
+	});
+
+	const hr = document.createElement('hr');
+	hr.className = 'jsdialog ui-separator horizontal';
+	container.appendChild(hr);
+
+	const moreSizeContainer = document.createElement('div');
+	moreSizeContainer.className = 'ui-combobox-entry jsdialog ui-grid-cell';
+	moreSizeContainer.id = 'page-size-more';
+
+	moreSizeContainer.addEventListener('click', (evt: MouseEvent) => {
+		map.sendUnoCommand('.uno:PageFormatDialog');
+		builder.callback('dialog', 'close', { id: data.id }, null);
+	});
+
+	const text = document.createElement('span');
+	text.textContent = _('More Paper Sizes...');
+	moreSizeContainer.appendChild(text);
+	container.appendChild(moreSizeContainer);
+
+	return container;
+}
+
+JSDialog.pageSizeEntry = function (
+	parentContainer: Element,
+	data: any,
+	builder: any,
+): boolean {
+	const element = createPageSizeEntryWidget(data, builder);
+	parentContainer.appendChild(element);
+	return false;
+};


### PR DESCRIPTION
Change-Id: Ib9b478357f0047c1ac346a251683fff5a308e5af


* Backport PR: #12760 
* Target version: master 

### Summary

- Implements a new PageSizeEntry widget to provide a custom dropdown UI.
- Renders all sizes in a single scrollable list with a sticky "More Paper Sizes…" entry kept outside the scrolling area.
- "More Paper Sizes…" opens the Page Style dialog directly on the Page tab.
- Keeps the list height shorter and responsive


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

