### PR TITLE
kit: make KitHelper.hpp self-contained

### DIFF
--- a/kit/KitHelper.hpp
+++ b/kit/KitHelper.hpp
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include <sstream>
 #include <string>
 #include <unordered_map>
 
@@ -19,6 +18,7 @@
 #include <Util.hpp>
 
 #define LOK_USE_UNSTABLE_API
+#include <LibreOfficeKit/LibreOfficeKit.h>
 #include <LibreOfficeKit/LibreOfficeKitEnums.h>
 
 namespace LOKitHelper


### PR DESCRIPTION
The include for LibreOfficeKitDocument was missing, sstream was an
unused include.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I51033b6bacc1f5bb5b1552e08b2a3b30539ccecf
