### PR TITLE
cypress: do not retry getBoundingClientRect() in removeShapeSelection()

### DIFF
--- a/cypress_test/integration_tests/common/impress_helper.js
+++ b/cypress_test/integration_tests/common/impress_helper.js
@@ -119,21 +119,19 @@ function removeShapeSelection() {
 	cy.log('>> removeShapeSelection - start');
 
 	// Remove selection with clicking on the top-left corner of the slide
-	cy.waitUntil(function() {
-		cy.cGet('.leaflet-canvas-container canvas')
-			.then(function(items) {
-				var XPos = items[0].getBoundingClientRect().left + 10;
-				var YPos = items[0].getBoundingClientRect().top + 10;
-				cy.cGet('body').click(XPos, YPos);
-				cy.cGet('body').type('{esc}');
-				cy.cGet('body').type('{esc}');
-			});
+	cy.cGet('.leaflet-canvas-container canvas')
+		.then(function(items) {
+			var XPos = items[0].getBoundingClientRect().left + 10;
+			var YPos = items[0].getBoundingClientRect().top + 10;
+			cy.cGet('body').click(XPos, YPos);
+			cy.cGet('body').type('{esc}');
+			cy.cGet('body').type('{esc}');
+		});
 
-		return cy.cGet('#document-container')
-			.then(function(overlay) {
-				return overlay.children('svg').length === 0;
-			});
-	});
+	cy.cGet('#document-container')
+		.should(function(overlay) {
+			expect(overlay.children('svg').length).to.equal(0);
+		});
 
 	cy.cGet('.leaflet-drag-transform-marker').should('not.exist');
 


### PR DESCRIPTION
This likely fixes the custom chromium renderer crash


Change-Id: I656346ac664a5a8a41f41b9ed6bed7d8dc395890

* Target version: master 

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

