### PR TITLE
FakeSocket - add a 'Queued' write wrapper.

### DIFF
--- a/android/lib/src/main/cpp/androidapp.cpp
+++ b/android/lib/src/main/cpp/androidapp.cpp
@@ -222,11 +222,7 @@ Java_org_libreoffice_androidlib_LOActivity_postMobileMessageNative(JNIEnv *env, 
             LOG_DBG("Actually sending to Online:" << fileURL);
 
             // Send the document URL to COOLWSD to setup the docBroker URL
-            struct pollfd pollfd;
-            pollfd.fd = currentFakeClientFd;
-            pollfd.events = POLLOUT;
-            fakeSocketPoll(&pollfd, 1, -1);
-            fakeSocketWrite(currentFakeClientFd, fileURL.c_str(), fileURL.size());
+            fakeSocketWriteQueue(currentFakeClientFd, fileURL.c_str(), fileURL.size());
         }
         else if (strcmp(string_value, "BYE") == 0)
         {
@@ -237,15 +233,7 @@ Java_org_libreoffice_androidlib_LOActivity_postMobileMessageNative(JNIEnv *env, 
         else
         {
             // Send the message to COOLWSD
-            char *string_copy = strdup(string_value);
-
-            struct pollfd pollfd;
-            pollfd.fd = currentFakeClientFd;
-            pollfd.events = POLLOUT;
-            fakeSocketPoll(&pollfd, 1, -1);
-            fakeSocketWrite(currentFakeClientFd, string_copy, strlen(string_copy));
-
-            free(string_copy);
+            fakeSocketWriteQueue(currentFakeClientFd, string_value, strlen(string_value));
         }
     }
     else

--- a/gtk/mobile.cpp
+++ b/gtk/mobile.cpp
@@ -227,15 +227,7 @@ static void handle_cool_message(WebKitUserContentManager *manager,
             // WebSocket.
             LOG_TRC_NOFILE("Actually sending to Online:" << fileURL);
 
-            // Must do this in a thread, too, so that we can return to the GTK+ main loop
-            std::thread([]
-            {
-                struct pollfd pollfd;
-                pollfd.fd = fakeClientFd;
-                pollfd.events = POLLOUT;
-                fakeSocketPoll(&pollfd, 1, -1);
-                fakeSocketWrite(fakeClientFd, fileURL.c_str(), fileURL.size());
-            }).detach();
+            fakeSocketWriteQueue(fakeClientFd, fileURL.c_str(), fileURL.size());
         }
         else if (strcmp(string_value, "BYE") == 0)
         {
@@ -248,17 +240,7 @@ static void handle_cool_message(WebKitUserContentManager *manager,
         }
         else
         {
-            // As above
-            char *string_copy = strdup(string_value);
-            std::thread([=]
-            {
-                struct pollfd pollfd;
-                pollfd.fd = fakeClientFd;
-                pollfd.events = POLLOUT;
-                fakeSocketPoll(&pollfd, 1, -1);
-                fakeSocketWrite(fakeClientFd, string_copy, strlen(string_copy));
-                free(string_copy);
-            }).detach();
+            fakeSocketWriteQueue(fakeClientFd, string_value, strlen(string_value));
         }
         g_free(string_value);
     }

--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -720,10 +720,7 @@ static IMP standardImpOfInputAccessoryView = nil;
         }
 
         const char *buf = [message.body UTF8String];
-        p.fd = self.document->fakeClientFd;
-        p.events = POLLOUT;
-        fakeSocketPoll(&p, 1, -1);
-        fakeSocketWrite(self.document->fakeClientFd, buf, strlen(buf));
+        fakeSocketWriteQueue(self.document->fakeClientFd, buf, strlen(buf));
     } else {
         LOG_ERR("Unrecognized kind of message received from WebView: " << [message.name UTF8String] << ":" << [message.body UTF8String]);
     }

--- a/net/FakeSocket.hpp
+++ b/net/FakeSocket.hpp
@@ -130,4 +130,9 @@ inline int fakeSocketClose(int)
 
 #endif // !MOBILEAPP
 
+inline ssize_t fakeSocketWriteQueue(int fd, const void *buf, size_t nbytes)
+{
+    return fakeSocketWrite(fd, buf, nbytes);
+}
+
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wasm/wasmapp.cpp
+++ b/wasm/wasmapp.cpp
@@ -126,11 +126,7 @@ void handle_cool_message(const char *string_value)
         LOG_TRC_NOFILE("Actually sending to Online:" << fileURL);
         std::cout << "Loading file [" << fileURL << "]" << std::endl;
 
-        struct pollfd pollfd;
-        pollfd.fd = fakeClientFd;
-        pollfd.events = POLLOUT;
-        fakeSocketPoll(&pollfd, 1, -1);
-        fakeSocketWrite(fakeClientFd, fileURL.c_str(), fileURL.size());
+        fakeSocketWriteQueue(fakeClientFd, fileURL.c_str(), fileURL.size());
     }
     else if (strcmp(string_value, "BYE") == 0)
     {
@@ -141,12 +137,7 @@ void handle_cool_message(const char *string_value)
     }
     else
     {
-        // As above
-        struct pollfd pollfd;
-        pollfd.fd = fakeClientFd;
-        pollfd.events = POLLOUT;
-        fakeSocketPoll(&pollfd, 1, -1);
-        fakeSocketWrite(fakeClientFd, string_value, strlen(string_value));
+        fakeSocketWriteQueue(fakeClientFd, string_value, strlen(string_value));
     }
 }
 


### PR DESCRIPTION
In many cases we want an instant 'buffer this message' write, that does a full-write without blocking.

fakeSocketWrite() already does this, and POLLOUT is flagged on every FakeSocket that is not shutdown; nor is there any error handling at any of the call sites. cf. FakeSocket.cpp /checkForPoll/

So wrap this in a #define wrapper for now in case we need to re-introduce a synchronous poll for OUT space.

Ultimately the data stream from the browser is typically of a manageable size, such that we can buffer it all without flow control, and trust to fast event compression on the read side.

Finally remove the extremely unhelpful idea of launching a thread to do each write before it catches on; no need for that raciness, inefficiency and risk of event re-ordering.


Change-Id: I6cbf0c70730cc7cbb644ecf959ddffb73a3c605d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

