### PR TITLE
fix: failed to send browsersetting on document close (backport)

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -113,7 +113,6 @@ app.definitions.Socket = L.Class.extend({
 	},
 
 	setUnloading: function() {
-		window.prefs.sendPendingBrowserSettingsUpdate();
 		if (this.socket.setUnloading)
 			this.socket.setUnloading();
 	},

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -50,6 +50,7 @@ class Dispatcher {
 					this.dispatch('acceptformula'); // save data from the edited cell on exit
 				}
 
+				window.prefs.sendPendingBrowserSettingsUpdate();
 				app.map.fire('postMessage', {
 					msgId: 'close',
 					args: { EverModified: app.map._everModified, Deprecated: true },

--- a/browser/src/global.d.ts
+++ b/browser/src/global.d.ts
@@ -157,6 +157,7 @@ interface Window {
 		get(key: string, defaultValue?: any): any;
 		set(key: string, value: any): void;
 		setMultiple(prefs: Record<string, string>): void;
+		sendPendingBrowserSettingsUpdate(): void;
 	};
 
 	allowUpdateNotification: boolean;


### PR DESCRIPTION
- we only want to send browsersetting on focus change and when document gets close.

Change-Id: Id66cd0f5ee0d2e448e68e6649920e390fc78f1ef