### PR TITLE
Context toolbar: Emphasize z-index level

### DIFF
--- a/browser/css/color-palette-dark.css
+++ b/browser/css/color-palette-dark.css
@@ -48,6 +48,7 @@
 	--color-warning: #eca700;
 	--color-success: #46ba61;
 
+	--color-box-shadow-light: rgba(0, 0, 0, 0.1);
 	--color-box-shadow: rgba(0, 0, 0, 0.5);
 	--color-hyperlink: #1d99f3;
 

--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -50,6 +50,7 @@
 
 	--color-presenter-console-btn-hover: #404040;
 
+	--color-box-shadow-light: rgba(77, 77, 77, 0.1);
 	--color-box-shadow: rgba(77, 77, 77, 0.5);
 	--color-hyperlink: #000080;
 

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -838,10 +838,12 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	padding: 5px;
 	transform: translateY(-105%);
 	z-index: 12;
+	border-radius: var(--border-radius);
 	border: solid var(--color-toolbar-border) 1px;
 	display: grid;
 	opacity: 1;
 	transition: all 0.25s allow-discrete;
+	box-shadow: 0 6px 18px var(--color-box-shadow-light);
 }
 
 #context-toolbar.hidden {


### PR DESCRIPTION
Before this commit the context toolbar had no shadow which was not
helping the visual distinction between that and the document.

Also add border radius so it's consistent with other elements that
float such as comments.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iebaf5334a8d334aa4dd3a70330db2f56e0a531d6
