### PR TITLE
[backport] PDF Viewer: hide context menu for read-only mode

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -244,7 +244,7 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 			var isMasterView = this._map['stateChangeHandler'].getItemValue('.uno:SlideMasterPage');
 			var pcw = document.getElementById('presentation-controls-wrapper');
 			var $trigger = $(pcw);
-			if (isMasterView === 'true') {
+			if (isMasterView === 'true' || app.isReadOnly()) {
 				$trigger.contextMenu(false);
 				return;
 			}
@@ -288,7 +288,7 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 		window.L.DomEvent.on(img, 'contextmenu', function(e) {
 			var isMasterView = this._map['stateChangeHandler'].getItemValue('.uno:SlideMasterPage');
 			var $trigger = $('#' + img.id);
-			if (isMasterView === 'true') {
+			if (isMasterView === 'true' || app.isReadOnly()) {
 				$trigger.contextMenu(false);
 				return;
 			}


### PR DESCRIPTION
for the page previews.


Change-Id: Ieed80a5dccfd73e463c4b71c108070f12d8851c7
(cherry picked from commit 6578f31079da43efde4c3a4fec7a31168a527266)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

