### PR TITLE
UI: enter edit mode in write protected file with edit button(mobile)

### DIFF
--- a/browser/src/control/Permission.js
+++ b/browser/src/control/Permission.js
@@ -206,6 +206,9 @@ window.L.Map.include({
 			this._textInput.setSwitchedToEditMode();
 		}
 
+		if (app.map['stateChangeHandler'].getItemValue('EditDoc') === 'false')
+			app.map.sendUnoCommand('.uno:EditDoc?Editable:bool=true');
+
 		app.events.fire('updatepermission', {perm : perm});
 
 		if (this._docLayer._docType === 'text') {


### PR DESCRIPTION
by default documents are opened in read only mode in mobile
to prevent accidental editing.
This read only mode is different from when file is actually
set with permission read-only(in desktop Edit -> Edit mode)

Currently online does not have any button equivalent to the desktop
to enter the edit mode, neither in desktop browser nor in mobile.

Without this patch if file is read only and user presses the pencil button,
UI changes to edit mode but file still can not be edited because of
restricted permissions.


Change-Id: Id2f9b787e4a6f6456c4d192987d2650a3b2b27d0


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

