### PR TITLE
external clipboard contents not set in NoCapsForKit mode

### DIFF
--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -264,6 +264,23 @@ namespace FileUtil
         return rootPath.toString();
     }
 
+    std::pair<std::string, std::string> buildPathsToJail(bool usingMountNamespaces, bool noCapsForKit,
+                                                         std::string localJailRoot, std::string jailDir)
+    {
+        std::string localDir = FileUtil::buildLocalPathToJail(
+            usingMountNamespaces, localJailRoot, jailDir);
+
+        // This is the location of the file as seen by the kit, the location as
+        // seen inside the jail. Ideally (and typically) noCaps is false, and
+        // the path inside the jail is simply 'jailDir'. But if noCaps is true,
+        // then chroot isn't possible and the jail is forced to work with the
+        // same paths as used outside the jail.
+        if (noCapsForKit)
+            jailDir = localDir;
+
+        return std::make_pair(localDir, jailDir);
+    }
+
     ssize_t read(int fd, void* buf, size_t nbytes)
     {
         char* p = static_cast<char*>(buf);

--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -107,6 +107,12 @@ namespace FileUtil
     /// -> /chroot/tmp/cool-jailId/tmp/user/doc/childId
     std::string buildLocalPathToJail(bool usingMountNamespaces, std::string localJailRoot, std::string jailPath);
 
+    // returns two strings
+    //   the first is the local path to the jailPath under localJailRoot as seen outside the jail
+    //   the second is that path as seen inside the jail, taking into account if capabilities are available.
+    std::pair<std::string, std::string> buildPathsToJail(bool usingMountNamespaces, bool noCapsForKit,
+                                                         std::string localJailRoot, std::string jailDir);
+
     // We work around some of the mess of using the same sources both on the server side and in unit
     // tests with conditional compilation based on BUILDING_TESTS.
 

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -1727,14 +1727,16 @@ bool ClientRequestDispatcher::handleClipboardRequest(const Poco::Net::HTTPReques
         {
             type = DocumentBroker::CLIP_REQUEST_SET;
 
-            std::string clipDir = JAILED_DOCUMENT_ROOT + std::string("clipboards");
             std::string clipName = "setclipboard." + tag;
 
             std::string jailId = docBroker->getJailId();
-            const Poco::Path filePath(FileUtil::buildLocalPathToJail(
-                COOLWSD::EnableMountNamespaces, COOLWSD::ChildRoot + jailId, clipDir));
-            clipFile = filePath.toString() + '/' + clipName;
-            jailClipFile = clipDir + '/' + clipName;
+
+            auto [clipDir, jailDir] = FileUtil::buildPathsToJail(COOLWSD::EnableMountNamespaces, COOLWSD::NoCapsForKit,
+                                                                 COOLWSD::ChildRoot + jailId,
+                                                                 JAILED_DOCUMENT_ROOT + std::string("clipboards"));
+
+            clipFile = clipDir + '/' + clipName;
+            jailClipFile = jailDir + '/' + clipName;
 
             ClipboardPartHandler handler(clipFile);
             Poco::Net::HTMLForm form(request, message, handler);


### PR DESCRIPTION
Change-Id: Ia440589da47f75aba0d3e1e5c337b65044d91bbd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

