### PR TITLE
Private/rparth07/navigator close button a11y

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -510,16 +510,20 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 
 /* Close Button Styling */
 .close-navigation-button {
-	width: var(--btn-img-size);
-	height: var(--btn-img-size);
+	min-width: auto !important;
+	width: var(--btn-img-size) !important;
+	height: var(--btn-img-size) !important;
+	border: none !important;
 	background-image: url('images/closedoc.svg');
 	background-repeat: no-repeat;
 	background-size: contain;
 	background-position: center;
-	background-color: transparent;
+	background-color: transparent !important;
 	cursor: pointer;
+	padding: 0 !important;
+	margin: 0 !important;
 }
-[data-theme='dark']  .close-navigation-button {
+[data-theme='dark'] .close-navigation-button {
 	background-image: url('images/dark/closedoc.svg');
 }
 
@@ -677,7 +681,7 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 #quickfind-container #quickfindcontrols {
 	position: absolute;
 	top: 0;
-	right: 0;		
+	right: 0;
 }
 
 #quickfind-container #quickfindcontrols button img {

--- a/browser/src/control/Control.NavigatorPanel.ts
+++ b/browser/src/control/Control.NavigatorPanel.ts
@@ -126,7 +126,7 @@ class NavigatorPanel extends SidebarBase {
 
 		// Create the close button inside the div
 		this.closeNavButton = window.L.DomUtil.create(
-			'span',
+			'button',
 			'close-navigation-button',
 			closeNavWrapper,
 		);
@@ -314,7 +314,6 @@ class NavigatorPanel extends SidebarBase {
 				} else {
 					app.map.sendUnoCommand('.uno:Navigator');
 				}
-				// TODO: handle properly keyboard navigation in navigator: ESC to exit, close button
 				this.focusSearch();
 			}.bind(this),
 		);


### PR DESCRIPTION
Navigator close button lack support for keyboard. pressing enter after focusing on it does nothing.

**Expected behavior:**
It should close the navigator.

**Enhancement:**
Ideally pressing Esc should also close the navigator if the focus is inside navigator.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

