### PR TITLE
browser: avoid TraceEvent name repetition

### DIFF
--- a/browser/src/app/SocketBase.ts
+++ b/browser/src/app/SocketBase.ts
@@ -100,7 +100,7 @@ class SocketBase {
 		name: string,
 		args?: any,
 	): CompleteTraceEvent | null {
-		return this.traceEvents.createAsyncTraceEvent(name, args);
+		return this.traceEvents.createAsync(name, args);
 	}
 
 	public _stringifyArgs(args: any): string {

--- a/browser/src/app/TracingEvents.ts
+++ b/browser/src/app/TracingEvents.ts
@@ -50,10 +50,7 @@ class TraceEvents {
 		// app.socket.sendMessage('sallogoverride ' + (app.socket.traceEventRecordingToggle ? '+WARN+INFO.sc' : 'default'));
 	}
 
-	public createAsyncTraceEvent(
-		name: string,
-		args?: any,
-	): CompleteTraceEvent | null {
+	public createAsync(name: string, args?: any): CompleteTraceEvent | null {
 		if (!this.recordingToggle) return null;
 
 		const result: CompleteTraceEvent = {


### PR DESCRIPTION
'TraceEvent' is implied by the class name of the method createAsync().


Change-Id: I1fbc4ccc4fa3f93a8517ab91c0a854fb9d375156


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
browser: avoid TraceEvent name repetition. 'TraceEvent' is implied by the class name of the method createAsync().

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

