### PR TITLE
notebookbar: use heuristic of isDesktop to select tooltip (25.04 backport)

### DIFF
--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -220,8 +220,9 @@ window.L.Control.NotebookbarBuilder = window.L.Control.JSDialogBuilder.extend({
 	// overriden
 	_createTabClick: function(builder, t, tabs, contentDivs, tabIds)
 	{
-		var tooltipCollapsed = _('Tap to expand');
-		var tooltipExpanded = _('Tap to collapse');
+		const isDesktop = window.mode.isDesktop();
+		const tooltipCollapsed = isDesktop ? _('Click to expand') : _('Tap to expand');
+		const tooltipExpanded = isDesktop ? _('Click to collapse') : _('Tap to collapse');
 		if ($(tabs[t]).hasClass('selected'))
 			tabs[t].setAttribute('data-cooltip', tooltipExpanded);
 		window.L.control.attachTooltipEventListener(tabs[t], builder.map);


### PR DESCRIPTION
- we expect in Desktop mode to be more accurate to use term "click"
- other devices have touch interface in most cases

Requires: new string translation