### PR TITLE
fix(cursor): suspend blinking during movement

### DIFF
--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -637,6 +637,14 @@ div.leaflet-cursor-container:hover > .leaflet-cursor-header {
 	animation: 1s blink step-end 0s infinite;
 }
 
+.blinking-cursor.blinking-suspended {
+	-webkit-animation: none;
+	-moz-animation: none;
+	-ms-animation: none;
+	-o-animation: none;
+	animation: none;
+}
+
 .blinking-cursor-hidden {
 	-webkit-animation: none !important;
 	-moz-animation: none !important;

--- a/browser/src/layer/marker/Cursor.ts
+++ b/browser/src/layer/marker/Cursor.ts
@@ -269,14 +269,14 @@ class Cursor {
 		this.container.style.top = pos.y + 'px';
 		this.container.style.left = this.transformX(pos.x) + 'px';
 		this.container.style.zIndex = this.zIndex + '';
-		// Restart blinking animation
+		// Suspend blinking animation during cursor movement
 		if (this.blink) {
-			window.L.DomUtil.removeClass(this.cursor, 'blinking-cursor');
+			window.L.DomUtil.addClass(this.cursor, 'blinking-suspended');
 			if (this.blinkSuspendTimeout) {
 				clearTimeout(this.blinkSuspendTimeout);
 			}
 			this.blinkSuspendTimeout = setTimeout(() => {
-				window.L.DomUtil.addClass(this.cursor, 'blinking-cursor');
+				window.L.DomUtil.removeClass(this.cursor, 'blinking-suspended');
 			}, 500);
 		}
 	}


### PR DESCRIPTION
- prevents cursor from disappearing when moving too fast in the document.


Change-Id: I589c7766e1908889466df89c187dd8acd455a1f3


* Resolves: #13504 
* Target version: master 

## How it works :

- setPos to suspend the blinking animation when the cursor position changes.
- Added a blinkSuspendTimeout to restart the blinking animation after 500ms of inactivity.

