### PR TITLE
fix context menu copy/paste slides

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -25,6 +25,7 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 		maxHeight: window.mode.isDesktop() ? 180: (window.mode.isTablet() ? 120: 60)
 	},
 	partsFocused: false,
+	contextMenuCopyActive: false,
 
 	initialize: function (container, preview, options) {
 		window.L.setOptions(this, options);
@@ -301,7 +302,7 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 						isHtmlName: true,
 						callback: function() {
 							that.copiedSlide = e;
-							that._map._clip._execCopyCutPaste('CopySlide');
+							that._map._clip._execCopyCutPaste('copy', '.uno:CopySlide');
 						},
 						visible: function() {
 							return true;
@@ -311,7 +312,7 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 						name: app.IconUtil.createMenuItemLink(_('Paste'), 'Paste'),
 						isHtmlName: true,
 						callback: function() {
-							that._map._clip._execCopyCutPaste('Paste')
+							that._map._clip._execCopyCutPaste('paste', ".uno:Paste")
 						},
 					},
 					newslide: {


### PR DESCRIPTION
we seem to lose focus, onBlur is called with no other frames in bt, and without focus we don't send CopySlides, workaround this with an additional bit to track there is an active context menu copy underway.


Change-Id: I97ce69936f8c001528dbfec6b2619bcd2e22ca4c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

