### PR TITLE
Add missing stylepreviewmore darkmode icon

### DIFF
--- a/browser/images/dark/lc_stylepreviewmore.svg
+++ b/browser/images/dark/lc_stylepreviewmore.svg
@@ -1,0 +1,1 @@
+<svg version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m4 4v8h4 1 2 1v-1-1-1-1-1-1-1-0.52539-0.47461h-1-6-1zm1 1h3v1 0.47461 0.52539 1 0.47461 0.52539 1 0.47461 0.52539h-2.293-0.70703v-6zm4 0h2v1h-2v-1zm0 2h2v1h-2v-1zm0 2h2v1h-2v-1z" fill="#FAFAFA"/></svg>


### PR DESCRIPTION
Change-Id: I72213046d3e3191bd33378b72ab077f6618b9b7a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
<img width="685" height="100" alt="Screenshot from 2025-11-06 17-01-47" src="https://github.com/user-attachments/assets/49b7bd88-37cc-4d2d-97df-5c0b32cf5bb3" />


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

