### PR TITLE
Private/rparth07/overflow group position

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -456,6 +456,14 @@ algned to the bottom */
 	justify-content: center;
 }
 
+/* Overflow dropdown highlighting */
+.overflow-dropdown-active {
+	background-color: rgba(var(--doc-type), 0.1) !important;
+	border: 1px solid rgb(var(--doc-type)) !important;
+	color: var(--color-text-dark) !important;
+	border-radius: var(--border-radius) !important;
+}
+
 .ui-toggle button,
 .ui-tab.jsdialog {
 	float: left !important;

--- a/browser/src/control/jsdialog/Widget.OverflowGroup.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowGroup.ts
@@ -187,6 +187,8 @@ function setupOverflowMenu(
 	// fill the updated menu after it is open
 	(overflowMenuButton as any)._onDropDown = (opened: boolean) => {
 		if (opened) {
+			overflowMenuButton.classList.add('overflow-dropdown-active');
+
 			// we need to schedule it 2 times as the first one happens just before
 			// layouting task adds menu container to the DOM
 			app.layoutingService.appendLayoutingTask(() => {
@@ -288,6 +290,8 @@ function setupOverflowMenu(
 				});
 			});
 		} else {
+			overflowMenuButton.classList.remove('overflow-dropdown-active');
+
 			const menu = JSDialog.GetDropdown(dropdownId);
 			migrateItems(menu, hiddenItems);
 		}


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

**Issue:** Overflow menus currently open on top of toolbar items, blocking their view instead of aligning below the toolbar for a cleaner layout.

Solution: 
1. calculate baseline-aligned position specifically for overflow menus
2. Highlight the currently active overflow dropdown

**Before:** 
1. <img width="954" height="241" alt="image" src="https://github.com/user-attachments/assets/232ac234-c84d-41fb-95e5-5c176c8e5ac6" />

2. <img width="1465" height="305" alt="image" src="https://github.com/user-attachments/assets/3b8bfc94-e1a8-4456-9943-e0f74cab4e5a" />


**After:**
1. 
<img width="1249" height="189" alt="image" src="https://github.com/user-attachments/assets/4680a5fa-2bf0-44ed-ae78-f267bc756ac6" />
2. 
<img width="1255" height="248" alt="image" src="https://github.com/user-attachments/assets/7a8fd0ae-9c18-42a6-9b62-f754ff91820b" />


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

