### PR TITLE
Pause drawing for any rehydration of visible tiles

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -247,7 +247,7 @@ class TileManager {
 	// The tile expansion ratio that the visible tile area will be expanded towards when
 	// updating during scrolling
 	private static directionalTileExpansion: number = 2;
-	private static pausedForDehydration: boolean = false;
+	private static pausedForCoherency: boolean = false;
 	private static shrinkCurrentId: any = null;
 
 	//private static _debugTime: any = {}; Reserved for future.
@@ -457,6 +457,14 @@ class TileManager {
 		);
 	}
 
+	private static visibleTilesReady(): boolean {
+		for (const tile of this.tiles.values()) {
+			if (tile.distanceFromView === 0 && tile.lastPendingId && !tile.isReady())
+				return false;
+		}
+		return true;
+	}
+
 	private static endTransactionHandleBitmaps(
 		deltas: any[],
 		bitmaps: ImageBitmap[],
@@ -474,23 +482,10 @@ class TileManager {
 			if (tile.isReady()) this.tileReady(tile.coords, visibleRanges);
 		}
 
-		if (this.pausedForDehydration) {
-			// Check if all current tiles are accounted for and resume drawing if so.
-			let shouldUnpause = true;
-			for (const tile of this.tiles.values()) {
-				if (
-					tile.distanceFromView === 0 &&
-					tile.lastPendingId &&
-					!tile.isReady()
-				) {
-					shouldUnpause = false;
-					break;
-				}
-			}
-			if (shouldUnpause) {
-				app.sectionContainer.resumeDrawing();
-				this.pausedForDehydration = false;
-			}
+		// Check if all current visible tiles are accounted for and resume drawing if so.
+		if (this.pausedForCoherency && this.visibleTilesReady()) {
+			app.sectionContainer.resumeDrawing();
+			this.pausedForCoherency = false;
 		}
 
 		if (this.nPendingWorkerTasks === 0)
@@ -880,6 +875,14 @@ class TileManager {
 
 	private static rehydrateTile(tile: Tile, wireMessage: boolean) {
 		if (tile.needsRehydration()) {
+			// If we dehydrate a visible tile, wait for it to be ready before drawing.
+			// We may want to consider this being a threshold rather than definitely-visible as
+			// dehydration is asynchronous and our scroll position may move.
+			if (tile.distanceFromView === 0 && !this.pausedForCoherency) {
+				app.sectionContainer.pauseDrawing();
+				this.pausedForCoherency = true;
+			}
+
 			// Re-hydrate tile from cached raw deltas.
 			if (this.debugDeltas)
 				window.app.console.log(
@@ -1302,7 +1305,6 @@ class TileManager {
 		// create a queue of coordinates to load tiles from. Rehydrate tiles if we're dealing
 		// with the currently visible area.
 		this.beginTransaction();
-		let dehydratedVisible = false;
 		for (var rangeIdx = 0; rangeIdx < tileRanges.length; ++rangeIdx) {
 			// Expand the 'current' area to add a small buffer around the visible area that
 			// helps us avoid visible tile updates.
@@ -1327,22 +1329,9 @@ class TileManager {
 					const tile = this.tiles.get(key);
 
 					if (!tile || tile.needsFetch()) queue.push(coords);
-					else if (isCurrent && this.makeTileCurrent(tile)) {
-						const tileIsVisible =
-							j >= tileRanges[rangeIdx].min.y &&
-							j <= tileRanges[rangeIdx].max.y &&
-							i >= tileRanges[rangeIdx].min.x &&
-							i <= tileRanges[rangeIdx].max.x;
-						if (tileIsVisible) dehydratedVisible = true;
-					}
+					else if (isCurrent) this.makeTileCurrent(tile);
 				}
 			}
-		}
-
-		// If we dehydrated a visible tile, wait for it to be ready before drawing
-		if (dehydratedVisible && !this.pausedForDehydration) {
-			app.sectionContainer.pauseDrawing();
-			this.pausedForDehydration = true;
 		}
 		this.endTransaction(null);
 
@@ -1955,10 +1944,10 @@ class TileManager {
 			return;
 		}
 
-		// If an update occurs while we're paused for dehydration, we haven't been able to
+		// If an update occurs while we're paused for visible tiles, we haven't been able to
 		// keep up with scrolling. In this case, we should stop expanding the current area
 		// so that it takes less time to dehydrate it.
-		if (this.pausedForDehydration) {
+		if (this.pausedForCoherency) {
 			if (this.shrinkCurrentId) clearTimeout(this.shrinkCurrentId);
 			this.shrinkCurrentId = setTimeout(() => {
 				this.shrinkCurrentId = null;


### PR DESCRIPTION
Previously, drawing was only paused if we trigger rehydration when requesting new tiles, but we should really pause drawing any time we're rehydrating visible content.

* Resolves: #12857 (maybe)
* Target version: master 

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

