### PR TITLE
Backport: Hyperlink Dailog: Fix alignments of text inputs

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2404,6 +2404,13 @@ kbd,
 
 /* Insert hyperlink dialog */
 
+
+#HyperlinkDocPage,
+#HyperlinkInternetPage,
+#HyperlinkMailPage {
+	width: 100%;
+}
+
 #HyperlinkInternetPage #grid2,
 #HyperlinkInternetPage #label2,
 #HyperlinkInternetPage #lbProtocol,
@@ -2437,6 +2444,7 @@ kbd,
 	grid-template-columns: 87px 1fr 38px !important;
 }
 
+#HyperlinkDocPage #frame1,
 [id^='Hyperlink'] .ui-grid-cell:empty,
 [id^='Hyperlink'] .hidden {
 	display: none;


### PR DESCRIPTION
Change-Id: I68b1c04cb7a4fd72f96686d18f6a36c087f6d961


* Backport: #12939 
* Target version: master 

### Summary
- Adjust width of text inputs for a uniform alignment 
- Hide empty frame in document page

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

