### PR TITLE
Backport: Impress: Add slide layout controls to the Design tab

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1771,6 +1771,34 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 			},
 			{ type: 'separator', id: 'design-themedialog-break', orientation: 'vertical' },
 			{
+				'type': 'overflowgroup',
+				'id': 'design-slide-layout',
+				'name':_('Slide Layout'),
+				'accessibility': { focusBack: true, combination: 'CS', de: null },
+				'more': {
+					'command':'.uno:PageSetup',
+					'accessibility': { focusBack: true, combination: 'ML', de: null }
+				},
+				'children': [
+					{
+						'id': 'home-change-layout:ChangeSlideLayoutMenu',
+						'type': 'menubutton',
+						'text': _('Change Layout'),
+						'icon': 'lc_changelayout.svg',
+						'command': '.uno:AssignLayout',
+						'accessibility': { focusBack: true, combination: 'CL', de: null }
+					},
+					{
+						'id': 'home-assign-layout',
+						'text': _('Reset Layout'),
+						'type': 'bigtoolitem',
+						'command': '.uno:AssignLayout',
+						'accessibility': { focusBack: true, combination: 'RS', de: null }
+					}
+				]
+			},
+			{ type: 'separator', id: 'design-slidelayout-break', orientation: 'vertical' },
+			{
 				'id': 'design-slide-size:SlideSizeMenu',
 				'class': 'unoSlideSize',
 				'type': 'menubutton',


### PR DESCRIPTION
Change-Id: I2173cd26c763e5e581c4c9809935187f26d86aff


* Resolves: #12775 
* Target version: master 

### Summary
- Added the two slide layout controls to the Design tab

- Matches user expectations: slide layout is a design decision, so keeping these controls in Design aligns with the mental model and common workflows.


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

