### PR TITLE
Backport: notebookbar: fix alignment of document title

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -37,12 +37,10 @@
 }
 
 .document-title {
-	height: 32px;
 	white-space: nowrap;
 	display: flex;
 	align-items: flex-start;
 	justify-content: center;
-	gap: 5px;
 	flex-direction: column;
 	flex: 1 1 auto;
 }


### PR DESCRIPTION
Change-Id: I9702bcc4f34a3c943a46fb9e80960cff244012fd


* Backport: #12897 
* Target version: master 

### Summary
- Removed fixed height and gap to allow proper text baseline alignment with other main-nav elements.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

