### PR TITLE
Improvement: Hide URL popup when ContextToolbar is shown

### DIFF
--- a/browser/src/control/Control.ContextToolbar.ts
+++ b/browser/src/control/Control.ContextToolbar.ts
@@ -63,7 +63,6 @@ class ContextToolbar extends JSDialogComponent {
 	}
 
 	showContextToolbarImpl(): void {
-		URLPopUpSection.closeURLPopUp();
 		this.pendingShow = false;
 
 		if (!this.initialized) {
@@ -101,7 +100,7 @@ class ContextToolbar extends JSDialogComponent {
 				window.L.DomUtil.addClass(this.container, 'hidden');
 				return;
 			}
-
+			URLPopUpSection.closeURLPopUp();
 			let statRect;
 			if (!TextSelections || !(statRect = TextSelections.getStartRectangle()))
 				return;


### PR DESCRIPTION
- Previously, I had a patch to hide the URL popup when the ContextToolbar appears, but I missed an important case.
- On double-click, the ContextToolbar is shown, but tile invalidation also occurs, which triggers the `showUrl` function again after the ContextToolbar logic completes.
- To address this, we can call `CloseUrl` during the layout rendering step for the contextual menu.
- This ensures the URL popup is closed consistently, even when tile invalidation happens for a URL in the document.

Change-Id: I46d9c4beb32ccc1276937cba8a2d491ff994d0e4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

