### PR TITLE
cypress: don't use unstable ids

### DIFF
--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -538,6 +538,10 @@ function assertVisiblePage(min, max, allPages) {
 	cy.cGet('#StatePageNumber').invoke('text').should('be.oneOf', expectedArray);
 }
 
+function getDropdown(dropdownId) {
+	return cy.cGet('[id^="' + dropdownId + '"].modalpopup');
+}
+
 module.exports.showSidebar = showSidebar;
 module.exports.hideSidebar = hideSidebar;
 module.exports.hideSidebarImpress = hideSidebarImpress;
@@ -571,3 +575,4 @@ module.exports.updateFollowingUsers = updateFollowingUsers;
 module.exports.assertVisiblePage = assertVisiblePage;
 module.exports.closeNavigatorSidebar = closeNavigatorSidebar;
 module.exports.sidebarToggle = sidebarToggle;
+module.exports.getDropdown = getDropdown;

--- a/cypress_test/integration_tests/desktop/calc/formula_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/formula_dialog_spec.js
@@ -13,7 +13,7 @@ describe(['tagdesktop'], 'Formula dialog tests', function() {
 	it('Formula dialog visual regression test', function() {
 		cy.wait(1000);
 
-		cy.cGet('#functiondialog-button').click();
+		cy.cGet('.unoFunctionDialog.formulabar').click();
 		cy.cGet('#FormulaDialog').should('be.visible');
 
 		cy.cGet('#FormulaDialog #function .ui-treeview-expander:nth(2)').click();

--- a/cypress_test/integration_tests/desktop/calc/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/image_operation_spec.js
@@ -26,8 +26,7 @@ describe(['tagdesktop'], 'Image Operation Tests', function() {
 		helper.assertImageSize(248, 63);
 
 		cy.cGet('#test-div-shape-handle-3').should('exist');
-		cy.cGet('#Crop').should('be.visible');
-		cy.cGet('#Crop').click();
+		cy.cGet('.unoCrop').should('be.visible').click();
 
 		cy.cGet('#test-div-shape-handle-3').then(($handle) => {
 			const rect = $handle[0].getBoundingClientRect();

--- a/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
@@ -2,6 +2,7 @@
 
 /* global describe it cy require expect beforeEach */
 var helper = require('../../common/helper');
+var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'JSDialog unit test', function() {
 
@@ -98,19 +99,21 @@ describe(['tagdesktop'], 'JSDialog unit test', function() {
 
 	it('Open hybrid help dialog', function() {
 		cy.cGet('#Help-tab-label').click();
-		cy.cGet('#online-help').click();
+		cy.cGet('.unoOnlineHelp').click();
 		cy.cGet('#online-help-content').should('exist');
 	});
 
 	it('JSDialog dropdown', function() {
-		cy.cGet('#toolbar-up #home-conditional-format-menu-button').click();
+		cy.cGet('#toolbar-up #Home .unoConditionalFormatMenu:visible').click();
+
+		desktopHelper.getDropdown('home-conditional-format-menu').should('exist');
 
 		// Click on overlay to close
 		cy.cGet('.jsdialog-overlay').click();
 
 		// Dropdown should be closed
 		cy.cGet('.jsdialog-overlay').should('not.exist');
-		cy.cGet('#home-conditional-format-menu-dropdown').should('not.exist');
+		desktopHelper.getDropdown('home-conditional-format-menu').should('not.exist');
 	});
 
 	it('JSDialog check enable edit input', function() {
@@ -129,7 +132,7 @@ describe(['tagdesktop'], 'JSDialog unit test', function() {
 
 	it('JSDialog check data validity options', function() {
 		cy.cGet('#Data-tab-label').click();
-		cy.cGet('#data-validation').click();
+		cy.cGet('.unoValidation').click();
 
 		// On changing options other fields should toggle enable and disable
 		cy.cGet('#data-input').should('be.disabled');
@@ -145,7 +148,8 @@ describe(['tagdesktop'], 'JSDialog unit test', function() {
 		})
 
 		cy.cGet('#Format-tab-label').click();
-		cy.cGet('#format-style-dialog').click();
+		// FIXME: below button has class with "." inside, best to rework it
+		cy.cGet('#Format [id^="format-style-dialog"]:visible button').click();
 		cy.cGet('#filter-input').select('4');
 		cy.wait(500);
 		cy.cGet('#flatview .ui-treeview-entry').rightclick();


### PR DESCRIPTION
- we add numbers to make ids unique, best to identify buttons by uno command which is stable
- added helper for dropdown menu element selector
