### PR TITLE
Backport: AdminIntegratorSettings: remove unnecessary underscore for localization

### DIFF
--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -590,7 +590,7 @@ class SettingIframe {
 			btn.type = 'button';
 			btn.className = `browser-setting-tab`;
 			btn.id = `bs-tab-${tab.id}`;
-			btn.textContent = _(tab.label);
+			btn.textContent = tab.label;
 			btn.addEventListener('click', () => {
 				navContainer
 					.querySelectorAll('.browser-setting-tab')
@@ -814,7 +814,7 @@ class SettingIframe {
 		const fieldset = document.createElement('fieldset');
 		fieldset.classList.add('xcu-settings-fieldset');
 		const legend = document.createElement('legend');
-		legend.textContent = _(this.settingLabels[key] || key);
+		legend.textContent = this.settingLabels[key] || key;
 		fieldset.appendChild(legend);
 		const childContent = this.renderSettingsOption(value, uniqueId);
 		fieldset.appendChild(childContent);
@@ -904,7 +904,7 @@ class SettingIframe {
 		uniqueId: string,
 		data: any,
 	): HTMLSpanElement {
-		const labelText = _(this.settingLabels[key] || key);
+		const labelText = this.settingLabels[key] || key;
 
 		return this.createCheckbox(
 			uniqueId,


### PR DESCRIPTION
_(string_variable) does not work. There has to be an actual string inside the parenthesis

Related: #12882 
Change-Id: I3f0a779d1ad66b5709515757f73e4ad52d93ba4c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

