### PR TITLE
Fix "getCellSimpleRectangle" function result.

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -663,19 +663,11 @@ window.L.Control.JSDialog = window.L.Control.extend({
 
 		if (app.calc.autoFilterCell) {
 			// This is an AutoFilterDialog. We have the row and column indexes. Get cell rectangle with this info.
-			cellRectangle = app.map._docLayer.sheetGeometry.getCellSimpleRectangle(
-				app.calc.autoFilterCell.column,
-				app.calc.autoFilterCell.row,
-				app.getScale()
-			);
+			cellRectangle = app.map._docLayer.sheetGeometry.getCellSimpleRectangle(app.calc.autoFilterCell.column, app.calc.autoFilterCell.row);
 		}
 		else if (app.calc.pivotTableFilterCell) {
 			// This is a pivot table filter dialog. We have the row and column indexes. Get cell rectangle with this info.
-			cellRectangle = app.map._docLayer.sheetGeometry.getCellSimpleRectangle(
-				app.calc.pivotTableFilterCell.column,
-				app.calc.pivotTableFilterCell.row,
-				app.getScale()
-			);
+			cellRectangle = app.map._docLayer.sheetGeometry.getCellSimpleRectangle(app.calc.pivotTableFilterCell.column, app.calc.pivotTableFilterCell.row);
 		}
 		else {
 			// This is a Cell DropDown. We will use current cell's rectangle.

--- a/browser/src/layer/tile/SheetGeometry.ts
+++ b/browser/src/layer/tile/SheetGeometry.ts
@@ -10,7 +10,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-/* global L */
 
 namespace cool {
 
@@ -361,22 +360,11 @@ export class SheetGeometry {
 			this._rows.getSize(unit));
 	}
 
-	// Returns the cell rectangle in SimpleRectangle.
-	public getCellSimpleRectangle(columnIndex: number, rowIndex: number, zoomScale: number = null): cool.SimpleRectangle {
-		var horizPosSize = this._columns.getElementData(columnIndex, zoomScale);
-		var vertPosSize = this._rows.getElementData(rowIndex, zoomScale);
-
-		/*
-			We need to create the SimpleRectangle as if the info is sent from the core side.
-			app.twipsToPixels is used internally in SimpleRectangle. That variable includes the scale. So we divide here to neutralize.
-			And dpiScale is used internally for CSS pixels. So we don't use dpiScale here but 15 const.
-		*/
-		return new cool.SimpleRectangle(
-			horizPosSize.startpos * 15 / zoomScale,
-			vertPosSize.startpos * 15 / zoomScale,
-			horizPosSize.size * 15 / zoomScale,
-			vertPosSize.size * 15 / zoomScale
-		);
+	// Returns the cell rectangle as SimpleRectangle in tile twips.
+	public getCellSimpleRectangle(columnIndex: number, rowIndex: number): cool.SimpleRectangle {
+		const horizPosSize = this._columns.getElementData(columnIndex);
+		const vertPosSize = this._rows.getElementData(rowIndex);
+		return cool.SimpleRectangle.fromCorePixels([horizPosSize.startpos, vertPosSize.startpos, horizPosSize.size, vertPosSize.size]);
 	}
 
 	// Returns the core pixel position/size of the requested cell at a specified zoom.


### PR DESCRIPTION
It was confusing the twip positions. Fixed.

The issue was visible via the features using the function: Autofilter dialog and pivot table filter dialog.


Change-Id: I9b5cfdaa706998503d715a01e1a1eb3bb1894cbb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

