### PR TITLE
browser: fix changes to numeric values

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -246,12 +246,12 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		var charCode = (typeof e.which == 'undefined') ? e.keyCode : e.which;
 		var charStr = String.fromCharCode(charCode);
 		var regex = new RegExp('^[0-9\\' + this._decimal + '\\' + this._minusSign + ']+$');
-		if (!charStr.match(regex))
+		if (!charStr.match(regex) && charCode !== 13)
 			return e.preventDefault();
 
 		var value = e.target.value;
 		if (!value)
-			return e.preventDefault();
+			return;
 
 		// no dup
 		if (this._decimal === charStr || this._minusSign === charStr) {
@@ -424,7 +424,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 	},
 
 	listenNumericChanges: function (data, builder, controls, customCallback) {
-		controls.spinfield.addEventListener('input', function() {
+		controls.spinfield.addEventListener('change', function() {
 			if (!this.checkValidity())
 				return;
 


### PR DESCRIPTION
"The 'input' event listener fires after the user inputs a valid number.

Change-Id: I3c50010a22de1f8abb1ac54875a3dc6d1b4f3662


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

