### PR TITLE
Fix : compact mode height of toolbar is wrong

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -357,7 +357,7 @@ algned to the bottom */
 .ui-overflow-manager .horizontal.notebookbar {
 	align-items: end;
 }
-.ui-overflow-group:not(.ui-overflow-group-container-with-label) {
+.notebookbar.ui-overflow-group:not(.ui-overflow-group-container-with-label) {
 	align-content: center;
 	height: 49px !important;
 	margin-bottom: 14px;


### PR DESCRIPTION
- Corrected the css to only target the overflow element in notbookbar mode to add height and bottom margin
- we do not need this to be applicable in compact mode
- this patch will fix the wrong height gets added on overflow menu added in compact mode

Before:
<img width="1957" height="195" alt="image" src="https://github.com/user-attachments/assets/51a8e808-362a-4fba-ade9-c267afd89be8" />

After:
<img width="1957" height="195" alt="image" src="https://github.com/user-attachments/assets/b21f30b2-85b4-487c-94b5-39bd0dbb4741" />


Change-Id: Id11a79ffaab270fb45d9f37fe5dca63a2be3f645


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

