### PR TITLE
Remove the Presenter Console menu item in mobile apps

### DIFF
--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -580,7 +580,10 @@ class Menubar extends window.L.Control {
 				{name: _('Fullscreen presentation'), id: 'fullscreen-presentation', type: 'action'},
 				{name: _('Present current slide'), id: 'presentation-currentslide', type: 'action'},
 				{name: _('Present in new window'), id: 'present-in-window', type: 'action'},
-				{name: _('Presenter Console'), id: 'presentation-in-console', type: 'action'}]
+				...(!window.ThisIsAMobileApp ? [
+					{name: _('Presenter Console'), id: 'presentation-in-console', type: 'action'}
+				] : [])
+			]
 			},
 			{name: _UNO('.uno:ToolsMenu', 'presentation'), id: 'tools', type: 'menu', menu: [
 				{uno: '.uno:SpellDialog'},


### PR DESCRIPTION
It was removed already from the Notebookbar.
Presenter console does not work in mobile apps, because a user cannot allow the "browser" to show pop ups.


Change-Id: I85673321d50d0ce84e2277ae4de402ee41d539de

