### PR TITLE
Backport: Slideshow: include progressbar.css in dist to fix 404 in iframe

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -813,6 +813,7 @@ build-cool: \
 	$(DIST_FOLDER)/device-mobile.css \
 	$(DIST_FOLDER)/device-tablet.css \
 	$(DIST_FOLDER)/device-desktop.css \
+	$(DIST_FOLDER)/progressbar.css \
 	$(DIST_FOLDER)/bundle.js \
 	$(DIST_FOLDER)/cool.html \
 	$(WASM_FILES)


### PR DESCRIPTION
Change-Id: I1e151d12be41388129ad83f1a051387b0c2036a7


* Backport: #13283 
* Target version: master 

### Summary
The slideshow iframe (slideshow-cypress-iframe) references progressbar.css to style its progress bar and buttons. However, in production, this resulted in a 404 error for /browser/<build-id>/progressbar.css because the file was not available in the dist/ folder. This caused the buttons in the slideshow iframe to appear unstyled, since progressbar.css was bundled into bundle.css

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

