### PR TITLE
always use json for sliderenderingcomplete messages

### DIFF
--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -1287,9 +1287,9 @@ app.definitions.Socket = class Socket extends SocketBase {
 			if (app.isExperimentalMode()) {
 				SlideBitmapManager.handleSlideRenderingComplete(e);
 			} else {
-				const status = textMsg.substring('sliderenderingcomplete:'.length + 1);
+				const json = JSON.parse(textMsg.substring('sliderenderingcomplete:'.length + 1));
 				this._map.fire('sliderenderingcomplete', {
-					success: status === 'success'
+					success: json.status === 'success'
 				});
 			}
 			return;

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2477,9 +2477,11 @@ bool ChildSession::renderNextSlideLayer(SlideCompressor& scomp, const unsigned w
             std::string json = jsonMsg;
             Poco::JSON::Parser parser;
             Poco::JSON::Object::Ptr root = parser.parse(json).extract<Poco::JSON::Object::Ptr>();
-            root->set("cacheKey", cacheKey);
             if (EnableExperimental)
+            {
+                root->set("cacheKey", cacheKey);
                 root->set("isCompressed", isCompressed);
+             }
 
             json = JsonUtil::jsonToString(root);
 
@@ -2641,7 +2643,7 @@ bool ChildSession::renderSlide(const StringVector& tokens)
                                                            &bufferWidth, &bufferHeight,
                                                            renderBackground, renderMasterPage);
     if (!success) {
-        sendTextFrame("sliderenderingcomplete: fail");
+        sendTextFrame("sliderenderingcomplete: {\"status\": \"fail\"}");
         return false;
     }
 
@@ -2674,7 +2676,7 @@ bool ChildSession::renderSlide(const StringVector& tokens)
                "\", \"compressedLayers\": " + (compressedLayers ? "true" : "false") +
                ", \"cacheKey\": \"" + tokens.substrFromToken(1) + "\"}";
     } else {
-        msg += (success ? "success" : "fail");
+        msg += std::string("{\"status\": \"") + (success ? "success" : "fail") + "\"}";
     }
     sendTextFrame(msg);
 

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -4688,16 +4688,19 @@ void DocumentBroker::handleGetSlideRequest(const StringVector& tokens,
 
 void DocumentBroker::handleSlideLayerResponse(const std::shared_ptr<Message>& message)
 {
-    size_t pos = Util::findInVector(message->data(), "\n");
-    std::string msg(message->data().data(), pos == std::string::npos ? message->size() : pos);
-    Poco::JSON::Object::Ptr jsonPtr;
-    JsonUtil::parseJSON(msg, jsonPtr);
-    const std::string key = JsonUtil::getJSONValue<std::string>(jsonPtr, "cacheKey");
+    if (EnableExperimental)
+    {
+        size_t pos = Util::findInVector(message->data(), "\n");
+        std::string msg(message->data().data(), pos == std::string::npos ? message->size() : pos);
+        Poco::JSON::Object::Ptr jsonPtr;
+        JsonUtil::parseJSON(msg, jsonPtr);
+        const std::string key = JsonUtil::getJSONValue<std::string>(jsonPtr, "cacheKey");
 
-    // This message has forwardToken which can cause issue if reused for forwardToClient when using cache.
-    // But we ignore it because when reusing cache we only send data from the message and not entire message
-    _slideLayerCache.insert(key, message);
-    LOG_INF("Slideshow: Cached a slide layer with cache key: " << key);
+        // This message has forwardToken which can cause issue if reused for forwardToClient when using cache.
+        // But we ignore it because when reusing cache we only send data from the message and not entire message
+        _slideLayerCache.insert(key, message);
+        LOG_INF("Slideshow: Cached a slide layer with cache key: " << key);
+    }
     forwardToClient(message);
 }
 


### PR DESCRIPTION
and be consistent with cacheKey as experimental, so make the other place we set it experimental as well and make using it controlled by experimental


Change-Id: If6079e5901a4bc339d5046d32a893f0985d67dcb


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

