### PR TITLE
cypress: document 'Delete Chart' test fix and remove wait.

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/delete_objects_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/delete_objects_spec.js
@@ -38,14 +38,16 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Delete Objects', function(
 	});
 
 	it('Delete Chart' , function() {
+		// Insert chart button not visible yet so click on the overflow button.
 		cy.cGet('#toolbar-up #overflow-button-other-toptoolbar .arrowbackground').click();
-		//insert
+		// Click on insert chart button.
 		cy.cGet('#insertobjectchart').click();
+		// Click on the ok button of chart jsdialog.
 		cy.cGet('.ui-pushbutton.jsdialog.button-primary').should($el => { expect(Cypress.dom.isDetached($el)).to.eq(false); }).click();
+		// Close the overflow toolbar. Doing this before closing the chart jsdialog does not work.
 		cy.cGet('.jsdialog-overlay').click();
 		cy.cGet('#test-div-shapeHandlesSection').should('exist');
-		cy.wait(300);
-		//delete
+		// delete
 		helper.typeIntoDocument('{del}');
 		cy.cGet('#test-div-shapeHandlesSection').should('not.exist');
 	});


### PR DESCRIPTION
Change-Id: I3395cdcb702b9db6c6b6f6f3a3e7ec21cd5e6c80


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
I ran into this unstable test and wrote a fix but found the same fix in master later except for the wait part and comments. The wait is not necessary. At least in my local it ran successfully 7/7.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

