### PR TITLE
Hyperlink Dailog: Fix alignments of text inputs

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2416,6 +2416,12 @@ kbd,
 
 /* Insert hyperlink dialog */
 
+#HyperlinkDocPage,
+#HyperlinkInternetPage,
+#HyperlinkMailPage {
+	width: 100%;
+}
+
 #HyperlinkInternetPage #grid2,
 #HyperlinkInternetPage #label2,
 #HyperlinkInternetPage #lbProtocol,
@@ -2449,6 +2455,7 @@ kbd,
 	grid-template-columns: 87px 1fr 38px !important;
 }
 
+#HyperlinkDocPage #frame1,
 [id^='Hyperlink'] .ui-grid-cell:empty,
 [id^='Hyperlink'] .hidden {
 	display: none;


### PR DESCRIPTION
Change-Id: I974e4284251cfacd6232eddf3cc5026896a24ebd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Adjust width of text inputs for a uniform alignment 
- Hide empty frame in document page

### PREVIEWS

**Before**
<img width="437" height="371" alt="image" src="https://github.com/user-attachments/assets/8b468836-01c3-41bc-9924-e69624757ac8" />


**After**
<img width="415" height="319" alt="image" src="https://github.com/user-attachments/assets/6a244d9d-ec40-4dc2-a5a9-a8a157e09909" />

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

