### PR TITLE
Allow to group/ungroup from context menu

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -54,7 +54,7 @@ window.L.Control.ContextMenu = window.L.Control.extend({
 					  'SpellCheckIgnoreAll', 'LanguageStatus', 'SpellCheckApplySuggestion', 'PageDialog',
 					  'CompressGraphic', 'GraphicDialog', 'InsertCaptionDialog',
 					  'AnimationEffects', 'ExecuteAnimationEffect',
-					  'InsertAnnotation'],
+					  'InsertAnnotation', 'FormatGroup', 'FormatUngroup'],
 
 			tracking: ['NextTrackedChange', 'PreviousTrackedChange', 'RejectTrackedChange', 'AcceptTrackedChange', 'ReinstateTrackedChange'],
 

--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -318,6 +318,7 @@ var unoCommandsArray = {
 	'FormatTitle':{global:{menu:_('Format Title...'),},},
 	'FormatTrendline':{global:{menu:_('Format Trend Line...'),},},
 	'FormatTrendlineEquation':{global:{menu:_('Format Trend Line Equation...'),},},
+	'FormatUngroup':{global:{menu:_('~Ungroup'),},},
 	'FormatWall':{global:{menu:_('Format Wall...'),},},
 	'FormatXErrorBars':{global:{menu:_('Format X Error Bars...'),},},
 	'FormatYErrorBars':{global:{menu:_('Format Y Error Bars...'),},},


### PR DESCRIPTION
- it was possible to group shapes from notebookbar but no way to ungroup
- context menu didn't have the both options
- this patch allows to use them using context menu
- notebookbar entry for ungroup should be introduced later too

[RecApp-2025-10-26-06:22:36.webm](https://github.com/user-attachments/assets/48ff6924-8993-45ab-822f-a572f61d0144)
