### PR TITLE
Backport: Snackbar: remove extra padding from feedback popup

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1996,12 +1996,15 @@ button.menubutton.sidebar > span {
 	grid-template-columns: repeat(2, auto);
 }
 
+#mobile-wizard.popup.snackbar [id$='button'] {
+	padding: 8px;
+}
+
 #mobile-wizard.popup.snackbar [id$='button'],
 .snackbar.jsdialog-container [id$='button'] {
 	color: #469cff !important;
 	font-weight: 600;
 	font-size: var(--header-font-size) !important;
-	padding: 8px;
 	display: flex;
 	align-items: center;
 }


### PR DESCRIPTION


Change-Id: Iabfbd5b7bdd7bb68d725570245960e083d69483c


* Backport : #12813 
* Target version: master 

### Summary
- Move padding from general snackbar buttons to mobile-wizard specific
 buttons only


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

