### PR TITLE
chore: bump ndk version to 28

### DIFF
--- a/android/app/build.gradle.in
+++ b/android/app/build.gradle.in
@@ -7,7 +7,7 @@ android {
     namespace 'org.libreoffice.androidapp'
     compileSdkVersion 35
     buildDir = "${rootProject.getBuildDir()}/app"
-    ndkVersion "22.1.7171670"
+    ndkVersion "28.2.13676358"
     buildFeatures.buildConfig = true
 
     defaultConfig {

--- a/android/lib/build.gradle.in
+++ b/android/lib/build.gradle.in
@@ -7,7 +7,7 @@ android {
     namespace 'org.libreoffice.androidlib'
     compileSdkVersion 35
     buildDir = "${rootProject.getBuildDir()}/lib"
-    ndkVersion "22.1.7171670"
+    ndkVersion "28.2.13676358"
     buildFeatures.buildConfig = true
 
     defaultConfig {


### PR DESCRIPTION
I've just picked commits to allow the supported NDK up to 29 on core. I plan to compile with 28. I want to compile both core and this app with the same version.


Change-Id: I6a6a6964fb2dbbe31455f9b12b2e51b5f3cc0632


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

