### PR TITLE
SslSocket: print ssl error_string in handleSslState

### DIFF
--- a/net/SslSocket.hpp
+++ b/net/SslSocket.hpp
@@ -308,8 +308,12 @@ private:
             const unsigned long bioError = ERR_peek_error();
             if (bioError != 0)
             {
+                const size_t errorStringLength = 256;
+                std::unique_ptr<char[]> errorString = std::make_unique<char[]>(errorStringLength);
+                ERR_error_string_n(bioError, errorString.get(), errorStringLength);
+
                 LOG_DBG("Unexpected SSL error ("
-                        << bioError
+                        << "'" << errorString << "'"
                         << ") after success implies uncleared earlier errors or "
                            "a bug in the SSL library");
                 ERR_clear_error();


### PR DESCRIPTION
So the logs are explicit about the error encountered.

We had errors reported:
https://github.com/CollaboraOnline/online/issues/8440

And I suspected other errors can occur.
Excepts the log don't let the user understand what's going on, or whether this is due to Collabora Online or an SSL configuration issue.

Change-Id: I80e00482eeca0fef8a719c1cc028a20d0b639a6a

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

