### PR TITLE
jsdialog: use native events for contextual toolbar

### DIFF
--- a/browser/src/control/Control.ContextToolbar.ts
+++ b/browser/src/control/Control.ContextToolbar.ts
@@ -23,15 +23,16 @@ class ContextToolbar extends JSDialogComponent {
 	disappearingBoundary: number = 150; // px
 	additionalContextButtons: Array<ToolItemWidgetJSON> = [];
 
-	constructor(map: any) {
+	constructor(map: MapInterface) {
 		super(map, 'ContextToolbar', 'notebookbar');
 		this.createBuilder();
 		this.setupContainer(undefined);
+		this.registerMessageHandlers();
 	}
 
 	protected createBuilder() {
 		this.builder = new window.L.control.notebookbarBuilder({
-			windowId: -2,
+			windowId: WindowId.Notebookbar,
 			mobileWizard: this,
 			map: this.map,
 			cssClass: 'notebookbar',
@@ -78,19 +79,13 @@ class ContextToolbar extends JSDialogComponent {
 			this.initialized = true;
 		}
 
-		this.registerMessageHandlers();
-
 		document.addEventListener('pointermove', this.pointerMove);
-		this.map.on('commandstatechanged', this.onCommandStateChanged, this);
 		this.changeOpacity(1);
 		this.showHideToolbar(true);
 	}
 
 	hideContextToolbar(): void {
-		this.unregisterMessageHandlers();
-
 		document.removeEventListener('pointermove', this.pointerMove);
-		this.map.off('commandstatechanged', this.onCommandStateChanged, this);
 		this.showHideToolbar(false);
 	}
 
@@ -408,20 +403,5 @@ class ContextToolbar extends JSDialogComponent {
 
 	changeOpacity(opacity: number) {
 		this.container.style.opacity = opacity.toString();
-	}
-
-	onCommandStateChanged(e: any): void {
-		var commandName = e.commandName;
-		if (commandName === '.uno:CharFontName') {
-			const control: any = this.container.querySelector('#fontnamecombobox');
-			if (control && typeof control.onSetText === 'function') {
-				control.onSetText(e.state);
-			}
-		} else if (commandName === '.uno:FontHeight') {
-			const control: any = this.container.querySelector('#fontsizecombobox');
-			if (control && typeof control.onSetText === 'function') {
-				control.onSetText(e.state);
-			}
-		}
 	}
 }


### PR DESCRIPTION
- do not register additional state change listeners to
  manually update state of the widgets
- we should just handle it in JSDialog natively
- we need to listen even if toolbar is not visible,
  so we update model and be ready to show updated
  version when needed

Steps to reproduce bug in Impress:
-    Activate textbox
-    Set one word with different font than rest of the text
-    Select full text
-    change font using sidebar

Result: contextual toolbar always show empty font name
Expected: it shows the same font as notebookbar and sidebar