### PR TITLE
JSDialog: Reposition popups after possible size changes.

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -960,6 +960,8 @@ L.Control.JSDialog = L.Control.extend({
 		if (!dialogContainer)
 			return;
 
+		const entryChanges = data.jsontype === 'popup' && innerData.action_type && innerData.action_type === 'rendered_entry';
+
 		// focus on element outside view will move viewarea leaving blank space on the bottom
 		if (innerData.action_type === 'grab_focus') {
 			app.layoutingService.appendLayoutingTask(() => {
@@ -973,6 +975,13 @@ L.Control.JSDialog = L.Control.extend({
 		}
 
 		builder.executeAction(dialogContainer, innerData);
+
+		if (entryChanges) {
+			app.layoutingService.appendLayoutingTask(() => {
+				// After entry changes we might have bigger/smaller content and need to repositon the dialog.
+				dialog.updatePos(dialog);
+			});
+		}
 	},
 
 	_clamp: function(value, min, max) {


### PR DESCRIPTION
Issue: After a new entry to the popup window, window's width and / or height may change. Window's first size may not fit the window and it may have got centered. Window's next size changes may fit the window and its position can be better aligned with the clicked point.

Fix:
Call updatePos after "rendered_entry" action.


Change-Id: Icc7ff9749051d1df8ecf13a1163860071fa1a96c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

