### PR TITLE
navigator: fix impress outline tab opening on first try

### DIFF
--- a/browser/src/control/Control.NavigatorPanel.ts
+++ b/browser/src/control/Control.NavigatorPanel.ts
@@ -281,7 +281,10 @@ class NavigatorPanel extends SidebarBase {
 			app.showNavigator = true;
 			// this will update the indentation marks for elements like ruler
 			app.map.fire('fixruleroffset');
-			if (app.map.isPresentationOrDrawing()) {
+			if (
+				app.map.isPresentationOrDrawing() &&
+				!this.isNavigationPanelVisible()
+			) {
 				this.switchNavigationTab('tab-slide-sorter');
 			} else {
 				this.switchNavigationTab('tab-navigator');
@@ -357,6 +360,10 @@ class NavigatorPanel extends SidebarBase {
 			this.navigationPanel.classList.add('visible');
 			this.floatingNavIcon.classList.remove('visible');
 		});
+	}
+
+	isNavigationPanelVisible(): boolean {
+		return this.navigationPanel.classList.contains('visible');
 	}
 
 	closeNavigation() {


### PR DESCRIPTION
problem:
in impress when try to open the outline tab in nav panel it will automatically switch to slide panel on first try


Change-Id: Ic00253d0c118d79cb413277af3246bbe82ddb3ab


* Target version: master 
.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

