### PR TITLE
Notebookbar: Fix vertical alignment of report-an-issue button in help tab

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -511,9 +511,9 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 							'command': '.uno:ReportIssue',
 							'accessibility': { focusBack: true, combination: 'K', de: null }
 						},
-						{ 'type': 'separator', 'id': 'help-reportissue-break', 'orientation': 'vertical' },
 					]
 				},
+				{ 'type': 'separator', 'id': 'help-reportissue-break', 'orientation': 'vertical' },
 				hasLatestUpdates ?
 					{
 						'type': 'toolbox',


### PR DESCRIPTION
Change-Id: I69b3ccc1edda31103c4c154a3fbc00e262c08505


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- The separator was incorrectly placed in the same toolbox container as the unotoolbutton, causing the container height to increase and misaligning the report-an-issue button vertically.

### PREVIEW
<img width="1150" height="121" alt="image" src="https://github.com/user-attachments/assets/388ef947-b8d6-4b05-abf0-2a7c83508fe3" />


**CURRENT FIX**
<img width="1150" height="121" alt="image" src="https://github.com/user-attachments/assets/808af681-d87d-48e8-a563-e1b486ba1c8d" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

