### PR TITLE
fix: synchronize disabled state with button and arrow background

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2068,6 +2068,8 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			hasImage = false;
 		}
 
+		const itemsToSyncWithContainer = [];
+
 		if (data.command || data.postmessage === true) {
 			var id = data.id ? data.id : (data.command && data.command !== '') ? data.command.replace('.uno:', '') : data.text;
 			var isUnoCommand = data.command && data.command.indexOf('.uno:') >= 0;
@@ -2093,7 +2095,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			button = window.L.DomUtil.create('button', 'ui-content unobutton', div);
 			button.id = buttonId;
 
-			JSDialog.SynchronizeDisabledState(div, [button]);
+			itemsToSyncWithContainer.push(button);
 
 			builder._addAriaLabel(button, data, builder);
 
@@ -2268,6 +2270,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 					builder.callback('toolbox', 'closemenu', parentContainer, data.command, builder);
 				};
 			}
+			itemsToSyncWithContainer.push(arrowbackground);
 		}
 
 		if (arrowbackground) {
@@ -2286,6 +2289,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			}
 		}
 
+		JSDialog.SynchronizeDisabledState(div, itemsToSyncWithContainer);
 		div._onDropDown = function(open) {
 			// Only set aria-expanded on the button if the arrow is not interactive
 			if (!isArrowInteractive)


### PR DESCRIPTION
Change-Id: Ib2b57e784dac222a634db09cb1b5057f96a2c0aa

**Before:**
<img width="1867" height="162" alt="image" src="https://github.com/user-attachments/assets/c3f92bee-1bd6-42e2-8d05-d941b4f8f928" />

**After:**
<img width="943" height="552" alt="image" src="https://github.com/user-attachments/assets/64fe8674-7cbc-44f6-81ab-7331749bb215" />

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

