### PR TITLE
The value of SecondJoinQuit::_viewsActive doesn't need to be preserved

### DIFF
--- a/test/UnitJoinDisconnect.cpp
+++ b/test/UnitJoinDisconnect.cpp
@@ -31,7 +31,6 @@ class SecondJoinQuit : public WopiTestServer
 
     std::size_t _checkFileInfoCount;
     std::size_t _viewCount;
-    std::size_t _viewsActive;
 
 public:
     SecondJoinQuit(const std::string& name, bool earlyQuit)
@@ -40,7 +39,6 @@ public:
         , _earlyQuit(earlyQuit)
         , _checkFileInfoCount(0)
         , _viewCount(0)
-        , _viewsActive(0)
     {
     }
 
@@ -65,8 +63,8 @@ public:
         {
             Poco::JSON::Parser parser0;
             Poco::JSON::Array::Ptr array = parser0.parse(message.substr(9)).extract<Poco::JSON::Array::Ptr>();
-            _viewsActive = array->size();
-            if (_phase == Phase::ModifyDoc && _viewsActive == 1)
+            auto const viewsActive = array->size();
+            if (_phase == Phase::ModifyDoc && viewsActive == 1)
 
             {
                 TRANSITION_STATE(_phase, Phase::Done);


### PR DESCRIPTION
Change-Id: I9bc208660e37997fb6569d7aec685964ba64339a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

