### PR TITLE
Force sending the client visible area on document load.

### DIFF
--- a/browser/src/app/ViewLayout.ts
+++ b/browser/src/app/ViewLayout.ts
@@ -83,7 +83,10 @@ class ViewLayoutBase {
 			' splity=' +
 			Math.round(splitPos.y);
 
-		if (this.clientVisibleAreaCommand !== newClientVisibleAreaCommand) {
+		if (
+			this.clientVisibleAreaCommand !== newClientVisibleAreaCommand ||
+			forceUpdate
+		) {
 			// Only update on some change
 			if (app.map._docLayer._ySplitter) {
 				app.map._docLayer._ySplitter.onPositionChange();

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -292,6 +292,8 @@ window.L.Map = window.L.Evented.extend({
 				if (window.ThisIsTheAndroidApp) {
 					window.postMobileMessage('hideProgressbar');
 				}
+
+				app.activeDocument.activeView.sendClientVisibleArea(true);
 			} else if (this._docLayer && app.sectionContainer) {
 				// remove the comments and changes
 				var commentSection = app.sectionContainer.getSectionWithName(app.CSections.CommentList.name);


### PR DESCRIPTION
Issue: After renaming a file, the tiles are not reloaded when document is re-loaded. Because the client visible area needs to be sent for the newly loaded document. This causes not-updated tiles on the views.


Change-Id: I6d8261ddc865f6e53361e743fa10f32503ddd8f3


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

