### PR TITLE
jsdialog: prevent adding empty space on top of tabpages

### DIFF
--- a/browser/src/control/jsdialog/Widget.Containers.ts
+++ b/browser/src/control/jsdialog/Widget.Containers.ts
@@ -36,7 +36,12 @@ JSDialog.container = function (
 	data: ContainerWidgetJSON | GridWidgetJSON,
 	builder: any,
 ) {
-	if ((data as GridWidgetJSON).cols && (data as GridWidgetJSON).rows)
+	if (
+		data.children &&
+		data.children.length > 1 &&
+		(data as GridWidgetJSON).cols &&
+		(data as GridWidgetJSON).rows
+	)
 		return JSDialog.grid(parentContainer, data, builder);
 
 	if (parentContainer && !parentContainer.id) parentContainer.id = data.id;
@@ -49,6 +54,8 @@ JSDialog.grid = function (
 	data: GridWidgetJSON,
 	builder: JSBuilder,
 ) {
+	if (data.children && data.children.length === 1) return true;
+
 	const rows = builder._getGridRows(data.children);
 	const cols = builder._getGridColumns(data.children);
 


### PR DESCRIPTION
Example was: Writer -> Format -> Page Style -> Area with None selected. The content was moved to vertical center of a tabpage causing weird whitespace on top.

<img width="476" height="531" alt="Snapshot_2025-09-19_17-54-34" src="https://github.com/user-attachments/assets/14813a9a-3e5e-496f-92cd-f68a9fdeecbb" />
