### PR TITLE
Impress: restore master slides sidebar in compact mode

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -21,6 +21,11 @@ img.sidebar.ui-image {
 	width: 300px;
 }
 
+#SdMasterPagesDeck .ui-iconview-entry img {
+	width: 90%;
+	height: 44px;
+}
+
 .sidebar.ui-grid {
 	row-gap: 8px;
 }

--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -501,6 +501,7 @@ class Menubar extends window.L.Control {
 				   {type: 'separator'},
 				   {uno: '.uno:ModifyPage'},
 					 {name: _UNO('.uno:SlideChangeWindow', 'presentation', true), id: 'transitiondeck', type: 'action'},
+					 {uno: '.uno:MasterSlidesPanel'},
 					 {uno: '.uno:CustomAnimation'}, // core version
 				   //{name: _UNO('.uno:CustomAnimation', 'presentation', true), id: 'animationdeck', type: 'action'}, // online version
 				])},

--- a/browser/src/control/Control.Sidebar.ts
+++ b/browser/src/control/Control.Sidebar.ts
@@ -45,6 +45,7 @@ class Sidebar extends SidebarBase {
 		const decks = [
 			'PropertyDeck',
 			'SdCustomAnimationDeck',
+			'SdMasterPagesDeck',
 			'NavigatorDeck',
 			'StyleListDeck',
 			'A11yCheckDeck',
@@ -64,6 +65,7 @@ class Sidebar extends SidebarBase {
 
 		if (deckId === 'PropertyDeck') return '.uno:SidebarDeck.PropertyDeck';
 		else if (deckId === 'SdCustomAnimationDeck') return '.uno:CustomAnimation';
+		else if (deckId === 'SdMasterPagesDeck') return '.uno:MasterSlidesPanel';
 		else if (deckId === 'NavigatorDeck') return '.uno:Navigator';
 		else if (deckId === 'StyleListDeck')
 			return '.uno:SidebarDeck.StyleListDeck';

--- a/browser/src/control/Control.TopToolbar.js
+++ b/browser/src/control/Control.TopToolbar.js
@@ -220,6 +220,7 @@ class TopToolbar extends JSDialog.Toolbar {
 			{type: 'toolitem',  id: 'sidebar', text: _UNO('.uno:Sidebar', '', true), command: '.uno:SidebarDeck.PropertyDeck', visible: false},
 			{type: 'toolitem',  id: 'modifypage', text: _UNO('.uno:ModifyPage', 'presentation', true), command: '.uno:ModifyPage', visible: false},
 			{type: 'toolitem',  id: 'customanimation', text: _UNO('.uno:CustomAnimation', 'presentation', true), command: '.uno:CustomAnimation', visible: false},
+			{type: 'toolitem',  id: 'masterslidespanel', text: _UNO('.uno:MasterSlidesPanel', 'presentation', true), command: '.uno:MasterSlidesPanel', visible: false},
 			{type: 'customtoolitem',  id: 'fold', text: _('Hide Menu'), desktop: true, mobile: false, visible: true},
 			{type: 'customtoolitem',  id: 'hamburger-tablet', desktop: false, mobile: false, tablet: true, iosapptablet: false, visible: false},
 		];

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -622,6 +622,10 @@ class UIManager extends window.L.Control {
 					app.socket.sendMessage('uno .uno:SidebarShow');
 					app.socket.sendMessage('uno .uno:CustomAnimation');
 					this.map.sidebar.setupTargetDeck('.uno:CustomAnimation');
+				} else if (this.getBooleanDocTypePref('SdMasterPagesDeck', false)) {
+					app.socket.sendMessage('uno .uno:SidebarShow');
+					app.socket.sendMessage('uno .uno:MasterSlidesPanel');
+					this.map.sidebar.setupTargetDeck('.uno:MasterSlidesPanel');
 				}
 			} else if (showSidebar && this.getBooleanDocTypePref('StyleListDeck', false)) {
 				app.socket.sendMessage('uno .uno:SidebarShow');

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -360,7 +360,8 @@ window.L.Map.include({
 
 		if ((command.startsWith('.uno:Sidebar') && !command.startsWith('.uno:SidebarShow')) ||
 			command.startsWith('.uno:CustomAnimation') || command.startsWith('.uno:ModifyPage') ||
-			command.startsWith('.uno:SidebarDeck') || command.startsWith('.uno:EditStyle')) {
+			command.startsWith('.uno:MasterSlidesPanel') || command.startsWith('.uno:SidebarDeck') || 
+			command.startsWith('.uno:EditStyle')) {
 
 			// sidebar control is present only in desktop/tablet case
 			if (this.sidebar) {

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -432,11 +432,12 @@ window.L.Map.WOPI = window.L.Handler.extend({
 		}
 		else if (msg.MessageId === 'Show_Sidebar') {
 			/* id is optional */
-                        if (msg.Values) {
+			if (msg.Values) {
 				switch (msg.Values.id) {
 				case 'Navigator':
 				case 'ModifyPage':
 				case 'CustomAnimation':
+				case 'MasterSlidesPanel':
 					this._map.sendUnoCommand(`.uno:${msg.Values.id}`);
 					return;
 				}


### PR DESCRIPTION
Change-Id: Idf27dc6eb53cdd68b6a94ff7d207adae88357b63


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- The master slides panel was previously moved from the sidebar to the notebookbar, which caused it to disappear in compact mode.
- This change restores access by adding a Master Slides entry under the View menu.
- Selecting this option reopens the Master Slides sidebar for easier access in compact layouts.
- Standardized the sizing of master slide thumbnails

### PREVIEW

https://github.com/user-attachments/assets/caeafb04-0ca4-493d-9110-d53ff7fba735



- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

