### PR TITLE
Impress: Slide Show: Center align navigation buttons within the slide

### DIFF
--- a/browser/css/progressbar.css
+++ b/browser/css/progressbar.css
@@ -69,6 +69,12 @@
 }
 
 /* slideshow nav btns  */
+.slideshow-nav-container {
+	left: 50% !important;
+	transform: translateX(-50%) !important;
+	background-color: rgba(0, 0, 0, 9.0) !important;
+}
+
 .slideshow-nav-container img {
 	flex: 1 1 25%;
 	margin-inline-start: 5px;


### PR DESCRIPTION
Change-Id: I597aaa9ab23be40ab96fe19e1e26fa10e1715959


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Previously, the navigation buttons were positioned relative to the window edge, often appearing outside the visible slide area
- This change centers the slideshow navigation buttons horizontally within the slide area, ensuring they visually align with the centered slide content.
- Applies a consistent background color to improve contrast and visibility.

### PREVIEWS

#### Laptop
<img width="1920" height="1200" alt="Screenshot from 2025-10-17 19-31-28" src="https://github.com/user-attachments/assets/0aca4ff2-a9ba-4616-8491-bfbd5d7f4c8c" />


#### Large Screen
<img width="2552" height="1431" alt="Screenshot from 2025-10-17 19-32-55" src="https://github.com/user-attachments/assets/7ae6ab48-c762-474c-a298-82ca3dff6c39" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

