### PR TITLE
accessibility:  added proper ARIA attribute for comboboxentry when has sub-menu

### DIFF
--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -80,6 +80,12 @@ JSDialog.comboboxEntry = function (parentContainer, data, builder) {
 	});
 
 	if (data.hasSubMenu) {
+		entry.setAttribute('aria-haspopup', true);
+		entry.setAttribute('aria-expanded', false);
+		entry._onDropDown = function(open) {
+			entry.setAttribute('aria-expanded', open);
+		};
+
 		entry.addEventListener('mouseover', function () {
 			builder.callback('combobox', 'showsubmenu', {id: data.comboboxId}, entryData, builder);
 		});


### PR DESCRIPTION
Change-Id: I0f389e02b2fa0bde0a15c6469123636e9e44c57f
**Before:**
<img width="1827" height="1714" alt="image" src="https://github.com/user-attachments/assets/2dce23d9-c705-4a83-9069-7b071faaa2d8" />


**After:**
1. 
<img width="1872" height="1661" alt="image" src="https://github.com/user-attachments/assets/98fe628e-ecfa-4f39-907d-2309ee78b09a" />
2. 
<img width="1770" height="1727" alt="image" src="https://github.com/user-attachments/assets/f0998b23-addb-4633-921a-650185df8db9" />


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

