### PR TITLE
automake silent rules: handle 'mkdir -p'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,10 @@ endif
 
 export ENABLE_DEBUG
 
+QUIET_MKDIRP = $(QUIET_MKDIRP_$(V))
+QUIET_MKDIRP_ = $(QUIET_MKDIRP_$(AM_DEFAULT_VERBOSITY))
+QUIET_MKDIRP_0 = @echo "  MKDIRP  " $@;
+
 bin_PROGRAMS = \
 	coolforkit-caps \
 	coolforkit-ns \
@@ -474,7 +478,7 @@ GIT_HASH := $(shell git log -1 --format=%h --abbrev=10)
 
 dist-hook:
 	git log -1 --format=%h --abbrev=10 > $(distdir)/dist_git_hash 2> /dev/null || rm $(distdir)/dist_git_hash
-	mkdir -p $(distdir)/bundled/include/LibreOfficeKit/
+	$(QUIET_MKDIRP) mkdir -p $(distdir)/bundled/include/LibreOfficeKit/
 	cp @LOKIT_PATH@/LibreOfficeKit/LibreOfficeKit.h \
 	   @LOKIT_PATH@/LibreOfficeKit/LibreOfficeKit.hxx \
 	   @LOKIT_PATH@/LibreOfficeKit/LibreOfficeKitEnums.h \
@@ -553,11 +557,11 @@ $(SYSTEM_STAMP): ${top_srcdir}/coolwsd-systemplate-setup $(CLEANUP_DEPS)
 
 @JAILS_PATH@:
 	@$(CLEANUP_COMMAND)
-	mkdir -p $@
+	$(QUIET_MKDIRP) mkdir -p $@
 
 @CACHE_PATH@:
 	@$(CLEANUP_COMMAND)
-	mkdir -p $@
+	$(QUIET_MKDIRP) mkdir -p $@
 
 presets-dir:
 	@rm -rf $(abs_top_srcdir)/test/data/presets
@@ -600,7 +604,7 @@ QUIET_SBOM_0 = @echo "  SBOM    " $@;
 setup-wsd: all @JAILS_PATH@ @CACHE_PATH@ presets-dir
 	@echo "Launching coolwsd"
 	@fc-cache "@LO_PATH@"/share/fonts/truetype
-	@mkdir -p $(abs_top_builddir)/test/samples
+	$(QUIET_MKDIRP) mkdir -p $(abs_top_builddir)/test/samples
 	$(QUIET_SAMPLES) $(abs_top_srcdir)/scripts/build-samples.py $(abs_top_srcdir)/test/samples $(abs_top_srcdir)/test/samples
 	@echo
 
@@ -777,15 +781,15 @@ $(abs_srcdir)/Doxyfile.cpp.cfg: config.d/Doxyfile.cpp.in
 
 doxygen: $(abs_srcdir)/Doxyfile.cpp.cfg
 	rm -rf doc/cpp
-	mkdir -p doc/cpp
+	$(QUIET_MKDIRP) mkdir -p doc/cpp
 	doxygen $(abs_srcdir)/Doxyfile.cpp.cfg
 
 $(abs_srcdir)/.vscode/settings.json: config.d/vscode/settings.json.am
-	mkdir -p $(abs_srcdir)/.vscode
+	$(QUIET_MKDIRP) mkdir -p $(abs_srcdir)/.vscode
 	sed -e 's|@COOL_DIR@|${abs_srcdir}|g' -e 's|@LOKIT_DIR@|${LOKIT_PATH}|g' $< > $@
 
 $(abs_srcdir)/.vscode/online.code-workspace: config.d/vscode/online.code-workspace.am
-	mkdir -p $(abs_srcdir)/.vscode
+	$(QUIET_MKDIRP) mkdir -p $(abs_srcdir)/.vscode
 	sed -e 's|@COOL_DIR@|${abs_srcdir}|g' -e 's|@LOKIT_DIR@|${LOKIT_PATH}|g' $< > $@
 
 gen-clangd: $(abs_srcdir)/compile_commands.json $(abs_srcdir)/.clangd
@@ -831,7 +835,7 @@ stress:
 		$(stress_file) $(trace_dir)/writer-quick.txt
 
 if ENABLE_CODE_COVERAGE
-GEN_COVERAGE_COMMAND=mkdir -p ${abs_top_srcdir}/gcov && \
+GEN_COVERAGE_COMMAND=$(QUIET_MKDIRP) mkdir -p ${abs_top_srcdir}/gcov && \
 lcov --no-external --capture --rc 'lcov_excl_line=' --rc 'lcov_excl_br_line=LOG_|TST_|LOK_|WSD_|TRANSITION|assert' \
 --compat libtool=on --directory ${abs_top_srcdir}/. --output-file ${abs_top_srcdir}/gcov/cool.coverage.test.info && \
 genhtml --prefix ${abs_top_srcdir}/. --ignore-errors source ${abs_top_srcdir}/gcov/cool.coverage.test.info \


### PR DESCRIPTION
Similar to commit 0e4528cf8082b48fdb5f8d451237aba267c98418 (automake
silent rules: handle scripts/unocommands.py, 2025-05-27), i.e. the
cmdline was sometimes hidden unconditionally, now it's hidden for
--enable-silent-rules and shown otherwise.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ie9b02c68c1f13f80292bca7d10b99a46781eb361
