### PR TITLE
Revert "wasm: limit threads using for scaling"

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1927,9 +1927,6 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
         HardwareResourceWarning = "lowresources";
     }
 
-#elif defined(__EMSCRIPTEN__)
-    // disable threaded image scaling for wasm for now
-    setenv("VCL_NO_THREAD_SCALE", "1", 1);
 #endif
 
     const auto redlining =


### PR DESCRIPTION
This reverts commit c231b3b2ecbba6165eeb1093a96160e10ccd029d. Conflicts:
	wsd/COOLWSD.cpp

This is not necessary, see the commit message of
3f7dd1d1e4df6219426c23b512dcc6416dd278d8 "Wasm: No need for preallocated threads via PTHREAD_POOL_SIZE" for details (and also see
fe87e451a3b90cda5994ccf42a64d5a8d4f7c41f "Restrict core comphelper threadpool MAX_CONCURRENCY in the Wasm build").


Change-Id: I15bc7874d0366f80055fc62287722a9abfd8699d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

