### PR TITLE
Backport: Notebookbar: Fix alignment inconsistencies for labeled unotoolbuttons

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -438,6 +438,11 @@ algned to the bottom */
 	margin-bottom: 14px !important;
 }
 
+.unotoolbutton.notebookbar.ui-content.has-label > *:not(.arrowbackground) {
+	height: var(--notebookbar-element-height) !important;
+	align-content: center;
+}
+
 .ui-overflow-manager .notebookbar.ui-overflow-group-container-with-label {
 	justify-content: center;
 }
@@ -1406,11 +1411,6 @@ input[type='number']:hover::-webkit-outer-spin-button {
 	padding: 0 5px;
 	width: 100%;
 	box-sizing: border-box;
-}
-
-.notebookbar .ui-overflow-group-inner {
-	height: var(--notebookbar-element-height);
-	align-content: center;
 }
 
 .ui-overflow-group-label {

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -218,6 +218,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 .root-container.notebookbar {
 	display: table-cell;
 	vertical-align: middle;
+	align-content: center;
 }
 
 #toolbar-wrapper.hasnotebookbar {
@@ -259,8 +260,10 @@ html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
 	color: var(--color-main-text);
 }
 
-.horizontal.notebookbar:has(.unoBezier_Unfilled) {
-	height: 100%;
+/* Curve isn't in a vertical notebookbar, so it's center-aligned by default instead of top-aligned. 
+	This rule ensures it aligns to the top. */
+.horizontal.notebookbar #insert-illustrations.ui-overflow-group .ui-overflow-group-content,
+.horizontal.notebookbar #insert-illustrations.ui-overflow-group .top-row-overflow-group {
 	align-items: start;
 }
 


### PR DESCRIPTION
Change-Id: I21643fc143ff5e2dd63f2b228b80615d28cf4597


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Unotoolbuttons with labels had varying heights across browsers, leading to misaligned toolbar elements. This change enforces a consistent height using `--notebookbar-element-height` and centers their content, ensuring uniform alignment in both Chrome and Safari.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

