### PR TITLE
Mend getLastPanDirection so we can pre-load pre-emptively again.

### DIFF
--- a/browser/src/app/ViewLayout.ts
+++ b/browser/src/app/ViewLayout.ts
@@ -110,11 +110,11 @@ class ViewLayoutBase {
 	}
 
 	public set viewedRectangle(rectangle: cool.SimpleRectangle) {
-		this._viewedRectangle = rectangle;
-
 		// maintain a view of where we're panning to.
-		if (!this._viewedRectangle.equals(this.lastViewedRectangle.toArray()))
+		if (!this._viewedRectangle.equals(rectangle.toArray()))
 			this.lastViewedRectangle = this._viewedRectangle.clone();
+
+		this._viewedRectangle = rectangle;
 
 		app.sectionContainer.onNewDocumentTopLeft();
 		app.sectionContainer.requestReDraw();


### PR DESCRIPTION
Mis-ordering of assignments made the pan-direction always 0,0. Significantly improves pre-loading when page-up/down. Trivially visible in the pre-load map.

Regression from 28a027905c8057967330d89fae463aa1a1a55e7c "Moves viewedRectangle and sendClientVisibleArea into ViewLayoutBase."

Change-Id: Ia2eb7cbe2cf07fe5a7ac1f90b77945b527e13ffd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

