### PR TITLE
KitHelper: use more ScopedString

### DIFF
--- a/kit/KitHelper.hpp
+++ b/kit/KitHelper.hpp
@@ -51,9 +51,8 @@ namespace LOKitHelper
 
     inline std::string getPartData(LibreOfficeKitDocument *loKitDocument, int part)
     {
-        char* ptrToData = loKitDocument->pClass->getPartInfo(loKitDocument, part);
-        std::string result(ptrToData);
-        std::free(ptrToData);
+        ScopedString ptrToData(loKitDocument->pClass->getPartInfo(loKitDocument, part));
+        std::string result(ptrToData.get());
         return result;
     }
 


### PR DESCRIPTION
Avoids manual resource management, using ScopedString, which was
introduced in commit 8306144b339332d5d57a7d24650edd3431250c3a
(KitHelper: avoid manual memory management in fetchCalcSpecificData(),
2025-09-22).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I56c57151c38ffee6dc3a28b38380ca61a31c8a9f
