### PR TITLE
Avoid error on context switch

### DIFF
--- a/browser/src/control/jsdialog/Component.Toolbar.ts
+++ b/browser/src/control/jsdialog/Component.Toolbar.ts
@@ -103,7 +103,7 @@ class Toolbar {
 	}
 
 	isItemHidden(id: string): boolean {
-		const item = this.parentContainer.querySelector('[id="' + id + '"]');
+		const item = this.parentContainer?.querySelector('[id="' + id + '"]');
 		if (!item) return true;
 		return item.classList.contains('hidden');
 	}


### PR DESCRIPTION
This fixes below bug:

1. Open compact mode
2. Switch to tabbed view
3. Put cursor in the different context inside document (table, picture)

Result: error

Uncaught TypeError: Cannot read properties of null (reading 'querySelector')
    at Toolbar.isItemHidden (Component.Toolbar.ts:106:37)
    at Toolbar.showItem (Component.Toolbar.ts:114:12)
    at Component.Toolbar.ts:207:9
    at Array.forEach (<anonymous>)
    at Toolbar.updateVisibilityForToolbar (Component.Toolbar.ts:206:10)
    at TopToolbar.onContextChange (Control.TopToolbar.js:91:8)

