### PR TITLE
jsdialog: add activateDefault for Widget.Edit.

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2463,6 +2463,13 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		builder._explorableMenu(parentContainer, title, data.children, builder, content, data.id);
 	},
 
+	// Finds and executes the default action on the built dialog
+	executeDefault: function() {
+		const button = this._container.querySelector('button.button-primary')
+		if (button)
+			button.click();
+	},
+
 	// executes actions like changing the selection without rebuilding the widget
 	executeAction: function(container, data) {
 		app.layoutingService.appendLayoutingTask(() => { this.executeActionImpl(container, data); });

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1996,7 +1996,8 @@ class UIManager extends window.L.Control {
 				type: 'edit',
 				password: !!passwordInput,
 				text: defaultValue,
-				labelledBy: 'info-modal-label1'
+				labelledBy: 'info-modal-label1',
+				activateDefault: true
 			},
 			{
 				id: '',

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -58,6 +58,7 @@ interface JSBuilder {
 		hasVerticalParent: boolean,
 	) => boolean;
 	updateWidget: (parentContainer: Element, updateJSON: any) => void;
+	executeDefault: () => void;
 	executeAction: (parentContainer: Element, actionJSON: any) => void;
 	callback: JSDialogCallback;
 	_defaultCallbackHandler: JSDialogCallback;
@@ -352,6 +353,7 @@ interface EditWidgetJSON extends WidgetJSON {
 	password: boolean; // is password field
 	hidden: boolean; // is hidden, TODO: duplicate?
 	changedCallback: any; // callback  for 'change' event
+	activateDefault: boolean; // activate default action on 'Enter' ?
 }
 
 interface SeparatorWidgetJSON extends WidgetJSON {

--- a/browser/src/control/jsdialog/Widget.Edit.ts
+++ b/browser/src/control/jsdialog/Widget.Edit.ts
@@ -106,7 +106,8 @@ class EditWidget {
 			callbackToUse(this.edit.input.value);
 		else {
 			var eventType = 'change';
-			if (e.key === 'Enter') eventType = 'activate';
+			if (e.key === 'Enter')
+				eventType = 'activate';
 			this.builder.callback(
 				'edit',
 				eventType,
@@ -114,6 +115,8 @@ class EditWidget {
 				this.edit.input.value,
 				this.builder,
 			);
+			if (e.key == 'Enter' && this.data.activateDefault)
+				this.builder.executeDefault();
 		}
 	}
 


### PR DESCRIPTION
Makes eg. launch calc, double-click sheet name, overtype <Enter> much more fluid and expected.

Idealy we would get activateDefault from the core glade files for more jsdialog items in future.


Change-Id: I6bf7da9cf92d0ba77d3fd22ad604775aa6aa37b8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

