### PR TITLE
jsdialog: compact mode sidebars / component messages

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -428,6 +428,7 @@ COOL_JS_LST =\
 	src/control/Control.ESignatureDialog.ts \
 	src/control/ColorPicker.ts \
 	src/control/jsdialog/Util.Shortcuts.ts \
+	src/control/jsdialog/Component.Base.ts \
 	src/control/jsdialog/Component.Toolbar.ts \
 	src/control/jsdialog/Definitions.Menu.ts \
 	src/control/jsdialog/Util.Dropdown.js \

--- a/browser/src/control/Control.MobileBottomBar.js
+++ b/browser/src/control/Control.MobileBottomBar.js
@@ -15,7 +15,7 @@
 /* global app JSDialog _ _UNO */
 class MobileBottomBar extends JSDialog.Toolbar {
 	constructor(map) {
-		super(map, 'toolbar-down')
+		super(map, 'MobileBottomBar', 'toolbar-down')
 
 		map.on('commandstatechanged', window.onCommandStateChanged);
 		map.on('updatetoolbarcommandvalues', window.onCommandStateChanged);

--- a/browser/src/control/Control.MobileSearchBar.ts
+++ b/browser/src/control/Control.MobileSearchBar.ts
@@ -16,7 +16,7 @@
 /* global _ _UNO */
 class MobileSearchBar extends Toolbar {
 	constructor(map: any) {
-		super(map, 'toolbar-search');
+		super(map, 'MobileSearchBar', 'toolbar-search');
 	}
 
 	getToolItems(): Array<ToolbarItem> {

--- a/browser/src/control/Control.MobileTopBar.ts
+++ b/browser/src/control/Control.MobileTopBar.ts
@@ -14,7 +14,7 @@
 
 class MobileTopBar extends JSDialog.Toolbar {
 	constructor(map: any) {
-		super(map, 'toolbar-up');
+		super(map, 'MobileTopBar', 'toolbar-up');
 
 		app.events.on('updatepermission', this.onUpdatePermission.bind(this));
 		map.on('commandstatechanged', this.onCommandStateChanged, this);

--- a/browser/src/control/Control.QuickFindPanel.ts
+++ b/browser/src/control/Control.QuickFindPanel.ts
@@ -12,7 +12,6 @@
  * JSDialog.QuickFindPanel
  */
 
-/* global app */
 const QUICKFIND_WINDOW_ID = -5;
 class QuickFindPanel extends SidebarBase {
 	constructor(map: any) {

--- a/browser/src/control/Control.QuickFindPanel.ts
+++ b/browser/src/control/Control.QuickFindPanel.ts
@@ -21,7 +21,8 @@ class QuickFindPanel extends SidebarBase {
 
 	onAdd(map: any) {
 		super.onAdd(map);
-		this.builder.setWindowId(QUICKFIND_WINDOW_ID);
+
+		this.builder?.setWindowId(QUICKFIND_WINDOW_ID);
 
 		this.map = map;
 		this.map.on('quickfind', this.onQuickFind, this);
@@ -99,12 +100,16 @@ class QuickFindPanel extends SidebarBase {
 	onQuickFind(data: any) {
 		const quickFindData = data.data;
 
-		if (this.container) this.container.innerHTML = '';
-		else console.error('QuickFind: no container');
+		if (!this.container) {
+			app.console.error('QuickFind: no container');
+			return;
+		}
+
+		this.container.innerHTML = '';
 
 		const modifiedData = this.addPlaceholderIfEmpty(quickFindData);
 
-		this.builder.build(this.container, [modifiedData], false);
+		this.builder?.build(this.container, [modifiedData], false);
 
 		app.showQuickFind = true;
 		// this will update the indentation marks for elements like ruler

--- a/browser/src/control/Control.SidebarBase.ts
+++ b/browser/src/control/Control.SidebarBase.ts
@@ -28,7 +28,7 @@ abstract class SidebarBase extends JSDialogComponent {
 	wrapper: HTMLElement;
 
 	constructor(map: any, type: SidebarType) {
-		super(map, 'Sidebar', type);
+		super(map, type, type);
 		this.type = type;
 		this.onAdd(map);
 	}

--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -15,7 +15,7 @@
 /* global $ app JSDialog _ _UNO  getPermissionModeElements URLPopUpSection */
 class StatusBar extends JSDialog.Toolbar {
 	constructor(map) {
-		super(map, 'toolbar-down');
+		super(map, 'Statusbar', 'toolbar-down');
 
 		map.on('doclayerinit', this.onDocLayerInit, this);
 		map.on('languagesupdated', this.onLanguagesUpdated, this);

--- a/browser/src/control/Control.TopToolbar.js
+++ b/browser/src/control/Control.TopToolbar.js
@@ -15,7 +15,7 @@
 /* global $ JSDialog _ _UNO app */
 class TopToolbar extends JSDialog.Toolbar {
 	constructor(map) {
-		super(map, 'toolbar-up');
+		super(map, 'TopToolbar', 'toolbar-up');
 		this.stylesSelectValue = null;
 
 		map.on('doclayerinit', this.onDocLayerInit, this);

--- a/browser/src/control/jsdialog/Component.Base.ts
+++ b/browser/src/control/jsdialog/Component.Base.ts
@@ -15,8 +15,6 @@
  *                  messages from JSDialogMessageRouter
  */
 
-declare var JSDialog: any;
-
 abstract class JSDialogComponent {
 	protected map: any;
 	protected name: string;

--- a/browser/src/control/jsdialog/Component.Base.ts
+++ b/browser/src/control/jsdialog/Component.Base.ts
@@ -1,0 +1,88 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Component.Base - base class for JSDialog components, wrappers which encapsulate
+ *                  target DOM container and it's dedicated JSBuilder, it also receives
+ *                  messages from JSDialogMessageRouter
+ */
+
+declare var JSDialog: any;
+
+abstract class JSDialogComponent {
+	protected map: any;
+	protected name: string;
+	protected builder?: JSBuilder;
+	protected container?: HTMLElement;
+	protected allowedJsonType: string;
+
+	constructor(map: any, name: string, allowedJsonType: string) {
+		this.map = map;
+		this.name = name;
+		this.allowedJsonType = allowedJsonType;
+	}
+
+	/// connects component to the JSDialogMessageRouter
+	protected registerMessageHandlers() {
+		this.map.on('jsdialogupdate', this.onJSUpdate, this);
+		this.map.on('jsdialogaction', this.onJSAction, this);
+	}
+
+	/// disconnects component from JSDialogMessageRouter
+	protected unregisterMessageHandlers() {
+		this.map.off('jsdialogupdate', this.onJSUpdate, this);
+		this.map.off('jsdialogaction', this.onJSAction, this);
+	}
+
+	/// create JSBuilder instance for this component
+	protected abstract createBuilder(): void;
+
+	/// assign or create container for the component
+	protected abstract setupContainer(parentContainer?: HTMLElement): void;
+
+	/// hanlde update message
+	protected onJSUpdate(e: any) {
+		var data = e.data;
+
+		if (data.jsontype !== this.allowedJsonType) return;
+
+		if (!this.container) return;
+
+		if (!this.builder) return;
+
+		app.console.debug(
+			'Component ' +
+				this.name +
+				' handles update message: ' +
+				JSON.stringify(data.control),
+		);
+		this.builder.updateWidget(this.container, data.control);
+	}
+
+	/// handle action message
+	protected onJSAction(e: any) {
+		var data = e.data;
+
+		if (data.jsontype !== this.allowedJsonType) return;
+
+		if (!this.builder) return;
+
+		if (!this.container) return;
+
+		app.console.debug(
+			'Component ' +
+				this.name +
+				' handles action message: ' +
+				JSON.stringify(data.data),
+		);
+		this.builder.executeAction(this.container, data.data);
+	}
+}

--- a/browser/src/control/jsdialog/Component.Toolbar.ts
+++ b/browser/src/control/jsdialog/Component.Toolbar.ts
@@ -18,30 +18,21 @@ declare var JSDialog: any;
 
 type ToolbarItem = any;
 
-class Toolbar {
-	protected map: any;
+class Toolbar extends JSDialogComponent {
 	protected docType: string;
-	protected builder: JSBuilder;
 	protected callback: JSDialogCallback;
 	protected toolbarElementId: string;
-	protected parentContainer: Element;
+	protected parentContainer: Element; // FIXME: can we drop as we have container in base?
 	protected customItems: Array<ToolbarItem>;
 
-	constructor(map: any, toolbarElementId: string) {
-		this.map = map;
+	constructor(map: any, name: string, toolbarElementId: string) {
+		super(map, name, 'toolbar');
+
 		this.docType = map.getDocType();
 		this.customItems = [];
 		this.toolbarElementId = toolbarElementId;
 
-		this.builder = new window.L.control.jsDialogBuilder({
-			mobileWizard: this,
-			map: this.map,
-			cssClass: 'jsdialog',
-			noLabelsForUnoButtons: true,
-			callback: this.callback ? this.callback.bind(this) : undefined,
-			suffix: 'toolbar',
-		});
-
+		this.createBuilder();
 		this.reset();
 		this.create();
 		this.updateVisibilityForToolbar('');
@@ -51,13 +42,30 @@ class Toolbar {
 		return [];
 	}
 
-	reset() {
-		this.parentContainer = window.L.DomUtil.get(this.toolbarElementId);
+	protected createBuilder() {
+		this.builder = new window.L.control.jsDialogBuilder({
+			mobileWizard: this,
+			map: this.map,
+			cssClass: 'jsdialog',
+			noLabelsForUnoButtons: true,
+			callback: this.callback ? this.callback.bind(this) : undefined,
+			suffix: 'toolbar',
+		});
+	}
+
+	protected setupContainer(parentContainer?: HTMLElement /* ignored */) {
+		this.container = this.parentContainer = window.L.DomUtil.get(
+			this.toolbarElementId,
+		);
 
 		// In case it contains garbage
 		if (this.parentContainer) this.parentContainer.replaceChildren();
 
 		window.L.DomUtil.addClass(this.parentContainer, 'ui-toolbar');
+	}
+
+	reset() {
+		this.setupContainer(undefined);
 	}
 
 	create() {

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -33,13 +33,13 @@ interface JSBuilderOptions {
 	cssClass: string; // class added to every widget root
 	windowId: number; // window id to be sent with dialogevent
 	map: any; // reference to map
-	mobileWizard: any; // reference to the parent container	FIXME: rename
-	useSetTabs: boolean; // custom tabs placement handled by the parent container
-	useScrollAnimation: boolean; // do we use animation for scrollIntoView
+	mobileWizard: JSDialogComponent; // reference to the parent component FIXME: rename
+	useSetTabs?: boolean; // custom tabs placement handled by the parent container
+	useScrollAnimation?: boolean; // do we use animation for scrollIntoView
 
 	// modifiers
-	noLabelsForUnoButtons: boolean; // create only icon without label
-	useInLineLabelsForUnoButtons: boolean; // create labels next to the icon
+	noLabelsForUnoButtons?: boolean; // create only icon without label
+	useInLineLabelsForUnoButtons?: boolean; // create labels next to the icon
 	suffix: string; // add a suffix to the element ID to make it unique among different builder instances.
 }
 


### PR DESCRIPTION
- share more code for message routing inside JSDialog components (so far it's repeated every time)
- foundation for the restoring of impress sidebars in compact mode
- foundation for more clear message handling for expanded icon views (https://github.com/CollaboraOnline/online/pull/12654)
- more typing used
- no functional change
