### PR TITLE
Backport: impress: prevent menu transition icons from being cut off with scroll

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -581,9 +581,16 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 }
 
 #transitions_icons.ui-iconview.notebookbar {
+	height: 55px;
 	max-height: 75px;
 	grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
 	flex-grow: 1;
+	scroll-snap-type: y mandatory;
+	scroll-behavior: smooth;
+}
+
+#transitions_icons.ui-iconview.notebookbar > *  {
+	scroll-snap-align: start;
 }
 
 /* Table Tab */


### PR DESCRIPTION
Change-Id: Ic444016bc915599aba177ef712a1d6e8c32cf356


* Backport: #12941 
* Target version: master 

### Summary
- Implemented CSS scroll snap for smooth element visibility 
- Adjusted container height to ensure icons display fully 
- Resolves issue where menu options appeared truncated and cut off during scroll

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

