### PR TITLE
fix(coolwsd): prevent duplicate access_token in fetchSettingFile URL

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -2203,7 +2203,21 @@ void FileServerRequestHandler::fetchSettingFile(const Poco::Net::HTTPRequest& re
     }
 
     Poco::URI dicUrl(fileUrl);
-    dicUrl.addQueryParameter("access_token", accessToken);
+    const auto& queryParams = dicUrl.getQueryParameters();
+    bool hasAccessToken = false;
+    for (const auto& param : queryParams)
+    {
+        if (param.first == "access_token")
+        {
+            hasAccessToken = true;
+            LOG_INF("File URL already contains access_token, skipping append");
+            break;
+        }
+    }
+    if (!hasAccessToken)
+    {
+        dicUrl.addQueryParameter("access_token", accessToken);
+    }
     if (noAuthHeader)
     {
         dicUrl.addQueryParameter("no_auth_header", "1");


### PR DESCRIPTION
Change-Id: I815c70916acebcb57b92310cab95366bb8ecc93d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

