### PR TITLE
notebookbar: empty styles

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -111,7 +111,6 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 	},
 
 	onRemove: function() {
-		clearTimeout(this.retry);
 		this.map.off('notebookbar');
 		this.map.off('jsdialogupdate', this.onJSUpdate, this);
 		this.map.off('jsdialogaction', this.onJSAction, this);

--- a/browser/src/control/Control.NotebookbarBase.ts
+++ b/browser/src/control/Control.NotebookbarBase.ts
@@ -19,7 +19,6 @@ class NotebookbarBase extends JSDialogComponent {
 
 	constructor(map: any, impl: any) {
 		super(map, 'Notebookbar', 'notebookbar');
-		this.map = map;
 		this.impl = impl;
 
 		this.createBuilder();
@@ -70,7 +69,7 @@ class NotebookbarBase extends JSDialogComponent {
 		this.container = parentContainer;
 	}
 
-	protected onJSUpdate(e: FireEvent) {
+	protected onJSUpdate(e: any) {
 		if (super.onJSUpdate(e)) {
 			this.impl?.setInitialized(true);
 			return true;
@@ -78,7 +77,7 @@ class NotebookbarBase extends JSDialogComponent {
 		return false;
 	}
 
-	protected onJSAction(e: FireEvent) {
+	protected onJSAction(e: any) {
 		if (super.onJSAction(e)) {
 			this.impl?.setInitialized(true);
 			return true;

--- a/browser/src/control/Control.NotebookbarBase.ts
+++ b/browser/src/control/Control.NotebookbarBase.ts
@@ -17,22 +17,33 @@ class NotebookbarBase extends JSDialogComponent {
 	/// reference to old JS Notebookbar
 	impl: any = null;
 
-	constructor(map: any) {
+	constructor(map: any, impl: any) {
 		super(map, 'Notebookbar', 'notebookbar');
 		this.map = map;
-	}
-
-	public onAdd(impl: any) {
 		this.impl = impl;
 
-		this.map.addControl(this.impl);
 		this.createBuilder();
 		this.impl.setBuilder(this.builder, this.model);
-		this.setupContainer(this.impl.container);
+
+		this.map.addControl(this.impl);
 
 		this.registerMessageHandlers();
 	}
 
+	// when we show the UI
+	public onAdd() {
+		this.impl.create();
+		this.setupContainer(this.impl.container);
+		if (this.builder) {
+			this.map.on(
+				'commandstatechanged',
+				this.builder.onCommandStateChanged,
+				this.builder,
+			);
+		}
+	}
+
+	// when we hide the UI
 	public onRemove() {
 		if (this.builder)
 			this.map.off(
@@ -40,12 +51,8 @@ class NotebookbarBase extends JSDialogComponent {
 				this.builder.onCommandStateChanged,
 				this.builder,
 			);
-		this.unregisterMessageHandlers();
-		if (this.impl) {
-			this.map.removeControl(this.impl);
-			delete this.impl;
-			this.impl = null;
-		}
+
+		if (this.impl) this.impl.onRemove();
 	}
 
 	protected createBuilder() {
@@ -57,12 +64,6 @@ class NotebookbarBase extends JSDialogComponent {
 			useSetTabs: true,
 			suffix: 'notebookbar',
 		});
-		if (this.builder)
-			this.map.on(
-				'commandstatechanged',
-				this.builder.onCommandStateChanged,
-				this.builder,
-			);
 	}
 
 	protected setupContainer(parentContainer?: HTMLElement) {
@@ -142,6 +143,6 @@ class NotebookbarBase extends JSDialogComponent {
 	}
 }
 
-JSDialog.NotebookbarBase = function (map: any) {
-	return new NotebookbarBase(map);
+JSDialog.NotebookbarBase = function (map: any, impl: any) {
+	return new NotebookbarBase(map, impl);
 };

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -160,10 +160,13 @@ window.L.Control.NotebookbarBuilder = window.L.Control.JSDialogBuilder.extend({
 			if (saveEle) {
 				if (state === 'true' &&  this.map.saveState) {
 					this.map.saveState.showModifiedStatus();
-					document.getElementById('file-save').classList.add('savemodified');
+					const button = document.getElementById('file-save');
+					if (button) button.classList.add('savemodified');
 				} else {
-					document.getElementById('save').classList.remove('savemodified');
-					document.getElementById('file-save').classList.remove('savemodified');
+					const button = document.getElementById('save');
+					if (button) button.classList.remove('savemodified');
+					const fileButton = document.getElementById('file-save');
+					if (fileButton) fileButton.classList.remove('savemodified');
 				}
 			}
 		}

--- a/browser/src/control/jsdialog/Component.Base.ts
+++ b/browser/src/control/jsdialog/Component.Base.ts
@@ -54,6 +54,8 @@ abstract class JSDialogComponent {
 
 		if (data.jsontype !== this.allowedJsonType) return false;
 
+		if (this.model) this.model.widgetUpdate(data);
+
 		if (!this.container) return false;
 
 		if (!this.builder) return false;
@@ -64,7 +66,6 @@ abstract class JSDialogComponent {
 				: data.control.id,
 		);
 
-		this.model.widgetUpdate(data);
 		this.builder.updateWidget(this.container, data.control);
 
 		return true;
@@ -76,6 +77,8 @@ abstract class JSDialogComponent {
 
 		if (data.jsontype !== this.allowedJsonType) return false;
 
+		if (this.model) this.model.widgetAction(data);
+
 		if (!this.builder) return false;
 
 		if (!this.container) return false;
@@ -86,7 +89,6 @@ abstract class JSDialogComponent {
 				: data.data.control_id,
 		);
 
-		this.model.widgetAction(data);
 		this.builder.executeAction(this.container, data.data);
 
 		return true;

--- a/browser/src/control/jsdialog/Widget.OverflowGroup.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowGroup.ts
@@ -294,7 +294,10 @@ JSDialog.OverflowGroup = function (
 
 	// first toolitem in the group
 	const firstItem = findFirstToolitem(data.children);
-	console.assert(firstItem, 'First toolitem inside overflow group not found');
+	app.console.debug(
+		firstItem,
+		'OverflowGroup: First toolitem inside overflow group not found',
+	);
 
 	// placeholder menu for a dropdown
 	const builtMenu = [

--- a/browser/src/docstate.ts
+++ b/browser/src/docstate.ts
@@ -304,5 +304,5 @@ if (activateValidation) {
 	window.app.file = new Proxy(window.app.file, validator);
 }
 
-(window as any).JSDialog = { verbose: false }; // initialize jsdialog module
+(window as any).JSDialog = { verbose: true }; // initialize jsdialog module
 (window as any).SlideShow = {}; // initialize slideshow module


### PR DESCRIPTION
- finally fixes case when first session opens compact mode but other user will join with notebookbar
- we need to listen core events always and always initialize notebookbar to remember style previews updates
- removes annoying assert which is not critical

It fixes case:
- open comact in A
- open tabbed in B
- switch A to tabbed - result no styles

caused by removed handlers and not recovered after switch, which are now deleted:
```
       onRemove: function() {
-               this.map.off('notebookbar');
-               this.map.off('jsdialogupdate', this.onJSUpdate, this);
-               this.map.off('jsdialogaction', this.onJSAction, this);
```

followup for https://github.com/CollaboraOnline/online/pull/13035