### PR TITLE
fix: adjust grid layout for charset display in Special Characters dialog after iconview converison

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -3001,3 +3001,7 @@ div [id^='themeview'].ui-iconview-entry, div [id^='themeview1col'].ui-iconview-e
 	width: 200px;
 	height: 146px
 }
+
+#SpecialCharactersDialog #showcharset.jsdialog.ui-iconview {
+	grid-template-columns: repeat(16, 1fr);
+}


### PR DESCRIPTION
Requires core patches:
1. https://gerrit.libreoffice.org/c/core/+/193345
2. https://gerrit.libreoffice.org/c/core/+/193346

Change-Id: Ie6f9260514d5493683a098642052c693c614086d

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

