### PR TITLE
slideshow: re-calculate canvas size if the slide has different size

### DIFF
--- a/browser/src/slideshow/LayerDrawing.ts
+++ b/browser/src/slideshow/LayerDrawing.ts
@@ -151,6 +151,22 @@ class LayerDrawing {
 		return this.helper.getSlideInfo(slideHash);
 	}
 
+	private getDocWidth(): number {
+		return this.helper.getDocWidth();
+	}
+
+	private getDocHeight(): number {
+		return this.helper.getDocHeight();
+	}
+
+	private setDocWidth(slideWidth: number): void {
+		this.helper.setDocWidth(slideWidth);
+	}
+
+	private setDocHeight(slideHeight: number): void {
+		this.helper.setDocHeight(slideHeight);
+	}
+
 	public getSlide(slideNumber: number): ImageBitmap {
 		const startSlideHash = this.helper.getSlideHash(slideNumber);
 		return this.slideCache.get(startSlideHash);
@@ -451,6 +467,14 @@ class LayerDrawing {
 		prefetch: boolean = false,
 		compressedLayers: boolean = false,
 	) {
+		if (
+			slideInfo.slideWidth > this.getDocWidth() ||
+			slideInfo.slideHeight > this.getDocHeight()
+		) {
+			this.setDocWidth(slideInfo.slideWidth);
+			this.setDocHeight(slideInfo.slideHeight);
+			this.onUpdatePresentationInfo();
+		}
 		const slideHash = slideInfo.hash;
 		const backgroundRendered = this.drawBackground(slideHash);
 		const masterPageRendered = this.drawMasterPage(slideHash);

--- a/browser/src/slideshow/LayersCompositor.ts
+++ b/browser/src/slideshow/LayersCompositor.ts
@@ -51,6 +51,22 @@ class LayersCompositor extends SlideCompositor {
 		return this.metaPresentation.getSlideInfo(slideHash);
 	}
 
+	public getDocWidth(): number {
+		return this.metaPresentation.getDocWidth();
+	}
+
+	public getDocHeight(): number {
+		return this.metaPresentation.getDocHeight();
+	}
+
+	public setDocWidth(slideWidth: number): void {
+		this.metaPresentation.setDocWidth(slideWidth);
+	}
+
+	public setDocHeight(slideHeight: number): void {
+		this.metaPresentation.setDocHeight(slideHeight);
+	}
+
 	public onUpdatePresentationInfo() {
 		this.layerDrawing.onUpdatePresentationInfo();
 		// TODO: optimize
@@ -81,8 +97,8 @@ class LayersCompositor extends SlideCompositor {
 
 	public getSlideSizePixel() {
 		return [
-			app.twipsToPixels * this.metaPresentation.slideWidth,
-			app.twipsToPixels * this.metaPresentation.slideHeight,
+			app.twipsToPixels * this.metaPresentation.getDocWidth(),
+			app.twipsToPixels * this.metaPresentation.getDocHeight(),
 		];
 	}
 
@@ -110,8 +126,8 @@ class LayersCompositor extends SlideCompositor {
 
 	public computeLayerSize(width: number, height: number) {
 		// compute the slide size in pixel with respect to the current resolution
-		const slideWidth = this.metaPresentation.slideWidth;
-		const slideHeight = this.metaPresentation.slideHeight;
+		const slideWidth = this.metaPresentation.getDocWidth();
+		const slideHeight = this.metaPresentation.getDocHeight();
 		const slideRatio = slideWidth / slideHeight;
 		const resolutionRatio = width / height;
 		if (slideRatio > resolutionRatio) {

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -102,6 +102,8 @@ interface SlideInfo {
 	prev: string;
 	indexInSlideShow?: number;
 	uniqueID: number;
+	slideWidth: number;
+	slideHeight: number;
 }
 
 interface PresentationInfo {
@@ -293,8 +295,8 @@ class SlideShowPresenter {
 		}
 
 		if (event.relativeX !== undefined && event.relativeY !== undefined) {
-			const x = event.relativeX * this._metaPresentation.slideWidth;
-			const y = event.relativeY * this._metaPresentation.slideHeight;
+			const x = event.relativeX * this._metaPresentation.getDocWidth();
+			const y = event.relativeY * this._metaPresentation.getDocHeight();
 
 			const clickedVideo = slideInfo.videos.find((videoInfo) =>
 				this.isPointInVideoArea(videoInfo, x, y),

--- a/browser/src/slideshow/engine/MetaPresentation.ts
+++ b/browser/src/slideshow/engine/MetaPresentation.ts
@@ -97,12 +97,20 @@ class MetaPresentation {
 		return this._numberOfSlides;
 	}
 
-	public get slideWidth(): number {
+	public getDocWidth(): number {
 		return this.docWidth;
 	}
 
-	public get slideHeight(): number {
+	public getDocHeight(): number {
 		return this.docHeight;
+	}
+
+	public setDocWidth(slideWidth: number) {
+		this.docWidth = slideWidth;
+	}
+
+	public setDocHeight(slideHeight: number) {
+		this.docHeight = slideHeight;
 	}
 
 	public getCurrentSlideIndex(): number {

--- a/browser/src/slideshow/engine/SlideShowHandler.ts
+++ b/browser/src/slideshow/engine/SlideShowHandler.ts
@@ -226,8 +226,8 @@ class SlideShowHandler {
 		aCommonParameterSet.nMinDuration = nDuration;
 		aCommonParameterSet.nMinNumberOfFrames =
 			aSlideTransitionHandler.getMinFrameCount();
-		aCommonParameterSet.nSlideWidth = this.theMetaPres.slideWidth;
-		aCommonParameterSet.nSlideHeight = this.theMetaPres.slideHeight;
+		aCommonParameterSet.nSlideWidth = this.theMetaPres.getDocWidth();
+		aCommonParameterSet.nSlideHeight = this.theMetaPres.getDocHeight();
 
 		return new SimpleActivity(
 			aCommonParameterSet,

--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -419,8 +419,8 @@ class SlideShowNavigator {
 			const width = canvas.clientWidth;
 			const height = canvas.clientHeight;
 
-			const x = (aEvent.offsetX / width) * this.theMetaPres.slideWidth;
-			const y = (aEvent.offsetY / height) * this.theMetaPres.slideHeight;
+			const x = (aEvent.offsetX / width) * this.theMetaPres.getDocWidth();
+			const y = (aEvent.offsetY / height) * this.theMetaPres.getDocHeight();
 
 			const shape = slideInfo.interactions.find((shape) =>
 				hitTest(shape.bounds, x, y),
@@ -479,8 +479,8 @@ class SlideShowNavigator {
 					const width = canvas.clientWidth;
 					const height = canvas.clientHeight;
 
-					const x = (aEvent.offsetX / width) * this.theMetaPres.slideWidth;
-					const y = (aEvent.offsetY / height) * this.theMetaPres.slideHeight;
+					const x = (aEvent.offsetX / width) * this.theMetaPres.getDocWidth();
+					const y = (aEvent.offsetY / height) * this.theMetaPres.getDocHeight();
 
 					aEventMultiplexer.notifyMouseMove({ x: x, y: y });
 					return;


### PR DESCRIPTION
so that the slide size does not exceed the canvas size, and it does not fail the following assertions:
```
assert(bufferWidth <= suggestedWidth);
assert(bufferHeight <= suggestedHeight);
```
in ChildSession::renderSlide in case of multiple slide sizes


Change-Id: Ia1a14861dddbd80f64214363c51b5424b7fe1a35


* Resolves: # <!-- related github issue -->
* Target version: master 

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

