### PR TITLE
jsdialog: Rework the CSS grid layouting

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2581,14 +2581,16 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		control.id = '';
 
 		buildFunc.bind(this)(temporaryParent, [data], false);
-		var backupGridSpan = control.style.gridColumn;
+		var backupGridColSpan = control.style.gridColumn;
+		var backupGridRowSpan = control.style.gridRow;
 
 		control.replaceWith(temporaryParent.firstChild)
 
 		var newControl = container.querySelector('[id=\'' + elementId + '\']');
 		if (newControl) {
 			newControl.scrollTop = scrollTop;
-			newControl.style.gridColumn = backupGridSpan;
+			newControl.style.gridColumn = backupGridColSpan;
+			newControl.style.gridRow = backupGridRowSpan;
 
 			// todo: is that needed? should be in widget impl?
 			if (data.has_default === true && (data.type === 'pushbutton' || data.type === 'okbutton')) {
@@ -2611,6 +2613,37 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		});
 	},
 
+	// Helper to compose the grid style for the row or column with span
+	_composeGridStyle: function(pos, size) {
+		let span, grid;
+		if (size) {
+			span = 'span ' + parseInt(size);
+		}
+		if (pos) {
+			grid = parseInt(pos) + 1;
+		}
+		if (span) {
+			if (grid) {
+				return grid + ' / ' + span;
+			}
+			return span;
+		}
+		return grid;
+	},
+
+	// Helper to set the grid styles for the row and column with span
+	_setGridStyles: function(control, data) {
+		let gridColumn = this._composeGridStyle(data.left, data.width);
+		if (gridColumn) {
+			control.style.gridColumn = gridColumn;
+		}
+
+		let gridRow = this._composeGridStyle(data.top, data.height);
+		if (gridRow) {
+			control.style.gridRow = gridRow;
+		}
+	},
+
 	postProcess: function(parent, data) {
 		if (!parent || !data || !data.id || data.id === '')
 			return;
@@ -2623,8 +2656,8 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 				window.L.DomUtil.addClass(parent, 'hidden');
 		}
 
-		if (control && data.width) {
-			control.style.gridColumn = 'span ' + parseInt(data.width);
+		if (control) {
+			this._setGridStyles(control, data);
 		}
 
 		// natural tab-order when using keyboard navigation
@@ -2743,9 +2776,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 				$(table).addClass('ui-grid-cell');
 
 				// if 'table' has no id - postprocess won't work...
-				if (childData.width) {
-					table.style.gridColumn = 'span ' + parseInt(childData.width);
-				}
+				this._setGridStyles(table, childData);
 
 				var childObject = table;
 

--- a/browser/src/control/jsdialog/Widget.Containers.ts
+++ b/browser/src/control/jsdialog/Widget.Containers.ts
@@ -87,10 +87,6 @@ JSDialog.grid = function (
 
 		for (let col = 0; col < cols; col++) {
 			const child = _getGridChild(data.children, row, col);
-			const isMergedCell =
-				prevChild &&
-				prevChild.width &&
-				parseInt(prevChild.left) + parseInt(prevChild.width) > col;
 
 			if (child) {
 				if (!child.id || child.id === '')
@@ -108,9 +104,6 @@ JSDialog.grid = function (
 
 				processedChildren.push(child);
 				prevChild = child;
-			} else if (!isMergedCell) {
-				// empty placeholder to keep correct order
-				window.L.DomUtil.create('div', 'ui-grid-cell', table);
 			}
 		}
 	}


### PR DESCRIPTION
Now handles the row spans.  The layout explicitely put the CSS grid locations and spans.
    
This fixes some incorrect layout like the 'Insert Manual Break' or the 'Cell Protection' dialogs
It also improves the layout of several other dialogs.



Change-Id: I03920cdedf959f0ee70d72996632bccea163e1c2


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

The CSS grid layout ignored the row span.
Instead we explictely position.

Requires https://gerrit.libreoffice.org/c/core/+/193501 (already on 25.04)

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

