### PR TITLE
wsd: do not send load failure a second time (Backport)

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -971,8 +971,8 @@ bool ChildSession::loadDocument(const StringVector& tokens)
     const bool loaded = _docManager->onLoad(getId(), getJailedFilePathAnonym(), renderOpts);
     if (!loaded || _viewId < 0)
     {
+        // Failed and communicated with the reason; do not send errors to the client.
         LOG_ERR("Failed to get LoKitDocument instance for [" << getJailedFilePathAnonym() << ']');
-        sendTextFrameAndLogError("error: cmd=load kind=faileddocloading");
         return false;
     }
 


### PR DESCRIPTION
When we fail to load, it could be because
of a password is needed. In that case,
we should not send a failure error as
we've already communicated that we need
a password. This broke the password-
protected document support.

Change-Id: I12c2e13a0ae9b4c66fee8d25d2b79ef946a73e84
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
(cherry picked from commit 4085768cbc1a714d790385824b792c9b5cedc20e)
