### PR TITLE
Fix formatting cursor handling in spreadsheet view

### DIFF
--- a/browser/css/spreadsheet.css
+++ b/browser/css/spreadsheet.css
@@ -1,9 +1,9 @@
-[data-docType='spreadsheet'] .leaflet-layer {
-	cursor: cell;
-}
-
 .spreadsheet-cursor {
 	cursor: cell !important;
+}
+
+.bucket-cursor.spreadsheet-cursor {
+	cursor: url('images/cursors/fill.png') 4 18, auto !important;
 }
 
 .spreadsheet-tabs-container {

--- a/browser/src/canvas/sections/AutoFillMarkerSection.ts
+++ b/browser/src/canvas/sections/AutoFillMarkerSection.ts
@@ -230,13 +230,13 @@ class AutoFillMarkerSection extends CanvasSectionObject {
 	}
 
 	public onMouseEnter () {
-		const grid: any = document.querySelector('.leaflet-layer');
+		const grid: any = document.querySelector('.leaflet-map-pane');
 		grid.classList.remove('spreadsheet-cursor');
 		grid.style.cursor = 'crosshair';
 	}
 
 	public onMouseLeave () {
-		const grid: any = document.querySelector('.leaflet-layer');
+		const grid: any = document.querySelector('.leaflet-map-pane');
 		grid.classList.add('spreadsheet-cursor');
 	}
 

--- a/browser/src/canvas/sections/CellCursorSection.ts
+++ b/browser/src/canvas/sections/CellCursorSection.ts
@@ -90,14 +90,14 @@ class CellCursorSection extends CanvasSectionObject {
 	public onMouseEnter(point: cool.SimplePoint, e: MouseEvent): void {
 		this.sectionProperties.mouseInside = true;
 		if (!app.file.textCursor.visible) return;
-		const grid: any = document.querySelector('.leaflet-layer');
+		const grid: any = document.querySelector('.leaflet-map-pane');
 		grid.classList.remove('spreadsheet-cursor');
 		grid.style.cursor = 'text';
 	}
 
 	public onMouseLeave(point: cool.SimplePoint, e: MouseEvent): void {
 		this.sectionProperties.mouseInside = false;
-		const grid: any = document.querySelector('.leaflet-layer');
+		const grid: any = document.querySelector('.leaflet-map-pane');
 		grid.classList.add('spreadsheet-cursor');
 		grid.style.cursor = '';
 	}

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -921,7 +921,7 @@ L.CalcTileLayer = L.CanvasTileLayer.extend({
 				if (this._map._docLayer._cursorMarker)
 					this._map._docLayer._cursorMarker.remove();
 
-				var grid = document.querySelector('.leaflet-layer');
+				var grid = document.querySelector('.leaflet-map-pane');
 				grid.classList.add('spreadsheet-cursor');
 				grid.style.cursor = '';
 			}

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1857,7 +1857,7 @@ L.CanvasTileLayer = L.Layer.extend({
 			return;
 		}
 
-		var grid = document.querySelector('.leaflet-layer');
+		var grid = document.querySelector('.leaflet-map-pane');
 		if (this.isCalc() && grid.style.cursor != 'text' && this._cellCursorSection.sectionProperties.mouseInside) {
 			grid.classList.remove('spreadsheet-cursor');
 			grid.style.cursor = 'text';


### PR DESCRIPTION
- Before this patch formatting mark icon do not change on formatting mark option get enabled
- Switched target from `.leaflet-layer` to `.leaflet-map-pane` for consistent class application
- Added `.bucket-cursor.spreadsheet-cursor` rule to ensure fill cursor displays correctly on spreadsheets

Before:

<img width="590" height="465" alt="image" src="https://github.com/user-attachments/assets/63d57733-ea78-4d78-9583-eab75e899be7" />

After:
<img width="592" height="473" alt="image" src="https://github.com/user-attachments/assets/dee9ec95-f6fc-47b9-91f8-2ee8771138ae" />


Fix:
[Screencast from 2025-09-12 23-54-33.webm](https://github.com/user-attachments/assets/d193e825-cab3-40af-a8ff-e5124b958247)



Change-Id: I78ce9f5037ba52160a7b6024d3c3ab5f4e25f6ff


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

