### PR TITLE
Add modified implementation for removeFile function

### DIFF
--- a/common/FileUtil-unix.cpp
+++ b/common/FileUtil-unix.cpp
@@ -94,54 +94,30 @@ namespace FileUtil
     }
 #endif
 
-    static int nftw_cb(const char *fpath, const struct stat*, int type, struct FTW*)
-    {
-        if (type == FTW_DP)
-        {
-            rmdir(fpath);
-        }
-        else if (type == FTW_F || type == FTW_SL)
-        {
-            unlink(fpath);
-        }
-
-        // Always continue even when things go wrong.
-        return 0;
-    }
 
     void removeFile(const std::string& path, const bool recursive)
     {
         LOG_DBG("Removing [" << Anonymizer::anonymizeUrl(path) << "] " << (recursive ? "recursively." : "only."));
+        std::error_code err;
 
-        try
+        if (recursive)
         {
-            struct stat sb;
-            errno = 0;
-            if (!recursive || stat(path.c_str(), &sb) == -1 || S_ISREG(sb.st_mode))
-            {
-                // Non-recursive directories and files that exist.
-                if (errno != ENOENT)
-                    Poco::File(path).remove(recursive);
-            }
-            else
-            {
-                // Directories only.
-                nftw(path.c_str(), nftw_cb, 128, FTW_DEPTH | FTW_PHYS);
-            }
+            std::filesystem::remove_all(path, err);
         }
-        catch (const std::exception& e)
+        else
         {
-            // Don't complain if already non-existent.
-            if (FileUtil::Stat(path).exists())
-            {
-                // Error only if it still exists.
-                LOG_ERR("Failed to remove ["
-                        << Anonymizer::anonymizeUrl(path) << "] " << (recursive ? "recursively: " : "only: ") << e.what());
-            }
+            std::filesystem::remove(path, err);
+        }
+
+        if (err != std::errc::no_such_file_or_directory)
+        {
+            LOG_ERR("Failed to remove ["
+                    << Anonymizer::anonymizeUrl(path) << "] " << (recursive ? "recursively: " : "only: ") << err.message());
         }
     }
 
-    /// Remove directories only, which must be empty for this to work.
+
+   /// Remove directories only, which must be empty for this to work.
     static int nftw_rmdir_cb(const char* fpath, const struct stat*, int type, struct FTW*)
     {
         if (type == FTW_DP)

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -70,6 +70,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testFindInVector);
     CPPUNIT_TEST(testJoinPair);
     CPPUNIT_TEST(testThreadPool);
+    CPPUNIT_TEST(testRemoveFile);
     CPPUNIT_TEST_SUITE_END();
 
     void testCOOLProtocolFunctions();
@@ -99,6 +100,7 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testFindInVector();
     void testJoinPair();
     void testThreadPool();
+    void testRemoveFile();
 
     size_t waitForThreads(size_t count);
 };
@@ -1195,6 +1197,58 @@ void WhiteBoxTests::testThreadPool()
     LOK_ASSERT_EQUAL(size_t(7), pool._threads.size());
 //    LOK_ASSERT_EQUAL(size_t(7 + existingUnrelatedThreads), waitForThreads(8 + existingUnrelatedThreads));
 }
+
+
+void WhiteBoxTests::testRemoveFile()
+{
+    constexpr std::string_view testname = __func__;
+    const std::string baseDir = FileUtil::getSysTempDirectoryPath();
+
+    // test for file
+    {
+        const std::string testFile = baseDir + "/removefile_test_file.tmp";
+        FileUtil::removeFile(testFile, false); // Curățare inițială
+
+        {
+            std::ofstream ofs(testFile);
+        }
+
+        LOK_ASSERT(FileUtil::Stat(testFile).exists());
+
+        FileUtil::removeFile(testFile, false);
+        LOK_ASSERT(!FileUtil::Stat(testFile).exists());
+
+        FileUtil::removeFile(testFile, false);
+        LOK_ASSERT(!FileUtil::Stat(testFile).exists());
+    }
+
+    // test for directory
+    {
+        const std::string testDir = baseDir + "/removefile_test_dir.tmp";
+        const std::string innerFile = testDir + "/inner_file.txt";
+
+        FileUtil::removeFile(testDir, true);
+
+        LOK_ASSERT(FileUtil::makeDirectory(testDir) == 0);
+        {
+            std::ofstream ofs(innerFile);
+        }
+
+        LOK_ASSERT(FileUtil::Stat(testDir).exists());
+        LOK_ASSERT(FileUtil::Stat(innerFile).exists());
+
+        FileUtil::removeFile(testDir, false);
+
+        LOK_ASSERT(FileUtil::Stat(testDir).exists());
+        LOK_ASSERT(FileUtil::Stat(innerFile).exists());
+
+        FileUtil::removeFile(testDir, true);
+
+        LOK_ASSERT(!FileUtil::Stat(testDir).exists());
+        LOK_ASSERT(!FileUtil::Stat(innerFile).exists());
+    }
+}
+
 
 CPPUNIT_TEST_SUITE_REGISTRATION(WhiteBoxTests);
 


### PR DESCRIPTION
Change-Id: Ieb0e10d7471468f1a9b7c15c35d5bf13ec10fd30


* Resolves: # https://github.com/CollaboraOnline/online/issues/13334
* Target version: master 

### Summary
I modernized the removeFile function by replacing the Poco::File and nftw dependency with  std::filesystem::remove and std::filesystem::remove_all.


### TODO

- [x] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

