### PR TITLE
Calc Sidebar: Fix oversized and misaligned text orientation buttons

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -472,6 +472,16 @@ algned to the bottom */
 	margin-bottom: 6px;
 }
 
+.sidebar .jsdialog.ui-alignment .ui-togglebutton.loOrientationBtn button {
+    padding: 2px !important;
+    margin-right: 4px;
+    min-width: 26px;
+    min-height: 26px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
 .ui-tab.hidden.jsdialog {
 	visibility: hidden !important;
 }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Fixes the oversized and misaligned text-orientation buttons in the Calc sidebar. These buttons inherited large padding from the generic `.ui-toggle button` style, making them appear too large and misaligned above the label. 

A targeted CSS override was added for `.sidebar .jsdialog.ui-alignment .ui-togglebutton.loOrientationBtn button` to reduce padding, enforce a 26×26px minimum size, align icons properly, and improve spacing. 

This restores correct visual alignment and consistency with other sidebar controls. UI-only fix; no functional behavior changed.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

