### PR TITLE
Fix: correctly detect imperial units for both 'en' and 'en-US' locales

### DIFF
--- a/browser/src/control/jsdialog/Widget.PageMarginEntry.ts
+++ b/browser/src/control/jsdialog/Widget.PageMarginEntry.ts
@@ -40,7 +40,7 @@ function createPageMarginEntryWidget(data: any, builder: any): HTMLElement {
 	container.setAttribute('aria-label', _('Page margin options'));
 
 	const lang = window.coolParams.get('lang') || 'en-US';
-	const useImperial = lang === 'en-US';
+	const useImperial = lang === 'en-US' || lang === 'en'; // we need to consider both short form as some user can user lang=en-US using document URL
 	const inchToCm = 2.54;
 
 	function formatLocalized(valueInInches: number): string {


### PR DESCRIPTION
Backport https://github.com/CollaboraOnline/online/pull/13305

* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

