### PR TITLE
cypress: add a test for calc view jump regression

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/annotation_spec.js
@@ -115,6 +115,27 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 		cy.cGet('.annotation-button-autosaved').should('be.visible');
 		cy.cGet('.annotation-button-delete').should('be.visible');
 	});
+
+	it('View Jump', function() {
+		helper.typeIntoInputField(helper.addressInputSelector, 'A100');
+		desktopHelper.insertComment();
+		/* comments are hidden in calc by default, so no visibility assert */
+		cy.cGet('#comment-container-1').should('exist')
+		cy.cGet('#Home-tab-label').click();
+
+		helper.typeIntoInputField(helper.addressInputSelector, 'A150');
+		helper.typeIntoInputField(helper.addressInputSelector, 'A135');
+
+		/* 
+			NOTE: this scrollbar position might change in future. one can
+			get the new scrollbar position by printing `x` to the console
+			in `assertScrollbarPosition` function.
+		*/
+		desktopHelper.assertScrollbarPosition('vertical', 250, 250);
+		desktopHelper.insertComment('second comment', false);
+		desktopHelper.assertScrollbarPosition('vertical', 250, 250);
+	});
+
 });
 
 describe(['tagdesktop'], 'Annotation Autosave Tests', function() {


### PR DESCRIPTION
[1] changed that behavior to show all the comments in case they were hidden and a new one was inserted. this introduced a "View Jump" regression in calc as all the comments are hidden in calc and when a new comment was inserted, all of them were made visible to be hidden immediately, introducing a jump in the view. [2] fixed this regression, and this commit adds a test for the fix.

[1]
show all the comments when a new comments is inserted and all were hidden commit a35773f2da04ec9456d6362e4bbdc150d4f94d9f

[2]
don't show all comments on 'insertComment' in calc commit fe54f019c976c6131cec1a261039988535b839f9


Change-Id: I87c4dfe7d6eddd33f251fb5d487354562c3411df


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

