### PR TITLE
helm: add DaemonSet to install seccomp profile on nodes

### DIFF
--- a/kubernetes/helm/collabora-online/templates/seccomp_profile_daemonset.yaml
+++ b/kubernetes/helm/collabora-online/templates/seccomp_profile_daemonset.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.installCOOLSeccompProfile }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "collabora-online.fullname" . }}-seccomp-profile-installer
+  labels:
+    {{- include "collabora-online.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      name: {{ include "collabora-online.fullname" . }}-seccomp-installer
+  template:
+    metadata:
+      labels:
+        name: {{ include "collabora-online.fullname" . }}-seccomp-installer
+    spec:
+      containers:
+      - name: installer
+        image: alpine:latest
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          if [ ! -f /host-seccomp/cool-seccomp-profile.json ]; then
+            wget -O /host-seccomp/cool-seccomp-profile.json \
+              https://raw.githubusercontent.com/CollaboraOnline/online/master/docker/cool-seccomp-profile.json
+            echo "Profile installed on $(hostname)"
+          else
+            echo "Profile already exists on $(hostname)"
+          fi
+          sleep infinity
+        volumeMounts:
+        - name: seccomp-profiles
+          mountPath: /host-seccomp
+      volumes:
+      - name: seccomp-profiles
+        hostPath:
+          path: /var/lib/kubelet/seccomp
+          type: DirectoryOrCreate
+      tolerations:
+      - operator: Exists  # Run on all nodes regardless of taints
+{{- end }}
+

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -135,6 +135,20 @@ podLabels: {}
 podSecurityContext: {}
 #  fsGroup: 2000
 
+# https://github.com/CollaboraOnline/online/blob/master/docker/cool-seccomp-profile.json
+# use DaemonSet to install seccomp profile to node's /var/lib/kubelet/seccomp directory
+# once this option is enabled you can set following securityContext to use cool-seccomp-profile
+# securityContext:
+#   privileged: false
+#   runAsNonRoot: true
+#   allowPrivilegeEscalation: false
+#   seccompProfile:
+#     type: "Localhost"
+#     localhostProfile: "cool-seccomp-profile.json"
+#   capabilities:
+#     drop: ["ALL"]
+installCOOLSeccompProfile: false
+
 securityContext: {}
 #  readOnlyRootFilesystem: false
 #  privileged: true


### PR DESCRIPTION
- Add seccomp_profile_daemonset that downloads and installs the cool-seccomp-profile.json to /var/lib/kubelet/seccomp on all nodes.

- This enables users to drop all Linux capabilities while still using Linux user namespaces for container isolation, providing enhanced security for CODE/COOL deployments in restricted environments.


Change-Id: I144130f58694aad5b9aabbeca4868317c51e28df