### PR TITLE
slideshow: fix null slideInfo error when closing during transition

### DIFF
--- a/browser/src/slideshow/engine/SlideShowHandler.ts
+++ b/browser/src/slideshow/engine/SlideShowHandler.ts
@@ -385,6 +385,7 @@ class SlideShowHandler {
 				this.bIsRewinding,
 		);
 		this.bIsTransitionRunning = false;
+		if (!this.presenter._checkAlreadyPresenting()) return;
 		if (this.bIsRewinding) {
 			this.theMetaPres.getMetaSlideByIndex(nNewSlide).hide();
 			this.slideShowNavigator.rewindToPreviousSlide();


### PR DESCRIPTION
slideshow: fix null slideInfo error when closing during transition

Add presenter state check in notifyTransitionEnd to prevent accessing, null slideInfo when slideshow is closed during slide transitions.

Reproduce Steps:
- Start Presentation Console.
- Press esc key while running transition.
- Before this fix, You would see console Error  : `Uncaught TypeError: can't access property "videos", slideInfo is null`

Change-Id: Id86ab7b5bee4dee96f1704ccca7b29ed5ad68450


* Resolves: # <!-- related github issue -->
* Target version: master 
