### PR TITLE
HideChangeTrackingControls: Hide controls in more places

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -214,7 +214,7 @@ export class Comment extends CanvasSectionObject {
 
 		this.createAuthorTable();
 
-		if (this.sectionProperties.data.trackchange && !this.map.isReadOnlyMode()) {
+		if (this.sectionProperties.data.trackchange && !this.map.isReadOnlyMode() && !app.map['wopi'].HideChangeTrackingControls) {
 			this.createTrackChangeButtons();
 		}
 

--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -54,7 +54,9 @@ window.L.Control.ContextMenu = window.L.Control.extend({
 					  'SpellCheckIgnoreAll', 'LanguageStatus', 'SpellCheckApplySuggestion', 'PageDialog',
 					  'CompressGraphic', 'GraphicDialog', 'InsertCaptionDialog',
 					  'AnimationEffects', 'ExecuteAnimationEffect',
-					  'NextTrackedChange', 'PreviousTrackedChange', 'RejectTrackedChange', 'AcceptTrackedChange', 'ReinstateTrackedChange', 'InsertAnnotation'],
+					  'InsertAnnotation'],
+
+			tracking: ['NextTrackedChange', 'PreviousTrackedChange', 'RejectTrackedChange', 'AcceptTrackedChange', 'ReinstateTrackedChange'],
 
 			text: ['TableInsertMenu',
 				   'InsertRowsBefore', 'InsertRowsAfter', 'InsertColumnsBefore', 'InsertColumnsAfter',
@@ -312,6 +314,7 @@ window.L.Control.ContextMenu = window.L.Control.extend({
 
 				if (commandName !== 'None' &&
 					this.options.whitelist.general.indexOf(commandName) === -1 &&
+					(this._map['wopi'].HideChangeTrackingControls || this.options.whitelist.tracking.indexOf(commandName) === -1) &&
 					!(docType === 'text' && this.options.whitelist.text.indexOf(commandName) !== -1) &&
 					!(docType === 'spreadsheet' && this.options.whitelist.spreadsheet.indexOf(commandName) !== -1) &&
 					!(docType === 'presentation' && this.options.whitelist.presentation.indexOf(commandName) !== -1) &&

--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -2048,7 +2048,7 @@ class Menubar extends window.L.Control {
 				if (type === 'unocommand') { // disable all uno commands
 					// Except the ones listed in allowedViewModeCommands:
 					var allowed = this.options.allowedViewModeCommands.includes(uno);
-					if (!allowed && app.isRedlineManagementAllowed()) {
+					if (!allowed && app.isRedlineManagementAllowed() && !this._map['wopi'].HideChangeTrackingControls) {
 						allowed = this.options.allowedRedlineManagementModeCommands.includes(uno);
 					}
 					if (!allowed) {
@@ -2077,7 +2077,7 @@ class Menubar extends window.L.Control {
 							break;
 						}
 					}
-					if (!allowed && app.isRedlineManagementAllowed())
+					if (!allowed && app.isRedlineManagementAllowed() && !this._map['wopi'].HideChangeTrackingControls)
 						allowed = this.options.allowedRedlineManagementModeActions.includes(id);
 					if (id === 'insertcomment' && (this._map.getDocType() !== 'drawing' && !app.isCommentEditingAllowed()))
 						allowed = false;
@@ -2435,7 +2435,7 @@ class Menubar extends window.L.Control {
 		}
 		if (this._map.isReadOnlyMode() && menuItem.type === 'menu') {
 			var found = this.options.allowedReadonlyMenus.includes(menuItem.id);
-			if (!found && app.isRedlineManagementAllowed())
+			if (!found && app.isRedlineManagementAllowed() && !this._map['wopi'].HideChangeTrackingControls)
 				found = this.options.allowedRedlineManagementMenus.includes(menuItem.id);
 			if (!found)
 				return false;

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -2435,6 +2435,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 	},
 
 	getReviewTab: function() {
+		// Note: when adding track changes elements, consider this._map['wopi'].HideChangeTrackingControls
 		var content = [
 			{
 				'id': 'review-spell-dialog',

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1910,6 +1910,7 @@ window.L.Control.NotebookbarImpress = window.L.Control.NotebookbarWriter.extend(
 	},
 
 	getReviewTab: function() {
+		// Note: when adding track changes elements, consider this._map['wopi'].HideChangeTrackingControls
 		var content = [
 			{
 				'id': 'review-spell-dialog',

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2169,6 +2169,7 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 	},
 
 	getReviewTab: function() {
+		var hideChangeTrackingControls = this._map['wopi'].HideChangeTrackingControls;
 		var content = [
 			{
 				'id': 'review-spelling-and-grammar-dialog',
@@ -2303,8 +2304,8 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 					},
 				]
 			},
-			{ type: 'separator', id: 'review-deletecomment-break', orientation: 'vertical' },
-			{
+			hideChangeTrackingControls ? {} : { type: 'separator', id: 'review-deletecomment-break', orientation: 'vertical' },
+			hideChangeTrackingControls ? {} : {
 				'type': 'overflowgroup',
 				'id': 'review-tracking',
 				'name':_('Tracking'),


### PR DESCRIPTION
Before, the option was checked, and respective elements were hidden
only in MenuBar._checkItemVisibility, meaning that it only worked
for main menu in compact mode.

This change makes it also work in notebookbar, context menus, and
in the comments in 'redlining_as_comments' mode.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: Ibad193cdfe997722302b59f70fb034d89414a63a
