### PR TITLE
fix: prevent focus from incorrectly grabbing the container in TreeViewControl

### DIFF
--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -679,7 +679,7 @@ class TreeViewControl {
 		level: number,
 		selectionElement: HTMLInputElement,
 	) {
-		let td, expander, span, text, img, icon, iconId, iconName, link, innerText;
+		let td, expander, span, text, img;
 
 		const rowElements = [];
 
@@ -1687,6 +1687,11 @@ class TreeViewControl {
 		(this._container as any).filterEntries = this.filterEntries.bind(this);
 		(this._container as any).highlightEntries =
 			this.highlightEntries.bind(this);
+
+		// Prevent grab_focus(in executeActionImpl) from focusing the container
+		(this._container as any).onFocus = () => {
+			// no-op: focus is already on the correct row
+		};
 
 		this.setupDragAndDrop(data, builder);
 		this.setupKeyEvents(data, builder);


### PR DESCRIPTION
Change-Id: I9edc342cf38f50689ef32285b045780235c80445

**Preview:**

[Screencast from 2025-10-09 16-13-54.webm](https://github.com/user-attachments/assets/0fc0e66f-dae0-477a-8825-94f7e33dc089)

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

