### PR TITLE
Backport: Notebookbar: Fix vertical alignment of report-an-issue button in help tab

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -495,9 +495,9 @@ L.Control.NotebookbarWriter = L.Control.Notebookbar.extend({
 							'command': '.uno:ReportIssue',
 							'accessibility': { focusBack: true, combination: 'K', de: null }
 						},
-						{ 'type': 'separator', 'id': 'help-reportissue-break', 'orientation': 'vertical' },
 					]
 				},
+				{ 'type': 'separator', 'id': 'help-reportissue-break', 'orientation': 'vertical' },
 				hasLatestUpdates ?
 					{
 						'type': 'toolbox',


### PR DESCRIPTION
Change-Id: Ic918dece732a443d3a8298ee334f43374acf73e3


* Backport: #12901 
* Target version: master 

### Summary
-  The separator was incorrectly placed in the same toolbox container as the unotoolbutton, causing the container height to increase and misaligning the report-an-issue button vertically.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

