### PR TITLE
Scrollbars: Apply unified custom scrollbar styling across all widgets

### DIFF
--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -83,7 +83,7 @@
 	--color-treeview-highlight: #FFEE80;
 	--color-treeview-highlight-text: #222;
 	--color-quickfind-border: #e1dfdd;
-	--scrollbar-color: #c0bfbc #fafafa;
+	--scrollbar-color: #c0bfbc transparent;
 	--color-background-hover: #F5F5F5;
 }
 

--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -59,6 +59,9 @@
 
 	/* Notebookbar */
 	--notebookbar-element-height: 64px;
+
+	/* Scrollbars */
+	--scrollbar-width: thin;
 }
 
 html {
@@ -347,8 +350,8 @@ body {
 	z-index: 990;
 	max-width: 350px;
 	overflow-y: auto;
-	scrollbar-width: thin;
-	scrollbar-color: var(--color-border) transparent;
+	scrollbar-width: var(--scrollbar-width);
+	scrollbar-color: var(--scrollbar-color);
 	height: 100%;
 }
 
@@ -644,7 +647,7 @@ body {
 	max-height: var(--annotation-input-size);
 	overflow: auto;
 	scrollbar-color: var(--scrollbar-color);
-	scrollbar-width: thin;
+	scrollbar-width: var(--scrollbar-width);
 }
 
 .cool-annotation-info-collapsed {
@@ -734,6 +737,8 @@ body {
 	margin-bottom: 8px;
 	box-sizing: border-box;
 	border-radius: var(--border-radius-s);
+	scrollbar-width: var(--scrollbar-width);
+	scrollbar-color: var(--scrollbar-color);
 }
 
 .cool-annotation-textarea a:link,

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -169,6 +169,8 @@ div#autoFillPreviewTooltip .lokdialog.ui-dialog-content.ui-widget-content {
 	background-color: var(--color-background-lighter) !important;
 	font-family: var(--jquery-ui-font);
 	line-height: 1.5;
+	scrollbar-color: var(--scrollbar-color);
+	scrollbar-width: var(--scrollbar-width);
 }
 [data-docType='spreadsheet'] .jsdialog-container .ui-dialog-content,
 [data-docType='text'] .jsdialog-container .ui-dialog-content {
@@ -308,6 +310,8 @@ td.jsdialog > [id^='table-box']:not(.sidebar) {
 	overflow: auto;
 	max-height: 500px;
 	max-width: 650px;
+	scrollbar-width: var(--scrollbar-width);
+	scrollbar-color: var(--scrollbar-color);
 }
 /* - Also used in SpellingDialog where suggestion come in form
      of an image*/
@@ -632,6 +636,8 @@ algned to the bottom */
 	line-height: var(--default-height);
 	align-content: start;
 	justify-content: stretch;
+	scrollbar-width: var(--scrollbar-width);
+	scrollbar-color: var(--scrollbar-color);
 }
 
 .modalpopup .ui-treeview {
@@ -2946,6 +2952,8 @@ kbd,
 	max-height: min(470px, 45vh);
 	overflow-x: hidden;
 	overflow-y: auto;
+	scrollbar-width: var(--scrollbar-width);
+	scrollbar-color: var(--scrollbar-color);
 }
 
 /* Writer - Form - Properties(Dropdown) */

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -637,8 +637,8 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 
 #quickfind-dock-wrapper #searchfinds {
 	overflow-y: auto;
-	scrollbar-width: thin;
-	scrollbar-color: var(--color-border) transparent;
+	scrollbar-width: var(--scrollbar-width);
+	scrollbar-color: var(--scrollbar-color);
 	max-height: calc(100vh - 350px);
 }
 

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -4,6 +4,8 @@
 	display: flex;
 	overflow-x: auto;
 	overflow-y: hidden;
+	scrollbar-color: var(--scrollbar-color);
+	scrollbar-width: var(--scrollbar-width);
 }
 
 /* stretch the fields */

--- a/browser/css/partsPreviewControl.css
+++ b/browser/css/partsPreviewControl.css
@@ -4,8 +4,8 @@
 	overflow-y: visible;
 	background: var(--color-background-lighter);
 	max-height: 95%;
-	scrollbar-color: var(--color-background-darker) var(--color-background-lighter);
-	scrollbar-width: thin;
+	scrollbar-color: var(--scrollbar-color);
+	scrollbar-width: var(--scrollbar-width);
 }
 
 #sidebar-panel {


### PR DESCRIPTION
Change-Id: I81441900517cf0661d821f966cecd3958bb7930a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Scrollbars were inconsistent, with some widgets using custom styles while others fell back to browser defaults. This patch introduces custom scrollbar variables that can be applied across dialogs, sidebars, menus, and other scrollable containers to ensure a uniform experience.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

