### PR TITLE
enable ctrl+p shortcut globally

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -461,6 +461,10 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	private textAreaKeyDown (ev: any): void {
+		if (window.KeyboardShortcuts.processEvent(app.UI.language.fromURL, ev)) {
+			return;
+		}
+
 		if (ev && ev.ctrlKey && ev.key === "Enter") {
 			this.map.mention?.closeMentionPopup(false);
 

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -22,12 +22,12 @@ class Dispatcher {
 	private actionsMap: any = {};
 
 	private addGeneralCommands() {
-		this.actionsMap['save'] = function () {
+		this.actionsMap['save'] = function (source?: string) {
 			// Save only when not read-only.
-			if (!app.map.isReadOnlyMode()) {
+			if (!app.map.isReadOnlyMode() && !app.map['wopi'].HideSaveOption) {
 				app.map.fire('postMessage', {
 					msgId: 'UI_Save',
-					args: { source: 'toolbar' },
+					args: { source: source || 'toolbar' },
 				});
 				if (!app.map._disableDefaultAction['UI_Save']) {
 					app.map.save(

--- a/browser/src/global.d.ts
+++ b/browser/src/global.d.ts
@@ -230,6 +230,7 @@ interface Window {
 		sendPendingBrowserSettingsUpdate(): void;
 		canPersist: boolean;
 	};
+	KeyboardShortcuts: KeyboardShortcuts;
 
 	allowUpdateNotification: boolean;
 	deeplEnabled: boolean;

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -456,20 +456,6 @@ window.L.Map.Keyboard = window.L.Handler.extend({
 				this._map._docLayer._preview.partsFocused = false;
 			}
 		}
-		else if (this._isCtrlKey(ev) && ev.keyCode === this.keyCodes.S) {
-			// Save only when not read-only and when HideSaveOption is false.
-			if (!this._map.isReadOnlyMode() && !this._map['wopi'].HideSaveOption) {
-				this._map.fire('postMessage', {msgId: 'UI_Save', args: { source: 'keyboard' }});
-				if (!this._map._disableDefaultAction['UI_Save']) {
-					this._map.save(
-						false /* An explicit save should terminate cell edit */,
-						false /* An explicit save should save it again */,
-					);
-				}
-			}
-			ev.preventDefault();
-		}
-
 	},
 
 	// _handleKeyEvent - checks if the given keyboard event shall trigger
@@ -854,12 +840,6 @@ window.L.Map.Keyboard = window.L.Handler.extend({
 			// Anyhow, by when editable area is populated with the focused paragraph
 			// we can't select its content or on next editing the content is overwritten.
 			// this._map._textInput.select();
-			return true;
-		case this.keyCodes.P: // p
-			this._map.print();
-			return true;
-		case this.keyCodes.S: // s
-			// Handle save event in globalEventHandler
 			return true;
 		case this.keyCodes.V[DEFAULT]: // v
 		case this.keyCodes.V[MAC]: // v (Safari) needs a separate mapping in keyCodes

--- a/browser/src/map/handler/Map.KeyboardShortcuts.ts
+++ b/browser/src/map/handler/Map.KeyboardShortcuts.ts
@@ -57,6 +57,7 @@ class ShortcutDescriptor {
     key: string | null;
     unoAction: string;
     dispatchAction: string;
+    dispatchData: any;
     viewType: ViewType;
     preventDefault: boolean;
     platform: Platform;
@@ -69,6 +70,7 @@ class ShortcutDescriptor {
         key = null,
         unoAction = null,
         dispatchAction = null,
+        dispatchData = null,
         viewType = null,
         preventDefault = true,
         platform = null,
@@ -111,6 +113,8 @@ class ShortcutDescriptor {
 
         If ommitted, no action will be dispatched when this keybind is pressed */
         dispatchAction?: string,
+        /** The optional data to pass to the sipatcher if dispatchAction is used*/
+        dispatchData?: any,
         /** The view type (Edit or ReadOnly) to restrict this keybind to
 
         If ommitted, the keybind will be active in both Edit and ReadOnly view types */
@@ -145,6 +149,7 @@ class ShortcutDescriptor {
         this.key = key;
         this.unoAction = unoAction;
         this.dispatchAction = dispatchAction;
+        this.dispatchData = dispatchData;
         this.viewType = viewType;
         this.preventDefault = preventDefault;
         this.platform = platform;
@@ -221,7 +226,7 @@ class KeyboardShortcuts {
                 this.map.sendUnoCommand(action);
             } else if (shortcut.dispatchAction) {
                 action = shortcut.dispatchAction;
-                app.dispatcher.dispatch(action);
+                app.dispatcher.dispatch(action, shortcut.dispatchData);
             }
 
             if (shortcut.preventDefault) {
@@ -300,6 +305,8 @@ keyboardShortcuts.definitions.set('default', new Array<ShortcutDescriptor>(
     new ShortcutDescriptor({ eventType: 'keydown', key: 'F1', dispatchAction: 'showhelp' }),
     new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.ALT, key: 'F1', dispatchAction: 'focustonotebookbar' }),
     new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 'f', dispatchAction: 'home-search' }),
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 'p', dispatchAction: 'print' }),
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 's', dispatchAction: 'save', dispatchData: 'keyboard' }),
 
     // Calc.
     new ShortcutDescriptor({ docType: 'spreadsheet', eventType: 'keydown', modifier: Mod.CTRL | Mod.SHIFT, key: 'PageUp' }),
@@ -369,4 +376,4 @@ keyboardShortcuts.definitions.set('de', new Array<ShortcutDescriptor>(
     new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL | Mod.SHIFT, key: '`', preventDefault: false, platform: Platform.MAC }), // Cycle through windows
 ));
 
-(window as any).KeyboardShortcuts = keyboardShortcuts;
+window.KeyboardShortcuts = keyboardShortcuts;

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -72,6 +72,31 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 		cy.cGet('.cool-annotation-autosavelabel').should('be.visible');
 	});
 
+	it('Global opreations without doc focused', function () {
+		cy.getFrameWindow().then(function (win) {
+			cy.spy(win.app.socket, 'sendMessage').as('sendMessage');
+		});
+		cy.getFrameWindow().then(function (win) {
+			cy.stub(win, 'open').as('windowOpen');
+		});
+
+		desktopHelper.insertComment();
+
+		cy.cGet('.cool-annotation-content-wrapper').click();
+
+		cy.cGet('body').type('{ctrl}p');
+
+
+		const downloadAsMessage = 'downloadas ' +
+			'name=print.pdf ' +
+			'id=print ' +
+			'format=pdf ' +
+			'options={\"ExportFormFields\":{\"type\":\"boolean\",\"value\":\"false\"},' +
+			'\"ExportNotes\":{\"type\":\"boolean\",\"value\":\"false\"}}';
+		cy.get('@sendMessage').should('have.been.calledWith', downloadAsMessage);
+		cy.get('@windowOpen').should('be.called');
+	});
+
 });
 
 describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {


### PR DESCRIPTION
Right now our code only captures the print shortcut if the document is
focused, otherwise the browser receives it and tries to print the whole
view. Also while editing a comment the save shortcut is not captured and
the browser tries to save the html page.

To fix that the print ans save shortcut have been moved to the new
Map.KeyboardShortcuts.ts file.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: Iec84e8428c709d3fb4de2fd6dfa7d8aa0c0353d4
(cherry picked from commit 7234171e17260b49211235342839e875d3a614dd)
