### PR TITLE
cypress: use helper to press buttons in Impress table test

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/table_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/table_operation_spec.js
@@ -9,17 +9,9 @@ describe(['tagdesktop'], 'Table operations', function() {
 	beforeEach(function() {
 		helper.setupAndLoadDocument('impress/table_operation.odp');
 		cy.viewport(1920,1080);
-	});
 
-	function selectOptionNotebookbar(optionId) {
-		var optionButton = cy.cGet(optionId);
-		// It takes time for the ui to enable the various table toolbar buttons after
-		// the table gets focus, but we can continue as soon as:
-		// a) the parent container is enabled
-		optionButton.parent().should('not.have.class', 'disabled');
-		// b) the specific button is enabled
-		optionButton.should('not.have.class', 'disabled').click();
-	}
+		desktopHelper.switchUIToNotebookbar();
+	});
 
 	function retriggerNewSvgForTableInTheCenter() {
 		impressHelper.removeShapeSelection();
@@ -43,9 +35,8 @@ describe(['tagdesktop'], 'Table operations', function() {
 	}
 
 	it('Insert Row Before', function() {
-		desktopHelper.switchUIToNotebookbar();
 		selectFullTable();
-		selectOptionNotebookbar('#table-insert-rows-before-button');
+		desktopHelper.getNbIcon('InsertRowsBefore', 'Table').click();
 		cy.cGet('.table-row-resize-marker').should('have.length', 4);
 		retriggerNewSvgForTableInTheCenter();
 		cy.cGet('#document-container g.Page g').should('have.class', 'com.sun.star.drawing.TableShape');
@@ -63,9 +54,8 @@ describe(['tagdesktop'], 'Table operations', function() {
 	});
 
 	it('Insert Row After', function() {
-		desktopHelper.switchUIToNotebookbar();
 		selectFullTable();
-		selectOptionNotebookbar('#table-insert-rows-after-button');
+		desktopHelper.getNbIcon('InsertRowsAfter', 'Table').click();
 
 		cy.cGet('.table-row-resize-marker').should('have.length', 4);
 		retriggerNewSvgForTableInTheCenter();
@@ -87,9 +77,8 @@ describe(['tagdesktop'], 'Table operations', function() {
 	});
 
 	it('Insert column before.', function() {
-		desktopHelper.switchUIToNotebookbar();
 		selectFullTable();
-		selectOptionNotebookbar('#table-insert-columns-before-button');
+		desktopHelper.getNbIcon('InsertColumnsBefore', 'Table').click();
 
 		cy.cGet('.table-column-resize-marker')
 			.should('have.length', 4);
@@ -113,9 +102,8 @@ describe(['tagdesktop'], 'Table operations', function() {
 	});
 
 	it('Insert column after.', function() {
-		desktopHelper.switchUIToNotebookbar();
 		selectFullTable();
-		selectOptionNotebookbar('#table-insert-columns-after-button');
+		desktopHelper.getNbIcon('InsertColumnsAfter', 'Table').click();
 
 		cy.cGet('.table-column-resize-marker')
 			.should('have.length', 4);
@@ -139,9 +127,8 @@ describe(['tagdesktop'], 'Table operations', function() {
 	});
 
 	it('Delete row.', function() {
-		desktopHelper.switchUIToNotebookbar();
 		selectFullTable();
-		selectOptionNotebookbar('#table-delete-rows-button');
+		desktopHelper.getNbIcon('DeleteRows', 'Table').click();
 
 		cy.cGet('.table-row-resize-marker')
 			.should('have.length', 2);
@@ -161,14 +148,13 @@ describe(['tagdesktop'], 'Table operations', function() {
 	});
 
 	it('Delete Column.', function() {
-		desktopHelper.switchUIToNotebookbar();
 		selectFullTable();
-		selectOptionNotebookbar('#table-insert-columns-before-button');
+		desktopHelper.getNbIcon('InsertColumnsBefore', 'Table').click();
 
 		cy.cGet('.table-column-resize-marker')
 			.should('have.length', 4);
 
-		selectOptionNotebookbar('#table-delete-columns-button');
+		desktopHelper.getNbIcon('DeleteColumns', 'Table').click();
 
 		cy.cGet('.table-column-resize-marker')
 			.should('have.length', 3);
@@ -192,9 +178,8 @@ describe(['tagdesktop'], 'Table operations', function() {
 	});
 
 	it('Delete Table', function() {
-		desktopHelper.switchUIToNotebookbar();
 		selectFullTable();
-		selectOptionNotebookbar('#table-delete-table-button');
+		desktopHelper.getNbIcon('DeleteTable', 'Table').click();
 
 		retriggerNewSvgForTableInTheCenter();
 
@@ -206,15 +191,13 @@ describe(['tagdesktop'], 'Table operations', function() {
 	});
 
 	it('Merge Row', function() {
-		desktopHelper.switchUIToNotebookbar();
 		selectFullTable();
 
 		cy.cGet('.table-row-resize-marker')
 			.should('have.length', 3);
 
-		selectOptionNotebookbar('#table-entire-row-button');
-		cy.wait(1000);
-		selectOptionNotebookbar('#table-merge-cells-button');
+		desktopHelper.getNbIcon('EntireRow', 'Table').click();
+		desktopHelper.getNbIcon('MergeCells', 'Table').should('not.be.disabled').click();
 
 		retriggerNewSvgForTableInTheCenter();
 
@@ -235,15 +218,13 @@ describe(['tagdesktop'], 'Table operations', function() {
 	});
 
 	it('Merge Column', function() {
-		desktopHelper.switchUIToNotebookbar();
 		selectFullTable();
 
 		cy.cGet('.table-row-resize-marker')
 			.should('have.length', 3);
 
-		selectOptionNotebookbar('#table-entire-column-button');
-		cy.wait(1000);
-		selectOptionNotebookbar('#table-merge-cells-button');
+		desktopHelper.getNbIcon('EntireColumn', 'Table').click();
+		desktopHelper.getNbIcon('MergeCells', 'Table').should('not.be.disabled').click();
 
 		retriggerNewSvgForTableInTheCenter();
 
@@ -265,13 +246,12 @@ describe(['tagdesktop'], 'Table operations', function() {
 
 	it.skip('Split Cells', function() {
 		// ToDo: Merge cells before calling split cells function.
-		desktopHelper.switchUIToNotebookbar();
 		impressHelper.selectTableInTheCenter();
 
 		cy.cGet('.table-row-resize-marker')
 			.should('have.length', 4);
 
-		selectOptionNotebookbar('.notebookbar #SplitCell');
+		desktopHelper.getNbIcon('SplitCell', 'Table').click();
 
 		cy.cGet('#SplitCellsDialog').should('be.visible');
 


### PR DESCRIPTION
- switch to notebookbar in "before" step
- use helper independent from button "id" but using an uno command name