### PR TITLE
Avoid Automake warning

### DIFF
--- a/wasm/Makefile.am
+++ b/wasm/Makefile.am
@@ -115,6 +115,8 @@ endif
 # required)":
 online_LDFLAGS += $(if $(filter -g,$(CXXFLAGS)),-Wno-limited-postlink-optimizations)
 
+all_local =
+
 if ENABLE_DEBUG
 
 online_LDFLAGS += \
@@ -125,7 +127,7 @@ online_LDFLAGS += \
 
 online.wasm.debug.wasm: | online$(EXEEXT)
 
-all-local: online.wasm.debug.wasm.dwp
+all_local += online.wasm.debug.wasm.dwp
 
 endif
 
@@ -146,7 +148,9 @@ emscripten-module.js: emscripten-module.js.m4
 		-DENABLE_WASM_ZETAJS=$(ENABLE_WASM_ZETAJS) \
 		-DENABLE_WASM_ZETAJS_EXAMPLE=$(ENABLE_WASM_ZETAJS_EXAMPLE) $< >$@
 
-all-local: emscripten-module.js
+all_local += emscripten-module.js
+
+all-local: $(all_local)
 
 clean-local:
 	rm -f \


### PR DESCRIPTION
> wasm/Makefile.am:148: warning: all-local was already defined in condition ENABLE_DEBUG, which is included in condition TRUE ...
> wasm/Makefile.am:127: ... 'all-local' previously defined here
> wasm/Makefile.am:148: warning: all-local was already defined in condition ENABLE_DEBUG, which is included in condition TRUE ...
> wasm/Makefile.am:127: ... 'all-local' previously defined here


Change-Id: I0e12cc33f191f697b8677003190c3b4645ee2b66


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

