### PR TITLE
use server_signature setting to influence default osinfo

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -823,7 +823,14 @@ bool ClientSession::_handleInput(const char *buffer, int length)
             std::string osVersionInfo(
                 ConfigUtil::getConfigValue<std::string>("per_view.custom_os_info", ""));
             if (osVersionInfo.empty())
-                osVersionInfo = Util::getLinuxVersion();
+            {
+                CONFIG_STATIC const bool sig = ConfigUtil::getBool("security.server_signature", false);
+                // Honour security.server_signature for reporting OS details too
+                if (sig)
+                    osVersionInfo = Util::getLinuxVersion();
+                else
+                    osVersionInfo = "unknown";
+            }
 
             sendTextFrame(std::string("osinfo ") + osVersionInfo);
         }


### PR DESCRIPTION
Change-Id: I237212834603b3df40a806e5ebd18c4d69bfbcc6


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

