### PR TITLE
Impress: Design tab: Responsive flex layout for master slide templates iconview

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1354,6 +1354,12 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	text-align: center;
 }
 
+#design-master-page-group-content.ui-overflow-group-inner {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+
 /* Icon View */
 
 .ui-iconview {
@@ -1364,6 +1370,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	max-height: 40vh;
 	gap: 2px;
 	padding: 2px;
+}
+
+#masterpageall_icons.ui-iconview {
+	display: flex;
 }
 
 .ui-iconview.mobile-wizard {


### PR DESCRIPTION
Change-Id: I579198f04f1f2b924e2d419eef91a523436d2423


* Backport: #12852 
* Target version: master 

### Summary
- Overrides original grid layout (which forces 3 fixed columns via 'grid-template-columns: 1fr 1fr 1fr',
 causing empty space/visible "missing" columns when fewer than 3 items are present, e.g., only 1 element)

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

