### PR TITLE
Handle image/png type on paste from external source

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -1068,6 +1068,15 @@ window.L.Clipboard = window.L.Class.extend({
 				return;
 			}
 			this._navigatorClipboardGetTypeCallback(clipboardContent, blob, 'text/plain');
+		} else if (clipboardContent.types.includes('image/png')) {
+			let blob;
+			try {
+				blob = await clipboardContent.getType('image/png');
+			} catch (error) {
+				window.app.console.log('clipboardContent.getType(image/png) failed: ' + error.message);
+				return;
+			}
+			this._navigatorClipboardGetTypeCallback(clipboardContent, blob, 'image/png');
 		} else {
 			window.app.console.log('navigator.clipboard has no text/html or text/plain');
 			return;


### PR DESCRIPTION
Copy an image from desktop app and paste into the document via context menu or Paste button at the top toolbar was not working.

So we improved the clipboard read code with this patch.


Change-Id: Ie29644d729e9110cadf3119b32b9364ca300baba


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

