### PR TITLE
Writer: Tracking changes menu (Accept and Reject)

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2356,94 +2356,20 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 						'vertical': 'true'
 					},
 					{
-						'type': 'container',
-						'children': [
-							{
-								'type': 'toolbox',
-								'children': [
-									{
-										'id': 'review-accept-tracked-change',
-										'type': 'toolitem',
-										'text': _UNO('.uno:AcceptTrackedChange', 'text'),
-										'command': '.uno:AcceptTrackedChange',
-										'accessibility': { focusBack: true, combination: 'AC', de: 'AC' }
-									}
-								]
-							},
-							{
-								'type': 'toolbox',
-								'children': [
-									{
-										'id': 'review-reject-tracked-change',
-										'type': 'toolitem',
-										'text': _UNO('.uno:RejectTrackedChange', 'text'),
-										'command': '.uno:RejectTrackedChange',
-										'accessibility': { focusBack: true, combination: 'JR', de: 'JR' }
-									}
-								]
-							}
-						],
-						'vertical': 'true'
+						'id': 'review-accept-tracked-change:AcceptTrackedChangesMenu',
+						'type': 'menubutton',
+						'text': _UNO('.uno:AcceptTrackedChange', 'text'),
+						'applyCallback': 'acceptTrackedChangeToNext',
+						'command': '.uno:AcceptTrackedChangeToNext',
+						'accessibility': { focusBack: true, combination: 'AC', de: 'AC' }
 					},
 					{
-						'type': 'container',
-						'children': [
-							{
-								'type': 'toolbox',
-								'children': [
-									{
-										'id': 'review-accept-tracked-change-to-next',
-										'type': 'toolitem',
-										'text': _UNO('.uno:AcceptTrackedChangeToNext', 'text'),
-										'command': '.uno:AcceptTrackedChangeToNext',
-										'accessibility': { focusBack: true, combination: 'AM', de: 'AM' }
-									}
-								]
-							},
-							{
-								'type': 'toolbox',
-								'children': [
-									{
-										'id': 'review-reject-tracked-change-to-next',
-										'type': 'toolitem',
-										'text': _UNO('.uno:RejectTrackedChangeToNext', 'text'),
-										'command': '.uno:RejectTrackedChangeToNext',
-										'accessibility': { focusBack: true, combination: 'JM', de: 'JM' }
-									}
-								]
-							}
-						],
-						'vertical': 'true'
-					},
-					{
-						'type': 'container',
-						'children': [
-							{
-								'type': 'toolbox',
-								'children': [
-									{
-										'id': 'acceptalltrackedchanges',
-										'type': 'customtoolitem',
-										'text': _UNO('.uno:AcceptAllTrackedChanges', 'text'),
-										'command': '.uno:AcceptAllTrackedChanges',
-										'accessibility': { focusBack: true, combination: 'AL', de: 'AL' }
-									}
-								]
-							},
-							{
-								'type': 'toolbox',
-								'children': [
-									{
-										'id': 'rejectalltrackedchanges',
-										'type': 'customtoolitem',
-										'text': _UNO('.uno:RejectAllTrackedChanges', 'text'),
-										'command': '.uno:RejectAllTrackedChanges',
-										'accessibility': { focusBack: true, combination: 'JL', de: 'JL' }
-									}
-								]
-							}
-						],
-						'vertical': 'true'
+						'id': 'review-reject-tracked-change:RejectTrackedChangesMenu',
+						'type': 'menubutton',
+						'text': _UNO('.uno:RejectTrackedChange', 'text'),
+						'applyCallback': 'rejectTrackedChangeToNext',
+						'command': '.uno:RejectTrackedChangeToNext',
+						'accessibility': { focusBack: true, combination: 'JR', de: 'JR' }
 					},
 					{
 						'type': 'container',

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -1773,6 +1773,42 @@ menuDefinitions.set('RecordTrackedChangesMenu', [
 	},
 ] as Array<MenuDefinition>);
 
+menuDefinitions.set('AcceptTrackedChangesMenu', [
+	{
+		id: 'review-accept-tracked-change',
+		text: _UNO('.uno:AcceptTrackedChange', 'text'),
+		uno: '.uno:AcceptTrackedChange',
+	},
+	{
+		id: 'review-accept-tracked-change-to-next',
+		text: _UNO('.uno:AcceptTrackedChangeToNext', 'text'),
+		uno: '.uno:AcceptTrackedChangeToNext',
+	},
+	{
+		id: 'acceptalltrackedchanges',
+		text: _UNO('.uno:AcceptAllTrackedChanges', 'text'),
+		uno: '.uno:AcceptAllTrackedChanges',
+	},
+] as Array<MenuDefinition>);
+
+menuDefinitions.set('RejectTrackedChangesMenu', [
+	{
+		id: 'review-reject-tracked-change',
+		text: _UNO('.uno:RejectTrackedChange', 'text'),
+		uno: '.uno:RejectTrackedChange',
+	},
+	{
+		id: 'review-reject-tracked-change-to-next',
+		text: _UNO('.uno:RejectTrackedChangeToNext', 'text'),
+		uno: '.uno:RejectTrackedChangeToNext',
+	},
+	{
+		id: 'rejectalltrackedchanges',
+		text: _UNO('.uno:RejectAllTrackedChanges', 'text'),
+		uno: '.uno:RejectAllTrackedChanges',
+	},
+] as Array<MenuDefinition>);
+
 menuDefinitions.set('ConditionalFormatMenu', [
 	{
 		text: _('Highlight cells with...'),

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -705,6 +705,14 @@ class Dispatcher {
 				app.map.sendUnoCommand('.uno:TrackChanges?TrackChanges:bool=false');
 			else app.map.sendUnoCommand('.uno:TrackChangesInAllViews');
 		};
+
+		this.actionsMap['acceptTrackedChangeToNext'] = function () {
+			app.map.sendUnoCommand('.uno:AcceptTrackedChangeToNext');
+		};
+
+		this.actionsMap['rejectTrackedChangeToNext'] = function () {
+			app.map.sendUnoCommand('.uno:RejectTrackedChangeToNext');
+		};
 	}
 
 	private addMobileCommands() {


### PR DESCRIPTION
Change-Id: I1d4b5d25294e84b843307957d6baf792a9d8f340


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- When the screen width is slightly reduced, the Tracking dialog’s changes menu folds prematurely, hiding essential
 action buttons even though there is still enough space to display them.

- To improve usability, the six separate action buttons for  "accept" and "reject" are replaced with two split buttons
 "Accept" and "Reject" allowing all actions to remain accessible  within the available space

### PREVIEW
<img width="1173" height="125" alt="Screenshot from 2025-10-09 11-05-14" src="https://github.com/user-attachments/assets/db92511e-c018-4229-b104-b13d9369a544" />

<img width="1027" height="187" alt="Screenshot from 2025-10-09 11-06-18" src="https://github.com/user-attachments/assets/c26d0fc4-81a8-47fd-b261-6c2923fa3147" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

