### PR TITLE
fix: ensure TemplateDialog navigation buttons have full width in writer

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -203,3 +203,8 @@ button#left.has-img > img {
 [data-theme='dark'] button#unselect_current.has-img > img {
 	filter: invert(.9)
 }
+
+/* Writer - Format - Page Style - Columns */
+div[id^='TemplateDialog'] #Columns :is(#back, #next) button.has-img {
+	width: 100%;
+}


### PR DESCRIPTION
Change-Id: I9933c0f03d190f3569d262c6a53844fa51552faa

Issue: Writer -> Page Style -> Columns tab has cropped icons
**Before:**
<img width="1833" height="1142" alt="image" src="https://github.com/user-attachments/assets/185a1e43-c365-48db-a2fa-3d9db8b16759" />
**After:**
<img width="627" height="693" alt="image" src="https://github.com/user-attachments/assets/b08086fe-725f-47f5-90d6-656ef9a06c3d" />

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

