### PR TITLE
copy slide: send copySlide command from slide context menu

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -25,7 +25,6 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 		maxHeight: window.mode.isDesktop() ? 180: (window.mode.isTablet() ? 120: 60)
 	},
 	partsFocused: false,
-	contextMenuCopyActive: false,
 
 	initialize: function (container, preview, options) {
 		window.L.setOptions(this, options);
@@ -231,6 +230,8 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 
 		var that = this;
 		img.onfocus = function () {
+			that._map._clip.clearSelection();
+			that._map._clip.setTextSelectionType('slide');
 			that.partsFocused = true;
 		};
 

--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -216,7 +216,6 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 				}
 			} else {
 				this._setPart(e);
-				this.partsFocused = true;
 				if (!window.mode.isDesktop()) {
 					// needed so on-screen keyboard doesn't pop up when switching slides,
 					// but would cause PgUp/Down to not work on desktop in slide sorter
@@ -236,6 +235,7 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 		};
 
 		img.onblur = function () {
+			that._map._clip.clearSelection();
 			that.partsFocused = false;
 		};
 
@@ -305,6 +305,8 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 						isHtmlName: true,
 						callback: function() {
 							that.copiedSlide = e;
+							that._map._clip.clearSelection();
+							that._map._clip.setTextSelectionType('slide');
 							that._map._clip._execCopyCutPaste('copy', '.uno:CopySlide');
 						},
 						visible: function() {

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -701,26 +701,13 @@ window.L.Clipboard = window.L.Class.extend({
 			return;
 		}
 
-		// When copying from the context menu we seem to lose focus before dispatching .uno:CopySlide and
-		// onblur is called and partsFocused is false so we don't do an explicit uno:CopySlide in
-		// the execCommand('copy') callback, workaround this here while we still know we want to do a
-		// copy slide.
-		const presentationContextMenuCopy = cmd == ".uno:CopySlide" && this._map.getDocType() === 'presentation';
-		if (presentationContextMenuCopy)
-                    this._map._docLayer._preview.contextMenuCopyActive = true;
-
 		if (!window.ThisIsTheiOSApp && // in mobile apps, we want to drop straight to navigatorClipboardRead as execCommand will require user interaction...
 			document.execCommand(operation) &&
 			serial !== this._clipboardSerial) {
 			window.app.console.log('copied successfully');
 			this._unoCommandForCopyCutPaste = null;
-			if (presentationContextMenuCopy)
-			    this._map._docLayer._preview.contextMenuCopyActive = false;
 			return;
 		}
-
-		if (presentationContextMenuCopy)
-		    this._map._docLayer._preview.contextMenuCopyActive = false;
 
 		if (operation == 'paste' && this._navigatorClipboardRead(false)) {
 			// execCommand(paste) failed, the new clipboard API is available, tried that
@@ -875,7 +862,7 @@ window.L.Clipboard = window.L.Class.extend({
 			return false;
 		}
 
-		if (this._selectionType !== 'text') {
+		if (this._selectionType !== 'text' && this._selectionType !== 'slide') {
 			return false;
 		}
 
@@ -1114,9 +1101,7 @@ window.L.Clipboard = window.L.Class.extend({
 	},
 
 	_doCopyCut: function(ev, unoName) {
-		if (this._map.getDocType() === 'presentation' &&
-			(this._map._docLayer._preview.partsFocused ||
-			 this._map._docLayer._preview.contextMenuCopyActive)) {
+		if (this._map.getDocType() === 'presentation' && this._map._docLayer._preview.partsFocused) {
 			unoName = 'CopySlide';
 		}
 		window.app.console.log(unoName);

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -621,7 +621,7 @@ window.L.Clipboard = window.L.Class.extend({
 	},
 
 	_beforeSelectImpl: function() {
-		if (this._map.getDocType() === 'presentation' && this._map._docLayer._preview.partsFocused)
+		if (this._selectionType === 'slide')
 			return;
 
 		// We need some spaces in there ...
@@ -1101,9 +1101,8 @@ window.L.Clipboard = window.L.Class.extend({
 	},
 
 	_doCopyCut: function(ev, unoName) {
-		if (this._map.getDocType() === 'presentation' && this._map._docLayer._preview.partsFocused) {
+		if (this._selectionType === 'slide')
 			unoName = 'CopySlide';
-		}
 		window.app.console.log(unoName);
 
 		if (this._isAnyInputFieldSelected(unoName === 'Copy'))


### PR DESCRIPTION
partially reverts 291be73a075643458e4d6b3f66386835


Change-Id: If4f9aafad83a86fb089ab82879ab75fd8dd2455c


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

