### PR TITLE
fix(browserstack): Specify provisioning profile

### DIFF
--- a/ios/MobileUITests/ExportOptions.plist
+++ b/ios/MobileUITests/ExportOptions.plist
@@ -6,5 +6,10 @@
   <string>release-testing</string>
   <key>uploadSymbols</key>
   <true/>
+  <key>provisioningProfiles</key>
+  <dict>
+    <key>com.collabora.office.Mobile</key>
+    <string>Browserstack distribution</string>
+  </dict>
 </dict>
 </plist>


### PR DESCRIPTION
To export an archive from xcodebuild, you need a provisioning profile.

In my testing environment, I was logged into xcode - so it generated one for me and picked it automatically. In CI, xcode won't pick up on a certificate it didn't generate automatically, so we need to specify one here manually...


Change-Id: I077867212040528bbb12d3f1d86078c76a6a6964


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

