### PR TITLE
Impress: initialize preview size according to it's page size

### DIFF
--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -231,11 +231,10 @@ window.L.ImpressTileLayer = window.L.CanvasTileLayer.extend({
 		if (statusJSON.width && statusJSON.height && this._documentInfo !== textMsg) {
 			if (statusJSON.partdimensions) {
 				this._partDimensions = [];
-				for (let i = 0; i < this._parts; i++) {
+				for (let i = 0; i < statusJSON.partdimensions.length; i++) {
 					this._partDimensions.push(new cool.SimplePoint(statusJSON.partdimensions[i].width, statusJSON.partdimensions[i].height));
 				}
 			}
-			else this._partDimensions = [];
 
 			app.activeDocument.fileSize = new cool.SimplePoint(statusJSON.width, statusJSON.height);
 
@@ -262,7 +261,7 @@ window.L.ImpressTileLayer = window.L.CanvasTileLayer.extend({
 
 			app.activeDocument.activeView.viewSize = app.activeDocument.fileSize.clone();
 
-			let allPagesResized = !this._partDimensions.length;
+			let allPagesResized = !statusJSON.currentpageresized;
 			this._updateMaxBounds(true, allPagesResized);
 
 			this._viewId = statusJSON.viewid;
@@ -308,7 +307,7 @@ window.L.ImpressTileLayer = window.L.CanvasTileLayer.extend({
 		if (app.file.fileBasedView)
 			TileManager.updateFileBasedView();
 
-		if (this.invalidatePreviewsUponContextChange === true && !statusJSON.partdimensions) {
+		if (this.invalidatePreviewsUponContextChange === true) {
 			this._invalidateAllPreviews();
 			this.invalidatePreviewsUponContextChange = false;
 		}

--- a/kit/KitHelper.hpp
+++ b/kit/KitHelper.hpp
@@ -163,22 +163,24 @@ namespace LOKitHelper
         resultInfo["height"] = std::to_string(height);
         resultInfo["viewid"] = std::to_string(viewId);
 
+        ScopedString values(loKitDocument->pClass->getCommandValues(loKitDocument, ".uno:AllPageSize"));
+        if (values)
+        {
+            Poco::JSON::Parser parser;
+            const auto var = parser.parse(values.get());
+            const auto obj = var.extract<Poco::JSON::Object::Ptr>();
+            if (obj && obj->has("parts"))
+            {
+                const auto parts = obj->getArray("parts");
+                std::ostringstream os;
+                parts->stringify(os);
+                resultInfo["partdimensions"] = os.str();
+            }
+        }
+
         if (diffSizePages)
         {
-            ScopedString values(loKitDocument->pClass->getCommandValues(loKitDocument, ".uno:AllPageSize"));
-            if (values)
-            {
-                Poco::JSON::Parser parser;
-                const auto var = parser.parse(values.get());
-                const auto obj = var.extract<Poco::JSON::Object::Ptr>();
-                if (obj && obj->has("parts"))
-                {
-                    const auto parts = obj->getArray("parts");
-                    std::ostringstream os;
-                    parts->stringify(os);
-                    resultInfo["partdimensions"] = os.str();
-                }
-            }
+            resultInfo["currentpageresized"] = std::to_string(true);
             return MapToJSONString(resultInfo);
         }
 


### PR DESCRIPTION
when loading a document having multiple sized slides, some previews are not rendered properly due to their page being differently sized.

The workaround was to just switch to that page, and the preview would be rendered properly.

This commit makes all parts' sizes available during document load, so that each preview can be set properly. This would also cause some previews to have different size (based on their aspect-ratio) in the slide sorter.


Change-Id: I5de9740f6f65d4dcf41d9010da804111d8561dca

* Target version: master 

### Summary

| **Before:**      | **After:**      |
| ------------- | ------------- |
| <img width="377" height="1212" alt="screenshot_23102025_114116" src="https://github.com/user-attachments/assets/dd3a8d42-3605-4b6c-b2c6-5d161c35cd23" /> | <img width="370" height="1122" alt="screenshot_23102025_114314" src="https://github.com/user-attachments/assets/c410948b-f967-4719-910b-72dd2984c79d" />|



  


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

