### PR TITLE
Backport: notebookbar: fix alignment of vertical tabs

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -359,8 +359,8 @@ algned to the bottom */
 }
 .notebookbar.ui-overflow-group:not(.ui-overflow-group-container-with-label) {
 	align-content: center;
-	height: 49px !important;
-	margin-bottom: 14px;
+	height: 4.25rem !important;
+	margin-bottom: 12px;
 }
 
 .ui-overflow-manager > .notebookbar.ui-iconview {
@@ -368,9 +368,9 @@ algned to the bottom */
 }
 
 .ui-overflow-manager > .notebookbar:not(.ui-separator):not(.ui-overflow-group):not(:has(.ui-overflow-group-container-with-label)) {
-	height: 49px;
+	height: 4.25rem;
 	/* 14px extra margin for containers without label */
-	margin-bottom: 14px;
+	margin-bottom: 12px;
 }
 .ui-overflow-manager .notebookbar.ui-overflow-group-container-with-label {
 	justify-content: end;


### PR DESCRIPTION


Change-Id: I7ed1dc906989912744d3b1ed955ef08a61ec623a


* Backport: #12946
* Target version: master 

### Summary
- Adjust container height to 4.25rem to match overflow-group container height. This ensures consistent alignment for both vertical and horizontal tabs across all states


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

