### PR TITLE
Remove emconfigure a.wasm that Autoconf fails to remove by itself

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2099,4 +2099,7 @@ if test -n "$poco_known_buggy"; then
     AC_MSG_WARN([Your version of POCO has known bugs: see dev-notes/dependency-issues.md])
 fi
 
+# Remove emconfigure artifacts that Autoconf fails to remove by itself:
+rm -f a.wasm
+
 dnl vim:set shiftwidth=4 softtabstop=4 expandtab:


### PR DESCRIPTION
...unlike e.g. a.out and a.exe for which at least GNU Autoconf 2.72 adds removal instructions into the generated configure script.  (Also see a similar configure.ac addition in
<https://git.libreoffice.org/core/+/599cbdb9c2a1184680bb89aa2978e8003eca93d9%5E%21> "WASM more initial bits and pieces".)


Change-Id: I37a8a9b747cf80e343d13d7e24691414005e0d3c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

