### PR TITLE
Remove special handling of comment scroll.

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -193,14 +193,6 @@ export class Comment extends CanvasSectionObject {
 		L.DomEvent.on(this.sectionProperties.container, 'click', this.onMouseClick, this);
 		L.DomEvent.on(this.sectionProperties.container, 'keydown', this.onEscKey, this);
 
-		this.sectionProperties.container.onwheel = function(e: WheelEvent) {
-			// Don't scroll the document if mouse is over comment content. Scrolling the comment content is priority.
-			if (!this.sectionProperties.contentNode.matches(':hover')) {
-				e.preventDefault();
-				app.sectionContainer.onMouseWheel(e);
-			}
-		}.bind(this);
-
 		for (var it = 0; it < events.length; it++) {
 			L.DomEvent.on(this.sectionProperties.container, events[it], L.DomEvent.stopPropagation, this);
 		}


### PR DESCRIPTION
Current condition causes to problem on scrolling long comments. Default is working good now.


Change-Id: Ia20185e26213ce80119dba44ecb2c667a6d90df1


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

