### PR TITLE
kit: don't set view lang if... [for co-25.04]

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2206,7 +2206,10 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
                                         session->getViewUserExtraInfo(), session->getViewUserPrivateInfo(),
                                         session->isReadOnly());
 
-    _loKitDocument->setViewLanguage(viewId, lang.c_str());
+    if (!lang.empty())
+    {
+        _loKitDocument->setViewLanguage(viewId, lang.c_str());
+    }
     _loKitDocument->setViewTimezone(viewId, userTimezone.c_str());
     _loKitDocument->setAccessibilityState(viewId, accessibilityState);
     if (session->isReadOnly())


### PR DESCRIPTION
...lang url parameter was not set by the client.


Change-Id: Ia3a5cba9a219a618f7bb8dc312354bf0b280541a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

