### PR TITLE
jsdialog: localize page margin units based on UI language

### DIFF
--- a/browser/src/control/jsdialog/Widget.PageMarginEntry.ts
+++ b/browser/src/control/jsdialog/Widget.PageMarginEntry.ts
@@ -39,6 +39,23 @@ function createPageMarginEntryWidget(data: any, builder: any): HTMLElement {
 	container.setAttribute('role', 'listbox');
 	container.setAttribute('aria-label', _('Page margin options'));
 
+	const lang = window.coolParams.get('lang') || 'en-US';
+	const useImperial = lang === 'en-US';
+	const inchToCm = 2.54;
+
+	function formatLocalized(valueInInches: number): string {
+		let value = valueInInches;
+		let unit = '"';
+		if (!useImperial) {
+			value = valueInInches * inchToCm;
+			unit = ' cm';
+		}
+		const formatted = new Intl.NumberFormat(lang, {
+			maximumFractionDigits: 1,
+		}).format(value);
+		return `${formatted}${unit}`;
+	}
+
 	const onMarginClick = (evt: MouseEvent) => {
 		const elm = evt.currentTarget as HTMLElement;
 		const key = elm.id;
@@ -103,12 +120,12 @@ function createPageMarginEntryWidget(data: any, builder: any): HTMLElement {
 		const topSpan = document.createElement('span');
 		topSpan.textContent = _('Top: {top}').replace(
 			'{top}',
-			`${opt.details.Top}"`,
+			formatLocalized(opt.details.Top),
 		);
 		const leftSpan = document.createElement('span');
 		leftSpan.textContent = _('Left: {left}').replace(
 			'{left}',
-			`${opt.details.Left}"`,
+			formatLocalized(opt.details.Left),
 		);
 		col1.appendChild(topSpan);
 		col1.appendChild(leftSpan);
@@ -118,12 +135,12 @@ function createPageMarginEntryWidget(data: any, builder: any): HTMLElement {
 		const bottomSpan = document.createElement('span');
 		bottomSpan.textContent = _('Bottom: {bottom}').replace(
 			'{bottom}',
-			`${opt.details.Bottom}"`,
+			formatLocalized(opt.details.Bottom),
 		);
 		const rightSpan = document.createElement('span');
 		rightSpan.textContent = _('Right: {right}').replace(
 			'{right}',
-			`${opt.details.Right}"`,
+			formatLocalized(opt.details.Right),
 		);
 		col2.appendChild(bottomSpan);
 		col2.appendChild(rightSpan);


### PR DESCRIPTION
- Switch page margin display from hardcoded inches to locale-aware units.
- For en-US, margins are shown in inches; for all other locales, values are converted to centimeters. Numbers are formatted using locale decimal separators via Intl.NumberFormat.

For en-US:  
<img width="266" height="387" alt="image" src="https://github.com/user-attachments/assets/8e2a7cfb-7f38-48ba-8b8a-41de26c05d1c" />

for en-UK:

<img width="266" height="387" alt="image" src="https://github.com/user-attachments/assets/45a022cf-c0e2-4df4-9d07-2324e4cfce14" />


for de (German):

<img width="266" height="387" alt="image" src="https://github.com/user-attachments/assets/ca0d215e-bc8a-480d-bf68-93b41711a81f" />


Change-Id: I51bf8034eca2086ed2ff4334bcaeb5b5f8eba13b


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

