### PR TITLE
Impress: Design tab: Replace ellipsis with master slide icon in overflow group

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1762,6 +1762,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'id': 'design-master-page-group',
 				'type': 'overflowgroup',
 				'name': _('Master Slide Templates'),
+				'icon': 'lc_masterslide.svg',
 				'children': [
 					{
 						'id': 'masterpageall_icons', // has to match core id


### PR DESCRIPTION
Change-Id: I0501c7cca9d612d92180232e4f6bcd2c66f5668a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Replace default ellipsis with proper master slide icon in overflow group

### PREVIEW
<img width="695" height="104" alt="image" src="https://github.com/user-attachments/assets/01b7f78b-dc79-443a-bc16-f03dc3ec80d5" />


- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

