### PR TITLE
Search Key not found accessibility support in Find and Replace Dialog

### DIFF
--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -1065,6 +1065,9 @@ function setupToolbar(e) {
 			toolbar.showItem('cancelsearch', false);
 			L.DomUtil.addClass(searchInput, 'search-not-found');
 			$('#findthis').addClass('search-not-found');
+			const searchbox = document.getElementById('searchbox');
+			if(searchbox && !searchbox.hasAttribute('aria-live'))
+				searchbox.setAttribute('aria-live', 'polite');
 			app.searchService.resetSelection();
 			setTimeout(function () {
 				$('#findthis').removeClass('search-not-found');

--- a/browser/src/control/jsdialog/Component.Toolbar.ts
+++ b/browser/src/control/jsdialog/Component.Toolbar.ts
@@ -124,7 +124,7 @@ class Toolbar {
 		});
 	}
 
-	isItemEnabled(id: string): boolean {
+	isItemDisabled(id: string): boolean {
 		const item = this.parentContainer.querySelector('[id="' + id + '"]');
 		if (!item) return true;
 		return (
@@ -135,7 +135,7 @@ class Toolbar {
 	enableItem(command: string, enable: boolean) {
 		if (!command) return;
 
-		if (this.isItemEnabled(command) === !enable) return;
+		if (this.isItemDisabled(command) === !enable) return;
 
 		this.builder.executeAction(this.parentContainer, {
 			control_id: command,


### PR DESCRIPTION
Changes:
1. added aria-live attribute to search box for improved screen reader support when search key not found
2. renamed isItemEnabled to isItemDisabled for clarity

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

