### PR TITLE
cypress: remove double click after copy in undo_redo_spec.js

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/undo_redo_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/undo_redo_spec.js
@@ -12,7 +12,6 @@ describe(['tagdesktop'], 'Editing Operations', function() {
 		impressHelper.dblclickOnSelectedShape();
 		helper.typeIntoDocument('{ctrl+a}');
 		helper.copy();
-		impressHelper.dblclickOnSelectedShape();
 		helper.clipboardTextShouldBeDifferentThan('Hello World');
 	}
 


### PR DESCRIPTION
which seems to make the test more stable.


Change-Id: I863754ffefe8690fcaf634aeefcd165f7539a450


* Resolves: # <!-- related github issue -->
* Target version: master 

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

