### PR TITLE
notebookbar: fix misaligned tabbed icons in ui-overflow-manager

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -34,6 +34,7 @@
 	border: 1px solid transparent;
 	color: var(--color-main-text);
 	border-radius: var(--border-radius);
+	height: max-content;
 }
 
 /* toolbuttons non selected hover */

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -355,7 +355,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
  buttons inside of grid are still center aligned but the sub container would be
 algned to the bottom */
 .ui-overflow-manager .horizontal.notebookbar {
-	align-items: end;
+	align-items: center;
 }
 .notebookbar.ui-overflow-group:not(.ui-overflow-group-container-with-label) {
 	align-content: center;
@@ -1341,7 +1341,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 .notebookbar .ui-overflow-group-inner {
-	height: 4rem;
+	height: 4.25rem;
 	align-content: center;
 }
 

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -414,7 +414,7 @@
 
 #closebutton {
 	width: 100%;
-	height: 100%;
+	height: 100% !important;
 	background: url('images/closedoc.svg') no-repeat center/24px !important;
 }
 


### PR DESCRIPTION
Change-Id: I38645deaf9d57ad14599dc1209b61409753a8930


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Change align-items from 'end' to 'normal' for consistent icon positioning 
- Add height: max-content to unotoolbuttons for consistent sizing

### PREVIEW
<img width="1466" height="127" alt="image" src="https://github.com/user-attachments/assets/478e8f84-56c0-4fa7-8d8f-f566783ec731" />

<img width="1805" height="127" alt="image" src="https://github.com/user-attachments/assets/8ccfc4ce-2fee-4a58-b43e-3acedf054385" />

<img width="1805" height="127" alt="image" src="https://github.com/user-attachments/assets/aa9150df-9c89-44f9-9c86-3e57f89e5361" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

