### PR TITLE
Snackbar: remove extra padding from feedback popup

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1996,12 +1996,15 @@ button.menubutton.sidebar > span {
 	grid-template-columns: repeat(2, auto);
 }
 
+#mobile-wizard.popup.snackbar [id$='button'] {
+	padding: 8px;
+}
+
 #mobile-wizard.popup.snackbar [id$='button'],
 .snackbar.jsdialog-container [id$='button'] {
 	color: #469cff !important;
 	font-weight: 600;
 	font-size: var(--header-font-size) !important;
-	padding: 8px;
 	display: flex;
 	align-items: center;
 }


### PR DESCRIPTION
Change-Id: I9a6367901409acd2603988c6adea1fa0696058f1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Move padding from general snackbar buttons to mobile-wizard specific  buttons only

### PREVIEW
<img width="449" height="101" alt="Screenshot from 2025-09-09 03-23-47" src="https://github.com/user-attachments/assets/2373fda4-166a-44fd-8aae-c7e56875413a" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

