### PR TITLE
Ruler: End-Drag was not called after user drags the ruler.

### DIFF
--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1210,21 +1210,26 @@ class UIManager extends window.L.Control {
 	// Ruler
 
 	/**
-	 * Shows the ruler.
+	 * Shows the rulers.
 	 */
 	showRuler(): void {
 		this._map.sendUnoCommand('.uno:ShowRuler');
-		$('.cool-ruler').show();
+
+		if (app.UI.horizontalRuler) app.UI.horizontalRuler.show();
+		if (app.UI.verticalRuler) app.UI.verticalRuler.show();
+
 		$('#map').addClass('hasruler');
 		this.setDocTypePref('ShowRuler', true);
 		this.map.fire('rulerchanged');
 	}
 
 	/**
-	 * Hides the ruler.
+	 * Hides the rulers.
 	 */
 	hideRuler(): void {
-		$('.cool-ruler').hide();
+		if (app.UI.horizontalRuler) app.UI.horizontalRuler.hide();
+		if (app.UI.verticalRuler) app.UI.verticalRuler.hide();
+
 		$('#map').removeClass('hasruler');
 		this.setDocTypePref('ShowRuler', false);
 		this.map.fire('rulerchanged');

--- a/browser/src/control/HRuler.ts
+++ b/browser/src/control/HRuler.ts
@@ -61,6 +61,8 @@ class HRuler extends Ruler {
 
 		if (app.map._docLayer._docType === 'presentation')
 			this.options.tileMargin = 0;
+
+		app.UI.horizontalRuler = this;
 	}
 
 	onAdd() {
@@ -132,6 +134,15 @@ class HRuler extends Ruler {
 				}
 			}
 		}
+	}
+
+	public show() {
+		this._rFace.parentElement.style.display = '';
+		this._updateParagraphIndentations();
+	}
+
+	public hide() {
+		this._rFace.parentElement.style.display = 'none';
 	}
 
 	_initiateIndentationMarkers() {
@@ -371,7 +382,7 @@ class HRuler extends Ruler {
 		this._rWrapper.style.visibility = '';
 	}
 
-	_updateParagraphIndentations() {
+	public _updateParagraphIndentations() {
 		var items = this._map['stateChangeHandler'];
 		var state = items.getItemValue('.uno:LeftRightParaMargin');
 		// in impress/draw values are not as per Inch factore we should consider this case
@@ -847,6 +858,8 @@ class HRuler extends Ruler {
 		// We can use TabStopContainer's position as the reference point, as they share the same reference point..
 		var element = document.getElementById(this._indentationElementId);
 
+		if (!element) return;
+
 		// The halfWidth of the shape..
 		var halfWidth =
 			(element.getBoundingClientRect().right -
@@ -914,6 +927,18 @@ class HRuler extends Ruler {
 				this._rFace,
 				'mousemove',
 				this._moveIndentation,
+				this,
+			);
+			window.L.DomEvent.on(
+				this._rFace,
+				'click',
+				this._moveIndentationEnd,
+				this,
+			);
+			window.L.DomEvent.on(
+				this._rFace,
+				'mouseleave',
+				this._moveIndentationEnd,
 				this,
 			);
 			window.L.DomEvent.on(

--- a/browser/src/control/VRuler.ts
+++ b/browser/src/control/VRuler.ts
@@ -47,6 +47,8 @@ class VRuler extends Ruler {
 		Object.assign(this.options, options);
 		this._map = map;
 		this.onAdd(); // VRuler created
+
+		app.UI.verticalRuler = this;
 	}
 
 	onAdd() {
@@ -112,6 +114,15 @@ class VRuler extends Ruler {
 				this._bMarginDrag.style.cursor = 'default';
 			}
 		}
+	}
+
+	public show() {
+		this._rFace.parentElement.style.display = '';
+		this._updateParagraphIndentations();
+	}
+
+	public hide() {
+		this._rFace.parentElement.style.display = 'none';
 	}
 
 	_initiateIndentationMarkers() {
@@ -247,7 +258,7 @@ class VRuler extends Ruler {
 		this._updateBreakPoints();
 	}
 
-	_updateParagraphIndentations() {
+	public _updateParagraphIndentations() {
 		// if ruler is hidden no need to calculate the indentation of the para
 		if (!this.options.showruler) return;
 		// for horizontal Ruler we need to also consider height of navigation and toolbar-wrapper

--- a/browser/src/docstate.ts
+++ b/browser/src/docstate.ts
@@ -79,6 +79,8 @@ window.app = {
 			fromBrowser: window.L.Browser.lang, // Again in global.js.
 			notebookbarAccessibility: null,
 		},
+		horizontalRuler: null, // HRuler instance that is used in Writer, Impress and Draw.
+		verticalRuler: null, // VRuler instance that is used in Writer.
 	},
 	file: {
 		editComment: false,

--- a/browser/src/global.d.ts
+++ b/browser/src/global.d.ts
@@ -226,6 +226,8 @@ interface Window {
 				fromBrowser: string;
 				notebookbarAccessibility: any;
 			};
+			horizontalRuler: HRuler | null;
+			verticalRuler: VRuler | null;
 		};
 		colorPalettes: any; // TODO declare according to Widget.ColorPicker.ts
 		colorNames: any; // TODO declare according to Widget.ColorPicker.ts

--- a/browser/src/map/handler/Map.StateChanges.js
+++ b/browser/src/map/handler/Map.StateChanges.js
@@ -75,6 +75,11 @@ window.L.Map.StateChangeHandler = window.L.Handler.extend({
 			}
 		}
 
+		if (e.commandName === '.uno:LeftRightParaMargin') {
+			if (app.UI.horizontalRuler) app.UI.horizontalRuler._updateParagraphIndentations();
+			if (app.UI.verticalRuler) app.UI.verticalRuler._updateParagraphIndentations();
+		}
+
 		if (commandName == '.uno:PageLinks') {
 			let links = [];
 			if (state && state.links) {

--- a/cypress_test/integration_tests/desktop/writer/notebookbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/notebookbar_spec.js
@@ -1,4 +1,4 @@
-/* global describe it cy beforeEach require Cypress */
+/* global expect describe it cy beforeEach require Cypress */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
@@ -57,6 +57,36 @@ describe(['tagdesktop'], 'Notebookbar checkbox widgets', function() {
 		cy.cGet('#showruler-input').check();
 		cy.cGet('#showruler-input').should('be.checked');
 		cy.cGet('.cool-ruler').should('be.visible');
+
+		cy.cGet('#lo-fline-marker').should('exist');
+
+		// Move the indentation marker.
+		cy.cGet('#lo-fline-marker').then(function(items) {
+			expect(items).to.have.lengthOf(1);
+			const boundingRectangle = items[0].getBoundingClientRect();
+			const x1 = boundingRectangle.left;
+			const y1 = boundingRectangle.top;
+
+			cy.wrap(x1).as('x1');
+
+			cy.cGet('#lo-fline-marker').realMouseDown(x1, y1); // Press mouse button.
+			cy.wait(500);
+			cy.cGet('#lo-fline-marker').realMouseMove(x1 + 100, y1); // Move mouse.
+			cy.wait(500);
+			cy.cGet('#lo-fline-marker').realMouseUp(x1, y1); // Release mouse button.
+			cy.wait(500);
+			cy.cGet('#lo-fline-marker').realMouseMove(x1, y1); // Move mouse back.
+		});
+
+		cy.cGet('#lo-fline-marker').should('be.visible');
+		cy.cGet('#lo-fline-marker').then(function(items) {
+			expect(items).to.have.lengthOf(1);
+			const boundingRectangle = items[0].getBoundingClientRect();
+			const x = boundingRectangle.left;
+
+			cy.wait(1000);
+			cy.get('@x1').should('not.be.equal', x);
+		});
 
 		cy.cGet('#showruler-input').uncheck();
 		cy.cGet('#showruler-input').should('not.be.checked');


### PR DESCRIPTION
Issues:
* Indentation markers are not visible after ruler is switched (redraw was required).
* Once the indentation markers start being dragged, they weren't released.

Fix:
* Add show / hide functions for rulers and make the instances global. So we can do some side tasks while showing them.
* Watch for ruler state changes and refresh rulers when they happen.

* Added a test that checks the visibility of the indentation marker, moves it, checks its final position.


Change-Id: Iba0f7ead677dfb7f4abc0585f11aeb86e1e92213


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

