### PR TITLE
cypress: increase wait in writer/sidebar_spec.js to reduce flakiness

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/sidebar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/sidebar_spec.js
@@ -14,7 +14,7 @@ describe(['tagdesktop'], 'Sidebar tests', function() {
 		cy.viewport(1000,660);
 		cy.wait(500); // wait to make fully rendered
 		cy.cGet('#sidebar-dock-wrapper').scrollTo(0,0,{ ensureScrollable: false });
-		cy.wait(500); // wait for animations
+		cy.wait(1000); // wait for animations
 		cy.cGet('#sidebar-dock-wrapper').compareSnapshot('sidebar_writer', 0.07);
 	});
 


### PR DESCRIPTION
Change-Id: Idc8acd4d14149812961ab598fcff9f65194f1917


* Target version: master 

The threshold in `compareSnapshot` should not be increased as it might not catch some visual regresssion.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

