### PR TITLE
First tile received should notify even late registered tasks

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -275,12 +275,14 @@ class TileManager {
 		}
 	}
 
-	public static isReceivedFirstTile(): boolean {
-		return this.receivedFirstTile;
-	}
-
 	public static appendAfterFirstTileTask(task: AfterFirstTileTask): void {
-		this.afterFirstTileTasks.push(task);
+		// in case we are already after the first tile -> do in next frame
+		if (this.receivedFirstTile)
+			app.layoutingService.appendLayoutingTask(() => {
+				task();
+			});
+		// wait for it
+		else this.afterFirstTileTasks.push(task);
 	}
 
 	/// Called before frame rendering to update details
@@ -1858,13 +1860,11 @@ class TileManager {
 
 		this.queueAcknowledgement(tileMsgObj);
 
-		if (!this.receivedFirstTile) {
-			// This was the first tile, exec the queued tasks.
-			this.receivedFirstTile = true;
-			while (this.afterFirstTileTasks.length > 0) {
-				const task = this.afterFirstTileTasks.shift();
-				task();
-			}
+		// This was the first tile, exec the queued tasks.
+		this.receivedFirstTile = true;
+		while (this.afterFirstTileTasks.length > 0) {
+			const task = this.afterFirstTileTasks.shift();
+			task();
 		}
 	}
 

--- a/browser/src/control/jsdialog/Util.OnDemandRenderer.ts
+++ b/browser/src/control/jsdialog/Util.OnDemandRenderer.ts
@@ -67,12 +67,9 @@ function onDemandRenderer(
 			observer.observe(placeholder);
 		}
 	};
-	if (TileManager.isReceivedFirstTile()) {
-		setupOnDemandRenderer();
-	} else {
-		// No first tile yet, delay sending the render request.
-		TileManager.appendAfterFirstTileTask(setupOnDemandRenderer);
-	}
+
+	// If no first tile yet, delay sending the render request.
+	TileManager.appendAfterFirstTileTask(setupOnDemandRenderer);
 }
 
 JSDialog.OnDemandRenderer = onDemandRenderer;


### PR DESCRIPTION
Sometimes we got missing style previews which depend on correct initialization notification in ServerConnectionService.ts , there was a case when tile was received earlier than task for "first tile received" was added.

Be sure we call the listeners even if they are late for a first tile.

The notifier was introduced in:

commit f22b8fbfde922f737274038246782d49af993710
cool#12184 browser, icon view: schedule style preview render after first tiles