### PR TITLE
accessibility: update heading levels in online help for correct content hierarchy

### DIFF
--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -321,11 +321,11 @@
 </div>
 <div id="online-help-content">
     <h1 class="help-dialog-header"><span class="productname">{productname}</span> Help</h1>
-    <p class="toc-h3 m-v-0"><button class="border-0 scroll-button" data-target="1327">Collaborative editing</button></p>
-    <p class="toc-h3 m-v-0"><button class="border-0 scroll-button" data-target="1333"><span class="productname">{productname}</span> user interface</button></p>
-    <p class="toc-h3 m-v-0"><button class="border-0 scroll-button" data-target="1335">Opening, closing, saving, printing and downloading documents</button></p>
-    <p class="toc-h3 m-v-0"><button class="border-0 scroll-button" data-target="1337">Editing documents</button></p>
-    <p class="toc-h3 m-v-0"><button class="border-0 scroll-button" data-target="1338">Advanced features</button></p>
+    <p class="toc-h2 m-v-0"><button class="border-0 scroll-button" data-target="1327">Collaborative editing</button></p>
+    <p class="toc-h2 m-v-0"><button class="border-0 scroll-button" data-target="1333"><span class="productname">{productname}</span> user interface</button></p>
+    <p class="toc-h2 m-v-0"><button class="border-0 scroll-button" data-target="1335">Opening, closing, saving, printing and downloading documents</button></p>
+    <p class="toc-h2 m-v-0"><button class="border-0 scroll-button" data-target="1337">Editing documents</button></p>
+    <p class="toc-h2 m-v-0"><button class="border-0 scroll-button" data-target="1338">Advanced features</button></p>
     <div class="spreadsheet link-section hide">
         <p class="toc-h2 m-v-0"><button class="border-0 scroll-button" data-target="1359"><span class="productname">{productname}</span> spreadsheets</button></p>
         <p class="toc-h3 m-v-0"><button class="border-0 scroll-button" data-target="1361">Editing spreadsheets</button></p>
@@ -357,7 +357,7 @@
 
     <a id="1327"/>
   <div class="section">
-    <h3 class="section-header">Collaborative editing</h3>
+    <h2 class="section-header">Collaborative editing</h2>
     <div class="sub-section">
     <ul>
       <li><p>Each user gets assigned a color. The cursor of each user will be shown in the assigned color. Note: you will see your cursor as black, blinking cursor, although others will see you with a different color.</p></li>
@@ -368,7 +368,7 @@
   </div>
     <a id="1333"/>
 <div class="section">
-    <h3 class="section-header"><span class="productname">{productname}</span> user interface</h3>
+    <h2 class="section-header"><span class="productname">{productname}</span> user interface</h2>
     <div class="sub-section"><p><span class="productname">{productname}</span> uses modern browser resources to adapt the user interface to the size of the viewing area, including small screens found in mobile devices. The interface is composed of:</p></div>
   <div class="sub-section">
     <p><span class="def">The document area:</span> The application area shows the document contents, either spreadsheets, presentations or text documents.</p>
@@ -406,7 +406,7 @@
 </div>
     <a id="1335"/>
     <div class="section">
-    <h3 class="section-header">Opening, closing, saving, printing and downloading documents</h3>
+    <h2 class="section-header">Opening, closing, saving, printing and downloading documents</h2>
     <p>Your documents are stored and managed in the cloud storage that is integrated with <span class="productname">{productname}</span>.</p>
     <div class="sub-section"><p>To download a document download it from the <span class="productname">{productname}</span> application’s <span class="ui">File</span> menu. The download formats available depends on the application. All applications exports documents in PDF format.</p></div>
     <div class="sub-section"><p>To open document, click on the file to open the <span class="productname">{productname}</span> module associated to the document format.</p></div>
@@ -416,28 +416,28 @@
     </div>
     <a id="1337"/>
     <div class="section">
-    <h3 class="section-header">Editing documents</h3>
+    <h2 class="section-header">Editing documents</h2>
     <p>Document editing should be familiar to everyone that has used an office application before, but here are some distinctive features:</p>
     <div class="sub-section">
-    <h4>Copy and Paste</h4>
+    <h3>Copy and Paste</h3>
     <p>Rich content copy/cut and paste is supported, not only within a given document, but also across documents on the same or different <span class="productname">{productname}</span>. For these internal uses, users can copy/cut content, including images and mixed content, on PC by using the keyboard shortcuts directly (<kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>X</kbd>, <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>C</kbd>, <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>V</kbd>). For security reasons it is necessary to use <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>V</kbd> to paste on PC, but context menus can be used for cut and copy. On Android or iOS selecting text by double tapping, and using a long-tap to access copy/cut/paste via the context menu is required.</p>
     <p>To copy larger pieces of content to other applications on your device, users need to press the <span class="ui">Start download</span> button, and then re-copy this to their clipboard in order to make it available to the target application to read. This is possible via a tiny widget that pops up in the bottom-right corner, and is only necessary to export the content for pasting in external applications. This step also converts complex object types into static images.</p>
     </div>
     <div class="sub-section">
-    <h4>Document repair</h4>
+    <h3>Document repair</h3>
     <p>When multiple people edit the same document concurrently, it is possible for their changes to conflict and this can cause some confusion. The Document Repair function allows users to undo other editor’s changes to the document to a previous state.</p>
     <p>To jump back to the selected state, select it with the mouse and hit <span class="ui">Jump to state</span>.</p>
     <div class="screenshot"><img alt="document repair" src="images/help/en/repair-document.png"/></div>
     <p>This is particularly useful – say when a colleague inadvertently selected all text in the document with <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>A</kbd> and proceeded to type over it destroying it – while you were concurrently editing.</p>
     </div>
     <div class="sub-section">
-    <h4>Inactive document</h4>
+    <h3>Inactive document</h3>
     <p>When <span class="productname">{productname}</span> detects that there has not been any activity in the browser for a while, it puts the document in an “Inactive” state. The document is shown with a transparent gray overlay, with the message “Inactive document – please click to resume editing”.</p>
     <div class="screenshot"><img alt="inactive document" src="images/help/en/inactive-document.png"/></div>
     <p>To continue editing, click on the document and the layover and message disappear. Any changes that may have been made by other users – while collaboratively editing the document – are re-loaded.</p>
     </div>
     <div class="sub-section">
-    <h4>Pasting</h4>
+    <h3>Pasting</h3>
     <p>When you paste content copied from within the same document, the format and elements are maintained. If you copy from another document, in another tab or browser window, or from outside of the browser, the pasted content will preserve rich text.</p>
     <p>You can paste as unformatted text with the keyboard shortcut: <kbd>Ctrl</kbd><span class="kbd--plus">+</span><kbd>Shift</kbd><span class="kbd--plus">+</span><kbd>V</kbd></p>
     <p>When you paste text from within the document, formatting will be respected. You can also paste objects, such as images, if they are copied from the document you are working in.</p>
@@ -447,9 +447,9 @@
     </div>
     <a id="1338"/>
 <div class="section">
-  <h3 class="section-header">Advanced features</h3>
+  <h2 class="section-header">Advanced features</h2>
   <div class="sub-section">
-    <h4>Adding charts</h4>
+    <h3>Adding charts</h3>
     <p><span class="productname">{productname}</span> supports inserting and visualization of charts in documents. To add a chart:</p>
     <ol>
       <li><p>Select a table in text document, a range in a spreadsheet or a table in a presentation.</p></li>
@@ -465,20 +465,20 @@
   <div class="sub-section"><p><span class="def">Chart formatting:</span> The same context menu brings you to chart data table and chart type selection.</p></div>
   <div class="sub-section"><p><span class="def">Data series formatting:</span> Open the context menu and choose <span class="ui">Format data series</span>.</p></div>
   <div class="sub-section">
-    <h4>Handling images</h4>
+    <h3>Handling images</h3>
     <p><span class="productname">{productname}</span> inserts images in the text document from your local computer or from your cloud storage. Inserted images are always embedded in the document.</p>
     <p><span class="def">Insert image:</span> Clicking on the <span class="ui">Insert image</span> icon allows you to choose an image from the cloud storage's folders and shares.</p>
     <p><span class="def">Insert local image:</span> opens the browser file picker to upload the image from your local computer and insert it into the document.</p>
     <p>Images can be resized, rotated and anchored. Text can be wrapped around the image. Select the image and open the context menu. Use the images handles to resize the image with the mouse.</p>
   </div>
   <div class="sub-section">
-    <h4>Comments in documents</h4>
+    <h3>Comments in documents</h3>
     <p>Insert comments in <span class="productname">{productname}</span> in places that need special reader attention. Comments are displayed on the right and carry the name and date of the issuer.</p>
     <div class="screenshot"><img alt="comment" src="images/help/en/comment.png"/></div>
     <p>Click on the submenu (<span class="cool-annotation-menu icon-size" ></span>) icon to reply, move and delete comments.</p>
   </div>
   <div class="sub-section">
-    <h4>Spellchecking</h4>
+    <h3>Spellchecking</h3>
     <p><span class="productname">{productname}</span> can check spelling in text documents, spreadsheets and presentations. A red wavy underline indicates misspelled words. Click on the right mouse button to open a context menu with suggested misspelling corrections.</p>
     <div class="screenshot"><img alt="spellchecking" src="images/help/en/red-wavy-underline.png"/></div>
     <p>To systematically spell-check the whole document use the <span class="ui">Tools</span> menu’s <span class="ui">Spelling</span> option.</p>
@@ -648,7 +648,7 @@
     <div class="section">
     <h2 class="section-header">Frequently Asked Questions</h2>
     <div class="sub-section">
-    <h4>What are the documents file formats supported by <span class="productname">{productname}</span>?</h4>
+    <h3>What are the documents file formats supported by <span class="productname">{productname}</span>?</h3>
     <p><span class="productname">{productname}</span> supports both reading and writing for the following file formats:</p>
     <ul>
       <li><p>Text documents: Microsoft formats DOC, DOCX, RTF. OpenDocument Format ODT</p></li>
@@ -657,7 +657,7 @@
     </ul>
   </div>
   <div class="sub-section">
-    <h4>How do I save a document with another name?</h4>
+    <h3>How do I save a document with another name?</h3>
     <ol>
       <li><p>Hover the mouse on the document name in the menu bar.</p></li>
       <li><p>Type the new file name in the text box and press <kbd>Enter</kbd>.</p></li>
@@ -665,47 +665,47 @@
     <p>A copy of the document is saved with the new name in the same folder.</p>
   </div>
   <div class="sub-section">
-    <h4>How can I quit <span class="productname">{productname}</span> without saving my edits?</h4>
+    <h3>How can I quit <span class="productname">{productname}</span> without saving my edits?</h3>
     <p><span class="productname">{productname}</span> saves the document in the background regularly, you can't just close without saving it. To abandon your changes, you must either undo them, or use the <span class="ui">Revision History </span> in the <span class="ui">File</span> menu.</p>
   </div>
   <div class="sub-section">
-    <h4>Can <span class="productname">{productname}</span> open a password-protected document?</h4>
+    <h3>Can <span class="productname">{productname}</span> open a password-protected document?</h3>
     <p>Yes. <span class="productname">{productname}</span> opens password-protected documents, but it is necessary to supply the password in the “Enter password” prompt at load time.</p>
   </div>
   <div class="sub-section">
-    <h4>How can I check spelling in my language?</h4>
+    <h3>How can I check spelling in my language?</h3>
     <p>Choose menu <span class="ui">Tools</span> → <span class="ui">Languages</span> and select the language for the whole document. Optionally you can set languages for the selected text and for the current paragraph.</p>
   </div>
   <div class="sub-section">
-    <h4>How can I remove the red wavy lines in my document?</h4>
+    <h3>How can I remove the red wavy lines in my document?</h3>
     <p>Choose menu <span class="ui">Tools</span> and uncheck <span class="ui">Automatic Spell Checking</span>.</p>
   </div>
   <div class="sub-section">
-    <h4>What is the blue wavy underline in some words in the text?</h4>
+    <h3>What is the blue wavy underline in some words in the text?</h3>
     <p>Grammar errors in the text is marked with the blue wavy underline. Click on the underlined text with the right mouse button to open a menu with suggestions to correct the grammar error and the offended grammar rules. Select the right suggestion to change the text.</p>
   </div>
   <div class="sub-section">
-    <h4>Is there a thesaurus?</h4>
+    <h3>Is there a thesaurus?</h3>
     <p>Yes. Click in the word you want and choose <span class="ui">Tools</span> → <span class="ui">Thesaurus</span>. A dialog opens with many suggestions for replacements.</p>
     <div class="screenshot"><img alt="" src="images/help/en/thesaurus.png"/></div>
   </div>
   <div class="sub-section">
-    <h4>What are the blue <span class="blue">¶</span> symbol and how can I remove from my text document?</h4>
+    <h3>What are the blue <span class="blue">¶</span> symbol and how can I remove from my text document?</h3>
     <p>The <span class="blue">¶</span> symbol is a formatting mark. It is used to help text alignment and editing and is not printed. To toggle it in the document display, choose menu <span class="ui">View</span> → <span class="ui">Formatting mark</span>.</p>
       </div>
     </div>
 <div class="text hide">
     <a id="1407"/>
     <div class="section">
-    <h3 class="section-header">Text documents</h3>
+    <h2 class="section-header">Text documents</h2>
     <div class="sub-section">
-    <h4>How do I get a word count of my document?</h4>
+    <h3>How do I get a word count of my document?</h3>
     <p>Word count is available in <span class="ui">Tools</span> → <span class="ui">Word count</span>. A dialog shows word counts for selection and for the whole document.</p>
     <div class="screenshot"><img alt="word count" src="images/help/en/word-count.png"/></div>
     <p>Word count is also displayed in the status bar. If no text is selected the word count is for the whole document. Otherwise the word count is for the selected text.</p>
     </div>
     <div class="sub-section">
-    <h4>How can I insert a currency, copyright or trademark symbol in the document?</h4>
+    <h3>How can I insert a currency, copyright or trademark symbol in the document?</h3>
     <p>You can insert these special characters in the document using the <span class="ui">Special Character</span> dialog.</p>
     <ol>
       <li><p>Place the cursor in the position to insert the character.</p></li>
@@ -718,7 +718,7 @@
     </ol>
     </div>
     <div class="sub-section">
-    <h4>Why can't I delete text? It just gets a strike-through?</h4>
+    <h3>Why can't I delete text? It just gets a strike-through?</h3>
     <p>You have the Track Changes feature enabled for the document. Track Changes records all changes in the text and shows the editions for later revision. Useful for marking changes in text and spreadsheets. Track changes are enabled choosing <span class="ui">Edit</span> → <span class="ui">Track Changes </span> → <span class="ui">Record</span>.</p>
     <p>With track changes enabled your document is shown the following manner:</p>
     <ul>
@@ -734,7 +734,7 @@
     <div class="screenshot"><img alt="" src="images/help/en/manage-changes.png"/></div>
     </div>
     <div class="sub-section">
-    <h4>How do I set the margins of the document?</h4>
+    <h3>How do I set the margins of the document?</h3>
     <p>Using the ruler drag the leftmost edge of the ruler to adjust the left margin, or the rightmost for the right margin.</p>
     <p>Using the page style</p>
     <ol>
@@ -744,7 +744,7 @@
     <div class="screenshot"><img alt="" src="images/help/en/page-style.png"/></div>
     </div>
     <div class="sub-section">
-    <h4>How do I change the page orientation to landscape inside my document</h4>
+    <h3>How do I change the page orientation to landscape inside my document</h3>
     <ol>
       <li><p>Place the cursor at the place where the page orientation is to change. Add an empty paragraph.</p></li>
       <li><p>Choose <span class="ui">Format</span> → <span class="ui">Paragraph</span>, <span class="ui">Text Flow </span> tab</p></li>
@@ -755,7 +755,7 @@
     <p>To return to portrait orientation, repeat the procedure, choosing Portrait in “With page style”.</p>
     </div>
     <div class="sub-section">
-    <h4>How can I make the new text look like other existing text?</h4>
+    <h3>How can I make the new text look like other existing text?</h3>
     <p>Directly:</p>
     <ol>
       <li><p>Select the text with the existing format</p></li>
@@ -771,7 +771,7 @@
     </ol>
     </div>
     <div class="sub-section">
-    <h4>Why did the text I just typed change automatically? How can I revert it?</h4>
+    <h3>Why did the text I just typed change automatically? How can I revert it?</h3>
     <p>You have the AutoCorrection enabled. AutoCorrection changes the text just typed into an internal table of corresponding text. In most cases, AutoCorrection fixes typos while you are typing. If AutoCorrection is not necessary, disable it in <span class="ui">Tools</span> → <span class="ui">AutoCorrection</span> → <span class="ui">While typing</span>.</p>
     </div>
     </div>
@@ -779,13 +779,13 @@
 <div class="spreadsheet hide">
     <a id="1409"/>
     <div class="section">
-    <h3 class="section-header">Spreadsheets</h3>
+    <h2 class="section-header">Spreadsheets</h2>
     <div class="sub-section">
-    <h4>How can I select data to print?</h4>
+    <h3>How can I select data to print?</h3>
     <p>Insert column and row breaks in the spreadsheet to narrow the print range and print the document to download. On printing the PDF, select the pages of interest.</p>
     </div>
     <div class="sub-section">
-    <h4>How can I import CSV data?</h4>
+    <h3>How can I import CSV data?</h3>
     <ol>
       <li><p>Load your CSV data in some native tool to your platform, select and copy it to the clipboard</p></li>
       <li><p>Activate the <span class="productname">{productname}</span> spreadsheet window.</p></li>
@@ -798,20 +798,20 @@
     <p>The CSV data is loaded into the selected cell where you pasted, according to these settings.</p>
     </div>
     <div class="sub-section">
-    <h4>How can I copy the formatting of existing cells to new ones?</h4>
+    <h3>How can I copy the formatting of existing cells to new ones?</h3>
     <p>This is easy to do using the Paintbrush tool in the toolbar.</p>
     <ol>
       <li><p>Format the source cell with the font, color background and more.</p></li>
-      <li><p>Click on the clone formatting icon <img class="icon-size" src="images/lc_formatpaintbrush.svg"/>. The mouse pointer turns to a paint bucket.</p></li>
+      <li><p>Click on the clone formatting icon <img alt="" class="icon-size" src="images/lc_formatpaintbrush.svg"/>. The mouse pointer turns to a paint bucket.</p></li>
       <li><p>Select the cells you want to format. Release the mouse button.</p></li>
     </ol>
     </div>
     <div class="sub-section">
-    <h4>What is “Clear Direct Formatting” icon?</h4>
+    <h3>What is “Clear Direct Formatting” icon?</h3>
     <p>Direct formatting is formatting applied directly to the selected contents of a paragraph or a spreadsheet cell, and overlaps its assigned style formatting. To restore the formatting to the style settings, select the text or spreadsheet cell and choose <span class="ui">Format</span> → <span class="ui">Clear Direct Formatting</span> or use the button in the toolbar.</p>
     </div>
     <div class="sub-section">
-    <h4>How do I rename a sheet?</h4>
+    <h3>How do I rename a sheet?</h3>
     <p>Rename a sheet in the spreadsheet document using the context menu (using the right mouse button) over the sheet tab in the bottom. Enter the new sheet name in the dialog that follows.</p>
     </div>
     </div>
@@ -819,16 +819,16 @@
 <div class="presentation hide">
     <a id="1411"/>
     <div class="section">
-    <h3 class="section-header">Presentations</h3>
+    <h2 class="section-header">Presentations</h2>
     <div class="sub-section">
-    <h4>How can I run my slide show?</h4>
+    <h3>How can I run my slide show?</h3>
     <ol>
       <li><p>Open the presentation in <span class="productname">{productname}</span></p></li>
       <li><p>Either choose <span class="ui">Slide Show</span> → <span class="ui">Full Screen Presentation</span> or click on the left-most icon in the bottom of the slide panel: <img class="icon-size" alt="" src="images/lc_dia.svg"></p></li>
     </ol>
     </div>
     <div class="sub-section">
-    <h4>How can I change the line, area and position of a shape in my slides?</h4>
+    <h3>How can I change the line, area and position of a shape in my slides?</h3>
     <ol>
       <li><p>Select the shape in your slide. A set of handles shows.</p></li>
       <li>


### PR DESCRIPTION
Change-Id: I8ea074236cb78fbcb288bb6c08f389efb4c2ae08

Issue:
- it should be noted that the heading structure within the dialog does not correspond to the logical content hierarchy. After the `<h1>` heading, `<h3>` headings follow directly, while an `<h2>` heading is missing.

Changes:
- update to follow hierarchy: `h1 -> h2 -> h3`


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

