### PR TITLE
jsdialog: Some placeholders are still necessary in grid

### DIFF
--- a/browser/src/control/jsdialog/Widget.Containers.ts
+++ b/browser/src/control/jsdialog/Widget.Containers.ts
@@ -87,6 +87,10 @@ JSDialog.grid = function (
 
 		for (let col = 0; col < cols; col++) {
 			const child = _getGridChild(data.children, row, col);
+			const isMergedCell =
+				prevChild &&
+				prevChild.width &&
+				parseInt(prevChild.left) + parseInt(prevChild.width) > col;
 
 			if (child) {
 				if (!child.id || child.id === '')
@@ -104,6 +108,9 @@ JSDialog.grid = function (
 
 				processedChildren.push(child);
 				prevChild = child;
+			} else if (!isMergedCell) {
+				// empty placeholder to keep correct layout in some cases.
+				window.L.DomUtil.create('div', 'ui-grid-cell', table);
 			}
 		}
 	}


### PR DESCRIPTION
This is just a cherry-pick.

Notable for the Formula Wizard

This partially revert commit 85e3ef172debd4ee48fb0343ddbd54631f398204 In general the placeholders are not needed, but in that case they are. It's possible the solution is more specific and we could get rid of them.


Change-Id: Ifa2f6a7f67f7ed02537618a02ad73375b3eb4a1f


* Resolves: #
* Target version: co-25.04 

### Summary

Backport of #13412

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

