### PR TITLE
wsd: simplify serializing sliderenderingcomplete:

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2667,16 +2667,17 @@ bool ChildSession::renderSlide(const StringVector& tokens)
 
     getLOKitDocument()->postSlideshowCleanup();
 
-    std::string msg = "sliderenderingcomplete: ";
-    if (EnableExperimental) {
-        msg += std::string("{\"status\": \"") + (success ? "success" : "fail") +
-               "\", \"slidehash\": \"" + hash +
-               "\", \"compressedLayers\": " + (compressedLayers ? "true" : "false") +
-               ", \"cacheKey\": \"" + tokens.substrFromToken(1) + "\"}";
-    } else {
-        msg += std::string("{\"status\": \"") + (success ? "success" : "fail") + "\"}";
+    std::ostringstream msg;
+    msg << "sliderenderingcomplete: " << R"({"status": ")" << (success ? "success" : "fail");
+    if (EnableExperimental)
+    {
+        msg << R"(", "slidehash": ")" << hash << R"(", "compressedLayers": )"
+            << (compressedLayers ? "true" : "false") << R"(, "cacheKey": ")"
+            << tokens.substrFromToken(1);
     }
-    sendTextFrame(msg);
+
+    msg << "\"}";
+    sendTextFrame(msg.str());
 
     return success;
 }


### PR DESCRIPTION
Simplifies the EnableExperimental log when
serializing the 'sliderenderingcomplete:'
command, converts the JSON literals to
raw string and uses std::ostringstream
to avoid temporary strings.

Change-Id: I5db8fd9a8b940954e685fd2b65ef63bb5c1ac3b8
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
