### PR TITLE
fix:replace var with const/let in the frame widget

### DIFF
--- a/browser/src/control/jsdialog/Widget.Frame.js
+++ b/browser/src/control/jsdialog/Widget.Frame.js
@@ -31,8 +31,8 @@ function _extractLabelText(data) {
 		return data.text;
 	}
 
-	for (var i = 0; i < data.children.length; i++) {
-		var label = _extractLabelText(data.children[i]);
+	for (let i = 0; i < data.children.length; i++) {
+		const label = _extractLabelText(data.children[i]);
 		if (label) return label;
 	}
 


### PR DESCRIPTION
Change-Id: I4468be2d04845ad892e4406f6b18c3f8a1250998


* Addresses: #12108, but does not resolve.
* Target version: master 

### Summary
Replaced var with const and let in this file https://github.com/CollaboraOnline/online/blob/master/browser/src/control/jsdialog/Widget.Frame.js

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

