### PR TITLE
fix: move preventDef variable declaration inside keydown event listener to work correctly after selecting the entry.

### DIFF
--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -883,9 +883,9 @@ class TreeViewControl {
 	) {
 		if (entry.enabled === false) return;
 
-		let preventDef = false;
-
 		tr.addEventListener('keydown', (event) => {
+			let preventDef = false;
+
 			if (event.key === ' ' && expander) {
 				expander.click();
 				tr.focus();


### PR DESCRIPTION
**issue:**
as preventDef was declare outside and when we try to select any entry and try to navigate using arrow keys or tab key nothing works and we stuck here

**solution:**
preventDef is incorrectly declared due to which it holds the prior value. This changes will fix this.


Change-Id: I1d7a9b0537441519ca9ca4d598a2da6eb8098e51

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

