### PR TITLE
jsdialog: alignment of popup buttons with text and images

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -181,6 +181,15 @@ button.has-img {
 	min-width: auto !important;
 }
 
+#container .ui-grid-cell button.jsdialog.has-img:not(.sidebar) {
+	display: grid;
+	grid-template-columns: 24px 1fr;
+	text-align: start;
+	gap: 5px;
+	width: 100% !important;
+	margin: 2px !important;
+}
+
 /* Thesaurus <- button */
 button#left.has-img > img {
 	width: 16px;


### PR DESCRIPTION
Change-Id: I82230311268a764e55c86b508f4aaf087e684774


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Set width to 100% to prevent varying button sizes from max-content 
- Consistent 24px column for icons with 5px gap from text 
- Scope limited to non-sidebar buttons via :not(.sidebar) to avoid unintended UI changes elsewhere.

### PREVIEW
<img width="216" height="349" alt="image" src="https://github.com/user-attachments/assets/8a748e0c-0725-4d9f-8367-b6b2809e990f" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

