### PR TITLE
unit-paste: avoid '_' in the pasted text

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -72,7 +72,7 @@ all_la_unit_tests = \
 	unit-oauth.la \
 	unit-wopi-versionrestore.la \
 	unit-rendering-options.la \
-	# unit-paste.la \
+	unit-paste.la \
 	unit-large-paste.la \
 	unit-typing.la \
 	unit-cursor.la \
@@ -303,8 +303,8 @@ unit_any_input_la_SOURCES = UnitAnyInput.cpp
 unit_any_input_la_LIBADD = $(CPPUNIT_LIBS)
 unit_large_paste_la_SOURCES = UnitLargePaste.cpp
 unit_large_paste_la_LIBADD = $(CPPUNIT_LIBS)
-# unit_paste_la_SOURCES = UnitPaste.cpp
-# unit_paste_la_LIBADD = $(CPPUNIT_LIBS)
+unit_paste_la_SOURCES = UnitPaste.cpp
+unit_paste_la_LIBADD = $(CPPUNIT_LIBS)
 unit_load_torture_la_SOURCES = UnitLoadTorture.cpp
 unit_load_torture_la_LIBADD = $(CPPUNIT_LIBS)
 unit_save_torture_la_SOURCES = UnitSaveTorture.cpp

--- a/test/UnitPaste.cpp
+++ b/test/UnitPaste.cpp
@@ -48,7 +48,7 @@ void UnitPaste::invokeWSDTest()
 
     for (int i = 0; i < 5; ++i)
     {
-        const std::string text = std::to_string(i + 1) + "_sh9le[;\"CFD7U[#B+_nW=$kXgx{sv9QE#\"l1y\"hr_" + Util::encodeId(Util::rng::getNext());
+        const std::string text = std::to_string(i + 1) + "sh9le[;\"CFD7U[#B+nW=$kXgx{sv9QE#\"l1y\"hr" + Util::encodeId(Util::rng::getNext());
         TST_LOG("Pasting text #" << i + 1 << ": " << text);
 
         // Always delete everything to have an empty doc.


### PR DESCRIPTION
This test started to fail after core.git co-25.04 commits
9179d7f676703fe598bba9acd5e0af9b29907c14 (tdf#162153 Introduce a new
dialog for pasting plain text as Markdown, 2025-09-29) and
da6b93e01c76fb1e1cc20dbca29fb96030521b24 (tdf#162153 Remove selection
dialog for markdown when pasting, 2025-09-29).

What happens is that we now try to detect if the pasted text is
markdown, and given that the "random" content matches the "foo _bar_
baz" pattern, what gets pasted and the plain text version of the
selection ("foo bar baz") doesn't match anymore.

Fix the problem by avoiding '_' in the pasted content, we intend to just
paste some content here.

Allows reverting commit f422b2f673751a31023b709c52bce977ea4e6207 (test:
temporarily disable unit-paste, 2025-09-30).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I63c13b3d4aa3bddebf69c2311f159cd056de42cc
