### PR TITLE
css: fix scaling of notebookbar fonts

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -30,7 +30,7 @@
 
 	--tooltip-font-size: 0.875rem;
 	--default-font-size: 0.75rem;
-	--overflow-group-font-size: 0.7rem;
+	--overflow-group-font-size: 8.5pt; /* do not scale labels of groups */
 	--medium-font-size: 0.875rem;
 	--header-font-size: 1rem;
 	/* tab min font-size */

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -359,7 +359,7 @@ algned to the bottom */
 }
 .notebookbar.ui-overflow-group:not(.ui-overflow-group-container-with-label) {
 	align-content: center;
-	height: 4.25rem !important;
+	height: 64px !important;
 	margin-bottom: 12px;
 }
 
@@ -368,7 +368,7 @@ algned to the bottom */
 }
 
 .ui-overflow-manager > .notebookbar:not(.ui-separator):not(.ui-overflow-group):not(:has(.ui-overflow-group-container-with-label)) {
-	height: 4.25rem;
+	height: 64px;
 	/* 12px extra margin for containers without label */
 	margin-bottom: 12px;
 }
@@ -1341,7 +1341,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 .notebookbar .ui-overflow-group-inner {
-	height: 4.25rem;
+	height: 64px;
 	align-content: center;
 }
 
@@ -1409,6 +1409,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 
 .ui-iconview-separator {
 	flex: 0 0 99%;
+}
+
+.ui-iconview-entry-title {
+	font-size: var(--default-font-size);
 }
 
 .icon-view-item-container {

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -240,7 +240,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 .notebookbar.ui-separator.vertical {
 	width: 1px;
 	background-color: var(--color-toolbar-border);
-	height: 4rem;
+	height: 64px;
 	margin: 0 2px;
 	box-sizing: border-box;
 }
@@ -436,22 +436,10 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 
 /* Styles preview */
 
-#home-stylesview-group-content {
-	margin-top: 2px;
-	margin-bottom: 2px;
-}
-
-#design-master-page-group-content {
-	margin-bottom: 3px;
-}
-
-#transitions-group-content {
-	margin-bottom: 5px;
-}
-
 #stylesview,
 #masterpageall_icons,
 #transitions_icons {
+	height: 64px;
 	overflow: auto;
 	display: grid;
 	row-gap: 0;
@@ -466,7 +454,6 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 }
 
 #stylesview {
-	height: 64px;
 	width: 35vw;
 	/* Preview base64's width = 100px + container border's etc */
 	grid-template-columns: repeat(auto-fit, minmax(122px, 1fr));
@@ -477,24 +464,19 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 }
 
 #masterpageall_icons {
-	height: 60px;
 	width: 15vw !important;
 	max-width: 265px;
 	min-width: 90px;
 	grid-template-columns: repeat(auto-fit, minmax(85px, 1fr));
 	grid-template-rows: repeat(auto-fit, minmax(80px, 1fr));
 	margin-left: 5px;
-	margin-top: 2px;
-	margin-bottom: 3px;
 }
 
-#transitions_icons {
-	height: 59px;
+#transitions_icons:not(.sidebar) {
 	width: 35vw;
 	grid-template-columns: repeat(auto-fit, minmax(122px, 1fr));
 	grid-template-rows: repeat(auto-fit, minmax(60px, 1fr));
 	margin-left: 10px;
-	margin-top: 7px;
 }
 
 #stylesview-btn {
@@ -620,7 +602,6 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 }
 
 #transitions_icons.ui-iconview.notebookbar {
-	height: 55px;
 	max-height: 75px;
 	grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
 	flex-grow: 1;


### PR DESCRIPTION
- when using non-default font size in the browser we had issues
- relative font size caused layout issues inside notebookbar
- let's unify all the units to absolute pixels for now
- simplify icon view sizing so all of them use exactly the same rules

Test with increased default font in the browser

BEFORE

<img width="1804" height="819" alt="Snapshot_2025-09-24_05-57-08" src="https://github.com/user-attachments/assets/c45b87cd-d936-45fb-9d50-ee1e408486d8" />


AFTER

<img width="1249" height="194" alt="Snapshot_2025-09-24_06-33-44" src="https://github.com/user-attachments/assets/f31f9bb9-38c8-45c9-aac3-9ae37303da56" />

