### PR TITLE
accessibility: set isNotebookbar flag in overriddenTabsControlHandler

### DIFF
--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -267,12 +267,12 @@ window.L.Control.NotebookbarBuilder = window.L.Control.JSDialogBuilder.extend({
 	},
 
 	_overriddenTabsControlHandler: function(parentContainer, data, builder) {
+		data.isNotebookbar = true;
 		data.tabs = builder.wizard.getTabs();
 		return builder._tabsControlHandler(parentContainer, data, builder, _('Tap to collapse'));
 	},
 
 	_overriddenTabPageHandler: function(parentContainer, data, builder) {
-		data.isNotebookbar = true;
 		var result = builder._tabPageHandler(parentContainer, data, builder);
 
 		var tabPage = parentContainer.lastChild;


### PR DESCRIPTION
**Context:**
we removed parentize hack from desktop as part of  8d2610ba85ade73e1b79b2e50eb84aed7dc73c9d commit. but accidentally, we added `isNotebookbar: true` flag in _overriddenTabPageHandler instead of _overriddenTabsControlHandler. Due to this, the navigation using arrow keys stopped working. This change will fix above issue.

Change-Id: I9c7481443a6795812a75911b64afeaecdf67f98a

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

