### PR TITLE
git-commit: Skip code formatting check when no Makefile is found

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -131,28 +131,32 @@ sub check_author()
 
 sub check_prettier()
 {
-    my $red = "\033[0;31m";
-    my $reset = "\033[0m";
-    my $hasmake = system("which make > /dev/null 2>&1") == 0;
-    my $hasgmake = system("which gmake > /dev/null 2>&1") == 0;
+    if (-e Makefile) {
+        my $red = "\033[0;31m";
+        my $reset = "\033[0m";
+        my $hasmake = system("which make > /dev/null 2>&1") == 0;
+        my $hasgmake = system("which gmake > /dev/null 2>&1") == 0;
 
-    my $make = $hasgmake? "gmake" : $hasmake? "make" : die  $red .
-                "\n===============================================\n" .
-                "  ERROR: Code formatting check failed\n" .
-                "===============================================\n" .
-                "Please install (gnu) make as `gmake` or `make`\n" .
-                "===============================================\n" .
-                $reset . "\n";
+        my $make = $hasgmake? "gmake" : $hasmake? "make" : die  $red .
+                    "\n===============================================\n" .
+                    "  ERROR: Code formatting check failed\n" .
+                    "===============================================\n" .
+                    "Please install (gnu) make as `gmake` or `make`\n" .
+                    "===============================================\n" .
+                    $reset . "\n";
 
-    system("$make prettier >/dev/null 2>&1") == 0
-        or die $red .
-                "\n===============================================\n" .
-                "  ERROR: Code formatting check failed\n" .
-                "===============================================\n" .
-                "Your code is not properly formatted.\n" .
-                "Please run '$make prettier-write' before committing.\n" .
-                "===============================================\n" .
-                $reset . "\n";
+        system("$make prettier >/dev/null 2>&1") == 0
+            or die $red .
+                    "\n===============================================\n" .
+                    "  ERROR: Code formatting check failed\n" .
+                    "===============================================\n" .
+                    "Your code is not properly formatted.\n" .
+                    "Please run '$make prettier-write' before committing.\n" .
+                    "===============================================\n" .
+                    $reset . "\n";
+    } else {
+        print "Skipping code formatting check, no Makefile found\n"
+    }
 }
 
 # Do the work :-)


### PR DESCRIPTION
...because e.g. we are committing from a source tree that is not used for building (because e.g. the build is done out-of-tree), which previously would have failed with an unhelpful

> ===============================================
>   ERROR: Code formatting check failed
> ===============================================
> Your code is not properly formatted.
> Please run 'gmake prettier-write' before committing.
> ===============================================


Change-Id: I7275467ffddb4a9efaeb0e4415bdded876a7d274


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

