### PR TITLE
issue#9176: show arrows for autofilter submenu [for co-25.04 branch]

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -47,6 +47,11 @@
 	padding-right: 5px;
 }
 
+div.ui-treeview-icon-column {
+	height: 100%;
+	text-align: right;
+}
+
 #AcceptRejectChangesDialog {
 	width: max-content;
 	max-width: 1000px;
@@ -1608,9 +1613,10 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	display: none;
 }
 
-/* hide arrow icons in the autofilter menu*/
-#menu img.jsdialog.autofilter.ui-treeview-checkbox {
-	display: none;
+/* border-less arrow icons in the autofilter menu */
+#menu img.jsdialog.autofilter.ui-treeview-checkbox.ui-treeview-image {
+	display: inline;
+	outline: none;
 }
 
 /* Word count dialog */


### PR DESCRIPTION
Change-Id: I216d1dde33986b190ed1456a617ac077e1f2a6eb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

