### PR TITLE
notebookbar: fix alignment of document title

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -37,12 +37,10 @@
 }
 
 .document-title {
-	height: 32px;
 	white-space: nowrap;
 	display: flex;
 	align-items: flex-start;
 	justify-content: center;
-	gap: 5px;
 	flex-direction: column;
 	flex: 1 1 auto;
 }


### PR DESCRIPTION
Change-Id: Ied5e04f5bf6e2bf3e00150d8613add54268fe140


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
-Removed fixed height and gap to allow proper text baseline alignment with other main-nav elements.


### PREVIEW
<img width="970" height="44" alt="image" src="https://github.com/user-attachments/assets/0a4f3cb9-99ad-4653-99c6-5d4256cc53c4" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

