### PR TITLE
fix(overflowGroup): don't let content leave window

### DIFF
--- a/browser/src/control/jsdialog/Widget.OverflowGroup.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowGroup.ts
@@ -16,7 +16,11 @@
 
 declare var JSDialog: any;
 
-function migrateItems(from: HTMLElement, to: HTMLElement) {
+function migrateItems(
+	from: HTMLElement,
+	to: HTMLElement,
+	ensureVisible: boolean = false,
+) {
 	if (!from) {
 		app.console.debug('overflow manager: no source for migration');
 		return;
@@ -28,6 +32,21 @@ function migrateItems(from: HTMLElement, to: HTMLElement) {
 		const htmlButton = button as HTMLElement;
 		to.appendChild(htmlButton);
 	});
+
+	if (ensureVisible) {
+		const width = to.clientWidth;
+		const posX = !to.style.marginInlineStart
+			? 0
+			: !to.style.marginInlineStart.endsWith('px')
+				? 0
+				: parseFloat(
+						to.style.marginInlineStart.slice(
+							0,
+							to.style.marginInlineStart.length - 2,
+						),
+					);
+		to.style.transform = `translateX(${Math.min(0, window.innerWidth - width - posX)}px)`;
+	}
 }
 
 function createMoreButton(
@@ -184,7 +203,7 @@ function setupOverflowMenu(
 					menu?.classList.add('ui-toolbar');
 					menu?.classList.add('ui-overflow-group-popup');
 
-					migrateItems(hiddenItems, menu);
+					migrateItems(hiddenItems, menu, true);
 				});
 			});
 		} else {


### PR DESCRIPTION
We have some overflow groups (I've found those in Review > Tracking are particularly succeptible to this) which tend to escape the window, even when the row they are on is scrolled all the way to the right.

We can't fix this while we're setting the position - both because that would be an overreach that could have weird effects on other dialogs and because at that point the controls aren't moved in so we don't know the final widths. What we can do, however, is transform our overflow dropdown back onto screen when parts of it would escape...

The implementation of this here is pretty crude. If a dropdown is larger than the screen size, it won't try to shrink it down to fit - it'll just make a different part of it offscreen... I guess, "let's refine this in followups"?


Change-Id: I6a6a696471b77b516607c197a44893f547e0655d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

