### PR TITLE
UNO: update search dialog command to include initial focus parameter

### DIFF
--- a/browser/src/app/LOUtil.ts
+++ b/browser/src/app/LOUtil.ts
@@ -266,6 +266,7 @@ class LOUtil {
 			closemobile: 'closedocmobile',
 			'file-saveas': 'saveas',
 			'home-search': 'recsearch',
+			searchdialog3finitialfocusreplace3abool3dtrue: 'searchdialog',
 			'addmb-menu': 'ok',
 			closetablet: 'view',
 			defineprintarea: 'menuprintranges',

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1038,7 +1038,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 										'id': 'home-search-dialog',
 										'type': 'toolitem',
 										'text': _('Replace'),
-										'command': '.uno:SearchDialog',
+										'command': '.uno:SearchDialog?InitialFocusReplace:bool=true',
 										'accessibility': { focusBack: false, 	combination: 'FD',	de: null }
 									}
 								]

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -1193,7 +1193,7 @@ window.L.Control.NotebookbarDraw = window.L.Control.NotebookbarImpress.extend({
 											'id': 'home-search-dialog',
 											'type': 'toolitem',
 											'text': _('Replace'),
-											'command': '.uno:SearchDialog',
+											'command': '.uno:SearchDialog?InitialFocusReplace:bool=true',
 											'accessibility': { focusBack: false, 	combination: 'FD',	de: null }
 										}
 									]

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1272,7 +1272,7 @@ window.L.Control.NotebookbarImpress = window.L.Control.NotebookbarWriter.extend(
 										'id': 'home-search-dialog',
 										'type': 'toolitem',
 										'text': _('Replace'),
-										'command': '.uno:SearchDialog',
+										'command': '.uno:SearchDialog?InitialFocusReplace:bool=true',
 										'accessibility': { focusBack: false, 	combination: 'FD',	de: null }
 									}
 								]

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1030,7 +1030,7 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 										'id': 'home-search-dialog',
 										'type': 'toolitem',
 										'text': _('Replace'),
-										'command': '.uno:SearchDialog',
+										'command': '.uno:SearchDialog?InitialFocusReplace:bool=true',
 										'accessibility': { focusBack: false, 	combination: 'FD',	de: 'US' }
 									}
 								]


### PR DESCRIPTION
Change-Id: I2f999f135118dc8ab7015fe97aae9de6cf8de6b8

Core changes requires: https://gerrit.libreoffice.org/c/core/+/191289

Changes:

1. Introduced new param `InitialFocusReplace` for `.uno:SearchDialog` to enable initial focus on replace tab when,
    1. Click on Replace button
    2. Use `Ctrl + H` shortcut 

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

