### PR TITLE
notebookbar: startup (backport 25.04)

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -139,7 +139,7 @@ L.Control.Notebookbar = L.Control.extend({
 		if (!this.builder)
 			return;
 
-		this._isNotebookbarLoadedOnCore = true;
+		this.setInitialized(true);
 
 		this.builder.updateWidget(this.container, data.control);
 	},
@@ -156,7 +156,7 @@ L.Control.Notebookbar = L.Control.extend({
 		if (!this.container)
 			return;
 
-		this._isNotebookbarLoadedOnCore = true;
+		this.setInitialized(true);
 
 		this.builder.executeAction(this.container, data.data);
 	},
@@ -172,9 +172,21 @@ L.Control.Notebookbar = L.Control.extend({
 	},
 
 	onNotebookbar: function(data) {
-		this._isNotebookbarLoadedOnCore = true;
+		this.setInitialized(true);
 		// setup id for events
 		this.builder.setWindowId(data.id);
+	},
+
+	setInitialized: function(initialized) {
+		this._isNotebookbarLoadedOnCore = initialized;
+		app.console.debug('Notebookbar: set initialized: ' + initialized);
+
+		if (this.container) {
+			if (initialized)
+				this.container.classList.add('initialized');
+			else
+				this.container.classList.remove('initialized');
+		}
 	},
 
 	showTabs: function() {
@@ -208,6 +220,7 @@ L.Control.Notebookbar = L.Control.extend({
 		$('.notebookbar-tabs-container').remove();
 		$('.notebookbar-shortcuts-bar').remove();
 		$(this.container).remove();
+		this.setInitialized(false);
 	},
 
 	loadTab: function(tabJSON) {

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -178,6 +178,9 @@ L.Control.Notebookbar = L.Control.extend({
 	},
 
 	setInitialized: function(initialized) {
+		if (this._isNotebookbarLoadedOnCore === initialized)
+			return;
+
 		this._isNotebookbarLoadedOnCore = initialized;
 		app.console.debug('Notebookbar: set initialized: ' + initialized);
 
@@ -224,6 +227,8 @@ L.Control.Notebookbar = L.Control.extend({
 	},
 
 	loadTab: function(tabJSON) {
+		app.console.debug('Notebookbar: loadTab');
+
 		this.clearNotebookbar();
 
 		this.container = L.DomUtil.create('div', 'notebookbar-scroll-wrapper', this.parentContainer);

--- a/browser/src/control/Control.QuickFindPanel.ts
+++ b/browser/src/control/Control.QuickFindPanel.ts
@@ -16,8 +16,6 @@
 const QUICKFIND_WINDOW_ID = -5;
 class QuickFindPanel extends SidebarBase {
 	constructor(map: any) {
-		// Initialize QuickFindPanel in core
-		app.socket.sendMessage('uno .uno:QuickFind');
 		super(map, SidebarType.QuickFind);
 	}
 

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -565,11 +565,12 @@ class UIManager extends L.Control {
 		if (window.mode.isDesktop() && !window.ThisIsAMobileApp) {
 			var showSidebar = this.getBooleanDocTypePref('ShowSidebar', true);
 
-			if (this.getBooleanDocTypePref('PropertyDeck', true)) {
+			if (showSidebar && this.getBooleanDocTypePref('PropertyDeck', true)) {
 				app.socket.sendMessage('uno .uno:SidebarShow');
+				this.map.sidebar.setAsInitialized();
 			}
 
-			if (this.map.getDocType() === 'presentation') {
+			if (showSidebar && this.map.getDocType() === 'presentation') {
 				if (this.getBooleanDocTypePref('SdSlideTransitionDeck', false)) {
 					app.socket.sendMessage('uno .uno:SidebarShow');
 					app.socket.sendMessage('uno .uno:SlideChangeWindow');
@@ -579,7 +580,7 @@ class UIManager extends L.Control {
 					app.socket.sendMessage('uno .uno:CustomAnimation');
 					this.map.sidebar.setupTargetDeck('.uno:CustomAnimation');
 				}
-			} else if (this.getBooleanDocTypePref('StyleListDeck', false)) {
+			} else if (showSidebar && this.getBooleanDocTypePref('StyleListDeck', false)) {
 				app.socket.sendMessage('uno .uno:SidebarShow');
 				app.socket.sendMessage('uno .uno:SidebarDeck.StyleListDeck');
 				this.map.sidebar.setupTargetDeck('.uno:SidebarDeck.StyleListDeck');

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -552,9 +552,6 @@ class UIManager extends L.Control {
 			}
 		});
 		this.map.contextToolbar = L.control.ContextToolbar(this.map);
-
-		// do it always as we need it for contextual toolbar
-		if (!window.mode.isMobile()) this.initializeNotebookbarInCore();
 	}
 
 	/**
@@ -1181,6 +1178,9 @@ class UIManager extends L.Control {
 	// Notebookbar helpers
 
 	initializeNotebookbarInCore(): void {
+		// do it always apart of mobile as we need it for contextual toolbar
+		if (window.mode.isMobile()) return;
+
 		this.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=notebookbar_online.ui');
 	}
 

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1184,6 +1184,15 @@ class UIManager extends L.Control {
 		this.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=notebookbar_online.ui');
 	}
 
+	// QuickFindPanel
+
+	initializeQuickFindInCore(): void {
+		if (!this.map.quickFindPanel) return;
+
+		// Initialize QuickFindPanel in core
+		app.socket.sendMessage('uno .uno:QuickFind');
+	}
+
 	/**
 	 * Returns whether the notebookbar is currently shown.
 	 */

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -555,6 +555,17 @@ class UIManager extends L.Control {
 	}
 
 	/**
+	 * Initializes the heavy components which require core side to work.
+	 * Scheduled to be executed after we do first tiles requests to not
+	 * block the document content rendering on a load.
+	 */
+	initializeLateComponents(): void {
+		this.initializeNotebookbarInCore();
+		this.initializeSidebar();
+		this.initializeQuickFindInCore();
+	}
+
+	/**
 	 * Initializes the sidebar based on saved state and preferences.
 	 */
 	initializeSidebar(): void {

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -304,8 +304,8 @@ L.Map = L.Evented.extend({
 
 			if (this._docLayer && !this._docLoadedOnce) {
 				// Let the first page finish loading then request core ui components
-				// TODO: make it deterministic by using the signal for first tiles received
-				setTimeout(this.uiManager.initializeLateComponents.bind(this.uiManager), 200);
+				TileManager.appendAfterFirstTileTask(
+					this.uiManager.initializeLateComponents.bind(this.uiManager));
 			}
 
 			// We have loaded.

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -302,12 +302,10 @@ L.Map = L.Evented.extend({
 			if (!window.mode.isMobile())
 				this.initializeModificationIndicator();
 
-			// Show sidebar.
 			if (this._docLayer && !this._docLoadedOnce) {
-				// Let the first page finish loading then load the sidebar and notebookbar
-				setTimeout(this.uiManager.initializeSidebar.bind(this.uiManager), 200);
-				setTimeout(this.uiManager.initializeNotebookbarInCore.bind(this.uiManager), 200);
-				setTimeout(this.uiManager.initializeQuickFindInCore.bind(this.uiManager), 400);
+				// Let the first page finish loading then request core ui components
+				// TODO: make it deterministic by using the signal for first tiles received
+				setTimeout(this.uiManager.initializeLateComponents.bind(this.uiManager), 200);
 			}
 
 			// We have loaded.

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -304,8 +304,9 @@ L.Map = L.Evented.extend({
 
 			// Show sidebar.
 			if (this._docLayer && !this._docLoadedOnce) {
-				// Let the first page finish loading then load the sidebar.
+				// Let the first page finish loading then load the sidebar and notebookbar
 				setTimeout(this.uiManager.initializeSidebar.bind(this.uiManager), 200);
+				setTimeout(this.uiManager.initializeNotebookbarInCore.bind(this.uiManager), 200);
 			}
 
 			// We have loaded.

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -307,6 +307,7 @@ L.Map = L.Evented.extend({
 				// Let the first page finish loading then load the sidebar and notebookbar
 				setTimeout(this.uiManager.initializeSidebar.bind(this.uiManager), 200);
 				setTimeout(this.uiManager.initializeNotebookbarInCore.bind(this.uiManager), 200);
+				setTimeout(this.uiManager.initializeQuickFindInCore.bind(this.uiManager), 400);
 			}
 
 			// We have loaded.

--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -371,6 +371,13 @@ function documentChecks(skipInitializedCheck = false) {
 		cy.wait(10000);
 	}
 
+	if (!skipInitializedCheck /* TODO: if notebookbar mode */) {
+		doIfOnDesktop(() => {
+			cy.cGet('.notebookbar-scroll-wrapper', {timeout : Cypress.config('defaultCommandTimeout') * 2.0})
+				.should('have.class', 'initialized');
+		});
+	}
+
 	// Wait for the sidebar to open.
 	if (Cypress.env('INTEGRATION') !== 'nextcloud') {
 		doIfOnDesktop(function() {

--- a/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
@@ -20,6 +20,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Invalidation tests.', func
 		helper.setupAndLoadDocument('writer/invalidations.odt');
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('div.clipboard').as('clipboard');
+		cy.cGet('#stylesview .ui-iconview-entry img').should('exist');
+		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '0 words, 0 characters');
 
 		// Add some main body text of X
 		ceHelper.type('X');
@@ -47,6 +49,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Invalidation tests.', func
 		helper.setupAndLoadDocument('writer/invalidations_headers.odt');
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('div.clipboard').as('clipboard');
+		cy.cGet('#stylesview .ui-iconview-entry img').should('exist');
+		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '2 words, 3 characters');
 
 		writerHelper.selectAllTextOfDoc();
 		cy.cGet('#toolbar-down #StateWordCount').should('have.text', 'Selected: 1 word, 1 character');
@@ -89,6 +93,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Invalidation tests.', func
 		helper.setupAndLoadDocument('writer/invalidations.odt');
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('div.clipboard').as('clipboard');
+		cy.cGet('#stylesview .ui-iconview-entry img').should('exist');
+		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '0 words, 0 characters');
 
 		// Add some main body text of X and bullet
 		ceHelper.type('XX');

--- a/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
@@ -5,6 +5,17 @@ var desktopHelper = require('../../common/desktop_helper');
 var ceHelper = require('../../common/contenteditable_helper');
 var writerHelper = require('../../common/writer_helper');
 
+function waitForInit(hasClass) {
+	// TODO: skipDocumentCheck=FALSE in beforeEach, let's do it here once for now
+	//       somehow it doesnt work for second iframe
+	if (hasClass) {
+		cy.cGet('#map', { timeout: 60 })
+			.should('have.class', 'initialized');
+	}
+
+	cy.cGet('#stylesview .ui-iconview-entry img').should('be.visible');
+}
+
 describe(['tagmultiuser'], 'Joining a document should not trigger an invalidation', function() {
 
 	beforeEach(function() {
@@ -21,14 +32,13 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 	it('Join document', function() {
 		cy.cSetActiveFrame('#iframe1');
 		cy.cGet('div.clipboard').as('clipboard');
-
-		cy.cGet('#stylesview .ui-iconview-entry img').should('be.visible');
+		waitForInit(true);
 		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '0 words, 0 characters');
 
 		ceHelper.type('X');
 
 		cy.cSetActiveFrame('#iframe2');
-		cy.cGet('#stylesview .ui-iconview-entry img').should('be.visible');
+		waitForInit(false);
 		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '1 word, 1 character');
 
 		cy.cSetActiveFrame('#iframe1');
@@ -59,14 +69,13 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 	it('Join after document save and modify', function() {
 		cy.cSetActiveFrame('#iframe1');
 		cy.cGet('div.clipboard').as('clipboard');
-
-		cy.cGet('#stylesview .ui-iconview-entry img').should('be.visible');
+		waitForInit(true);
 		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '0 words, 0 characters');
 
 		ceHelper.type('X');
 
 		cy.cSetActiveFrame('#iframe2');
-		cy.cGet('#stylesview .ui-iconview-entry img').should('be.visible');
+		waitForInit(false);
 		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '1 word, 1 character');
 
 		cy.cSetActiveFrame('#iframe1');

--- a/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
@@ -13,7 +13,11 @@ function waitForInit(hasClass) {
 			.should('have.class', 'initialized');
 	}
 
+	cy.cGet('.notebookbar-scroll-wrapper', { timeout: 20 })
+			.should('have.class', 'initialized');
 	cy.cGet('#stylesview .ui-iconview-entry img').should('be.visible');
+
+	cy.cGet('div.clipboard').as('clipboard');
 }
 
 describe(['tagmultiuser'], 'Joining a document should not trigger an invalidation', function() {
@@ -31,11 +35,11 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 
 	it('Join document', function() {
 		cy.cSetActiveFrame('#iframe1');
-		cy.cGet('div.clipboard').as('clipboard');
 		waitForInit(true);
 		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '0 words, 0 characters');
 
 		ceHelper.type('X');
+		cy.wait(1000);
 
 		cy.cSetActiveFrame('#iframe2');
 		waitForInit(false);
@@ -53,6 +57,7 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 			// joining triggered a theme related invalidation
 			cy.cSetActiveFrame('#iframe2');
 			cy.get('#form2').submit();
+			cy.wait(1000);
 
 			cy.cSetActiveFrame('#iframe1');
 			writerHelper.selectAllTextOfDoc();
@@ -68,11 +73,11 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 
 	it('Join after document save and modify', function() {
 		cy.cSetActiveFrame('#iframe1');
-		cy.cGet('div.clipboard').as('clipboard');
 		waitForInit(true);
 		cy.cGet('#toolbar-down #StateWordCount').should('have.text', '0 words, 0 characters');
 
 		ceHelper.type('X');
+		cy.wait(1000);
 
 		cy.cSetActiveFrame('#iframe2');
 		waitForInit(false);
@@ -104,7 +109,10 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 			cy.cGet('#toolbar-down #StateWordCount').should('have.text', 'Selected: 1 word, 1 character');
 			cy.cGet('.leaflet-layer').click({force:true});
 			cy.cGet('#toolbar-down #StateWordCount').should('have.text', '1 word, 1 character');
+
 			ceHelper.type('X');
+			cy.wait(1000);
+
 			cy.cGet('#toolbar-down #StateWordCount').should('have.text', '1 word, 2 characters');
 
 			cy.cGet('.empty-deltas').should(($after) => {


### PR DESCRIPTION
- it helps with the bug where Writer -> References tab was updated before we got core widget updates
- in above case we got clean styles previews because we rebuilt notebookbar but we didn't insert updates we got so far
- backports boot management, so we initialize core components only after first tile is received by a client so we have more time to do a "references update", it's not a proper fix but reduces the probability of an event
will be continued