### PR TITLE
wsd: shutdown the socket in ensureDisconnected

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1263,7 +1263,18 @@ public:
         {
             _doneDisconnect = true;
             if (_socketHandler)
+            {
                 _socketHandler->onDisconnect();
+
+                // The SocketHandler has a weak pointer to us and we could
+                // be getting destroyed at this point, so it won't get a
+                // reference to us from the weak pointer, and so can't disconnect.
+                if (!isShutdown())
+                {
+                    asyncShutdown(); // signal
+                    shutdownConnection(); // real -> setShutdown()
+                }
+            }
         }
 
         if (isOpen())


### PR DESCRIPTION
There is an edge-case when the socket
is being destroyed and the SocketHandler
has no reference to us. In this case we
need to do the shutting down ourselves.

Change-Id: I2c45537af2549eefa883699f21ce3a89228656e5
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
(cherry picked from commit 2a2e8a23929ea4df3be88e7899c5806ef7a0f645)
