### PR TITLE
Table resize marker: Remove unnecessary classes.

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -252,17 +252,6 @@ body {
 	cursor: col-resize;
 }
 
-.table-column-resize-marker.hovered {
-	margin-left: 0px;
-	margin-top: 0px;
-	width: var(--btn-size);
-	height: var(--btn-size);
-	background-image: url('images/table-column-resize-marker-hover.svg');
-	background-size: 100% 100%;
-	background-repeat: no-repeat;
-	cursor: col-resize;
-}
-
 .table-row-resize-marker {
 	margin-left: 0px;
 	margin-top: 0px;
@@ -275,17 +264,6 @@ body {
 }
 
 .table-row-resize-marker:hover {
-	margin-left: 0px;
-	margin-top: 0px;
-	width: var(--btn-size);
-	height: var(--btn-size);
-	background-image: url('images/table-row-resize-marker-hover.svg');
-	background-size: 100% 100%;
-	background-repeat: no-repeat;
-	cursor: row-resize;
-}
-
-.table-row-resize-marker.hovered {
 	margin-left: 0px;
 	margin-top: 0px;
 	width: var(--btn-size);

--- a/browser/src/canvas/sections/TableResizeMarkerSection.ts
+++ b/browser/src/canvas/sections/TableResizeMarkerSection.ts
@@ -132,14 +132,11 @@ class TableResizeMarkerSection extends HTMLObjectSection {
 		if (this.sectionProperties.markerType === 'column')
 			this.calculateLeftMostAndRightMostAvailableX();
 		else this.calculateTopMostAndBottomMostAvailableY();
-
-		this.getHTMLObject()?.classList.add('hovered');
 	}
 
 	public onMouseLeave(point: cool.SimplePoint, e: MouseEvent): void {
 		this.stopPropagating(e);
 		this.sectionProperties.dragStartPosition = null;
-		this.getHTMLObject()?.classList.remove('hovered');
 	}
 
 	public onMouseDown(point: cool.SimplePoint, e: MouseEvent): void {
@@ -287,6 +284,8 @@ class TableResizeMarkerSection extends HTMLObjectSection {
 			if (this.sectionProperties.markerType === 'column')
 				this.columnDrag(point);
 			else this.rowDrag(point);
+
+			this.adjustHTMLObjectPosition();
 		}
 	}
 


### PR DESCRIPTION
I had added them because they were under map element. Then i fixed the issue. Now they conflict with the possible themeing patches and also not needed anymore.


Change-Id: I432840be86596b08216a60833eeb450ac3762ac2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

