### PR TITLE
Slide selector - keep selection on contextmenu if inside selection.

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -254,7 +254,8 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 				nPos = that._findClickedPart(frame);
 
 			$trigger.contextMenu(true);
-			that._setPart(e);
+			if (!that._isSelected(e))
+				that._setPart(e);
 			$.contextMenu({
 				selector: '#'+frame.id,
 				className: 'cool-font',
@@ -290,7 +291,8 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 				return;
 			}
 			$trigger.contextMenu(true);
-			that._setPart(e);
+			if (!that._isSelected(e))
+				that._setPart(e);
 
 			$.contextMenu({
 				selector: '#' + img.id,
@@ -465,6 +467,15 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 			}
 		}
 		app.sectionContainer.getSectionWithName(app.CSections.Scroll.name).onScrollBy({x: currentScrollX, y: buttonType === 'prev' ? -scrollBySize : scrollBySize});
+	},
+
+	_isSelected: function (e) {
+		var part = this._findClickedPart(e.target.parentNode);
+		var partId = parseInt(part) - 1; // The first part is just a drop-site for reordering.
+		if (partId < 0)
+			return false;
+		else
+			return app.impress.isSlideSelected(partId);
 	},
 
 	_setPart: function (e) {


### PR DESCRIPTION
Otherwise, we multi-select, right-click to eg. delete and loose just one slide only.


Change-Id: Ia5f60998e52b0f24d3dc723fecca3b61ce12b546


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

