### PR TITLE
Make mode lines consistent in .cpp/.hpp files

### DIFF
--- a/clang/plugin.cpp
+++ b/clang/plugin.cpp
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
  * Copyright the Collabora Online contributors.
  *

--- a/clang/test/capture.cpp
+++ b/clang/test/capture.cpp
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 #include <functional>
 
 class C

--- a/clang/test/refcounting.cpp
+++ b/clang/test/refcounting.cpp
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 #include <memory>
 
 class CheckFileInfo

--- a/common/CoolMount.cpp
+++ b/common/CoolMount.cpp
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
  * Copyright the Collabora Online contributors.
  *

--- a/tools/map.cpp
+++ b/tools/map.cpp
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
  * Copyright the Collabora Online contributors.
  *

--- a/tools/mount.cpp
+++ b/tools/mount.cpp
@@ -1,4 +1,4 @@
-/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
  * Copyright the Collabora Online contributors.
  *

--- a/wsd/PlatformDesktop.hpp
+++ b/wsd/PlatformDesktop.hpp
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -33,3 +34,5 @@
 #include <wsd/SpecialBrokers.hpp>
 
 #endif
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/PlatformMobile.hpp
+++ b/wsd/PlatformMobile.hpp
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -23,3 +24,5 @@
 #endif
 
 #endif // MOBILEAPP
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/PlatformUnix.hpp
+++ b/wsd/PlatformUnix.hpp
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -17,3 +18,5 @@
 #endif
 
 #endif
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/SslConfig.hpp
+++ b/wsd/SslConfig.hpp
@@ -1,3 +1,4 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -13,3 +14,5 @@
 #include <Poco/Net/SSLManager.h>
 #include <SslSocket.hpp>
 #endif
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
* Resolves: #13329
* Target version: master 

### Summary

This PR ensures all .cpp/.hpp files have consistent editor modelines (Emacs at top, Vim at end), as specified in issue #13329.

**Changes made:**
- Added Emacs modeline at top for files that were missing it:
  - `clang/plugin.cpp`
  - `clang/test/capture.cpp`
  - `clang/test/refcounting.cpp`
  
- Fixed Emacs modeline (changed `Mode: C` to `Mode: C++`) for:
  - `common/CoolMount.cpp`
  - `tools/map.cpp`
  - `tools/mount.cpp`

- Added both Emacs (top) and Vim (bottom) modelines for:
  - `wsd/PlatformDesktop.hpp`
  - `wsd/PlatformMobile.hpp`
  - `wsd/PlatformUnix.hpp`
  - `wsd/SslConfig.hpp`

All modelines now follow the standard format:
- Emacs: `/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */`
- Vim: `/* vim:set shiftwidth=4 softtabstop=4 expandtab: */`


### TODO

- [x] Add missing Emacs modelines
- [x] Fix incorrect Mode: C to Mode: C++
- [x] Add missing Vim modelines

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

