### PR TITLE
On Canvas elements: don't use serif on usernames, hyperlink tooltips

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -175,6 +175,7 @@ body {
 	position: fixed;
 }
 #document-container {
+	font-family: var(--cool-font);
 	background-color: var(--color-main-background);
 	position: relative;
 	margin: 0;


### PR DESCRIPTION
And any other element that is a child of document-container.
Add missing font-family.

I have opted for the --cool-font even
thought we have --docs-font that is used in things like
contentControlSection because we now have hyperlink and user names
coexisting with context toolbar and I would rather make sure we don't
use too many different fonts there.

In the future we should probably only have one of those font variables
but that needs analysis and possibly a change that is not safe. So,
for now simply add cool-font to the container seems more reasonable.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I0ce8ff80bd8a6d82227eede421a6703e071ac4e4
