### PR TITLE
Impress Cypress destkop: Retype search text after re-opening the sear…

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/find_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/find_dialog_spec.js
@@ -58,6 +58,7 @@ describe(['tagdesktop'], 'Searching via find dialog' ,function() {
 
 		// Search next instance
 		findHelper.openFindDialog();
+		findHelper.typeIntoSearchField('a');
 		findHelper.findNext();
 		findHelper.closeFindDialog();
 
@@ -78,6 +79,7 @@ describe(['tagdesktop'], 'Searching via find dialog' ,function() {
 
 		// Search prev instance
 		findHelper.openFindDialog();
+		findHelper.typeIntoSearchField('a');
 		findHelper.findPrev();
 		findHelper.closeFindDialog();
 
@@ -116,6 +118,7 @@ describe(['tagdesktop'], 'Searching via find dialog' ,function() {
 
 		// Search next instance
 		findHelper.openFindDialog();
+		findHelper.typeIntoSearchField('a');
 		findHelper.findNext();
 		findHelper.closeFindDialog();
 
@@ -135,6 +138,7 @@ describe(['tagdesktop'], 'Searching via find dialog' ,function() {
 
 		// Search next instance, which is in the beginning of the document.
 		findHelper.openFindDialog();
+		findHelper.typeIntoSearchField('a');
 		findHelper.findNext();
 		findHelper.closeFindDialog();
 


### PR DESCRIPTION
…ch dialog.

Issue: Now we are not remembering the last search. See:
* https://gerrit.libreoffice.org/c/core/+/191089


Change-Id: Iba4f3a5060357409ec5431782beb1906ad42fa47


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

