### PR TITLE
followme slide: allow users to follow and unfollow slideshow 

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -168,23 +168,11 @@ class SlideShowPresenter {
 		);
 
 		// Follow me slide hooks
-		this._map.on('newfollowmepresentation', this._onStartInWindow, this);
 		this._map.on(
-			'dispatcheffect',
-			this._slideShowNavigator.dispatchEffect,
-			this._slideShowNavigator,
+			'newfollowmepresentation dispatcheffect rewindeffect followvideo endpresentation',
+			this.handleFollowMeEvents,
+			this,
 		);
-		this._map.on(
-			'rewindeffect',
-			this._slideShowNavigator.rewindEffect,
-			this._slideShowNavigator,
-		);
-		this._map.on(
-			'followvideo',
-			this._slideShowNavigator.followVideo,
-			this._slideShowNavigator,
-		);
-		this._map.on('endpresentation', this.endPresentation, this);
 	}
 
 	removeHooks() {
@@ -210,18 +198,31 @@ class SlideShowPresenter {
 		);
 
 		// Follow me slide hooks
-		this._map.off('newfollowmepresentation', this._onStartInWindow, this);
 		this._map.off(
-			'dispatcheffect',
-			this._slideShowNavigator.dispatchEffect,
-			this._slideShowNavigator,
+			'newfollowmepresentation dispatcheffect rewindeffect followvideo endpresentation',
+			this.handleFollowMeEvents,
+			this,
 		);
-		this._map.off(
-			'rewindeffect',
-			this._slideShowNavigator.rewindEffect,
-			this._slideShowNavigator,
-		);
-		this._map.off('endpresentation', this.endPresentation, this);
+	}
+
+	handleFollowMeEvents(info: any) {
+		switch (info.type) {
+			case 'newfollowmepresentation':
+				this._onStartInWindow(0);
+				break;
+			case 'dispatcheffect':
+				this._slideShowNavigator.dispatchEffect();
+				break;
+			case 'rewindeffect':
+				this._slideShowNavigator.rewindEffect();
+				break;
+			case 'followvideo':
+				this._slideShowNavigator.followVideo(info);
+				break;
+			case 'endpresentation':
+				this.endPresentation(true);
+				break;
+		}
 	}
 
 	private _handlePresenterCanvasClick(event: any) {

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -173,7 +173,7 @@ class SlideShowPresenter {
 
 		// Follow me slide hooks
 		this._map.on(
-			'newfollowmepresentation dispatcheffect rewindeffect followvideo endpresentation displayslide',
+			'newfollowmepresentation dispatcheffect rewindeffect followvideo endpresentation displayslide effect',
 			this.handleFollowMeEvents,
 			this,
 		);
@@ -203,7 +203,7 @@ class SlideShowPresenter {
 
 		// Follow me slide hooks
 		this._map.off(
-			'newfollowmepresentation dispatcheffect rewindeffect followvideo endpresentation displayslide',
+			'newfollowmepresentation dispatcheffect rewindeffect followvideo endpresentation displayslide effect',
 			this.handleFollowMeEvents,
 			this,
 		);
@@ -227,6 +227,9 @@ class SlideShowPresenter {
 				break;
 			case 'displayslide':
 				this._slideShowNavigator.setLeaderSlide(info);
+				break;
+			case 'effect':
+				this._slideShowNavigator.setLeaderEffect(info);
 				break;
 			case 'endpresentation':
 				if (!this.isFollowing()) return;

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -707,8 +707,7 @@ class SlideShowPresenter {
 	}
 
 	endPresentation(force: boolean) {
-		if (this.isLeader())
-			app.socket.sendMessage('slideshowfollow endpresentation');
+		this.sendSlideShowFollowMessage('endpresentation');
 		this.checkDarkMode(false);
 
 		console.debug('SlideShowPresenter.endPresentation');
@@ -1065,8 +1064,7 @@ class SlideShowPresenter {
 
 	/// called when user triggers the in-window presentation using UI
 	_onStartInWindow(that: any) {
-		if (this._isLeader)
-			app.socket.sendMessage('slideshowfollow newfollowmepresentation');
+		this.sendSlideShowFollowMessage('newfollowmepresentation');
 		this._startSlide = that?.startSlideNumber ?? 0;
 		if (!this._onPrepareScreen(true))
 			// opens full screen, has to be on user interaction
@@ -1197,6 +1195,10 @@ class SlideShowPresenter {
 
 	isFollowing(): boolean {
 		return this._isFollowing;
+	}
+
+	sendSlideShowFollowMessage(msg: string): void {
+		if (this.isLeader()) app.socket.sendMessage('slideshowfollow ' + msg);
 	}
 }
 

--- a/browser/src/slideshow/engine/SlideShowHandler.ts
+++ b/browser/src/slideshow/engine/SlideShowHandler.ts
@@ -477,6 +477,13 @@ class SlideShowHandler {
 
 		if (this.nCurrentEffect >= this.aNextEffectEventArray.size()) return false;
 
+		if (this.presenter.isLeader()) {
+			app.socket.sendMessage(
+				'slideshowfollow effect ' +
+					JSON.stringify({ currentEffect: this.nCurrentEffect }),
+			);
+		}
+
 		this.notifyNextEffectStart();
 
 		this.aNextEffectEventArray.at(this.nCurrentEffect).fire();
@@ -725,6 +732,12 @@ class SlideShowHandler {
 		}
 
 		this.bIsRewinding = false;
+		if (this.presenter.isLeader()) {
+			app.socket.sendMessage(
+				'slideshowfollow effect ' +
+					JSON.stringify({ currentEffect: this.nCurrentEffect - 1 }),
+			);
+		}
 	}
 
 	/** rewindToPreviousSlide

--- a/browser/src/slideshow/engine/SlideShowHandler.ts
+++ b/browser/src/slideshow/engine/SlideShowHandler.ts
@@ -477,12 +477,9 @@ class SlideShowHandler {
 
 		if (this.nCurrentEffect >= this.aNextEffectEventArray.size()) return false;
 
-		if (this.presenter.isLeader()) {
-			app.socket.sendMessage(
-				'slideshowfollow effect ' +
-					JSON.stringify({ currentEffect: this.nCurrentEffect }),
-			);
-		}
+		this.presenter.sendSlideShowFollowMessage(
+			'effect ' + JSON.stringify({ currentEffect: this.nCurrentEffect }),
+		);
 
 		this.notifyNextEffectStart();
 
@@ -732,12 +729,9 @@ class SlideShowHandler {
 		}
 
 		this.bIsRewinding = false;
-		if (this.presenter.isLeader()) {
-			app.socket.sendMessage(
-				'slideshowfollow effect ' +
-					JSON.stringify({ currentEffect: this.nCurrentEffect - 1 }),
-			);
-		}
+		this.presenter.sendSlideShowFollowMessage(
+			'effect ' + JSON.stringify({ currentEffect: this.nCurrentEffect - 1 }),
+		);
 	}
 
 	/** rewindToPreviousSlide

--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -25,6 +25,7 @@ class SlideShowNavigator {
 	private lastClickTime: number = 0;
 	private readonly RAPID_CLICK_THRESHOLD = 500; // 500ms
 	private currentLeaderSlide: number = -1;
+	private currentLeaderEffect: number = -1;
 
 	constructor(slideShowHandler: SlideShowHandler) {
 		this.slideShowHandler = slideShowHandler;
@@ -223,9 +224,18 @@ class SlideShowNavigator {
 		this.currentLeaderSlide = info.currentSlide;
 	}
 
+	setLeaderEffect(info: any) {
+		this.currentLeaderEffect = info.currentEffect;
+	}
+
 	followLeaderSlide() {
 		this.presenter.setFollowing(true);
-		this.displaySlide(this.currentLeaderSlide, true);
+		// const currentEffect = this.currentLeaderEffect;
+		if (this.currentLeaderSlide === this.currentSlide)
+			this.slideShowHandler.rewindAllEffects();
+		else this.displaySlide(this.currentLeaderSlide, true);
+		for (let i = 0; i <= this.currentLeaderEffect; i++)
+			this.slideShowHandler.skipNextEffect();
 	}
 
 	displaySlide(nNewSlide: number, bSkipTransition: boolean) {

--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -81,8 +81,7 @@ class SlideShowNavigator {
 	}
 
 	dispatchEffect() {
-		if (this.presenter.isLeader())
-			app.socket.sendMessage('slideshowfollow dispatcheffect');
+		this.presenter.sendSlideShowFollowMessage('dispatcheffect');
 		const currentTime = Date.now();
 		const timeDiff = currentTime - this.lastClickTime;
 		NAVDBG.print(
@@ -129,8 +128,7 @@ class SlideShowNavigator {
 	}
 
 	rewindEffect() {
-		if (this.presenter.isLeader())
-			app.socket.sendMessage('slideshowfollow rewindeffect');
+		this.presenter.sendSlideShowFollowMessage('rewindeffect');
 		NAVDBG.print(
 			'SlideShowNavigator.rewindEffect: current index: ' + this.currentSlide,
 		);
@@ -239,12 +237,10 @@ class SlideShowNavigator {
 	}
 
 	displaySlide(nNewSlide: number, bSkipTransition: boolean) {
-		if (this.presenter.isLeader()) {
-			app.socket.sendMessage(
-				'slideshowfollow displayslide ' +
-					JSON.stringify({ currentSlide: nNewSlide }),
-			);
-		}
+		this.presenter.sendSlideShowFollowMessage(
+			'displayslide ' + JSON.stringify({ currentSlide: nNewSlide }),
+		);
+
 		NAVDBG.print(
 			'SlideShowNavigator.displaySlide: current index: ' +
 				this.currentSlide +
@@ -403,15 +399,14 @@ class SlideShowNavigator {
 			if (shape) {
 				this._onExecuteInteraction(shape.clickAction);
 			} else if (videoInfo) {
-				if (this.presenter.isLeader()) {
-					const parameters = {
-						currentSlide: this.currentSlide,
-						videoInfoId: videoInfo.id,
-					};
-					app.socket.sendMessage(
-						'slideshowfollow followvideo ' + JSON.stringify(parameters),
-					);
-				}
+				this.presenter.sendSlideShowFollowMessage(
+					'followvideo ' +
+						JSON.stringify({
+							currentSlide: this.currentSlide,
+							videoInfoId: videoInfo.id,
+						}),
+				);
+
 				const video = this.presenter.getVideoRenderer(
 					slideInfo.hash,
 					videoInfo,


### PR DESCRIPTION

* Target version: master 

### Summary
when a follower tries to navigate the presentation himself
he automatically unfollows the presentation and free to navigate
follower has extra button in presentation bar to start following the
presentation again which brings them to the same slide as leader and
follows again


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

