### PR TITLE
Impress: Set partsFocused to false to prevent accidential deletion.

### DIFF
--- a/browser/src/canvas/sections/ImpressSelectionRectangle.ts
+++ b/browser/src/canvas/sections/ImpressSelectionRectangle.ts
@@ -54,6 +54,7 @@ class SelectionRectangle extends CanvasSectionObject {
 
 	public onMouseDown(point: cool.SimplePoint, e: MouseEvent): void {
 		this.sectionProperties.positionOnMouseDown = point;
+		app.map._docLayer._preview.partsFocused = false;
 	}
 
 	public onNewDocumentTopLeft(): void {


### PR DESCRIPTION
Issue: After switching to a slide, if use presses "delete" key on the keyboard, the selected part is deleted. Because apperantly tilesSection's onClick event is not called in this branch. In master branch, this doesn't exist. This is a placeholder until missing commits are backported.


Change-Id: Ic85693a6a53cfcac2117e579dc7d717814bf807d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

