### PR TITLE
Canvas: Check size when needed.

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -375,7 +375,7 @@ window.L.CalcTileLayer = window.L.CanvasTileLayer.extend({
 		}
 	},
 
-	_syncTileContainerSize: function() {
+	_syncTileContainerSize: function(force = false) {
 		if (!this._map) return false;
 
 		if (!this._container) return false;
@@ -401,7 +401,7 @@ window.L.CalcTileLayer = window.L.CanvasTileLayer.extend({
 		const sizeChanged = oldMapSize[0] !== newMapSize[0] || oldMapSize[1] !== newMapSize[1];
 
 		// Early exit. If there is no need to update the size, return here.
-		if (sizeChanged) {
+		if (sizeChanged || force) {
 			this._resizeMapElementAndTilesLayer(mapElement, marginLeft, marginTop, newMapSize);
 
 			this._map.invalidateSize(false, new cool.Point(oldMapSize[0], oldMapSize[1]));
@@ -414,7 +414,7 @@ window.L.CalcTileLayer = window.L.CanvasTileLayer.extend({
 		// Center the view w.r.t the new map-pane position using the current zoom.
 		this._map.setView(this._map.getCenter());
 
-		if (sizeChanged) {
+		if (sizeChanged || force) {
 			// We want to keep cursor visible when we show the keyboard on mobile device or tablet
 			this._nonDesktopChecksAfterResizeEvent(heightIncreased);
 


### PR DESCRIPTION
Issue:
  If renewAllSections is called when canvas is invisible, its size is checked, and an invisible element's size seems 0.
  That 0, since it is read, is applied to the canvas element.

Usage scenario:
When Calc is hosted in an iframe and that iframe is hidden via css display: none, showing it again by removing that style results in a blank sheet. Resizing the window 'fixes' the issue.
-> If after hiding the canvas, a user triggers resize somehow, the canvas's size is set to zero (because at the time, it is not visible and its size is fetched as zero). A user can
trigger that resize event via adding / removing rows to a Calc sheet. That action in return, triggers a new sheet geometry, which in return calls resize, because only a few rows may be visible after the user action.
And we need to check that scenario. There may be other actions that may trigger this unwanted result.

Fix:
  When the element is made visible again, canvas size is still 0 (we set it manually).
  To avoid this, we check if canvas size is 0, if it is, we check the document container's size.