### PR TITLE
formulabar: allow to keep selection when leaving input area

### DIFF
--- a/browser/src/control/jsdialog/Widget.FormulabarEdit.js
+++ b/browser/src/control/jsdialog/Widget.FormulabarEdit.js
@@ -448,7 +448,7 @@ function _formulabarEditControl(parentContainer, data, builder) {
 
 	// hide old selection when user starts to select something else
 	textLayer.addEventListener('mousedown', function() {
-		textLayer.addEventListener('mouseleave', textSelectionHandler, {once: true});
+		textLayer.addEventListener('mouseup', textSelectionHandler, {once: true});
 		builder.callback('edit', 'grab_focus', container, null, builder);
 
 		cursorLayer.querySelectorAll('.selection').forEach(function (element) {


### PR DESCRIPTION
- this was annoying when user started to press the mouse button then moved mouse cursor out of the input field
- as a result we finished selection and it wasn't possible to just move mouse back to the field and continue

regression from commit 039283733eb0bf0d2da800db381b9a95a755e5e3
formulabar: trigger mouseleave event only after mousedown event