### PR TITLE
Backport: jsdialog: alignment of buttons with text and images

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -181,6 +181,15 @@ button.has-img {
 	min-width: auto !important;
 }
 
+#container .ui-grid-cell button.jsdialog.has-img:not(.sidebar) {
+	display: grid;
+	grid-template-columns: 24px 1fr;
+	text-align: start;
+	gap: 5px;
+	width: 100% !important;
+	margin: 2px !important;
+}
+
 /* Thesaurus <- button */
 button#left.has-img > img {
 	width: 16px;


### PR DESCRIPTION
Change-Id: Ia7d13e1e109be5c1bd481642c0c80ed9a759dd8b


* Backport: #12954
* Target version: master 

### Summary
- Set width to 100% to prevent varying button sizes from max-content 
- Consistent 24px column for icons with 5px gap from text 
- Scope limited to non-sidebar buttons via :not(.sidebar) to avoid unintended UI changes elsewhere.


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

