### PR TITLE
jsdialog: use default action on enter inside input modal

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -322,7 +322,7 @@ window.L.Control.JSDialog = window.L.Control.extend({
 		defaultButton.style.display = 'none';
 		defaultButton.onclick = function() {
 			if (instance.defaultButtonId) {
-				var button = instance.form.querySelector('#' + instance.defaultButtonId);
+				const button = instance.form.querySelector('#' + instance.defaultButtonId + ' button');
 				if (button)
 					button.click();
 			}


### PR DESCRIPTION
jsdialog: fix default button action

- we introduced the default button support in
  commit https://github.com/CollaboraOnline/online/commit/e36eabd3588b7759d739a1d9926cb5ba00a276f6

```
  Author: Szymon Kłos <szymon.klos@collabora.com>
  Date:   Fri Dec 10 18:45:35 2021 +0100

    jsdialog: handle default button
    
    - default button is the first button in the form
    - change main container of a dialog into <form>
    - create hidden default button as a first element in the form
```

- but button got additional wrapper due to
  commit https://github.com/CollaboraOnline/online/commit/e02e1df76d8379e4da7e7c87f10c594bc558d6d2
  Introduce Freemium options
  
  with fixed id so it targets root node of a widget in
  commit c4300d027f8ac55a88af6777746e4cf91c36678f
  jsdialog: root node of a widget should have the id

what made the click event target wrong (wrapper, not a button)

This fixes behavior of "enter" pressed when focused inside edit field
in Calc rename input modal