### PR TITLE
wsd: fix: failed to detect memory limits when using CGroups2

### DIFF
--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -592,7 +592,7 @@ Admin::Admin()
         << (_totalAvailMemKb ? (totalUsedMemKb * 100. / _totalAvailMemKb) : 100) << "% of limit)");
 
     if (_totalAvailMemKb < 1000 * 1024)
-        LOG_WRN("Low memory condition detected: only " << _totalAvailMemKb / 1024
+        LOG_ERR("Low memory condition detected: only " << _totalAvailMemKb / 1024
                                                        << " MB of RAM available");
 
     LOG_INF("Hardware threads: " << std::thread::hardware_concurrency());


### PR DESCRIPTION
- this patch reads CGroups2 memory limits
- The v2 memory controller exposes memory.max (hard cap) and memory.high (soft cap) https://facebookmicrosites.github.io/cgroup2/docs/memory-controller.html
- Steps to test:
1. create a cgroup `sudo mkdir /sys/fs/cgroup/test-memory`
2. Set `high` and `max` values
```sh
echo "629145600" | sudo tee /sys/fs/cgroup/test-memory/memory.max
echo "503316480" | sudo tee /sys/fs/cgroup/test-memory/memory.high
```
3. Move current shell process to `test-memory` cgroup
```sh
echo $$ | sudo tee /sys/fs/cgroup/test-memory/cgroup.procs
```
4. Start `coolwsd` observe logs to see error for low memory.


Change-Id: Ib22f7664df05b90ece146ab1a37b402a278932ac


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

