### PR TITLE
jsdialog: add spacing between icon and label in menu buttons

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1725,6 +1725,9 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	justify-content: center;
 }
 
+.jsdialog.menubutton img {
+	margin-inline-end: 4px;
+}
 
 button.menubutton.sidebar > span {
 	box-shadow: none !important;


### PR DESCRIPTION
Change-Id: Id93a5693b896b12c1bc07c89e5ea5ea0f20232de


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Add 4px right margin to menubutton images  to improve visual separation between icons and text labels.

### PREVIEW
<img width="262" height="378" alt="Screenshot from 2025-09-18 17-32-09" src="https://github.com/user-attachments/assets/12cdb463-4afe-40ca-90b9-87e5b1677503" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

