### PR TITLE
Impress: Handle CTRL+C and CTRL+V differently when slide sorter is fo…

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -235,11 +235,6 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 			that.partsFocused = true;
 		};
 
-		img.onblur = function () {
-			that._map._clip.clearSelection();
-			that.partsFocused = false;
-		};
-
 		var that = this;
 		window.L.DomEvent.on(frame, 'contextmenu', function(e) {
 			var isMasterView = this._map['stateChangeHandler'].getItemValue('.uno:SlideMasterPage');

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -415,7 +415,6 @@ window.L.Map.Keyboard = window.L.Handler.extend({
 			return;
 		}
 		else if (this._map._docLayer && (this._map._docLayer._docType === 'presentation' || this._map._docLayer._docType === 'drawing') && this._map._docLayer._preview.partsFocused === true) {
-
 			if (!this.modifier && (ev.keyCode === this.keyCodes.DOWN || ev.keyCode === this.keyCodes.UP ||
 				               ev.keyCode === this.keyCodes.RIGHT || ev.keyCode === this.keyCodes.LEFT ||
 				               ev.keyCode === this.keyCodes.PAGEDOWN || ev.keyCode === this.keyCodes.PAGEUP ||
@@ -440,20 +439,19 @@ window.L.Map.Keyboard = window.L.Handler.extend({
 					this._map.deletePage(this._map._docLayer._selectedPart);
 				}
 				ev.preventDefault();
-				return;
 			}
-			else if (ev.ctrlKey) {
-				if (!ev.altKey && ev.keyCode === this.keyCodes.HOME)
-					this._map.setPart(0);
-				else if (!ev.altKey && ev.keyCode === this.keyCodes.END)
-					this._map.setPart(this._map._docLayer._parts - 1);
-				else {
-					this._handleCtrlCommand(ev);
-					return;
-				}
+			else if (ev.ctrlKey && !ev.altKey && ev.keyCode === this.keyCodes.HOME)
+				app.map.setPart(0);
+			else if (ev.ctrlKey && !ev.altKey && ev.keyCode === this.keyCodes.END)
+				app.map.setPart(app.map._docLayer._parts - 1);
+			else if (ev.ctrlKey && !ev.altKey && this.keyCodes.C.includes(ev.keyCode)) {
+				app.map._clip.clearSelection();
+				app.map._clip.setTextSelectionType('slide');
 			}
-			else {
+			else if (!ev.ctrlKey) {
 				this._map._docLayer._preview.partsFocused = false;
+				app.map._clip.clearSelection();
+				app.map.focus();
 			}
 		}
 	},

--- a/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
@@ -40,6 +40,21 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', functio
 
 	});
 
+	it('Check slide sorter focus', function() {
+		cy.cGet('#insertpage-button').click();
+		cy.wait(100);
+
+		// Set the focus to slide sorter.
+		cy.cGet('#preview-frame-part-0').click();
+		cy.cGet('#preview-frame-part-1').click();
+
+		// Slide sorter should keep focus while user clicks on different slides.
+		cy.window().then(win => {
+			const app = win['0'].app;
+			cy.expect(app.map._docLayer._preview.partsFocused).to.be.equal(true);
+		});
+	});
+
 	it('Duplicate slide', function() {
 		// Also check if comments are getting duplicated
 		desktopHelper.closeNavigatorSidebar();


### PR DESCRIPTION
…cused.

Issue:
    When user clicks on a slide and then performs "CTRL+C", document should send an ".uno:CopySlide" command to the core side.
    But after clicking on a slide, 2 callbacks are fired: "onfocus" and "onblur". Seems that "onblur" fired after the onfocus callback, interestingly.
    This causes slide sorter to lose focus (partsFocused = false). Thus, an ".uno:Copy" command is sent instead of ".uno:CopySlide" command.

Fix:
   onblur event doesn't seem to be reliable for this operation. It is better to handle the copy and paste events in Map.Keyboard code.
   That part already handles other key combinations of slide sorter.
   Also, after declaring that slide sorter lost focus (Map.Keyboard -> partsFocused = false), we need to set the focus to the document.
   Adding that map.focus() call also ensure better user experience.

Also adds a test for slide sorter focus.


Change-Id: I70a4320a44613f7b83c52393bbcb65e904ce55f4


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

