### PR TITLE
Fix typo for --color-background-dark in spreadsheet.css

### DIFF
--- a/browser/css/spreadsheet.css
+++ b/browser/css/spreadsheet.css
@@ -85,7 +85,7 @@
 
 #spreadsheet-header-corner-container {
 	border: 1px solid var(--color-border-dark);
-	background-color: var(--colo-background-dark);
+	background-color: var(--color-background-dark);
 	cursor: pointer;
 
 	position: absolute;
@@ -110,7 +110,7 @@
 
 .spreadsheet-header-corner-styles {
 	border: 1px solid var(--color-border-dark);
-	background-color: var(--colo-background-dark);
+	background-color: var(--color-background-dark);
 	font: var(--default-font-size)/1.5 var(--cool-font);
 	color: var(--color-text-dark);
 	cursor: pointer;
@@ -118,7 +118,7 @@
 
 #spreadsheet-header-columns-container {
 	border: 1px solid var(--color-border-dark);
-	background-color: var(--colo-background-dark);
+	background-color: var(--color-background-dark);
 
 	position: absolute;
 	display: inline-block;
@@ -132,7 +132,7 @@
 
 #spreadsheet-header-rows-container {
 	border: 1px solid var(--color-border-dark);
-	background-color: var(--colo-background-dark);
+	background-color: var(--color-background-dark);
 
 	position: absolute;
 	left: 0;


### PR DESCRIPTION
The var was named --colo-background-dark, which is obviously a typo and doesn't exist.

Change-Id: Ifd00da7d699949cf07d08784e06a00fce9aa1eb4
