### PR TITLE
UI: Prevent hyperlink preview from showing when contextual toolbar is active

### DIFF
--- a/browser/src/control/Control.ContextToolbar.ts
+++ b/browser/src/control/Control.ContextToolbar.ts
@@ -61,6 +61,7 @@ class ContextToolbar {
 	}
 
 	showContextToolbarImpl(): void {
+		URLPopUpSection.closeURLPopUp();
 		this.pendingShow = false;
 
 		if (!this.initialized) {


### PR DESCRIPTION


- UI: Show hyperlink preview only when cursor is inside the link
- Previously the hyperlink preview would appear on text selection and overlap the contextual toolbar. Now it appears only when the text cursor is placed inside a hyperlink.


Now:

[Screencast from 2025-09-19 19-18-08.webm](https://github.com/user-attachments/assets/4c73873f-ec9f-4837-869d-4adbfc21476d)


Change-Id: I34992b2c3da600afb0f6b334a89ee721d42c5f4b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

