### PR TITLE
perf: cache colors for drawing in group headers in calc

### DIFF
--- a/browser/src/control/Control.CornerGroup.ts
+++ b/browser/src/control/Control.CornerGroup.ts
@@ -33,15 +33,7 @@ export class CornerGroup extends GroupBase {
 		this._map = window.L.Map.THIS;
 		this._map.on('sheetgeometrychanged', this.update, this);
 		this._map.on('viewrowcolumnheaders', this.update, this);
-		this._map.on('darkmodechanged', this._cornerGroupColors, this);
-
-		this._cornerGroupColors();
-	}
-
-	private _cornerGroupColors(): void {
-		const colors = this.getColors();
-		this.backgroundColor = colors.backgroundColor;
-		this.borderColor = colors.borderColor;
+		this._map.on('darkmodechanged', this._updateColors, this);
 	}
 
 	update(): void {

--- a/browser/src/control/Control.GroupBase.ts
+++ b/browser/src/control/Control.GroupBase.ts
@@ -64,9 +64,9 @@ export abstract class GroupBase extends CanvasSectionObject {
 
 		this._map.on('sheetgeometrychanged', this.update, this);
 		this._map.on('viewrowcolumnheaders', this.update, this);
-		this._map.on('darkmodechanged', this._groupBaseColors, this);
+		this._map.on('darkmodechanged', this._updateColors, this);
 		this._createFont();
-		this._groupBaseColors();
+		this._updateColors();
 		this.update();
 		this.isRemoved = false;
 	}
@@ -109,11 +109,9 @@ export abstract class GroupBase extends CanvasSectionObject {
 		return this._cachedColors;
 	}
 
-	private _groupBaseColors(): void {
-		const colors = this.getColors();
-		this.backgroundColor = colors.backgroundColor;
-		this.borderColor = colors.borderColor;
-		this._textColor = colors.textColor;
+	protected _updateColors(): void {
+		this._cachedColors = null; // reset cache
+		this.getColors(); // refresh the cache
 	}
 
 	// This returns the required width for the section.


### PR DESCRIPTION
- related to drawing performance
- we should avoid touching the DOM
- no need to recalculate the same color on all the frames
- cache it and reuse

BEFORE:
<img width="1359" height="580" alt="Screenshot From 2025-11-18 13-48-43" src="https://github.com/user-attachments/assets/fc17fc8f-84f1-4f71-8d61-953ee173321c" />

AFTER:
<img width="1359" height="692" alt="Screenshot From 2025-11-18 13-56-56" src="https://github.com/user-attachments/assets/bf8c991a-0558-4afc-aca9-ef18889b21a1" />

It required spreadsheet with grouped columns and rows to show the issue in the profile