### PR TITLE
Private/rparth07/page style remove empty tab

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -205,6 +205,8 @@ button#left.has-img > img {
 }
 
 /* Writer - Format - Page Style - Columns */
-div[id^='TemplateDialog'] #Columns :is(#back, #next) button.has-img {
+/* Writer - Format - Columns */
+div[id^='TemplateDialog'] #Columns :is(#back, #next) button.has-img,
+#ColumnDialog :is(#back, #next) button.has-img {
 	width: 100%;
 }

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2853,8 +2853,8 @@ kbd,
 	width: max-content;
 }
 
-/* Writer - Format - Page Style */
-div [id^='TemplateDialog'] #tabcontrol #Area.jsdialog,
-#PageTemplateDialog #tabcontrol #Background.jsdialog {
+/* Prevents adding empty space on top of tabpages */
+/* i.e Writer - Format - Page Style */
+.single-child-grid {
 	align-self: start;
 }

--- a/browser/src/control/jsdialog/Widget.Containers.ts
+++ b/browser/src/control/jsdialog/Widget.Containers.ts
@@ -53,10 +53,13 @@ JSDialog.grid = function (
 	const cols = builder._getGridColumns(data.children);
 
 	const processedChildren = [];
+	const isSingleChild = data.children && data.children.length === 1;
 
 	const table = window.L.DomUtil.create(
 		'div',
-		builder.options.cssClass + ' ui-grid',
+		builder.options.cssClass +
+			' ui-grid' +
+			(isSingleChild ? ' single-child-grid' : ''),
 		parentContainer,
 	);
 	table.id = data.id;

--- a/cypress_test/integration_tests/desktop/writer/sidebar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/sidebar_spec.js
@@ -14,7 +14,7 @@ describe(['tagdesktop'], 'Sidebar tests', function() {
 		cy.wait(500); // wait to make fully rendered
 		cy.cGet('#sidebar-dock-wrapper').scrollTo(0,0,{ ensureScrollable: false });
 		cy.wait(500); // wait for animations
-		cy.cGet('#sidebar-dock-wrapper').compareSnapshot('sidebar_writer', 0.1);
+		cy.cGet('#sidebar-dock-wrapper').compareSnapshot('sidebar_writer', 0.07);
 	});
 
 	it('Show table panel multiple times', function() {


### PR DESCRIPTION
Issue: please see #12959,

Idea: > [we could possibly add some specific class for the "empty row" case to have easier css](https://github.com/CollaboraOnline/online/pull/12959#pullrequestreview-3256104710)

Changes:
1. Instead of avoid creating the grid with single child element, this change allows creation of it but adds class `single-child-grid` and we can target this specific class to avoid creating empty tab spaces at all places instead of targeting them individually.
2. Adjust snapshot comparison threshold for sidebar visual test to capture broken sidebar more strictly
3. Made arrow navigation button visible in `Writer -> Format -> Column` dialog
i.e. 
<img width="556" height="283" alt="image" src="https://github.com/user-attachments/assets/6f0ab127-04a2-4b92-98b0-f5746ba18558" />


**Preview for grid changes:**
Almost all tab pages from Page Style dialog from writer are affected. Here are previews for some of them.

1. <img width="1247" height="701" alt="image" src="https://github.com/user-attachments/assets/f8ba5aa7-79cf-4dee-9238-cbbc80e5e045" />
2. <img width="1249" height="694" alt="image" src="https://github.com/user-attachments/assets/507785c9-0df7-4099-8683-bdef5f794480" />
3. <img width="1254" height="337" alt="image" src="https://github.com/user-attachments/assets/7e947a27-442a-485b-bbf1-cfba29baf84a" />
4. <img width="1245" height="467" alt="image" src="https://github.com/user-attachments/assets/e463c72d-752e-4d2c-a809-3ea233ec077e" />

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

