### PR TITLE
Backport: notebookbar: fix misaligned tabbed icons in ui-overflow-manager

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -34,6 +34,7 @@
 	border: 1px solid transparent;
 	color: var(--color-main-text);
 	border-radius: var(--border-radius);
+	height: max-content;
 }
 
 /* toolbuttons non selected hover */

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -355,7 +355,7 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
  buttons inside of grid are still center aligned but the sub container would be
 algned to the bottom */
 .ui-overflow-manager .horizontal.notebookbar {
-	align-items: end;
+	align-items: center;
 }
 .notebookbar.ui-overflow-group:not(.ui-overflow-group-container-with-label) {
 	align-content: center;
@@ -1341,7 +1341,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 .notebookbar .ui-overflow-group-inner {
-	height: 4rem;
+	height: 4.25rem;
 	align-content: center;
 }
 

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -414,7 +414,7 @@
 
 #closebutton {
 	width: 100%;
-	height: 100%;
+	height: 100% !important;
 	background: url('images/closedoc.svg') no-repeat center/24px !important;
 }
 


### PR DESCRIPTION
Change-Id: I434dbaccdf206c4a320633c14b769355a3ec9a62


* Backport: #12918 
* Target version: master 

### Summary
- Change align-items from 'end' to 'center' for consistent icon positioning 
- Add height: max-content to unotoolbuttons for consistent sizing


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

