### PR TITLE
don't show all comments on 'insertComment' in calc

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -28,8 +28,15 @@ window.L.Map.include({
 			are hidden, the new comment also goes into hiding as it
 			is saved. so we show all the comments instead of hiding
 			the newly inserted one.
+
+			comments in a 'spreadsheet' are hidden by default and
+			only visible on hover. therefore we wouldn't want to
+			show all the comments in a spreadsheet, this jumps the
+			view as all the comments are quickly shown and hidden
+			again.
 		*/
-		app.map.showComments(true);
+		if (app.map._docLayer._docType !== 'spreadsheet')
+			app.map.showComments(true);
 
 		var avatar = undefined;
 		var author = this.getViewName(this._docLayer._viewId);


### PR DESCRIPTION
comments in a 'spreadsheet' are hidden by default and only visible on hover. therefore we wouldn't want to show all the comments in a spreadsheet, this jumps the view as all the comments are quickly shown and hidden again.


Change-Id: I0bd0664fe486253e74d368200112261754e1f9f0 (cherry picked from commit fe54f019c976c6131cec1a261039988535b839f9)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

