### PR TITLE
formulabar: do not hide on notebookbar collapse (backport 25.04)

### DIFF
--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1286,8 +1286,7 @@ class UIManager extends window.L.Control {
 		if (this.isNotebookbarCollapsed() || this.isMenubarHidden())
 			return;
 
-		this.moveObjectVertically($('#formulabar'), -1);
-		$('#toolbar-wrapper').css('display', 'none');
+		$('#toolbar-row').css('display', 'none');
 
 		$('#document-container').addClass('tabs-collapsed');
 	}
@@ -1301,8 +1300,7 @@ class UIManager extends window.L.Control {
 		if (!this.isNotebookbarCollapsed())
 			return;
 
-		this.moveObjectVertically($('#formulabar'), 1);
-		$('#toolbar-wrapper').css('display', '');
+		$('#toolbar-row').css('display', '');
 
 		$('#document-container').removeClass('tabs-collapsed');
 	}

--- a/cypress_test/integration_tests/desktop/calc/formulabar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/formulabar_spec.js
@@ -8,8 +8,11 @@ describe(['tagdesktop'], 'Formulabar tests', function() {
 	beforeEach(function() {
 		helper.setupAndLoadDocument('calc/formulabar.ods');
 		cy.cGet('#pos_window-input-address').should('have.value', 'AB106');
-		cy.cGet('#sc_input_window.formulabar .ui-custom-textarea-cursor-layer')
-			.should('not.have.text', '');
+	});
+
+	it('Do not hide on notebookbar collapse', function() {
+		cy.cGet('#Home-tab-label').click();
+		cy.cGet('#sc_input_window.formulabar').should('be.visible');
 	});
 
 	// FIXME: need to stabilize


### PR DESCRIPTION
- it was not intended
- also when using notebookbar in collapsed mode in calc then on formula selection we got error message because of that

Backport of: https://github.com/CollaboraOnline/online/pull/13498