### PR TITLE
Fix MobileApp's insertfile name argument

### DIFF
--- a/browser/src/map/handler/Map.FileInserter.js
+++ b/browser/src/map/handler/Map.FileInserter.js
@@ -184,24 +184,22 @@ window.L.Map.FileInserter = window.L.Handler.extend({
 		if (window.ThisIsAMobileApp) {
 			// Pass the file contents as a base64-encoded parameter in an insertfile message
 			var reader = new FileReader();
-			reader.onload = (function() {
-				return function(e) {
-					var byteBuffer = new Uint8Array(e.target.result);
-					var strBytes = '';
-					for (var i = 0; i < byteBuffer.length; i++) {
-						strBytes += String.fromCharCode(byteBuffer[i]);
-					}
+			reader.onload = function(e) {
+				var byteBuffer = new Uint8Array(e.target.result);
+				var strBytes = '';
+				for (var i = 0; i < byteBuffer.length; i++) {
+					strBytes += String.fromCharCode(byteBuffer[i]);
+				}
 
-					if (type === 'multimedia') {
-						window.postMobileMessage('insertfile name=' + name + ' type=' + type +
-											       ' data=' + window.btoa(strBytes) +
-											       ' width=' + size.width + ' height=' + size.height);
-					} else {
-						window.postMobileMessage('insertfile name=' + name + ' type=' + type +
-											       ' data=' + window.btoa(strBytes));
-					}
-				};
-			})();
+				if (type === 'multimedia') {
+					window.postMobileMessage('insertfile name=' + name + ' type=' + type +
+										       ' data=' + window.btoa(strBytes) +
+										       ' width=' + size.width + ' height=' + size.height);
+				} else {
+					window.postMobileMessage('insertfile name=' + name + ' type=' + type +
+										       ' data=' + window.btoa(strBytes));
+				}
+			};
 			reader.onerror = function(e) {
 				window.postMobileError('Error when reading file: ' + e);
 			};


### PR DESCRIPTION
The insertfile name argument appears to generally be a Date.now() string (cf. all the call sites of _sendFile in browser/src/map/handler/Map.FileInserter.js), but af1bc0bfa5bc1af85d9c457e3b09537973d8a384 "Implement JavaScript parts of inserting an image in a mobile app", for no apparent reason, had started to instead use some actual file name (aFile.name) in this MobileApp scenario---but which causes syntactic issues in the insertfile message when that name contains e.g. a space.


Change-Id: Ie4c02464f09c2ab30b30e7c4ae61dc3fb728f0c8


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

