### PR TITLE
Impress: fix preview rendering when switching to a page having differ…

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -58,6 +58,7 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 		map.on('tilepreview', this._updatePreview, this);
 		map.on('insertpage', this._insertPreview, this);
 		map.on('deletepage', this._deletePreview, this);
+		map.on('scrolllimit', this._invalidateCurrentPart, this);
 		map.on('scrolllimits', this._invalidateParts, this);
 		map.on('scrolltopart', this._scrollToPart, this);
 		map.on('beforerequestpreview', this._beforeRequestPreview, this);
@@ -866,6 +867,26 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 					      fetchThumbnail: this.options.fetchThumbnail});
 		}
 
+	},
+
+	_invalidateCurrentPart: function () {
+		if (!this._container ||
+		    !this._partsPreviewCont ||
+		    !this._previewInitialized ||
+		    !this._previewTiles)
+			return;
+
+		// When a new slide is inserted
+		if (this._previewTiles[this._map._docLayer._selectedPart] === undefined) {
+			this._invalidateParts();
+			return;
+		}
+		this._previewTiles[this._map._docLayer._selectedPart].fetched = false;
+		this._map.getPreview(this._map._docLayer._selectedPart, this._map._docLayer._selectedPart,
+				     this.options.maxWidth,
+				     this.options.maxHeight,
+				     {autoUpdate: this.options.autoUpdate,
+				      fetchThumbnail: this.options.fetchThumbnail});
 	},
 
 	focusCurrentSlide: function () {

--- a/browser/src/control/Parts.js
+++ b/browser/src/control/Parts.js
@@ -228,8 +228,15 @@ window.L.Map.include({
 
 		if (docLayer._docType === 'text') return;
 
-		const tileWidth = docLayer._partWidthTwips ? docLayer._partWidthTwips: app.activeDocument.fileSize.x;
-		const tileHeight = docLayer._partHeightTwips ? docLayer._partHeightTwips: app.activeDocument.fileSize.y;
+		// Use part specific dimensions if available, otherwise fall back to document size
+		let tileWidth, tileHeight;
+		if (docLayer._partDimensions.length === docLayer._parts) {
+			tileWidth = docLayer.getPartWidth(part);
+			tileHeight = docLayer.getPartHeight(part);
+		} else {
+			tileWidth = docLayer._partWidthTwips ? docLayer._partWidthTwips: app.activeDocument.fileSize.x;
+			tileHeight = docLayer._partHeightTwips ? docLayer._partHeightTwips: app.activeDocument.fileSize.y;
+		}
 
 		const docRatio = tileWidth / tileHeight;
 		const imgRatio = maxWidth / maxHeight;

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1059,6 +1059,9 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 			app.definitions.otherViewCursorSection.updateVisibilities();
 			this.updateAllTextViewSelection();
 		}
+		else if (textMsg.startsWith('partstatus:')) {
+			this._onStatusMsg(textMsg);
+		}
 		else if (textMsg.startsWith('textselection:')) {
 			this._onTextSelectionMsg(textMsg);
 		}
@@ -4063,7 +4066,7 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 		return this._cssPixelsToTwips(pixels);
 	},
 
-	_updateMaxBounds: function (sizeChanged) {
+	_updateMaxBounds: function (sizeChanged, allPages = true) {
 		if (app.activeDocument.fileSize.x === 0 || app.activeDocument.fileSize.y === 0) {
 			return;
 		}
@@ -4079,7 +4082,8 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 		}
 
 		this._docPixelSize = {x: docPixelLimits.x, y: docPixelLimits.y};
-		this._map.fire('scrolllimits', {});
+		if (allPages) this._map.fire('scrolllimits', {});
+		else this._map.fire('scrolllimit', {})
 	},
 
 	// Used with filebasedview.

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1159,6 +1159,23 @@ bool ChildSession::getStatus()
     return sendTextFrame("status: " + status);
 }
 
+bool ChildSession::getPartStatus()
+{
+    std::string status;
+
+    getLOKitDocument()->setView(_viewId);
+
+    status = LOKitHelper::documentStatus(getLOKitDocument()->get(), true);
+
+    if (status.empty())
+    {
+        LOG_ERR("Failed to get part status.");
+        return false;
+    }
+
+    return sendTextFrame("partstatus:" + status);
+}
+
 namespace
 {
 
@@ -3659,6 +3676,10 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
             if (payload == ".uno:ModifiedStatus=true") {
                 _docManager->getSlideLayerCache().erase_all();
             }
+        }
+        else if (payload.find(".uno:CurrentPageResize") != std::string::npos)
+        {
+            getPartStatus();
         }
         else
             sendTextFrame("statechanged: " + payload);

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -85,6 +85,7 @@ public:
     virtual ~ChildSession();
 
     bool getStatus();
+    bool getPartStatus();
     int getViewId() const { return _viewId; }
     void setViewId(const int viewId) { _viewId = viewId; }
     const std::string& getViewUserId() const { return getUserId(); }


### PR DESCRIPTION
…ent size

We assume all the pages in document to have same size. So when multiple previews are updated at once, they disregard individual page sizes which causes the previews to look bad.

`_invalidateCurrentPart` limits the invalidation to only current part in case of switching to a page having different size or when only the current page is resized.

Though there are still some cases where we invalidate tiles of multiple parts which also updates multiple previews. That's why I'm storing individual page sizes in `_partDimensions`

Corresponding core patch: https://gerrit.libreoffice.org/c/core/+/192004

Change-Id: Ic69da1dda0b7d43c847ca06de0ceba57ed56ef0a

* Target version: master 

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

