### PR TITLE
Backport: jsdialog: add spacing between icon and label in menubuttons

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1726,6 +1726,9 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	justify-content: center;
 }
 
+.jsdialog.menubutton img {
+	margin-inline-end: 4px;
+}
 
 button.menubutton.sidebar > span {
 	box-shadow: none !important;


### PR DESCRIPTION
Change-Id: Ife6148b77a8cc794cd4f7dac4cc601061451689c


* Backport: #12909 
* Target version: master 

### Summary
- Add 4px right margin to menubutton images to improve visual separation

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

