### PR TITLE
Remove second, redundant call of UnitBase::uninit

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4168,15 +4168,6 @@ int COOLWSD::main(const std::vector<std::string>& /*args*/)
         throw;
     }
 
-    const int unitReturnValue = UnitBase::uninit();
-    if (unitReturnValue != EXIT_OK)
-    {
-        // Overwrite the return value if the unit-test failed.
-        LOG_INF("Overwriting process [coolwsd] exit status ["
-                << returnValue << "] with unit-test status: " << unitReturnValue);
-        returnValue = unitReturnValue;
-    }
-
     cleanup(returnValue);
 
     LOG_INF("Process [coolwsd] finished with exit status: " << returnValue);


### PR DESCRIPTION
...which is already unconditionally called in COOLWSD::innerMain.

As Ash said at
<https://matrix.to/#/!ZLwFhFGGuRuiYyBrqf:libera.chat/$1Uk4s8GY631h3GcINW_2WBS8Pgq6P64x6nj9CcSjLnI?via=ericeira.cloud&via=t2bot.io&via=matrix.org>: "There was a scenario (that I can't remember now) that made this necessary. Perhaps an early failure? An exception? But I'm sure it was intentional because it was needed. Perhaps we can simplify it and return it only when needed (this time with a proper comment) ?"


Change-Id: I9fc3c1e4c6f34003d1c8952453438425f16b72b5


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

