### PR TITLE
Impress: Design tab: Responsive flex layout for master slide template iconview

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1354,6 +1354,11 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	text-align: center;
 }
 
+#design-master-page-group-content.ui-overflow-group-inner {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
 /* Icon View */
 
 .ui-iconview {
@@ -1364,6 +1369,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	max-height: 40vh;
 	gap: 2px;
 	padding: 2px;
+}
+
+#masterpageall_icons.ui-iconview {
+	display: flex;
 }
 
 .ui-iconview.mobile-wizard {


### PR DESCRIPTION
Change-Id: I2130abb1c2192f509cbda01bee5650d84dd4f19d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Overrides original grid layout (which forces 3 fixed columns via 'grid-template-columns: 1fr 1fr 1fr', causing empty space/visible "missing" columns when fewer than 3 items are present, e.g., only 1 element)

### PREVIEW
<img width="343" height="146" alt="image" src="https://github.com/user-attachments/assets/e6e7d363-3e78-44c6-8f78-fb6a3dbf1242" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

