### PR TITLE
fix(touch): stop zoom popping up onscreen keyboard

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -188,6 +188,7 @@ class CanvasSectionContainer {
 	private scrollLineHeight: number = 30; // This will be overridden.
 	private mouseIsInside: boolean = false;
 	private inZoomAnimation: boolean = false;
+	private postZoomReplay: boolean = false;
 	private zoomChanged: boolean = false;
 	private documentAnchorSectionName: string = null; // This section's top left point declares the point where document starts.
 	private documentAnchor: Array<number> = null; // This is the point where document starts inside canvas element. Initial value shouldn't be [0, 0].
@@ -319,6 +320,14 @@ class CanvasSectionContainer {
 
 	public isInZoomAnimation (): boolean {
 		return this.inZoomAnimation;
+	}
+
+	public setPostZoomReplay (postZoomReplay: boolean) {
+		this.postZoomReplay = postZoomReplay;
+	}
+
+	public isPostZoomReplay (): boolean {
+		return this.postZoomReplay;
 	}
 
 	public setZoomChanged (zoomChanged: boolean) {

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2930,8 +2930,10 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 
 	_onZoomEnd: function () {
 		this._isZooming = false;
+		app.sectionContainer.setPostZoomReplay(true);
 		if (!this.isCalc())
 			this._replayPrintTwipsMsgs(false);
+		app.sectionContainer.setPostZoomReplay(false);
 		this._onUpdateCursor(null, true);
 		TextCursorSection.updateVisibilities();
 	},
@@ -3103,10 +3105,10 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 
 			var hasMobileWizardOpened = this._map.uiManager.mobileWizard ? this._map.uiManager.mobileWizard.isOpen() : false;
 			var hasIframeModalOpened = $('.iframe-dialog-modal').is(':visible');
-			// Don't show the keyboard when the Wizard is visible.
+			// Don't show the keyboard when the Wizard is visible, or when we have just been in a zoom
 			if (!window.mobileWizard && !window.pageMobileWizard &&
 				!window.insertionMobileWizard && !hasMobileWizardOpened &&
-				!JSDialog.IsAnyInputFocused() && !hasIframeModalOpened) {
+				!JSDialog.IsAnyInputFocused() && !hasIframeModalOpened && !app.sectionContainer.isPostZoomReplay()) {
 				// If the user is editing, show the keyboard, but don't change
 				// anything if nothing is changed.
 


### PR DESCRIPTION
Previously, when you used pinch zoom on a mobile device, your onscreen keyboard would often pop up. This happened because some messages which you got during the zoom might normally trigger keyboard popup. Despite us ignoring these messages during the zoom, we would replay them after the zoom - popping up the keyboard when you released your fingers.

To fix this, we need to record whether we're in a post zoom animation. If so, we should treat it as a situation where focusing the input should be done without triggering the keyboard. The rest of the code there is still important, so we can't avoid running these deferred messages or even cutting out as much of the code as we do when in the regular zoom state...


Change-Id: I5699457a439cbdd8a63f9f3e429be8286a6a6964


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

