### PR TITLE
fix(android): disable edge-to-edge mode

### DIFF
--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -2,7 +2,9 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <style name="LibreOfficeTheme" parent="LibreOfficeTheme.Base"/>
 
-    <style name="LibreOfficeTheme.Base" parent="Theme.AppCompat.DayNight.NoActionBar"/>
+    <style name="LibreOfficeTheme.Base" parent="Theme.AppCompat.DayNight.NoActionBar">
+        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:ignore="NewApi">true</item>
+    </style>
 
     <style name="ListItemText">
         <item name="android:gravity">center_vertical</item>
@@ -12,10 +14,12 @@
 
     <style name="LibreOfficeTheme.Toolbar" parent="Theme.AppCompat.DayNight.NoActionBar">
         <item name="colorPrimary">@color/toolbar_background</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:ignore="NewApi">true</item>
     </style>
 
     <style name="LibreOfficeTheme.NavigationView">
         <item name="colorPrimary">@android:color/black</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:ignore="NewApi">true</item>
     </style>
 
     <style name="NewDocumentTextView">
@@ -27,5 +31,6 @@
         <item name="android:typeface">normal</item>
         <item name="android:padding">5dp</item>
         <item name="android:background">?android:attr/colorPrimary</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:ignore="NewApi">true</item>
     </style>
 </resources>


### PR DESCRIPTION
Google has turned on edge-to-edge mode by default for all API-version-35 Android apps. This makes our app underlay the toolbar, which is a bad thing as you can't click on elements that are underneath the toolbar.

The true solution is figuring out how to modify every activity to turn the bar text the right color and add some padding (I guess to both top and bottom depending on the navigation bar mode?) but for now it's easier to Just Opt Out


Change-Id: I6a6a696444fb71e6bce1dd8260d1c9f11dff96dd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

