### PR TITLE
browser: move one "trace event" function to TracingEvents.ts

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -279,6 +279,7 @@ COOL_JS_LST =\
 	src/app/Log.ts \
 	src/app/Debug.ts \
 	src/app/SocketBase.ts \
+	src/app/TracingEvents.ts \
 	src/Leaflet.js \
 	src/errormessages.js \
 	src/unocommands.js \
@@ -1116,6 +1117,7 @@ pot:
 		src/control/jsdialog/Widget.SidebarContainers.ts \
 		src/control/jsdialog/Widget.TreeView.ts \
 		src/app/SocketBase.ts \
+		src/app/TracingEvents.ts \
 		src/core/Socket.js \
 		src/docdispatcher.ts \
 		src/docstate.ts \

--- a/browser/src/app/SocketBase.ts
+++ b/browser/src/app/SocketBase.ts
@@ -44,13 +44,13 @@ class SocketBase {
 	private _renderEventTimerStart: DOMHighResTimeStamp | undefined;
 	private _slurpTimerDelay: number | undefined;
 	private _slurpTimerLaunchTime: number | undefined;
-	private traceEventRecordingToggle: boolean;
 	private timer: ReturnType<typeof setInterval> | undefined;
 	private asyncTraceEventCounter: number;
 	private asyncTracePseudoThread: number;
 	private threadLocalLoggingLevelToggle: boolean;
 
 	private socket?: SockInterface;
+	private traceEvents: TraceEvents;
 
 	constructor(map: MapInterface) {
 		window.app.console.debug('socket.initialize:');
@@ -61,7 +61,6 @@ class SocketBase {
 		this._handlingDelayedMessages = false;
 		this._inLayerTransaction = false;
 		this._slurpDuringTransaction = false;
-		this.traceEventRecordingToggle = false;
 		this.asyncTraceEventCounter = 0;
 		// simulate a threads per live async event to help the chrome
 		// renderer.
@@ -76,5 +75,19 @@ class SocketBase {
 		this._slurpTimerLaunchTime = undefined;
 		this.timer = undefined;
 		this.socket = undefined;
+		this.traceEvents = new TraceEvents(this);
+	}
+
+	// we need typing of this function in TraceEvents.ts
+	public sendMessage(msg: MessageInterface): void {
+		console.assert(false, 'This should not be called!');
+	}
+
+	get traceEventRecordingToggle(): boolean {
+		return this.traceEvents.getRecordingToggle();
+	}
+
+	public setTraceEventLogging(enabled: boolean) {
+		this.traceEvents.setLogging(enabled);
 	}
 }

--- a/browser/src/app/TracingEvents.ts
+++ b/browser/src/app/TracingEvents.ts
@@ -1,0 +1,42 @@
+/* -*- js-indent-level: 8; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+class TraceEvents {
+	private recordingToggle: boolean;
+	private socket: SocketBase;
+
+	constructor(socket: SocketBase) {
+		this.socket = socket;
+		this.recordingToggle = false;
+	}
+
+	public getRecordingToggle(): boolean {
+		return this.recordingToggle;
+	}
+
+	public setLogging(enabled: boolean) {
+		this.recordingToggle = enabled;
+		this.socket.sendMessage(
+			'traceeventrecording ' + (this.recordingToggle ? 'start' : 'stop'),
+		);
+
+		// Just as a test, uncomment this to toggle SAL_WARN and
+		// SAL_INFO selection between two states: 1) the default
+		// as directed by the SAL_LOG environment variable, and
+		// 2) all warnings on plus SAL_INFO for sc.
+		//
+		// (Note that coolwsd sets the SAL_LOG environment variable
+		// to "-WARN-INFO", i.e. the default is that nothing is
+		// logged from core.)
+
+		// app.socket.sendMessage('sallogoverride ' + (app.socket.traceEventRecordingToggle ? '+WARN+INFO.sc' : 'default'));
+	}
+}

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1926,22 +1926,6 @@ app.definitions.Socket = class Socket extends SocketBase {
 		return command;
 	}
 
-	setTraceEventLogging(enabled) {
-		this.traceEventRecordingToggle = enabled;
-		this.sendMessage('traceeventrecording ' + (this.traceEventRecordingToggle ? 'start' : 'stop'));
-
-		// Just as a test, uncomment this to toggle SAL_WARN and
-		// SAL_INFO selection between two states: 1) the default
-		// as directed by the SAL_LOG environment variable, and
-		// 2) all warnings on plus SAL_INFO for sc.
-		//
-		// (Note that coolwsd sets the SAL_LOG environment variable
-		// to "-WARN-INFO", i.e. the default is that nothing is
-		// logged from core.)
-
-		// app.socket.sendMessage('sallogoverride ' + (app.socket.traceEventRecordingToggle ? '+WARN+INFO.sc' : 'default'));
-	}
-
 	_stringifyArgs(args) {
 		return (args == null ? '' : (' args=' + JSON.stringify(args)));
 	}


### PR DESCRIPTION
Other trace event related functions will be moved to TracingEvents.ts in a similar way.

Change-Id: I3c88f760601894f9bcddeb7097b9668f2c625763

* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

