### PR TITLE
Mobile: Calc: fix the top bar being cropped

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -174,7 +174,7 @@ textarea.cool-annotation-textarea {
 	z-index: auto !important;
 	flex-direction: column;
 }
-#toolbar-wrapper.mobile #formulabar-row {
+.main-nav:not(.readonly) #toolbar-wrapper.mobile #formulabar-row {
 	z-index: 11;
 }
 .toolbar-row {


### PR DESCRIPTION
Before this commit the top bar was being cropped because the formula bar
was now appearing even on read-only mode due to the following
commit:

afba6586d97ce26587752f6acf501cc071a8f4ba

-

The formula bar is not meant to be shown in the read-only mode

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I3327d41a0282391bcd62c7d41ceb3a884246e66d
