### PR TITLE
Navigator: Results bar: add missing up/down arrows

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -325,7 +325,15 @@ body {
 	height: 100%;
 }
 
-#sidebar-dock-wrapper, #navigator-dock-wrapper, #quickfind-dock-wrapper {
+#quickfind-dock-wrapper {
+	display: none;
+	position: relative;
+	z-index: 990;
+	max-width: 350px;
+	height: 100%;
+}
+
+#sidebar-dock-wrapper, #navigator-dock-wrapper {
 	display: none;
 	background: var(--color-background-lighter);
 	position: relative;

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -671,6 +671,27 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	grid-template-columns: 1fr;
 }
 
+#quickfind-container #quickfindcontrols {
+	position: absolute;
+	top: 0;
+	right: 0;		
+}
+
+#quickfind-container #quickfindcontrols button img {
+	width: var(--btn-img-size-m);
+	height: var(--btn-img-size-m);
+}
+
+#quickfind-container #quickfindcontrols button {
+	width: var(--btn-size-m);
+	height: var(--btn-size-m);
+	background-color: var(--color-background-lighter) !important;
+}
+
+#quickfind-container #quickfindcontrols button:hover {
+	background-color: var(--color-background-dark) !important;
+}
+
 #navigation-sidebar.visible {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
Change-Id: I32d31720be8174aad7b4504bca3d70ce34411bdc


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Add CSS to properly render up/down pushbuttons
- Updates code to match master branch - these changes were missing and not properly ported from commit f200fffc31 (PR #12701)

### PREVIEWS

**CURRENT 25.04**
<img width="261" height="1213" alt="Screenshot from 2025-09-23 12-02-21" src="https://github.com/user-attachments/assets/ec3083e6-ed80-44c3-a307-30a80437a702" />

**NEW UPDATE**
<img width="261" height="1213" alt="Screenshot from 2025-09-23 12-03-04" src="https://github.com/user-attachments/assets/4642d2c4-540f-4adf-9231-b049e50b42bd" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

