### PR TITLE
Make code compile when libcap-devel is not available

### DIFF
--- a/common/Seccomp.cpp
+++ b/common/Seccomp.cpp
@@ -28,7 +28,6 @@
 #endif
 #include <malloc.h>
 #include <signal.h>
-#include <sys/capability.h>
 #include <sys/prctl.h>
 #include <sys/syscall.h>
 #endif // __linux__

--- a/common/security.h
+++ b/common/security.h
@@ -14,7 +14,9 @@
 
 #pragma once
 
-#ifdef __linux__
+#include <config.h>
+
+#if HAVE_LIBCAP
 #include <sys/capability.h>
 #endif
 #include <sys/types.h>
@@ -81,7 +83,7 @@ inline int hasCorrectUID([[maybe_unused]] const char* appName)
 /** Return 0 if no capability is set on the current binary. Positive number gives the bitfield of caps that are set, negative an error. */
 inline int hasAnyCapability()
 {
-#ifdef __linux__
+#if HAVE_LIBCAP
     cap_t caps = cap_get_proc();
     if (caps == nullptr)
     {
@@ -112,7 +114,7 @@ inline int hasAnyCapability()
 /** Drop all capabilities. return zero on success, negative on error. */
 inline int dropAllCapabilities()
 {
-#ifdef __linux__
+#if HAVE_LIBCAP
     cap_t caps = cap_init();
     if (caps == nullptr)
     {

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3561,6 +3561,7 @@ void lokit_main(
             }
 
 #ifndef __FreeBSD__
+#if HAVE_LIBCAP
             if (usingMountNamespace)
             {
                 // create another namespace, map back to original uid/gid after mount
@@ -3587,6 +3588,7 @@ void lokit_main(
 
             assert(origuid == geteuid());
             assert(origgid == getegid());
+#endif
 #endif
 
             if (!bindMount)


### PR DESCRIPTION
We did not take the define HAVE_LIBCAP into account at all places using cap_* functions which lead to compilation failures when libcap-devel was not installed. This adds HAVE_LIBCAP to the places that makes sense and makes the code compile again.

If this makes sense I don't know as libcap could just be mandatory when using Linux, which would simplify the code a bit.


Change-Id: I11a9c6df2553c3602446565cd59e6a0ccba8e002


