### PR TITLE
Comment Card: Fix cursor flicker on menu icon hover

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -848,7 +848,7 @@ body {
 	vertical-align: top;
 	border: 1px solid transparent !important;
 	display: inline-block !important;
-	cursor: pointer;
+	cursor: inherit;
 	box-sizing: border-box;
 }
 
@@ -901,6 +901,8 @@ body {
 	justify-content: flex-end;
 	align-items: center;
 	column-gap: 4px;
+	cursor: pointer;
+	padding: 0 !important;
 }
 
 .cool-annotation-child-line {


### PR DESCRIPTION
Change-Id: Iab046d9ed8adff6521c5f072b7e8417bf82cf4a1


* Resolves: #13449 13449
* Target version: master 

### Summary
- Hovering over the annotation menu icons caused the cursor to alternate between the default arrow and the pointer. This happened because the parent element used the default cursor while the icons used `cursor: pointer`.

- The annotation-menubar now inherits a consistent pointer cursor, removing the flicker and ensuring a stable hover experience.


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

