### PR TITLE
notebookbar: switch from compact mode

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -111,6 +111,11 @@ L.Control.Notebookbar = L.Control.extend({
 			$('#invertbackground').hide();
 	},
 
+	resetInCore: function() {
+		this.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=Default');
+		this.setInitialized(false);
+	},
+
 	onRemove: function() {
 		clearTimeout(this.retry);
 		this.map.off('commandstatechanged', this.builder.onCommandStateChanged, this.builder);
@@ -125,6 +130,7 @@ L.Control.Notebookbar = L.Control.extend({
 			this.floatingNavIcon.classList.remove('hasnotebookbar');
 		$('.main-nav #document-header').remove();
 		this.clearNotebookbar();
+		this.resetInCore();
 	},
 
 	onJSUpdate: function (e) {

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -568,7 +568,8 @@ class UIManager extends L.Control {
 	 */
 	initializeLateComponents(): void {
 		app.console.debug('UIManager: late components init');
-		this.initializeNotebookbarInCore();
+		if (this.getCurrentMode() === 'notebookbar')
+			this.initializeNotebookbarInCore();
 		this.initializeSidebar();
 		this.initializeQuickFindInCore();
 	}
@@ -822,7 +823,7 @@ class UIManager extends L.Control {
 		}
 
 		window.prefs.set('compactMode', uiMode.mode === 'classic');
-		this.initializeSidebar();
+		this.initializeLateComponents();
 		this.insertCustomButtons();
 
 		// this code ensures that elements in the notebookbar have their "selected" status


### PR DESCRIPTION
 notebookbar: initialize after switch from compact mode
    
    This fixes regression from commit 9eecda2c5b162864be277f6f5884c6795cdac676
    notebookbar: single initialization
    
    1. Open compact mode
    2. Switch to tabbed mode
    Result: empty style previews in Writer case