### PR TITLE
Rewrite rectangle merging in CPolyUtil.rectanglesToPointSet

### DIFF
--- a/browser/src/layer/vector/CPolyUtil.ts
+++ b/browser/src/layer/vector/CPolyUtil.ts
@@ -12,30 +12,40 @@ namespace CPolyUtil {
 		   Machine Intelligence and Pattern Recognition. Vol. 6. North-Holland, 1988. 97-104.
 		   http://www.science.smith.edu/~jorourke/Papers/OrthoConnect.pdf
 		*/
-		var eps = 20;
-		// Glue rectangles if the space between them is less then eps
-		for (var i = 0; i < rectangles.length - 1; i++) {
-			for (var j = i + 1; j < rectangles.length; j++) {
-				for (var k = 0; k < rectangles[i].length; k++) {
-					for (var l = 0; l < rectangles[j].length; l++) {
-						if (Math.abs(rectangles[i][k].x - rectangles[j][l].x) < eps) {
-							rectangles[j][l].x = rectangles[i][k].x;
-						}
-						if (Math.abs(rectangles[i][k].y - rectangles[j][l].y) < eps) {
-							rectangles[j][l].y = rectangles[i][k].y;
-						}
-					}
-				}
+		// Helper function for sorted array insert.
+		function sortedIndex(array: Array<cool.Point>, value: cool.Point, compare: (a: cool.Point, b: cool.Point) => number) : number {
+			let low = 0;
+			let high = array.length;
+			while (low < high) {
+				const mid = (low + high) >>> 1;
+				if (compare(value, array[mid]) > 0) low = mid + 1;
+				else high = mid;
+			}
+			return low;
+		}
+
+		// Glue rectangles if the space between them is less than eps
+		const eps = 20;
+		const pointsX = new Array<cool.Point>();
+		const pointsY = new Array<cool.Point>();
+		for (let i = 0; i < rectangles.length; i++) {
+			for (let j = 0; j < rectangles[i].length; j++) {
+				pointsX.splice(sortedIndex(pointsX, rectangles[i][j], (a, b) => a.x - b.x), 0, rectangles[i][j]);
+				pointsY.splice(sortedIndex(pointsY, rectangles[i][j], (a, b) => a.y - b.y), 0, rectangles[i][j]);
 			}
 		}
 
-		var points = new Set<cool.Point>();
-		for (i = 0; i < rectangles.length; i++) {
-			for (j = 0; j < rectangles[i].length; j++) {
-				if (!points.delete(rectangles[i][j])) {
-					points.add(rectangles[i][j]);
-				}
-			}
+		let lastPointX = 0;
+		let lastPointY = 0;
+		for (let i = 1; i < pointsX.length; ++i) {
+			if (Math.abs(pointsX[lastPointX].x - pointsX[i].x) < eps)
+				pointsX[i].x = pointsX[lastPointX].x;
+			else
+				lastPointX = i;
+			if (Math.abs(pointsY[lastPointY].y - pointsY[i].y) < eps)
+				pointsY[i].y = pointsY[lastPointY].y;
+			else
+				lastPointY = i;
 		}
 
 		// cool.Point comparison function for sorting a list of CPoints w.r.t x-coordinate.
@@ -67,6 +77,12 @@ namespace CPolyUtil {
 			}
 		}
 
+		// Collect points and horizontal and vertical edges.
+		const points = new Set<cool.Point>();
+		for (const point of pointsX)
+			if (!points.delete(point))
+				points.add(point);
+
 		var sortX = Array.from(points.values()).sort(xThenY);
 		var sortY = Array.from(points.values()).sort(yThenX);
 
@@ -74,7 +90,7 @@ namespace CPolyUtil {
 		var edgesV = new Map<cool.Point, cool.Point>();
 
 		var len = points.size;
-		i = 0;
+		let i = 0;
 		while (i < len) {
 			var currY = sortY[i].y;
 			while (i < len && sortY[i].y === currY) {


### PR DESCRIPTION
This is follow-up from #13060. Performance when searching in writer is very bad if you get a lot of search hits - this is mostly down to an O(N^2) algorithm that iterates over the rectangles returned by the backend, which can number in the 10s of thousands. This commit rewrites that algorithm using bisection sort on an already-sorted array so the efficiency is close to O(N). There should be no change in behaviour.

Note, we do have what looks like a very efficient alternative to this in geometry.ts (`rectanglesToPolygon`), but unlike this one in CPolyUtil, it does not deal with disjoint rectangles. I think there may actually be good reasons to have both of these, though perhaps some backend changes would negate the need for this one.

In the case described in #13060 of searching for 'the' in the large test document, this now goes from 21 seconds (after the optimisations in #13060) down to 4.6 seconds. There are likely still more savings in this function, but now layout is quite high in the profile too. I think the next most sensible thing to do would be to split processing of search results to the visible/near-visible area.

* Target version: master 

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

