### PR TITLE
wsd: fix: ERR Incorrect JSON property [SpellOnline]

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -1915,7 +1915,7 @@ function getInitializerClass() {
 				if (global.deviceFormFactor) {
 					msg += ' deviceFormFactor=' + global.deviceFormFactor;
 				}
-				var spellOnline = window.prefs.get('SpellOnline');
+				var spellOnline = window.prefs.get('spellOnline');
 				if (spellOnline) {
 					msg += ' spellOnline=' + spellOnline;
 				}

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -418,7 +418,7 @@ window.L.Map.include({
 			if (val && (json === undefined || json === null)) {
 				 // because it is toggle, state has to be the opposite
 				var state = !(val === 'true');
-				window.prefs.set('SpellOnline', state);
+				window.prefs.set('spellOnline', state);
 			}
 		}
 

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -229,7 +229,7 @@ app.definitions.Socket = class Socket extends SocketBase {
 			};
 			msg += ' options=' + JSON.stringify(options);
 		}
-		var spellOnline = window.prefs.get('SpellOnline');
+		var spellOnline = window.prefs.get('spellOnline');
 		if (spellOnline) {
 			msg += ' spellOnline=' + spellOnline;
 		}

--- a/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/invalidations_spec.js
@@ -11,7 +11,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Invalidation tests.', func
 		// Turn off SpellChecking by default because grammar checking,
 		// when available, currently adds an extra empty update when
 		// grammar checking kicks in at server-side idle after a change.
-		localStorage.setItem('SpellOnline', false);
+		localStorage.setItem('spellOnline', false);
 		cy.viewport(1920,1080);
 	});
 

--- a/cypress_test/integration_tests/multiuser/calc/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/calc/invalidations_spec.js
@@ -9,7 +9,7 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 		// Turn off SpellChecking by default because grammar checking,
 		// when available, currently adds an extra empty update when
 		// grammar checking kicks in at server-side idle after a change.
-		localStorage.setItem('SpellOnline', false);
+		localStorage.setItem('spellOnline', false);
 		helper.setupAndLoadDocument('calc/invalidations.ods',true);
 		desktopHelper.switchUIToNotebookbar();
 	});

--- a/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/invalidations_spec.js
@@ -26,7 +26,7 @@ describe(['tagmultiuser'], 'Joining a document should not trigger an invalidatio
 		// Turn off SpellChecking by default because grammar checking,
 		// when available, currently adds an extra empty update when
 		// grammar checking kicks in at server-side idle after a change.
-		localStorage.setItem('SpellOnline', false);
+		localStorage.setItem('spellOnline', false);
 		helper.setupAndLoadDocument('writer/invalidations.odt',
 																/* skipDocumentCheck */ true,
 																/* isMulti */ true);


### PR DESCRIPTION
- There is inconsistency on how client sets ui settings/browsersettings.
- It sets most of the properties like 'darkTheme' with 1st letter not capital. But 'SpellOnline' property has 1st letter capital
- This patches makes the naming consitent

Change-Id: I09728def6acd414f340f6254ac18fc3bd1cfe2d0

* Target version: master 