### PR TITLE
cypress-test: for replace tab in find and replace dialog

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/replace_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/replace_dialog_spec.js
@@ -1,0 +1,35 @@
+/* global describe it cy beforeEach require */  
+  
+var helper = require('../../common/helper');  
+  
+describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Replace Dialog Tests', function() {  
+    beforeEach(function() {  
+        helper.setupAndLoadDocument('writer/search_bar.odt');  
+    });  
+      
+    it('Ctrl H should open search dialog with replace tab active', function() {
+        helper.typeIntoDocument('{ctrl}h');
+        cy.cGet('#FindReplaceDialog').should('be.visible');
+
+        // Verify that the replace tab is active
+        cy.cGet('#replace_tab_btn').should('have.class', 'checked');
+        // Verify that the replace input field is visible
+        cy.cGet('#FindReplaceDialog.jsdialog input#replaceterm-input-dialog').should('be.visible');
+        // Verify that the focus is on find input field
+        cy.cGet('#FindReplaceDialog.jsdialog input#searchterm-input-dialog').should('be.focused');
+    });
+
+    it('Replace button should open search dialog with replace tab active', function() {
+        cy.viewport(1920,1080);
+        // Click the Replace button from the notebookbar
+        cy.cGet('#home-search-dialog-button').click();
+        cy.cGet('#FindReplaceDialog').should('be.visible');
+
+        // Verify that the replace tab is active
+        cy.cGet('#replace_tab_btn').should('have.class', 'checked');
+        // Verify that the replace input field is visible
+        cy.cGet('#FindReplaceDialog.jsdialog input#replaceterm-input-dialog').should('be.visible');
+        // Verify that the focus is on find input field
+        cy.cGet('#FindReplaceDialog.jsdialog input#searchterm-input-dialog').should('be.focused');
+    });
+});


### PR DESCRIPTION
Scenarios:
- ctrl + h should open find and replace dialog with replace tab as active
- clicking on Replace button should open find and replace dialog with replace tab as active


Change-Id: I9f2eba4bd9890a9a64c4b6b54a528b1d41604228

Relevant PR: #12931

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

