### PR TITLE
notebookbar: fix for empty styles

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -28,6 +28,7 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 	FORMULAS_TAB_ID: 'Formula-tab-label',
 
 	additionalShortcutButtons: [],
+	hiddenItems: [],
 
 	onAdd: function (map) {
 		// log and test window.ThisIsTheiOSApp = true;
@@ -710,4 +711,21 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 			childrenArray = this.getOptionsSectionData();
 		builder.build(optionsSection, childrenArray);
 	},
+
+	hideItem: function(itemId) {
+		app.console.debug('Notebookbar: hide item: ' + itemId);
+
+		if (!this.hiddenItems.includes(itemId))
+			this.hiddenItems.push(itemId);
+
+		app.map.fire('jsdialogaction', { data: {
+				jsontype: 'notebookbar',
+				action: 'action',
+				data: {
+					control_id: itemId,
+					action_type: 'hide'
+				}
+			}
+		});
+	}
 });

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -424,7 +424,7 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 		var hasAccessibilitySupport = window.enableAccessibility;
 		var hasAccessibilityCheck = this.map.getDocType() === 'text';
 		var hasAbout = window.L.DomUtil.get('about-dialog') !== null;
-		var hasServerAudit = !!this.map.serverAuditDialog;
+		var hasServerAudit = !this.hiddenItems.includes('server-audit');
 
 		var content = [
 				{

--- a/browser/src/control/Control.ServerAuditDialog.ts
+++ b/browser/src/control/Control.ServerAuditDialog.ts
@@ -362,9 +362,6 @@ class ServerAuditDialog {
 					this.open.bind(this),
 				);
 			}
-
-			// but if we any results, enable the toolbar entry for the server audit
-			this.map.uiManager.refreshUI();
 		}
 	}
 

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -709,7 +709,7 @@ class UIManager extends window.L.Control {
 	}
 
 	/**
-	 * Refreshes the notebookbar.
+	 * Refreshes the notebookbar. WARNING: if we got core updates for JSDialog widgets, they will be lost.
 	 */
 	refreshNotebookbar(): void {
 			var selectedTab = $('.ui-tab.notebookbar[aria-selected="true"]').attr('id') || 'Home-tab-label';
@@ -1394,7 +1394,7 @@ class UIManager extends window.L.Control {
 	}
 
 	/**
-	 * Refreshes the UI.
+	 * Refreshes the UI. WARNING: if we got core updates for JSDialog widgets, they will be lost.
 	 */
 	refreshUI(): void {
 		if (this.notebookbar && !this.map._shouldStartReadOnly())

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1351,7 +1351,9 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 			var serverAudit = textMsg.substr(12).trim();
 			if (serverAudit !== 'disabled') {
 				// if isAdminUser property is not set by integration - enable audit dialog for all users
-				if (app.isAdminUser !== false)
+				if (app.isAdminUser === false)
+					this._map.uiManager.notebookbar.hideItem('server-audit');
+				else
 					this._map.serverAuditDialog = JSDialog.serverAuditDialog(this._map);
 
 				var json = JSON.parse(serverAudit);


### PR DESCRIPTION
notebookbar: do not reload, just hide server audit
    
    - load time might be different in different instances
    - server audit dialog was reloading notebookbar on message
      from core
    - when we reload notebookbar we lose all previous updates
      like style previews
    - do not reload, instead hide server audit when needed
      so we do not break style previews in case of different event orders
