### PR TITLE
Backport: Impress: Design tab: Replace ellipsis with master slide icon in overflow group

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1754,6 +1754,7 @@ L.Control.NotebookbarImpress = L.Control.NotebookbarWriter.extend({
 				'id': 'design-master-page-group',
 				'type': 'overflowgroup',
 				'name': _('Master Slide Templates'),
+				'icon': 'lc_masterslide.svg',
 				'children': [
 					{
 						'id': 'masterpageall_icons', // has to match core id


### PR DESCRIPTION
Change-Id: I37f093b35d593b6eefea6463690784761c84ebde


* Backport: #12870 
* Target version: master 

### Summary
- Replace default ellipsis with proper master slide icon in overflow group


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

