### PR TITLE
Remove duplicate `function` option from insert tab in NotebookbarCalc

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1680,13 +1680,6 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 						'accessibility': { focusBack: true,	combination: 'IS', de: null }
 					},
 					{
-						'id': 'insert-function-dialog',
-						'type': 'bigtoolitem',
-						'text': _UNO('.uno:FunctionDialog', 'spreadsheet'),
-						'command': '.uno:FunctionDialog',
-						'accessibility': { focusBack: true,	combination: 'FD', de: null }
-					},
-					{
 						'id': 'Insert-Section-PivotTable-Ext',
 						'type': 'container',
 						'children': [


### PR DESCRIPTION
Before:

<img width="543" height="183" alt="image" src="https://github.com/user-attachments/assets/c527748f-1ad9-4b79-9170-eb886d5566c9" />



Change-Id: I9d8514dd91458338c069a2a8da7824b36446653e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

