### PR TITLE
Fix Separator issue for overflow menu popup in compact modified

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -265,12 +265,13 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 }
 .jsdialog.ui-separator.vertical {
 	margin: 5px 0px;
-	padding-right: 1px;
 	background-color: var(--color-background-darker);
 }
 
 .ui-toolbar .ui-separator.vertical {
 	height: 14px;
+	width: 1px;
+	padding: 0px; /* Set padding to 0px, as the padding in `browser/css/toolbar.css` overrides it for the separator. */
 	align-self: center;
 	margin: 0 3px;
 }


### PR DESCRIPTION
- in compact mode separator looks too big
- Before this patch because some padding intervention done from `.ui-toolbar > div > div` in toolbar.css class
- the separator got the width which was around 6px
- this patch will fix the issue and will make the separator width to `1px`

Before:
<img width="347" height="167" alt="image" src="https://github.com/user-attachments/assets/cd492d3b-8ea4-4c8f-82a2-145f41482e9d" />

After:
<img width="347" height="167" alt="image" src="https://github.com/user-attachments/assets/8dda8458-bf81-4e8f-8ff5-f823ee79b28b" />

Change-Id: Ic9563e8c340a88307648b42b21012603031d6763


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

