### PR TITLE
Private/rparth07/render as static

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2360,15 +2360,6 @@ button.menubutton.sidebar > span {
 	align-items: center;
 }
 
-#FormulaDialog #ParameterPage :is(#editdesc, #pardesc),
-#FormulaDialog #ALTBOX #funcdesc {
-	margin: auto 0px;
-	color: var(--color-main-text);
-	font-size: var(--default-font-size);
-	line-height: var(--default-height);
-	padding-left: inherit;
-}
-
 #FormulaDialog #ALTBOX #headline {
 	font-weight: bold;
 }
@@ -2815,4 +2806,15 @@ kbd,
 /* Writer - Form - Properties(Dropdown) */
 #ContentControlDialog #tabindexlabel {
 	width: max-content;
+}
+
+/* Apply label styling to static text for consistent appearance */
+#FormulaDialog #ParameterPage :is(#editdesc, #pardesc),
+#FormulaDialog #ALTBOX #funcdesc,
+#GotoPageDialog #grid1 #page_count {
+	margin: auto 0px;
+	color: var(--color-main-text);
+	font-size: var(--default-font-size);
+	line-height: var(--default-height);
+	padding-left: inherit;
 }

--- a/browser/src/control/Control.QuickFindPanel.ts
+++ b/browser/src/control/Control.QuickFindPanel.ts
@@ -86,6 +86,7 @@ class QuickFindPanel extends SidebarBase {
 			modifiedData.children.unshift({
 				id: 'quickfind-placeholder',
 				type: 'fixedtext',
+				renderAsStatic: true,
 				text: _('Type in the search box to find anything in your document'),
 				visible: true,
 			});


### PR DESCRIPTION
Changes:
1. added renderAsStatic flag to render as `<span>` instead of `<label>` for static text
2. Improved styling for static text for consistent appearance

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

