### PR TITLE
fuzz: avoid config in ConfigUtil::getBool()

### DIFF
--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -423,6 +423,11 @@ std::string getString(const std::string& key, const std::string& def)
 
 bool getBool(const std::string& key, const bool def)
 {
+    if constexpr (Util::isFuzzing())
+    {
+        return def;
+    }
+
     assert(Config && "Config is not initialized.");
     return (Config != nullptr) ? Config->getBool(key, def) : def;
 }

--- a/fuzzer/data/crash-c0de3095bea23cfd6ecc78df11bb116fb1810cb3
+++ b/fuzzer/data/crash-c0de3095bea23cfd6ecc78df11bb116fb1810cb3
@@ -1,0 +1,1 @@
+coolclient 0.1


### PR DESCRIPTION
Similar to how e.g. getConfigValue() does the same.

Otherwise we would hit this assert:

    #8 0x7f5402583bb1 in __assert_fail (/lib64/libc.so.6+0x4fbb1) (BuildId: e73f122ac8337391700ae348e766d457a83a7e01)
    #9 0x562b956563d1 in ConfigUtil::getBool(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, bool) /home/collabora/jenkins/workspace/fuzzer-clientsession/common/ConfigUtil.cpp:426:5
    #10 0x562b94ef74d7 in ClientSession::_handleInput(char const*, int) /home/collabora/jenkins/workspace/fuzzer-clientsession/wsd/ClientSession.cpp:827:48
    #11 0x562b955ed519 in Session::handleMessage(std::vector<char, std::allocator<char>> const&) /home/collabora/jenkins/workspace/fuzzer-clientsession/common/Session.cpp:378:13

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ied91343958300cb4195c461e38e6bee92853373c
