### PR TITLE
JSDialog fixes (backport 25.04)

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -316,7 +316,7 @@ window.L.Control.JSDialog = window.L.Control.extend({
 		defaultButton.style.display = 'none';
 		defaultButton.onclick = function() {
 			if (instance.defaultButtonId) {
-				var button = instance.form.querySelector('#' + instance.defaultButtonId);
+				const button = instance.form.querySelector('#' + instance.defaultButtonId + ' button');
 				if (button)
 					button.click();
 			}


### PR DESCRIPTION
* fixes default action on "Enter" in input modals (like rename sheet dialog box)
* Backports of: https://github.com/CollaboraOnline/online/pull/13205