### PR TITLE
Notebookbar: Fix toolbar alignments on safari

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -438,6 +438,11 @@ algned to the bottom */
 	margin-bottom: 14px !important;
 }
 
+.unotoolbutton.notebookbar.ui-content.has-label > *:not(.arrowbackground) {
+	height: var(--notebookbar-element-height) !important;
+	align-content: center;
+}
+
 .ui-overflow-manager .notebookbar.ui-overflow-group-container-with-label {
 	justify-content: center;
 }
@@ -1408,10 +1413,6 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	box-sizing: border-box;
 }
 
-.notebookbar .ui-overflow-group-inner {
-	height: var(--notebookbar-element-height);
-	align-content: center;
-}
 
 .ui-overflow-group-label {
 	font-family: var(--jquery-ui-font);

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -218,6 +218,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 .root-container.notebookbar {
 	display: table-cell;
 	vertical-align: middle;
+	align-content: center;
 }
 
 #toolbar-wrapper.hasnotebookbar {
@@ -259,8 +260,10 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	color: var(--color-main-text);
 }
 
-.horizontal.notebookbar:has(.unoBezier_Unfilled) {
-	height: 100%;
+/* Curve isn't in a vertical notebookbar, so it's center-aligned by default instead of top-aligned. 
+	This rule ensures it aligns to the top. */
+.horizontal.notebookbar #insert-illustrations.ui-overflow-group .ui-overflow-group-content,
+.horizontal.notebookbar #insert-illustrations.ui-overflow-group .top-row-overflow-group {
 	align-items: start;
 }
 


### PR DESCRIPTION
Change-Id: I7059c81ff35b975176b0ee65af7e0293b4973810


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Unotoolbuttons with labels had varying heights across browsers, leading to misaligned toolbar elements. This change enforces a consistent height using `--notebookbar-element-height` and centers their content, ensuring uniform alignment in both Chrome and Safari.

### PREVIEWS

**SAFARI**
<img width="1673" height="157" alt="Screenshot 2025-11-04 at 14 34 55" src="https://github.com/user-attachments/assets/cefd07a2-32ba-4831-9cd0-8af7bc4868e8" />

<img width="1673" height="157" alt="Screenshot 2025-11-04 at 14 35 43" src="https://github.com/user-attachments/assets/939b299a-cd8b-43cb-acbe-9f8ed449e9cd" />

<img width="1673" height="157" alt="Screenshot 2025-11-04 at 14 36 10" src="https://github.com/user-attachments/assets/28b0d8fd-0dfe-41d6-95d9-662e1cbf265f" />

**CHROME**
<img width="1915" height="141" alt="image" src="https://github.com/user-attachments/assets/4291c298-f45f-4c49-ab2a-2c57476584b9" />

<img width="1915" height="141" alt="image" src="https://github.com/user-attachments/assets/06a56bc5-bc23-42cf-9d68-b5e39b63568e" />

<img width="1915" height="141" alt="image" src="https://github.com/user-attachments/assets/62daf026-42c8-4d91-b683-c8f7ceb59225" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

