### PR TITLE
Impress: Remove scrollbar on transitions notebookbar

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -618,7 +618,6 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 /* Transition Tab */
 
 #Transition-container.notebookbar {
-	width: 100%;
 	justify-items: stretch;
 }
 


### PR DESCRIPTION
Change-Id: I511e72ce336ccf1d105b4e74338cd6aacdea4463


* Resolves: #13234
* Target version: master 

### Summary
- The Transitions notebookbar displayed an unnecessary horizontal scrollbar because its width was set to 100% while an additional 5px left padding was applied.

### SUMMARY

#### Before
<img width="1913" height="137" alt="image" src="https://github.com/user-attachments/assets/a89f7dc1-80b5-40f1-a7bf-5946c19c1bc2" />


#### After
<img width="1913" height="137" alt="image" src="https://github.com/user-attachments/assets/81589b13-886e-4bc4-b580-4222200b3b20" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

