### PR TITLE
cid#551133 Expression with no effect

### DIFF
--- a/browser/admin/src/AdminSocketLog.js
+++ b/browser/admin/src/AdminSocketLog.js
@@ -12,15 +12,13 @@
  * Socket to be intialized on opening the log page in Admin console
  */
 
-/* global Admin $ AdminSocketBase */
+/* global Admin AdminSocketBase */
 
 var AdminSocketLog = AdminSocketBase.extend({
 	_logLines: '',
 
 	constructor: function(host) {
 		this.base(host);
-		// There is a "$" is never used error. Let's get rid of this. This is vanilla script and has not more lines than the one with JQuery.
-		$('#form-channel-list').id;
 	},
 
 	refreshLog: function() {


### PR DESCRIPTION
I feel this line is here to avoid:

  15:17  warning  '$' is defined but never used  no-unused-vars

so we can drop it if we drop importing $


Change-Id: I3ee8121162fbc82bfdb79df57e63c552a6a7c3d0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

