### PR TITLE
trim docbroker caches when kit memory trims

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1099,6 +1099,8 @@ void Document::trimIfInactive()
     SigUtil::addActivity("trimIfInactive");
     _loKit->trimMemory(4096);
     _deltaGen->dropCache();
+    // Inform docbroker that document has (deep) trimmed memory
+    sendTextFrame("memorytrimmed:");
 }
 
 void Document::trimAfterInactivity()

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -287,6 +287,13 @@ void DocumentBroker::assertCorrectThread(const char* filename, int line) const
     _poll->assertCorrectThread(filename, line);
 }
 
+void DocumentBroker::clearCaches()
+{
+    if (_tileCache)
+        _tileCache->clear();
+    _slideLayerCache.erase_all();
+}
+
 // The inner heart of the DocumentBroker - our poll loop.
 void DocumentBroker::pollThread()
 {
@@ -858,8 +865,7 @@ void DocumentBroker::pollThread()
     COOLWSD::doHousekeeping();
 #endif
 
-    if (_tileCache)
-        _tileCache->clear();
+    clearCaches();
 
     LOG_INF("Finished docBroker polling thread for docKey [" << _docKey << ']');
 }
@@ -4482,6 +4488,10 @@ bool DocumentBroker::handleInput(const std::shared_ptr<Message>& message)
                     COOLWSD::writeTraceEventRecording(message->data().data() + firstLine.size() + 1,
                                                       message->size() - firstLine.size() - 1);
             }
+        }
+        else if (message->firstTokenMatches("memorytrimmed:"))
+        {
+            clearCaches();
         }
 #if ENABLE_DEBUG
         else if (message->firstTokenMatches("unitresult:"))

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -419,6 +419,8 @@ public:
         _cursorHeight = h;
     }
 
+    void clearCaches();
+
     void invalidateTiles(const std::string& tiles, CanonicalViewId canonicalViewId)
     {
         // Remove from cache.


### PR DESCRIPTION
Change-Id: If1f28e20364f6fb26dec43391a955ea0ae2329a0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

