### PR TITLE
Fix the scroll issue on focus cell

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -474,7 +474,8 @@ class CanvasSectionContainer {
 	}
 
 	public isDocumentObjectVisible (section: CanvasSectionObject): boolean {
-		return app.isRectangleVisibleInTheDisplayedArea(
+		return section.isAlwaysVisible ||
+			app.isRectangleVisibleInTheDisplayedArea(
 			[
 				Math.round(section.position[0] * app.pixelsToTwips),
 				Math.round(section.position[1] * app.pixelsToTwips),

--- a/browser/src/canvas/CanvasSectionObject.ts
+++ b/browser/src/canvas/CanvasSectionObject.ts
@@ -36,6 +36,7 @@ class CanvasSectionObject {
 	zIndex: number;
 	interactable: boolean = true;
 	isAnimating: boolean = false;
+	isAlwaysVisible: boolean = false;
 	windowSection: boolean = false;
 	sectionProperties: any = {};
 	boundsList: Array<CanvasSectionObject> = []; // The sections those this section can propagate events to. Updated by container.

--- a/browser/src/canvas/sections/FocusCellSection.ts
+++ b/browser/src/canvas/sections/FocusCellSection.ts
@@ -37,6 +37,7 @@ class FocusCellSection extends CanvasSectionObject {
 		this.sectionProperties.rowRectangle = null;
 		this.sectionProperties.maxCol = 268435455;
 		this.sectionProperties.maxRow = 20971124;
+		this.isAlwaysVisible = true;
 	}
 
 	public onCellAddressChanged(): void {
@@ -84,13 +85,13 @@ class FocusCellSection extends CanvasSectionObject {
 
 		this.context.fillRect(
 			0,
-			-this.position[1],
+			-app.calc.cellCursorRectangle.pY1,
 			app.calc.cellCursorRectangle.pWidth,
 			this.sectionProperties.maxCol,
 		);
 
 		this.context.fillRect(
-			-this.position[0],
+			-app.calc.cellCursorRectangle.pX1,
 			0,
 			this.sectionProperties.maxRow,
 			app.calc.cellCursorRectangle.pHeight,
@@ -101,13 +102,13 @@ class FocusCellSection extends CanvasSectionObject {
 
 		this.context.strokeRect(
 			0,
-			-this.position[1],
+			-app.calc.cellCursorRectangle.pY1,
 			app.calc.cellCursorRectangle.pWidth,
 			this.sectionProperties.maxCol,
 		);
 
 		this.context.strokeRect(
-			-this.position[0],
+			-app.calc.cellCursorRectangle.pX1,
 			0,
 			this.sectionProperties.maxRow,
 			app.calc.cellCursorRectangle.pHeight,


### PR DESCRIPTION
Section size was wrong so when we scroll the sheet section seems out of visible area.
In this patch we are using the actaul section size.


Change-Id: I58cdc19c79210ecc1e925c8efd0b3313b68823ef


* Resolves: #12520
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

