### PR TITLE
Backport 500-Error Handling

### DIFF
--- a/test/UnitWOPIDocumentConflict.cpp
+++ b/test/UnitWOPIDocumentConflict.cpp
@@ -403,9 +403,164 @@ public:
     }
 };
 
+/// Simulate an upload timeout that precipitates a "conflict."
+/// When the upload times out (i.e. takes longer than *we* expected),
+/// there are really two outcomes: 1) the upload eventually was
+/// successful (this case), and the document has been updated in storage,
+/// or, 2) the upload fails (UnitConflictAfterTimeoutFailure), and the
+/// document is not updated in storage. Either way, since we timed out, we
+/// never know the result. In case #1, the modified timestamp in
+/// storage would have changed, and any subsequent upload will fail,
+/// since the timestamp that we will send with subsequent uploads,
+/// which represents the expected last-modify date/time, will be invalid.
+/// This test simulates this particular scenario and verifies that
+/// we are able to recover gracefully from it.
+class UnitConflictRecoveryTimeout : public WopiTestServer
+{
+    STATE_ENUM(Phase, Load, WaitLoadStatus, WaitModifiedStatus, WaitUploaded, WaitDestroy)
+    _phase;
+
+    std::atomic_int _uploadAttemptCount;
+
+    static constexpr int ConnectionTimeoutSeconds = 1;
+
+public:
+    UnitConflictRecoveryTimeout()
+        : WopiTestServer("UnitConflictRecoveryTimeout")
+        , _phase(Phase::Load)
+        , _uploadAttemptCount(0)
+    {
+    }
+
+    void configure(Poco::Util::LayeredConfiguration& config) override
+    {
+        WopiTestServer::configure(config);
+
+        // We intentionally fail uploading twice, so need at least 3 tries.
+        config.setUInt("per_document.limit_store_failures", 3);
+        config.setBool("per_document.always_save_on_exit", false);
+        config.setUInt("net.connection_timeout_secs", ConnectionTimeoutSeconds); // Timeout quickly.
+        config.setUInt("per_document.min_time_between_uploads_ms", 100); // Short retry interval.
+    }
+
+    std::unique_ptr<http::Response>
+    assertPutFileRequest(const Poco::Net::HTTPRequest& request) override
+    {
+        ++_uploadAttemptCount;
+        LOG_TST("PutFile: " << _uploadAttemptCount << ", Phase: " << name(_phase));
+
+        const std::string wopiTimestamp = request.get("X-COOL-WOPI-Timestamp", std::string());
+
+        if (_uploadAttemptCount == 1)
+        {
+            LOK_ASSERT_MESSAGE("Unexpected forced upload", !wopiTimestamp.empty());
+
+            // First attempt, timeout.
+            LOG_TST("PutFile: sleeping");
+            // Don't sleep for 2 x ConnectionTimeoutSeconds, as the
+            // CheckFileInfo request may timeout, since we're stuck here.
+            sleep(ConnectionTimeoutSeconds); // Connection timeout.
+            usleep(300'000); // Go over, to be certain we timed-out the upload.
+            LOG_TST("PutFile: woke up");
+        }
+        else
+        {
+            LOK_ASSERT_MESSAGE("Expected forced upload", wopiTimestamp.empty());
+        }
+
+        // Success.
+        LOG_TST("PutFile: returning success");
+        return nullptr;
+    }
+
+    virtual std::unique_ptr<http::Response>
+    assertCheckFileInfoRequest(const Poco::Net::HTTPRequest& /*request*/) override
+    {
+        if (_uploadAttemptCount == 1)
+        {
+            // The CheckFileInfo following an upload timeout.
+            // While we're "processing" the slow upload request, close the document.
+            TRANSITION_STATE(_phase, Phase::WaitDestroy);
+            WSD_CMD("closedocument");
+
+            LOG_TST("CheckFileInfo: sleeping");
+            sleep(ConnectionTimeoutSeconds); // Connection timeout.
+            usleep(300'000); // Go over, to be certain we timed-out the upload.
+            LOG_TST("CheckFileInfo: woke up");
+        }
+
+        return nullptr; // Success.
+    }
+
+    /// The document is loaded.
+    bool onDocumentLoaded(const std::string& message) override
+    {
+        LOG_TST("Got: [" << message << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitLoadStatus);
+
+        TRANSITION_STATE(_phase, Phase::WaitModifiedStatus);
+        WSD_CMD("key type=input char=97 key=0");
+        WSD_CMD("key type=up char=0 key=512");
+
+        return true;
+    }
+
+    /// The document is modified. Save it.
+    bool onDocumentModified(const std::string& message) override
+    {
+        LOG_TST("Got: [" << message << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitModifiedStatus);
+
+        TRANSITION_STATE(_phase, Phase::WaitUploaded);
+        WSD_CMD("save dontTerminateEdit=0 dontSaveIfUnmodified=0");
+
+        return true;
+    }
+
+    void onDocumentUploaded(bool success) override
+    {
+        LOG_TST("Uploaded: " << (success ? "success" : "failure"));
+        LOK_ASSERT(_phase == Phase::WaitUploaded || _phase == Phase::WaitDestroy);
+        LOK_ASSERT_EQUAL_MESSAGE("Expected the first upload to fail", _uploadAttemptCount == 1,
+                                 !success);
+    }
+
+    // Wait for clean unloading.
+    void onDocBrokerDestroy(const std::string& docKey) override
+    {
+        LOG_TST("Destroyed dockey [" << docKey << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitDestroy);
+
+        passTest("Document uploaded on closing as expected.");
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::Load:
+            {
+                TRANSITION_STATE(_phase, Phase::WaitLoadStatus);
+
+                LOG_TST("Load: initWebsocket.");
+                initWebsocket("/wopi/files/0?access_token=anything");
+
+                WSD_CMD("load url=" + getWopiSrc());
+                break;
+            }
+            case Phase::WaitLoadStatus:
+            case Phase::WaitModifiedStatus:
+            case Phase::WaitUploaded:
+            case Phase::WaitDestroy:
+                break;
+        }
+    }
+};
+
 UnitBase** unit_create_wsd_multi(void)
 {
-    return new UnitBase*[4]{ new UnitWOPIDocumentConflict(), new UnitConflictAfterTimeoutSuccess(),
+    return new UnitBase*[5]{ new UnitConflictRecoveryTimeout(), new UnitWOPIDocumentConflict(),
+                             new UnitConflictAfterTimeoutSuccess(),
                              new UnitConflictAfterTimeoutFailure(), nullptr };
 }
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -5120,6 +5120,10 @@ void DocumentBroker::getIOStats(uint64_t &sent, uint64_t &recv)
 #if !MOBILEAPP
 void DocumentBroker::checkFileInfo(const std::shared_ptr<ClientSession>& session, int redirectLimit)
 {
+    assert(_docState.activity() == DocumentState::Activity::SyncFileTimestamp &&
+           "Unexpected activity for CheckFileInfo");
+    assert(_storage && "Unexpected to not have Storage instance duing SyncFileTimestamp");
+
     if (!session)
     {
         assert(session && "Expected a valid session to CheckFileInfo");
@@ -5140,6 +5144,9 @@ void DocumentBroker::checkFileInfo(const std::shared_ptr<ClientSession>& session
         assert(&checkFileInfo == _checkFileInfo.get() && "Unknown CheckFileInfo instance");
         assert(checkFileInfo.completed() &&
                "Expected CheckFileInfo to be completed when calling the continuation");
+
+        // End the SyncFileTimestamp activity, but don't reset _checkFileInfo yet (it's our caller).
+        endActivity();
 
         if (checkFileInfo.state() == CheckFileInfo::State::Pass && checkFileInfo.wopiInfo())
         {
@@ -5175,13 +5182,8 @@ void DocumentBroker::checkFileInfo(const std::shared_ptr<ClientSession>& session
 
                 handleDocumentConflict();
             }
-
-            // End the SyncFileTimestamp activity, but don't reset _checkFileInfo yet.
-            endActivity();
-            return;
         }
-
-        // Failed, but don't end the SyncFileTimestamp activity yet.
+        else
         {
             // We failed to get CheckFileInfo.
             _storage->setLastModifiedTimeUnSafe(); // We can't trust the LastModifiedTime.

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -5182,26 +5182,35 @@ void DocumentBroker::checkFileInfo(const std::shared_ptr<ClientSession>& session
         }
 
         // Failed, but don't end the SyncFileTimestamp activity yet.
-        std::shared_ptr<ClientSession> failedSession = weakSession.lock();
-        if (failedSession)
         {
-            if (checkFileInfo.state() == CheckFileInfo::State::Timedout)
+            // We failed to get CheckFileInfo.
+            _storage->setLastModifiedTimeUnSafe(); // We can't trust the LastModifiedTime.
+
+            std::shared_ptr<ClientSession> failedSession = weakSession.lock();
+            if (checkFileInfo.state() == CheckFileInfo::State::Unauthorized)
             {
-                // Timeout means we don't know whether the session is valid or not. Leave it alone.
-                LOG_INF("CheckFileInfo on [" << _docKey << "] for session #"
-                                             << failedSession->getId() << " timed-out");
+                if (failedSession)
+                {
+                    // Got some response, but not positive. This is an expired session.
+                    LOG_WRN("CheckFileInfo on ["
+                            << failedSession->getId()
+                            << "] failed because it has invalid access_token for [" << _docKey
+                            << "], resetting the authorization token");
+                    failedSession->invalidateAuthorizationToken();
+                }
+                else
+                {
+                    LOG_WRN("CheckFileInfo failed and its session is expired");
+                }
             }
             else
             {
-                // Got some response, but not positive. This is an expired session.
-                LOG_WRN("Session [" << failedSession->getId() << "] has invalid access_token for ["
-                                    << _docKey << "], resetting the authorization token");
-                failedSession->invalidateAuthorizationToken();
+                assert(checkFileInfo.state() == CheckFileInfo::State::Timedout ||
+                       checkFileInfo.state() == CheckFileInfo::State::Fail);
+                LOG_INF("CheckFileInfo on ["
+                        << _docKey << "] for session #"
+                        << (failedSession ? failedSession->getId() : "<expired>") << " timed-out");
             }
-        }
-        else
-        {
-            LOG_WRN("CheckFileInfo failed and its session is expired");
         }
     };
 

--- a/wsd/wopi/CheckFileInfo.hpp
+++ b/wsd/wopi/CheckFileInfo.hpp
@@ -33,7 +33,7 @@ class CheckFileInfo : public std::enable_shared_from_this<CheckFileInfo>
 {
 public:
     /// The CheckFileInfo State.
-    STATE_ENUM(State, None, Active, Timedout, Fail, Pass);
+    STATE_ENUM(State, None, Active, Timedout, Unauthorized, Fail, Pass);
 
     /// Create an instance with a SocketPoll and a RequestDetails instance.
     CheckFileInfo(const std::shared_ptr<TerminatingPoll>& poll, const Poco::URI& url,


### PR DESCRIPTION
- **wsd: differentiate unauthorized CheckFileInfo response**
- **wsd: end SyncFileTimestamp activity when CheckFileInfo fails**
- **wsd: test: SyncFileTimestamp failure test**
