### PR TITLE
browser: provide explicit type for 'this'...

### DIFF
--- a/browser/src/app/TracingEvents.ts
+++ b/browser/src/app/TracingEvents.ts
@@ -83,9 +83,8 @@ class TraceEvents {
 		);
 
 		const sockObj = this.socket;
-		result.finish = function () {
+		result.finish = function (this: CompleteTraceEvent) {
 			sockObj.traceEvents.decrementAsyncPseudoThread();
-			// 'this' is of type CompleteTraceEvent at call-time.
 			if (this.active) {
 				sockObj.sendTraceEvent(
 					name,
@@ -98,7 +97,7 @@ class TraceEvents {
 				this.active = false;
 			}
 		};
-		result.abort = function () {
+		result.abort = function (this: CompleteTraceEvent) {
 			sockObj.traceEvents.decrementAsyncPseudoThread();
 			this.active = false;
 		};


### PR DESCRIPTION
so compiler can type check the function body. At least for me vim+lsp does not autocomplete after 'this.' in the function body without this patch.


Change-Id: Ic44fe45e2a7cf0c50f329abe6d018bd411ba74db


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Provide explicit type for 'this' so the compiler can type check the function body. At least for me vim+lsp does not autocomplete after 'this.' in the function body without this patch.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

