### PR TITLE
wsd: log capabilities before and after entering namespace

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3563,9 +3563,25 @@ void lokit_main(
             if (usingMountNamespace)
             {
                 // create another namespace, map back to original uid/gid after mount
+                cap_t caps = cap_get_proc();
+                if (caps != nullptr)
+                {
+                    char* capText = cap_to_text(caps, nullptr);
+                    LOG_TRC("Caps[" << capText << "] before entering nested usernamespace");
+                    cap_free(capText);
+                    cap_free(caps);
+                }
                 LOG_DBG("Move into user namespace as uid " << origuid);
                 if (!JailUtil::enterUserNS(origuid, origgid))
                     LOG_ERR("Linux user namespace for kit failed: " << strerror(errno));
+                caps = cap_get_proc();
+                if (caps != nullptr)
+                {
+                    char* capText = cap_to_text(caps, nullptr);
+                    LOG_TRC("Caps[" << capText << "] after entering nested usernamespace");
+                    cap_free(capText);
+                    cap_free(caps);
+                }
             }
 
             assert(origuid == geteuid());


### PR DESCRIPTION
- This log is added for debugging purposes, to determine why in some cases we don't have chroot permission inside the usernamespace.


Change-Id: Ie5cb43e9137f74390bbabbb9485dcf3b99fe8388

* Target version: master 