### PR TITLE
Fix ruler drag marker Lines

### DIFF
--- a/browser/src/control/Control.NavigatorPanel.ts
+++ b/browser/src/control/Control.NavigatorPanel.ts
@@ -279,8 +279,6 @@ class NavigatorPanel extends SidebarBase {
 			// TODO: remove jQuery animation
 			$('#navigator-dock-wrapper').show(200);
 			app.showNavigator = true;
-			// this will update the indentation marks for elements like ruler
-			app.map.fire('fixruleroffset');
 			if (
 				app.map.isPresentationOrDrawing() &&
 				!this.isNavigationPanelVisible()
@@ -359,6 +357,8 @@ class NavigatorPanel extends SidebarBase {
 		app.layoutingService.appendLayoutingTask(() => {
 			this.navigationPanel.classList.add('visible');
 			this.floatingNavIcon.classList.remove('visible');
+			// this will update the indentation marks for elements like ruler
+			app.map.fire('fixruleroffset');
 		});
 	}
 

--- a/browser/src/control/HRuler.ts
+++ b/browser/src/control/HRuler.ts
@@ -405,9 +405,7 @@ class HRuler extends Ruler {
 		this.options.rightParagraphIndent *= pxPerMm100;
 
 		// Get navigatiosidebar width only when navigation sidebar is visible
-		const navigationsidebarWidth = app.showNavigator
-			? this._getNavigationSidebarWidth()
-			: 0;
+		const navigationsidebarWidth = this._getNavigationSidebarWidth();
 
 		// rTSContainer is the reference element.
 		const pStartPosition =
@@ -423,17 +421,14 @@ class HRuler extends Ruler {
 		// We calculated the positions. Now we should move them to left in order to make their sharp edge point to the right direction..
 		this._firstLineMarker.style.left =
 			fLinePosition -
-			this._getNavigationSidebarWidth() -
 			this._firstLineMarker.getBoundingClientRect().width / 2.0 +
 			'px';
 		this._pStartMarker.style.left =
 			pStartPosition -
-			this._getNavigationSidebarWidth() -
 			this._pStartMarker.getBoundingClientRect().width / 2.0 +
 			'px';
 		this._pEndMarker.style.left =
 			pEndPosition -
-			this._getNavigationSidebarWidth() -
 			this._pEndMarker.getBoundingClientRect().width / 2.0 +
 			'px';
 
@@ -822,7 +817,8 @@ class HRuler extends Ruler {
 			(element.getBoundingClientRect().right -
 				element.getBoundingClientRect().left) *
 			0.5;
-		this._markerVerticalLine.style.left = String(newLeft + halfWidth) + 'px';
+		this._markerVerticalLine.style.left =
+			String(newLeft + halfWidth + this._getNavigationSidebarWidth()) + 'px';
 	}
 
 	_moveIndentationEnd(e: Event) {


### PR DESCRIPTION
- before this patch drag markers are not working expected with user's mouse pointer
- this only happens when navigator bar is open
- this patch will fix some calculation issues while setting place for this drag marker
- also some cleanup like removing `this._getNavigationSidebarWidth() ` because we already considered that above for those markers variable so no need to again subtract that

before:

[Screencast from 2025-10-01 12-06-12.webm](https://github.com/user-attachments/assets/970b0212-1122-46fa-a8f0-387517bd8d7d)

Now:

[Screencast from 2025-10-01 19-19-34.webm](https://github.com/user-attachments/assets/61bd7be8-4607-4f4e-b4ee-7c6573b0daed)


Change-Id: I4122471eb6efd9c214ac137f01a7c05625b4a60f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

