### PR TITLE
Make UnitWSD checkTimeout a little less racy

### DIFF
--- a/common/Unit.cpp
+++ b/common/Unit.cpp
@@ -642,6 +642,11 @@ UnitWSD& UnitWSD::get()
     return *globalWSD;
 }
 
+UnitWSD* UnitWSD::getMaybeNull()
+{
+    return GlobalWSD;
+}
+
 void UnitWSD::onExitTest(TestResult result, const std::string&)
 {
     if (haveMoreTests())

--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -410,6 +410,8 @@ public:
 
     static UnitWSD& get();
 
+    static UnitWSD* getMaybeNull();
+
     /// Applies the default config.
     /// This is needed to initialize the logging subsystem early.
     static void defaultConfigure(Poco::Util::LayeredConfiguration& /* config */);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -3910,7 +3910,9 @@ int COOLWSD::innerMain()
         // Unit test timeout
         if (UnitWSD::isUnitTesting() && !SigUtil::getShutdownRequestFlag())
         {
-            UnitWSD::get().checkTimeout(timeSinceStartMs);
+            if (auto const unit = UnitWSD::getMaybeNull()) {
+                unit->checkTimeout(timeSinceStartMs);
+            }
         }
 
 #if !MOBILEAPP


### PR DESCRIPTION
I saw a failed test where the call to UnitWSD::get() in COOLWSD::innerMain caused the

>     assert(globalWSD);

in UnitWSD::get to fire, apparently because a call to UnitWSD::DocBrokerDestroy had already cleared GlobalWSD (see the commit message of a330f9e75717de96c72794d0ac672f75376c9711 "UT Stability: Resolve UnitBase's UnitWSD::get() data-race").

The object pointed to by GlobalWSD should only be destroyed in UnitBase::uninit, so it should be safe to let the new UnitWSD::getMaybeNull pass out a pointer that should not become dangling while it is being used (and which the existing UnitWSD::get apparently doesn't worry about, either).


Change-Id: I8bbedc384f1d064e9d7b790d27b00b2a4db796af


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

