### PR TITLE
fix(debug): resize viewport with onscreen keyboard

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -31,7 +31,7 @@ m4_ifelse(IOSAPP,[true],
 <meta charset="utf-8">
 m4_ifelse(MOBILEAPP, [true],
 [
-  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no, interactive-widget=resizes-content">
 ],
 [
   %BROWSER_VIEWPORT%

--- a/browser/html/debug.html
+++ b/browser/html/debug.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, interactive-widget=resizes-content">
     <title>Online</title>
     <style>
         html, body, iframe

--- a/browser/html/wasm.html
+++ b/browser/html/wasm.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="viewport"content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no, interactive-widget=resizes-content">
     <title>Online</title>
     <style>
         html,

--- a/test/FileServeWhiteBoxTests.cpp
+++ b/test/FileServeWhiteBoxTests.cpp
@@ -303,7 +303,7 @@ void FileServeTests::testPreProcessedFile()
 <html %UI_RTL_SETTINGS% style="height:100%"><head><meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 <title>Online Editor</title>
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=no, interactive-widget=resizes-content">
 
 <script>
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -84,7 +84,7 @@ using Poco::Util::Application;
 // We have files that are at least 2.5 MB already.
 // WASM files are in the order of 30 MB, however,
 constexpr auto MaxFileSizeToCacheInBytes = 50 * 1024 * 1024;
-constexpr std::string_view MetaViewPort = "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, minimum-scale=1\">";
+constexpr std::string_view MetaViewPort = "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, minimum-scale=1, interactive-widget=resizes-content\">";
 
 namespace
 {


### PR DESCRIPTION
This is a very similar change to nextcloud/richdocuments#5137, which resized our iframe when we opened the onscreen keyboard. This does the same change for all our viewport specifiers (although I note that the cool.html.m4 change will have no effect for integrators since as this option has no effect when used in an iframe...)

Not finding some way to resize the content when the keyboard is popped up has the following undesireable effects:
- Focusing the hidden input causes the page to shift up and down on some devices as not all of it fits on the screen at once and some browsers want to keep the hidden input "in view"
- #13274 is ineffective, as you can't detect the height of the screen properly
- The bottom toolbar is almost always hidden behind the keyboard (in portrait or landscape)


Change-Id: I4d5a0c09c2130f92a0711ad731cad9e96a6a6964


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

