### PR TITLE
quickfind navigator, use same background as the rest of the ui

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -327,7 +327,6 @@ body {
 
 #quickfind-dock-wrapper {
 	display: none;
-	background: var(--color-background-lighter);
 	position: relative;
 	z-index: 990;
 	max-width: 350px;


### PR DESCRIPTION
Change-Id: I71633f8c62c2ab23eb733f1d40a3e918c6909d88


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

