### PR TITLE
accessibility: use proper aria attributes for edit widget

### DIFF
--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -354,6 +354,7 @@ interface EditWidgetJSON extends WidgetJSON {
 	password: boolean; // is password field
 	hidden: boolean; // is hidden, TODO: duplicate?
 	changedCallback: any; // callback  for 'change' event
+	aria?: AriaAttributeJSON; // ARIA attributes
 }
 
 // type: 'checkbox'
@@ -366,4 +367,9 @@ interface CheckboxWidgetJSON extends WidgetJSON {
 
 interface SeparatorWidgetJSON extends WidgetJSON {
 	orientation: string;
+}
+
+interface AriaAttributeJSON {
+	label?: string;
+	description?: string;
 }

--- a/browser/src/control/jsdialog/Widget.Edit.ts
+++ b/browser/src/control/jsdialog/Widget.Edit.ts
@@ -91,8 +91,17 @@ class EditWidget {
 
 		if (data.placeholder) {
 			edit.setAttribute('placeholder', data.placeholder);
+		}
+
+		if (data.labelledBy) {
+			edit.setAttribute('aria-labelledby', data.labelledBy + '-label');
+		}
+		else if (data.aria && data.aria.label) {
+			edit.setAttribute('aria-label', data.aria.label);
+		} else if (data.placeholder) {
 			edit.setAttribute('aria-label', data.placeholder);
 		}
+
 		return result;
 	}
 


### PR DESCRIPTION
Change-Id: I09084033ad3367caf0b08b79d4edaeae25ec91fb

Required core patch: https://gerrit.libreoffice.org/c/core/+/194232

**Edit:**
This PR is no longer needed due to #13537. Currently marked it as draft and let's close this only after #13537 is merged.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

