### PR TITLE
Change group name in home tab of " "Illustrations" to "Insert" in writer

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -953,8 +953,8 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 			},
 			{
 				'type': 'overflowgroup',
-				'id': 'home-illustrations',
-				'name':_('Illustrations'),
+				'id': 'home-insert',
+				'name':_('Insert'),
 				'accessibility': { focusBack: false,	combination: 'IT',	de:	null },
 				'children': [
 					{


### PR DESCRIPTION
- Naming changes is done because  "Illustrations"  is confusing name for this group in naming tab


Change-Id: Id35bc86ef5bc8df164b31eb422ca4fb7de6f623b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

