### PR TITLE
Fix disabled clipboard option on overflow trigger

### DIFF
--- a/browser/src/control/jsdialog/Widget.OverflowGroup.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowGroup.ts
@@ -225,7 +225,8 @@ function findFirstToolitem(
 	for (const item of items) {
 		if (
 			item.type.indexOf('toolitem') >= 0 ||
-			item.type.indexOf('colorlistbox') >= 0
+			item.type.indexOf('colorlistbox') >= 0 ||
+			item.type.indexOf('menubutton') >= 0
 		)
 			return item;
 		else if (item.children && item.children.length) {


### PR DESCRIPTION
- In some case like clipboard overflow group the first item we are considering as representation of that group is either first ever `toolitem` or `colorlistbox`
- we should also get `menubutton` into account for OverflowGroup representation


Change-Id: Icad82f2a3cd8bcb1f7a329298019d51e7a6c7158


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

