### PR TITLE
Fixed UI of position and size menu in calc

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -203,6 +203,15 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	grid-gap: 4px;
 }
 
+.jsdialog.ui-grid {
+	align-items: center;
+}
+
+#grid2-cell-0-2 {
+	grid-column: 3;
+	grid-row: 1 / span 2;
+}
+
 /* Special Characters dialog */
 #SpecialCharactersDialog #viewgrid,
 #SpecialCharactersDialog #favgrid {


### PR DESCRIPTION
Change-Id: I3f8ecdabbed00c7d44687ba93960b6ad7ba9852b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

