### PR TITLE
Backport: Impress: Remove scrollbar on transitions notebookbar

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -606,7 +606,6 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 /* Transition Tab */
 
 #Transition-container.notebookbar {
-	width: 100%;
 	justify-items: stretch;
 }
 


### PR DESCRIPTION
Change-Id: I7f8e0c5a89a9b6246dfd5bfd8ee76d75d7af0114


* Backport: #13240
* Target version: master 

### Summary
- The Transitions notebookbar displayed an unnecessary horizontal scrollbar because its width was set to 100% while an additional 5px left padding was applied.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

