### PR TITLE
notebookbar: show audit button correctly (backport)

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -110,6 +110,11 @@ L.Control.Notebookbar = L.Control.extend({
 		var isDarkMode = window.prefs.getBoolean('darkTheme');
 		if (!isDarkMode)
 			$('#invertbackground').hide();
+
+		if (!this.map.serverAuditDialog) {
+			this.hideItem('server-audit');
+			this.hideItem('help-serveraudit-break');
+		}
 	},
 
 	resetInCore: function() {
@@ -712,18 +717,33 @@ L.Control.Notebookbar = L.Control.extend({
 		builder.build(optionsSection, childrenArray);
 	},
 
+	// dynamically show/hide items
+
 	hideItem: function(itemId) {
 		app.console.debug('Notebookbar: hide item: ' + itemId);
 
-		if (!this.hiddenItems.includes(itemId))
+		if (!this.hiddenItems.includes(itemId)) {
 			this.hiddenItems.push(itemId);
+			this.showItemImpl(itemId, false);
+		}
+	},
 
+	showItem: function(itemId) {
+		app.console.debug('Notebookbar: show item: ' + itemId);
+
+		if (this.hiddenItems.includes(itemId)) {
+			this.hiddenItems.splice(this.hiddenItems.indexOf(itemId), 1);
+			this.showItemImpl(itemId, true);
+		}
+	},
+
+	showItemImpl: function(itemId, show) {
 		app.map.fire('jsdialogaction', { data: {
 				jsontype: 'notebookbar',
 				action: 'action',
 				data: {
 					control_id: itemId,
-					action_type: 'hide'
+					action_type: show ? 'show' : 'hide'
 				}
 			}
 		});

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1351,10 +1351,14 @@ L.CanvasTileLayer = L.Layer.extend({
 			var serverAudit = textMsg.substr(12).trim();
 			if (serverAudit !== 'disabled') {
 				// if isAdminUser property is not set by integration - enable audit dialog for all users
-				if (app.isAdminUser === false)
-					this._map.uiManager.notebookbar.hideItem('server-audit');
-				else
+				if (app.isAdminUser !== false) {
 					this._map.serverAuditDialog = JSDialog.serverAuditDialog(this._map);
+
+					if (this._map.uiManager.notebookbar) {
+						this._map.uiManager.notebookbar.showItem('server-audit');
+						this._map.uiManager.notebookbar.showItem('help-serveraudit-break');
+					}
+				}
 
 				var json = JSON.parse(serverAudit);
 				app.setServerAuditFromCore(json.serverAudit);


### PR DESCRIPTION
Backport of https://github.com/CollaboraOnline/online/pull/13006

This is followup for commit c0423d6f3f362dd30a9a0751afb1a7c78169a187 
notebookbar: do not reload, just hide server audit

We should show the button only if needed. Not leaving it until we detect it should be hidden.

Also this fixes problem in compact mode where non-admin user got error due to lack of notebookbar:
Exception TypeError: Cannot read properties of null (reading 'hideItem') emitting event ...
