### PR TITLE
jsdialog: spinfield: special case setting of step

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -370,14 +370,26 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		if (data.step != undefined) {
 			// we don't want to show error popups due to browser step validation
 			// so be sure all the values will be acceptted, check only precision
-			var step = getPrecision(data.step);
-			var value = data.value ? getPrecision(data.value) : 1;
-			var minStep = getPrecision(data.min);
-			var maxStep = getPrecision(data.max);
 
-			step = Math.min(step, value, minStep, maxStep);
+			// these are set by core when there is no explicit min/max.
+			const noMin = -2147483648;
+			const noMax =  2147483647;
+			if (data.min === noMin && data.max === noMax && data.step === 1) {
+				// This is to allow decimal points in user input
+				// and the step button will increment/decrement
+				// according to current value's precision.
+				$(spinfield).attr('step', 'any');
 
-			$(spinfield).attr('step', step);
+			} else {
+				var step = getPrecision(data.step);
+				var value = data.value ? getPrecision(data.value) : 1;
+				var minStep = getPrecision(data.min);
+				var maxStep = getPrecision(data.max);
+
+				step = Math.min(step, value, minStep, maxStep);
+
+				$(spinfield).attr('step', step);
+			}
 		}
 
 		const isDisabled = data.enabled === false;


### PR DESCRIPTION
If core did not explicitly set min/max and step is 1, allow decimal points in user input by setting step='any'. Actual step will be determined by the browser based on the current input's precision.


Change-Id: I9c61c2dca587ebb200aae2b38354d14611771365


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

