### PR TITLE
Backport: Impress: Design-tab: Set uniform height for slide template icons

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -768,3 +768,12 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	width: var(--btn-img-size);
 	height: var(--btn-img-size);
 }
+
+#masterpageall_icons .notebookbar.ui-iconview-entry {
+	height: 2.75rem;
+}
+
+#masterpageall_icons .notebookbar.ui-iconview-entry img {
+	height: 100%;
+	width: 100%;
+}


### PR DESCRIPTION
Change-Id: I10a4d6e9cabb4544f991c93e0cbca7487ea4ce31


* Backport: #12799 
* Target version: master 

### Summary
- Set fixed height of 2.75rem for masterpageall_icons entries to ensure consistent preview sizes across all slide templates in notebookbar

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

