### PR TITLE
two fixes to unocommands.py

### DIFF
--- a/scripts/unocommands.py
+++ b/scripts/unocommands.py
@@ -429,13 +429,24 @@ def writeTranslations(onlineDir, translationsDir, strings):
         f.write('{\n')
 
         writeComma = False
+
         for key in sorted(translations.keys()):
             if writeComma:
                 f.write(',\n')
             else:
                 writeComma = True
+
+            value = translations[key]
+
+            # Remove trailing access keys like " (~T)", they are unused
+            value = re.sub(r' \(~[A-Z]\)', '', value)
+
+            # Sometimes translation contains ~ when source does not, and it may leak
+            if '~' not in key:
+                value = value.replace('~', '')
+
             f.write('"' + key.replace('"', '\\\"') + '":"' +
-                    translations[key].replace('"', '\\\"') + '"')
+                    value.replace('"', '\\\"') + '"')
 
         f.write('\n}\n')
 


### PR DESCRIPTION
- remove the trailing access key like " (~T)" from translations, usually that use non-latin script, because they are unused anyway
- remove ~ character from translations, when the source does not have it, because we saw it leak to other parts of UI by mistake
- we don't remove ~ in general from translations, although they are unused at the moment, we get rid of them when we use the translation


Change-Id: I8080d223d06beba430f5f132c7560291f4b1f5f3


* Resolves: 
<img width="416" height="250" alt="image" src="https://github.com/user-attachments/assets/5c19f786-1546-4968-920b-c50a375d6bae" />

