### PR TITLE
Fix custom page margin dialog not opening in Writer

### DIFF
--- a/browser/src/control/jsdialog/Widget.PageMarginEntry.ts
+++ b/browser/src/control/jsdialog/Widget.PageMarginEntry.ts
@@ -34,6 +34,7 @@ function createPageMarginEntryWidget(data: any, builder: any): HTMLElement {
 	const options: PageMarginOptions = data.options;
 	const container = document.createElement('div');
 	const map = builder.map;
+	const isCalc = map._docLayer.isCalc();
 	container.className = 'margins-popup-container';
 
 	const onMarginClick = (evt: MouseEvent) => {
@@ -140,7 +141,7 @@ function createPageMarginEntryWidget(data: any, builder: any): HTMLElement {
 	custom.id = 'customMarginsLink';
 	custom.textContent = _('Custom Margins…');
 	custom.addEventListener('click', (evt: MouseEvent) => {
-		map.sendUnoCommand('.uno:PageFormatDialog');
+		map.sendUnoCommand(isCalc ? '.uno:PageFormatDialog' : '.uno:PageDialog');
 		builder.callback('dialog', 'close', { id: data.id }, null);
 	});
 	container.appendChild(custom);


### PR DESCRIPTION
Change-Id: I261db87e2618177f486dd79264004bb7fbbd0566


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Writer uses '.uno:PageDialog' while Calc uses '.uno:PageFormatDialog'. 
- Updated sendUnoCommand to use the correct UNO command per application.

### PREVIEW

https://github.com/user-attachments/assets/a4bc7403-c132-45a0-b8dd-8de961e3208b



- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

