### PR TITLE
Scrollbar: prevent double scrollbar in listbox

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2936,7 +2936,7 @@ kbd,
 
 /* Listbox UI grid */
 .jsdialog.ui-grid[role='listbox'] {
-	max-height: 470px;
+	max-height: min(470px, 45vh);
 	overflow-x: hidden;
 	overflow-y: auto;
 }


### PR DESCRIPTION
Change-Id: Ic8a276feb80e05dd2b31f6b1d6f65d42e1c2719e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
 - Changed max-height from fixed 470px to min(470px, 55vh) to ensure the listbox container adapts to viewport size. This prevents the double scrollbar issue that occurred when container height was less than max-height, as the responsive constraint ensures proper overflow behavior across different screen sizes.

### PREVIEW

<img width="789" height="543" alt="image" src="https://github.com/user-attachments/assets/0df25fcd-9d8b-412a-b392-eec636a85ab6" />

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

