### PR TITLE
fix comments not fully visible on reload (when sidebar is hidden and window width is not too large)

### DIFF
--- a/browser/src/app/ViewLayoutWriter.ts
+++ b/browser/src/app/ViewLayoutWriter.ts
@@ -24,6 +24,7 @@ class ViewLayoutWriter extends ViewLayoutBase {
 		app.map.on('resize', this.documentZoomOrResizeCallback, this);
 		app.map.on('deleteannotation', this.annotationOperationsCallback, this);
 		app.map.on('insertannotation', this.annotationOperationsCallback, this);
+		app.map.on('importannotations', this.annotationOperationsCallback, this);
 		app.map.on(
 			'showannotationschanged',
 			this.annotationOperationsCallback,

--- a/browser/src/layer/tile/WriterTileLayer.js
+++ b/browser/src/layer/tile/WriterTileLayer.js
@@ -51,6 +51,7 @@ window.L.WriterTileLayer = window.L.CanvasTileLayer.extend({
 				comment.parent = comment.parentId.toString();
 			});
 			app.sectionContainer.getSectionWithName(app.CSections.CommentList.name).importComments(values.comments);
+			app.map.fire('importannotations');
 		}
 		else if (values.redlines && values.redlines.length > 0) {
 			app.sectionContainer.getSectionWithName(app.CSections.CommentList.name).importChanges(values.redlines);


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

