### PR TITLE
Slideshow: include progressbar.css in dist to fix 404 in iframe

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -832,6 +832,7 @@ build-cool: \
 	$(DIST_FOLDER)/device-mobile.css \
 	$(DIST_FOLDER)/device-tablet.css \
 	$(DIST_FOLDER)/device-desktop.css \
+	$(DIST_FOLDER)/progressbar.css \
 	$(DIST_FOLDER)/bundle.js \
 	$(DIST_FOLDER)/cool.html \
 	$(WASM_FILES) \


### PR DESCRIPTION
Change-Id: I06b63a904ab7db29c5eb59b21f136b6d8b48d94c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
The slideshow iframe `slideshow-cypress-iframe` references progressbar.css to style its progress bar and buttons. However, in production, this resulted in a 404 error for /browser/<build-id>/progressbar.css because the file was not available in the dist/ folder. This caused the buttons in the slideshow iframe to appear unstyled, since progressbar.css was bundled into bundle.css

https://github.com/CollaboraOnline/online/blob/4b4cb5ee04e75e33d39da4a49633113746ee220e/browser/src/slideshow/SlideShowPresenter.ts#L833

Now we have progressbar.css loaded in the slideshow-cypress-iframe

<img width="335" height="217" alt="Screenshot from 2025-10-24 15-28-28" src="https://github.com/user-attachments/assets/307b0476-0946-4df1-ba8e-98513faefed6" />



### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

