### PR TITLE
Isfileodf for 25.04

### DIFF
--- a/browser/src/app/LOUtil.ts
+++ b/browser/src/app/LOUtil.ts
@@ -684,7 +684,16 @@ class LOUtil {
 
 	public static isFileODF(map: any): boolean {
 		var ext = LOUtil.getFileExtension(map);
-		return ext === 'odt' || ext === 'ods' || ext === 'odp' || ext == 'odg';
+		return (
+			ext === 'odt' ||
+			ext === 'ods' ||
+			ext === 'odp' ||
+			ext === 'odg' ||
+			ext === 'fodt' ||
+			ext === 'fods' ||
+			ext === 'fodp' ||
+			ext === 'fodg'
+		);
 	}
 
 	public static containsDOMRect(


### PR DESCRIPTION
Most of the samples that are printed by "make run" are actually flat ODF so this is more irritating for developers than users.


Change-Id: I30dc6e3e81487ed5ea9884bd5fc01c3dae7b84cb (cherry picked from commit 6b77cab395a549c560d79ed71822b4b3b682b898)


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

