### PR TITLE
browser: call TraceEvents.send() directly

### DIFF
--- a/browser/src/app/TracingEvents.ts
+++ b/browser/src/app/TracingEvents.ts
@@ -70,33 +70,20 @@ class TraceEvents {
 		result.active = true;
 		result.args = args;
 
-		this.socket.sendTraceEvent(
-			name,
-			'S',
-			undefined,
-			args,
-			result.id,
-			result.tid,
-		);
+		this.send(name, 'S', undefined, args, result.id, result.tid);
 
-		const sockObj = this.socket;
-		result.finish = function (this: CompleteTraceEvent) {
-			sockObj.traceEvents.decrementAsyncPseudoThread();
-			if (this.active) {
-				sockObj.sendTraceEvent(
-					name,
-					'F',
-					undefined,
-					this.args,
-					this.id,
-					this.tid,
-				);
-				this.active = false;
+		result.finish = () => {
+			// this refers to the current TraceEvents object.
+			this.decrementAsyncPseudoThread();
+			if (result.active) {
+				this.send(name, 'F', undefined, result.args, result.id, result.tid);
+				result.active = false;
 			}
 		};
-		result.abort = function (this: CompleteTraceEvent) {
-			sockObj.traceEvents.decrementAsyncPseudoThread();
-			this.active = false;
+		result.abort = () => {
+			// this refers to the current TraceEvents object.
+			this.decrementAsyncPseudoThread();
+			result.active = false;
 		};
 		return result;
 	}


### PR DESCRIPTION
browser: call TraceEvents.send() directly, avoid wrapper call.

Change-Id: I3ef9b7ba7811bda3324b167997dfcf142381803d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
browser: call TraceEvents.send() directly

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

