### PR TITLE
followme slideshow: reset leader info at the end of presentation

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -245,9 +245,8 @@ class SlideShowPresenter {
 				if (this.isFollowing()) this._slideShowNavigator.followVideo(info);
 				break;
 			case 'displayslide':
-				info.currentEffect = -1;
 				this._slideShowNavigator.setLeaderSlide(info);
-				this._slideShowNavigator.setLeaderEffect(info);
+				this._slideShowNavigator.resetLeaderEffect();
 				break;
 			case 'effect':
 				this._slideShowNavigator.setLeaderEffect(info);
@@ -259,6 +258,8 @@ class SlideShowPresenter {
 			case 'endpresentation':
 				this.setLeader(false);
 				this.setFollower(false);
+				this._slideShowNavigator.resetLeaderEffect();
+				this._slideShowNavigator.resetLeaderSlide();
 				this._map.uiManager.showButton('slide-presentation-follow-me', true);
 				this._map.uiManager.showButton('slide-presentation-follow', false);
 				if (!this.isFollowing()) return;

--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -234,12 +234,20 @@ class SlideShowNavigator {
 		return this.currentLeaderSlide;
 	}
 
+	resetLeaderSlide() {
+		this.currentLeaderSlide = -1;
+	}
+
 	setLeaderEffect(info: any) {
 		this.currentLeaderEffect = info.currentEffect;
 	}
 
 	getLeaderEffect(): number {
 		return this.currentLeaderEffect;
+	}
+
+	resetLeaderEffect() {
+		this.currentLeaderEffect = -1;
 	}
 
 	followLeaderSlide() {


### PR DESCRIPTION
if not reset next time slideshow may start from incorrect position for the followers in same session


Change-Id: Ic7978b73721ea94b01137ca1c20ca264a9250e20


* Target version: master 



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

