### PR TITLE
Backport: Scrollbars: prevent double scrollbar in listbox

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2936,7 +2936,7 @@ kbd,
 
 /* Listbox UI grid */
 .jsdialog.ui-grid[role='listbox'] {
-	max-height: 470px;
+	max-height: min(470px, 45vh);
 	overflow-x: hidden;
 	overflow-y: auto;
 }


### PR DESCRIPTION
Change-Id: Ia5235229c3263be717f67a36020170be3c6f2283


* Backport: #13373 
* Target version: master 

### Summary
- Changed max-height from fixed 470px to min(470px, 45vh) to ensure the listbox container adapts to viewport size. This prevents the double scrollbar issue that occurred when container height was less than max-height, as the responsive constraint ensures proper overflow behavior across different screen sizes.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

