### PR TITLE
jsdialog: fix incorrect autofilter subdialog position

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -654,6 +654,8 @@ window.L.Control.JSDialog = window.L.Control.extend({
 		*/
 		let cellRectangle;
 
+		this.parentAutofilter = instance.form;
+
 		if (app.calc.autoFilterCell) {
 			// This is an AutoFilterDialog. We have the row and column indexes. Get cell rectangle with this info.
 			cellRectangle = app.map._docLayer.sheetGeometry.getCellSimpleRectangle(
@@ -708,7 +710,7 @@ window.L.Control.JSDialog = window.L.Control.extend({
 	},
 
 	calculateSubmenuAutoFilterPosition: function(instance, parentAutofilter) {
-		var parentAutofilter = parentAutofilter.getBoundingClientRect();
+		var parentAutofilter = parentAutofilter.getElementsByClassName("ui-treeview-entry selected")[0].getBoundingClientRect();
 		instance.posx = parentAutofilter.right;
 		instance.posy = parentAutofilter.top;
 


### PR DESCRIPTION
regression from: 47729f2f540c34d8b1c58a42bd5909e64ca2338a

Change-Id: I5ec8aafdd19dea315e4f155600a8d42400af9d12


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

