### PR TITLE
follow me slideshow: fix move in reverse direction

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -178,7 +178,7 @@ class SlideShowPresenter {
 
 		// Follow me slide hooks
 		this._map.on(
-			'newfollowmepresentation dispatcheffect rewindeffect followvideo endpresentation displayslide effect',
+			'newfollowmepresentation dispatcheffect rewindeffect followvideo endpresentation displayslide effect skipalleffect',
 			this.handleFollowMeEvents,
 			this,
 		);
@@ -208,7 +208,7 @@ class SlideShowPresenter {
 
 		// Follow me slide hooks
 		this._map.off(
-			'newfollowmepresentation dispatcheffect rewindeffect followvideo endpresentation displayslide effect',
+			'newfollowmepresentation dispatcheffect rewindeffect followvideo endpresentation displayslide effect skipalleffect',
 			this.handleFollowMeEvents,
 			this,
 		);
@@ -231,9 +231,15 @@ class SlideShowPresenter {
 				if (this.isFollowing()) this._slideShowNavigator.followVideo(info);
 				break;
 			case 'displayslide':
+				info.currentEffect = -1;
 				this._slideShowNavigator.setLeaderSlide(info);
+				this._slideShowNavigator.setLeaderEffect(info);
 				break;
 			case 'effect':
+				this._slideShowNavigator.setLeaderEffect(info);
+				break;
+			case 'skipalleffect':
+				info.currentEffect = Number.POSITIVE_INFINITY;
 				this._slideShowNavigator.setLeaderEffect(info);
 				break;
 			case 'endpresentation':

--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -216,6 +216,7 @@ class SlideShowNavigator {
 		this.isRewindingToPrevSlide = true;
 		this.displaySlide(prevSlide, true);
 		this.isRewindingToPrevSlide = false;
+		this.presenter.sendSlideShowFollowMessage('skipalleffect');
 	}
 
 	setLeaderSlide(info: any) {
@@ -233,7 +234,7 @@ class SlideShowNavigator {
 			this.slideShowHandler.rewindAllEffects();
 		else this.displaySlide(this.currentLeaderSlide, true);
 		for (let i = 0; i <= this.currentLeaderEffect; i++)
-			this.slideShowHandler.skipNextEffect();
+			if (!this.slideShowHandler.skipNextEffect()) break;
 	}
 
 	displaySlide(nNewSlide: number, bSkipTransition: boolean) {


### PR DESCRIPTION
problem:
when follower unfollows and meanwhile leader has moved in reverse direction when follower rejoins the presentation he may end up on the incorrect position because by going to previous slide no effects were played(being on last effect already) which means effect number 0. which results into rejoining from the beginning of the slide


Change-Id: Ib7323cf16964169bfde2db8acafb6d26d5e3b2a2


* Target version: master 



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

