### PR TITLE
notebookbar overflow: avoid scrollbar by not assuming 0 px width

### DIFF
--- a/browser/src/control/jsdialog/Widget.OverflowManager.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowManager.ts
@@ -19,6 +19,7 @@ class OverflowManager {
 	parentContainer: HTMLElement;
 	data: ContainerWidgetJSON;
 	lastMaxWidth: number = -1;
+	scheduledRefresh: boolean = false;
 
 	constructor(parentContainer: Element, data: ContainerWidgetJSON) {
 		this.parentContainer = parentContainer as HTMLElement;
@@ -66,11 +67,15 @@ class OverflowManager {
 	}
 
 	onResize(event: Event) {
-		app.layoutingService.appendLayoutingTask(() => this.onRefresh(event));
+		if (!this.scheduledRefresh) {
+			app.layoutingService.appendLayoutingTask(() => this.onRefresh(event));
+			this.scheduledRefresh = true;
+		}
 	}
 
 	// sometimes we want to call it synchronously as it is already in the task (tab switch)
 	onRefresh(event: Event & { force?: boolean }) {
+		this.scheduledRefresh = false;
 		if (!this.parentContainer) return;
 		if (this.lastMaxWidth === window.innerWidth) return;
 


### PR DESCRIPTION
- sometimes we showed the scrollbar after mode switch (compact -> nb)
- in that case required width was 0 for some groups
- we need to assume nothing has width equal 0, it's just not ready yet

example logs we are interested in:
```
overflow manager: "View-container" max: 1 req: 0
```