### PR TITLE
Make hyperlink dialog fields aligned

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2421,21 +2421,23 @@ kbd,
 	display: none;
 }
 
-/* Third column has nothing to display */
-#\~Mail #grid1 {
-	grid-template-columns: 1fr 3fr 0px !important;
+#HyperlinkInternetPage #grid1,
+#HyperlinkInternetPage #grid3,
+#HyperlinkMailPage #grid3 {
+	grid-template-columns: 1fr 3fr !important;
 	column-gap: 0px !important;
 }
 
-#\~Internet #grid1, #\~Internet #grid3, #\~Mail #grid3 {
-	grid-template-columns: 1fr 3fr !important;
+/* Third column has nothing to display */
+#HyperlinkMailPage #grid1 {
+	grid-template-columns: 1fr 3fr 0px !important;
 	column-gap: 0px !important;
 }
 
 /* Unlike frame1, and both frames on the mail page, this only has one element,
    and is therefore a div not a fieldset. Fieldsets have 2px margin on both sides,
    so add it here to to align elements. */
-#\~Internet #frame2 {
+#HyperlinkInternetPage #frame2 {
 	margin-left: 2px;
 	margin-right: 2px;
 }


### PR DESCRIPTION
We want the different grids to the the same size; I don't think linking them is possible, so set the title to always use 25% of the space given.

Add 2px margin to both sides of the div so it has the same margin as the fieldsets. Add 0px column gap to avoid allocating space to the column with the hidden element in the mail tab.


Change-Id: I6a6a696456fba9bf724de77e985c8386476171a2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

