### PR TITLE
cypress: make Delete Chart test in Calc more stable

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/delete_objects_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/delete_objects_spec.js
@@ -41,9 +41,10 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function(
 		cy.cGet('#toolbar-up #overflow-button-other-toptoolbar .arrowbackground').click();
 		//insert
 		cy.cGet('#insertobjectchart').click();
-		cy.cGet('.jsdialog-overlay').click();
 		cy.cGet('.ui-pushbutton.jsdialog.button-primary').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
+		cy.cGet('.jsdialog-overlay').click();
 		cy.cGet('#test-div-shapeHandlesSection').should('exist');
+		cy.wait(300);
 		//delete
 		helper.typeIntoDocument('{del}');
 		cy.cGet('#test-div-shapeHandlesSection').should('not.exist');


### PR DESCRIPTION
1. close the overflow dropdown after the dialog closes
2. add wait after the dialog closes


Change-Id: Ia265395721742230af7fd06e4970772572455581

* Target version: master