### PR TITLE
notebookbar: avoid scrollbars

### DIFF
--- a/browser/src/control/jsdialog/Widget.OverflowManager.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowManager.ts
@@ -30,7 +30,7 @@ class OverflowManager {
 	}
 
 	calculateMaxWidth(): number {
-		const margin = 5;
+		const margin = 20; // how many px more has to be visible after last widget
 		let nextElement = this.parentContainer.nextSibling as HTMLElement;
 		// floating right element after spacer
 		if (nextElement && nextElement.classList.contains('ui-spacer'))

--- a/cypress_test/integration_tests/desktop/writer/sidebar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/sidebar_spec.js
@@ -38,6 +38,8 @@ describe(['tagdesktop'], 'Sidebar tests', function() {
 	});
 
 	function checkMathElementsVisibility() {
+		cy.viewport(2000, 1080);
+
 		cy.cGet('#Insert-tab-label').click();
 		cy.cGet('#Insert .unoInsertObjectStarMath').click();
 


### PR DESCRIPTION
- in some themes we use additional margin on the sides of a notebookbar
- that is not accounted in our algorithm for max width calculation
- let's increase required additional space after last visible element so we can afford additional margins without showing scrollbars due to delayed fold decision
- this is rather workaround, we should better discover limits of our parent container - but it is more safe than rework

