### PR TITLE
Fix: Ctrl+F in Writer consistently opens Navigator search only

### DIFF
--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1331,11 +1331,12 @@ class UIManager extends L.Control {
 	 * Focuses the search functionality.
 	 */
 	focusSearch(): void {
-		if (this.map.isText() && !app.showNavigator) {
+		const isTextDoc = this.map.isText();
+		if (isTextDoc && !app.showNavigator) {
 			this.map.navigator.preFocusQuickFind();
 			this.showNavigator();
 		}
-		else {
+		else if(!isTextDoc){
 			app.socket.sendMessage('uno .uno:SearchDialog');
 		}
 		this.map.fire('focussearch');


### PR DESCRIPTION
- Ensure Ctrl+F always opens the Navigation sidebar (if closed) and focuses its search box.
- Prevent Ctrl+F from also triggering the Find dialog on subsequent presses.
- Keep Ctrl+H behavior to open the standard Find dialog.


Change-Id: I59827a21d69ca330712b3b76b51a673fe719bade


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

