### PR TITLE
Fix Separator issue for overflow menu popup in compact modified

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -265,12 +265,13 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 }
 .jsdialog.ui-separator.vertical {
 	margin: 5px 0px;
-	padding-right: 1px;
 	background-color: var(--color-background-darker);
 }
 
 .ui-toolbar .ui-separator.vertical {
 	height: 14px;
+	width: 1px;
+	padding: 0px; /* Set padding to 0px, as the padding in `browser/css/toolbar.css` overrides it for the separator. */
 	align-self: center;
 	margin: 0 3px;
 }


### PR DESCRIPTION
Backport of : https://github.com/CollaboraOnline/online/pull/12841

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

