### PR TITLE
hyperlink dialog: alignment for document page

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2445,6 +2445,20 @@ kbd,
 	margin-right: 2px;
 }
 
+#HyperlinkDocPage #grid5 {
+	grid-template-columns: 87px 1fr 38px !important;
+}
+
+[id^='Hyperlink'] .ui-grid-cell:empty,
+[id^='Hyperlink'] .hidden {
+	display: none;
+}
+
+/* grid requires all elements to occupy space, but we can reduce their sizing */
+[id^='Hyperlink'] #browse button {
+	margin: auto;
+	max-height: 32px;
+}
 
 /* feature_lock */
 #modal-dialog-unlock-features-popup {


### PR DESCRIPTION
before
<img width="420" height="326" alt="h3" src="https://github.com/user-attachments/assets/281dbfb2-0318-4423-9e72-fbffd34eb2ae" />

after
<img width="328" height="267" alt="Snapshot_2025-09-19_15-36-14" src="https://github.com/user-attachments/assets/887d645e-8274-4de8-8b3e-bd2554493464" />
