### PR TITLE
Use a more specific test

### DIFF
--- a/coolwsd-systemplate-setup
+++ b/coolwsd-systemplate-setup
@@ -142,7 +142,7 @@ find $LOCALBASE/share -name '*.pcf.gz' | xargs rm -f
 
 # Same for /usr/local/share/fonts
 
-if test "$LOCALBASE" != "usr/local/"; then
+if test -d /${LOCALBASE}/local/share/fonts ; then
     mkdir -p $LOCALBASE/local/share || exit 1
     ${CP} -r -p -L /${LOCALBASE}/local/share/fonts $LOCALBASE/local/share
 


### PR DESCRIPTION
In commit c1def507eee4b218f563203a8cb1840ccd0f84dc (Also copy fonts
from /usr/local/share/fonts, 2025-05-02), the check was implemented
to test if LOCALBASE is not /usr/local, because it might be in some
cases. In the (mistakenly created) PR #11815,  vmiklos suggested to
test if the source font directory really exists; that idea seems to
cover the existing test as well.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: Ib2826c764322547f92446e464d12adcfa16033ad
