### PR TITLE
jsdialog: Some placeholders are still necessary in grid

### DIFF
--- a/browser/src/control/jsdialog/Widget.Containers.ts
+++ b/browser/src/control/jsdialog/Widget.Containers.ts
@@ -87,6 +87,10 @@ JSDialog.grid = function (
 
 		for (let col = 0; col < cols; col++) {
 			const child = _getGridChild(data.children, row, col);
+			const isMergedCell =
+				prevChild &&
+				prevChild.width &&
+				parseInt(prevChild.left) + parseInt(prevChild.width) > col;
 
 			if (child) {
 				if (!child.id || child.id === '')
@@ -104,6 +108,9 @@ JSDialog.grid = function (
 
 				processedChildren.push(child);
 				prevChild = child;
+			} else if (!isMergedCell) {
+				// empty placeholder to keep correct layout in some cases.
+				window.L.DomUtil.create('div', 'ui-grid-cell', table);
 			}
 		}
 	}


### PR DESCRIPTION
Notable for the Formula Wizard


Change-Id: Ifa2f6a7f67f7ed02537618a02ad73375b3eb4a1f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Revert some of the change in #13388 that happen to be needed in this case.

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

