### PR TITLE
Improve ProxyProtocol aka richdocumentscode

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1381,6 +1381,8 @@ function getInitializerClass() {
 			req.addEventListener('loadend', function() {
 				that.msgInflight--;
 			});
+			if (that.sendQueue !== '')
+				that.sendQueue = that.sendQueue + 'E\n';
 			req.send(that.sendQueue);
 			that.sendQueue = '';
 			that.msgInflight++;

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1164,7 +1164,7 @@ function getInitializerClass() {
 		this.id = global.proxySocketCounter++;
 		this.msgInflight = 0;
 		this.openInflight = 0;
-		this.inSerial = 0;
+		this.inSerial = -1;
 		this.outSerial = 0;
 		this.minPollMs = 25; // Anything less than ~25 ms can overwhelm the HTTP server.
 		this.maxPollMs = 500; // We can probably go as much as 1-2 seconds without ill-effect.

--- a/wsd/ProxyProtocol.cpp
+++ b/wsd/ProxyProtocol.cpp
@@ -206,7 +206,14 @@ void ProxyProtocolHandler::processBufferedMessages()
         uint64_t expectedSerial = _inSerial + 1;
         auto it = _serialQueue.find(expectedSerial);
         if (it == _serialQueue.end())
+        {
+            LOG_DBG("Cannot find serial[" << expectedSerial << ']');
             break;
+        }
+        else
+        {
+            LOG_DBG("Found serial[" << expectedSerial << ']');
+        }
 
         // Process the buffered message
         LOG_TRC("Processing serial[" << it->second->serial << ']');
@@ -272,7 +279,6 @@ void ProxyProtocolHandler::sendAndClose(const std::shared_ptr<StreamSocket> &str
     streamSocket->asyncShutdown();
 }
 
-// TODO: handle input that was not fully read by the previous message
 void ProxyProtocolHandler::handleIncomingMessage(SocketDisposition &disposition)
 {
     auto streamSocket = std::static_pointer_cast<StreamSocket>(disposition.getSocket());

--- a/wsd/ProxyProtocol.cpp
+++ b/wsd/ProxyProtocol.cpp
@@ -175,7 +175,7 @@ ProxyProtocolHandler::parseEmitIncoming(const std::shared_ptr<StreamSocket>& soc
             ;
         *it = '\0';
 
-        uint64_t serial = strtoull(&in[1], nullptr, 16);
+        int64_t serial = strtoull(&in[1], nullptr, 16);
         in.erase(in.begin(), it + 1);
 
         it = in.begin();

--- a/wsd/ProxyProtocol.cpp
+++ b/wsd/ProxyProtocol.cpp
@@ -175,7 +175,7 @@ ProxyProtocolHandler::parseEmitIncoming(const std::shared_ptr<StreamSocket>& soc
             ;
         *it = '\0';
 
-        int64_t serial = strtoull(&in[1], nullptr, 16);
+        uint64_t serial = strtoull(&in[1], nullptr, 16);
         in.erase(in.begin(), it + 1);
 
         it = in.begin();
@@ -203,7 +203,7 @@ void ProxyProtocolHandler::processBufferedMessages()
 {
     while (!_serialQueue.empty())
     {
-        int64_t expectedSerial = _inSerial + 1;
+        uint64_t expectedSerial = _inSerial + 1;
         auto it = _serialQueue.find(expectedSerial);
         if (it == _serialQueue.end())
             break;

--- a/wsd/ProxyProtocol.hpp
+++ b/wsd/ProxyProtocol.hpp
@@ -74,7 +74,7 @@ public:
     void processBufferedMessages();
 
     void handleRequest(bool isWaiting, const std::shared_ptr<StreamSocket> &socket);
-
+    void sendAndClose(const std::shared_ptr<StreamSocket> &streamSocket);
     /// tell our handler we've received a close.
     void notifyDisconnected();
 

--- a/wsd/ProxyProtocol.hpp
+++ b/wsd/ProxyProtocol.hpp
@@ -11,6 +11,8 @@
 
 #pragma once
 
+#include "StateEnum.hpp"
+#include <map>
 #include <memory>
 #include <net/Socket.hpp>
 
@@ -47,7 +49,13 @@ public:
         // connections & sockets come and go a lot.
     }
 
-public:
+    STATE_ENUM(
+        ParseStatus,
+        SUCCESS, // true
+        PROTOCOL_ERROR, // false - but we should give up here and close the connection & session
+        AGAIN // false - but we should wait for more data to be read from the socket
+    );
+
     /// Clear all external references
     void dispose() override { _msgHandler.reset(); }
 
@@ -59,7 +67,11 @@ public:
     void dumpState(std::ostream&, const std::string&) const override {}
     // instead do it centrally.
     void dumpProxyState(std::ostream& os);
-    bool parseEmitIncoming(const std::shared_ptr<StreamSocket> &socket);
+
+    // Non-destructive message parsing
+    ParseStatus parseEmitIncoming(const std::shared_ptr<StreamSocket>& socket);
+    ParseStatus hasCompleteMessage(const Buffer& in, size_t& frameSize);
+    void processBufferedMessages(uint64_t expectedSerial);
 
     void handleRequest(bool isWaiting, const std::shared_ptr<StreamSocket> &socket);
 
@@ -88,6 +100,22 @@ private:
             insert(end(), terminator, terminator + 1);
         }
     };
+
+    // TODO: move _serialQueue to ClientSession
+    struct BufferedMessage
+    {
+        uint64_t serial;
+        std::vector<char> data;
+
+        BufferedMessage(uint64_t s, const std::vector<char>& d)
+            : serial(s)
+            , data(d)
+        {
+        }
+    };
+
+    std::map<uint64_t, std::unique_ptr<BufferedMessage>> _serialQueue;
+
     /// queue things when we have no socket to hand.
     std::vector<std::shared_ptr<Message>> _writeQueue;
     std::vector<std::weak_ptr<StreamSocket>> _outSockets;

--- a/wsd/ProxyProtocol.hpp
+++ b/wsd/ProxyProtocol.hpp
@@ -119,7 +119,7 @@ private:
     /// queue things when we have no socket to hand.
     std::vector<std::shared_ptr<Message>> _writeQueue;
     std::vector<std::weak_ptr<StreamSocket>> _outSockets;
-    int64_t _inSerial;
+    uint64_t _inSerial;
     uint64_t _outSerial;
 };
 

--- a/wsd/ProxyProtocol.hpp
+++ b/wsd/ProxyProtocol.hpp
@@ -26,7 +26,7 @@ class ProxyProtocolHandler : public ProtocolHandlerInterface
 {
 public:
     ProxyProtocolHandler() :
-        _inSerial(0),
+        _inSerial(-1),
         _outSerial(0)
     {
     }
@@ -119,7 +119,7 @@ private:
     /// queue things when we have no socket to hand.
     std::vector<std::shared_ptr<Message>> _writeQueue;
     std::vector<std::weak_ptr<StreamSocket>> _outSockets;
-    uint64_t _inSerial;
+    int64_t _inSerial;
     uint64_t _outSerial;
 };
 

--- a/wsd/ProxyProtocol.hpp
+++ b/wsd/ProxyProtocol.hpp
@@ -20,7 +20,7 @@
  * Implementation that builds a websocket like protocol from many
  * individual proxied HTTP requests back to back.
  *
- * we use a trivial framing: [T(ext)|B(inary)]<hex-serial->\n<hex-length>\n<content>\n
+ * we use a trivial framing: [T(ext)|B(inary)]<hex-serial->\n<hex-length>\n<content>\nE\n
  */
 class ProxyProtocolHandler : public ProtocolHandlerInterface
 {

--- a/wsd/ProxyProtocol.hpp
+++ b/wsd/ProxyProtocol.hpp
@@ -71,7 +71,7 @@ public:
     // Non-destructive message parsing
     ParseStatus parseEmitIncoming(const std::shared_ptr<StreamSocket>& socket);
     ParseStatus hasCompleteMessage(const Buffer& in, size_t& frameSize);
-    void processBufferedMessages(uint64_t expectedSerial);
+    void processBufferedMessages();
 
     void handleRequest(bool isWaiting, const std::shared_ptr<StreamSocket> &socket);
 


### PR DESCRIPTION
- non-destructively checking that the length matches in parseEmitIncoming before consuming
- queueing messages whose serial has not monotonically increased to be processed in-order

TODO:
- calling 'parseEmitIncoming' inside 'handleIncomingMessage'
- move `serialQueue` to ClientSession

Change-Id: I928b10caefed423146156dfac2cf41125876b0a6

* Resolves: # <!-- related github issue -->
* Target version: master
