### PR TITLE
Fix the hyperlink popup glitch

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1895,11 +1895,6 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 			app.sectionContainer.onCursorPositionChanged();
 		}
 
-		this._map.hyperlinkUnderCursor = obj.hyperlink;
-		URLPopUpSection.closeURLPopUp();
-		if (obj.hyperlink && obj.hyperlink.link)
-			URLPopUpSection.showURLPopUP(obj.hyperlink.link, new cool.SimplePoint(app.file.textCursor.rectangle.x1, app.file.textCursor.rectangle.y1));
-
 		if (!this._map.editorHasFocus() && app.file.textCursor.visible && weAreModifier) {
 			// Regain cursor if we had been out of focus and now have input.
 			// Unless the focus is in the Calc Formula-Bar, don't steal the focus.
@@ -1917,6 +1912,15 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 			this.lastCursorPos = app.file.textCursor.rectangle.clone();
 		}
 
+		const isHyperlinkChanged = this._isHyperlinkChanged(obj.hyperlink);
+		this._map.hyperlinkUnderCursor = obj.hyperlink;
+		if (URLPopUpSection.isOpen() && !(obj.hyperlink && obj.hyperlink.link))
+			URLPopUpSection.closeURLPopUp();
+
+		if (obj.hyperlink && obj.hyperlink.link &&
+			( !URLPopUpSection.isOpen() || updateCursor || isHyperlinkChanged))
+			URLPopUpSection.showURLPopUP(obj.hyperlink.link, new cool.SimplePoint(app.file.textCursor.rectangle.x1, app.file.textCursor.rectangle.y1));
+
 		// If modifier view is different than the current view
 		// we'll keep the caret position at the same point relative to screen.
 		this._onUpdateCursor(
@@ -1926,6 +1930,22 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 
 		// Only for reference equality comparison.
 		this._lastVisibleCursorRef = app.file.textCursor.rectangle.clone();
+	},
+
+	_isHyperlinkChanged: function(hyperlink)
+	{
+		// If there is a new hyperlink or existing hyperlink changed or deleted
+		if (hyperlink && hyperlink.link)
+		{
+			if ((this._map.hyperlinkUnderCursor == null || this._map.hyperlinkUnderCursor == undefined) ||
+				(this._map.hyperlinkUnderCursor.link != hyperlink.link ||
+			     this._map.hyperlinkUnderCursor.text != hyperlink.text))
+				return true;
+		}
+		else if (this._map.hyperlinkUnderCursor != null && this._map.hyperlinkUnderCursor != undefined)
+				return true;
+
+		return false;
 	},
 
 	_updateEditor: function(textMsg) {


### PR DESCRIPTION
invalidatecursor call is closing and opening hyperlink popup without any condition. Just checking if link is exist. That causes a flicker.

In this patch we are checking if the popup is open and cursor position changes We should control them before close and open action.


Change-Id: Iec73a5ea8d75871cdd3c87d2610213bbc2ac0f97


* Resolves: #9013
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

