### PR TITLE
Fix #13349: Replace string concatenation with operator<< in logs

### DIFF
--- a/common/CharacterConverter.hpp
+++ b/common/CharacterConverter.hpp
@@ -51,7 +51,7 @@ public:
     {
         if (reinterpret_cast<int64_t>(_iconvd) == -1)
         {
-            LOG_WRN("Failed to initize iconv and cannot convert [" + source + ']');
+            LOG_WRN("Failed to initize iconv and cannot convert [" << source << ']');
             return source;
         }
 

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -117,8 +117,10 @@ public:
     {
         if (_docManager == nullptr)
         {
+
             LOG_TRC("No DocManager; dropping message to client-"
                     << getId() << ": " << std::string_view(buffer, length));
+
             return false;
         }
         const auto msg = "client-" + getId() + ' ' + std::string(buffer, length);
@@ -130,6 +132,7 @@ public:
         if (_docManager == nullptr)
         {
             LOG_TRC("No DocManager; dropping binary to client-" << getId());
+
             return false;
         }
         const auto msg = "client-" + getId() + ' ' + std::string(buffer, length);

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2724,7 +2724,7 @@ bool Document::trackDocModifiedState(const std::string &stateChanged)
 
 void Document::disableBgSave(const std::string &reason)
 {
-    LOG_WRN("Disabled background save " + reason);
+    LOG_WRN("Disabled background save " << reason);
     _isBgSaveDisabled = true;
 }
 

--- a/kit/KitWebSocket.cpp
+++ b/kit/KitWebSocket.cpp
@@ -299,7 +299,7 @@ void BgSaveParentWebSocketHandler::handleMessage(const std::vector<char>& data)
              object->get("jsontype").toString() == "formulabar"))
             // white-listing to avoid popup & dialog & other interactive errors
         {
-            LOG_DBG("Unexpected but benign jsdialog message from bgsave process " +
+            LOG_DBG("Unexpected but benign jsdialog message from bgsave process " <<
                     COOLProtocol::getAbbreviatedMessage(data));
             return;
         }

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -1044,8 +1044,8 @@ inline std::string getAllText(const std::shared_ptr<http::WebSocketSession>& soc
             else if ((prefix + expected) == text)
                 return text;
             else
-                LOG_DBG("text selection mismatch text received: '" + text +
-                        "' is not what is expected: '" + prefix + expected + "'");
+                LOG_DBG("text selection mismatch text received: '" << text <<
+                        "' is not what is expected: '" << prefix << expected << "'");
         }
     }
 

--- a/tools/Replay.hpp
+++ b/tools/Replay.hpp
@@ -570,7 +570,7 @@ public:
             TileDesc desc = TileDesc::parse(tokens);
 
             sendMessage("tileprocessed tile=" + desc.generateID());
-            LOG_TST(_logPre << "Sent tileprocessed tile= " + desc.generateID());
+            LOG_TST(_logPre << "Sent tileprocessed tile= " << desc.generateID());
         }
         else if (tokens.equals(0, "error:"))
         {

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -380,7 +380,7 @@ void AdminSocketHandler::handleMessage(const std::vector<char> &payload)
         }
         else
         {
-            LOG_WRN("Document migration failed for dockey:" + dockey +
+            LOG_WRN("Document migration failed for dockey:" << dockey <<
                         ", reason has been changed");
         }
     }

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1840,7 +1840,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
                 LOG_WRN("Quarantine path is relative. Please use an absolute path for better "
                         "reliability");
 
-            LOG_DBG("Initializing quarantine at [" + path << ']');
+            LOG_DBG("Initializing quarantine at [" << path << ']');
             Quarantine::initialize(path);
         }
     }
@@ -1862,10 +1862,10 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
             Poco::File p(path);
             try
             {
-                LOG_TRC("Creating cache directory [" + path << ']');
+                LOG_TRC("Creating cache directory [" << path << ']');
                 p.createDirectories();
 
-                LOG_DBG("Created cache directory [" + path << ']');
+                LOG_DBG("Created cache directory [" << path << ']');
             }
             catch (const std::exception& ex)
             {
@@ -3598,7 +3598,7 @@ void COOLWSD::innerMain()
     }
     if (locale)
     {
-        LOG_INF("Locale is set to " + std::string(locale));
+        LOG_INF("Locale is set to " << std::string(locale));
         ::setenv("LC_ALL", locale, 1);
     }
 #endif // !IOS

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -337,7 +337,7 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
             return;
         }
 
-        LOG_TRC("Session [" << getId() << "] sending getclipboard name=" + tag + specific);
+        LOG_TRC("Session [" << getId() << "] sending getclipboard name=" << tag << specific);
         docBroker->forwardToChild(client_from_this(), "getclipboard name=" + tag + specific);
         _clipSockets.push_back(socket);
     }

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1267,7 +1267,7 @@ void FileServerRequestHandler::readDirToHash(const std::string &basePath, const 
                        "Unexpected data in uncompressedFile after failed read");
                 if (size < 0)
                 {
-                    LOG_ERR("Failed to read file [" << basePath + relPath
+                    LOG_ERR("Failed to read file [" << basePath << relPath
                                                     << "] or is too large to cache and serve");
                 }
             }
@@ -1288,7 +1288,7 @@ void FileServerRequestHandler::readDirToHash(const std::string &basePath, const 
                        "Unexpected data in uncompressedFile after failed read");
                 if (size < 0)
                 {
-                    LOG_ERR("Failed to read file [" << basePath + relPath
+                    LOG_ERR("Failed to read file [" << basePath << relPath
                                                     << "] or is too large to cache and serve");
                 }
 
@@ -1305,7 +1305,7 @@ void FileServerRequestHandler::readDirToHash(const std::string &basePath, const 
             const int initResult = deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY);
             if (initResult != Z_OK)
             {
-                LOG_ERR("Failed to deflateInit2 for file [" << basePath + relPath
+                LOG_ERR("Failed to deflateInit2 for file [" << basePath << relPath
                                                             << "], result: " << initResult);
                 // Add the uncompressed version; it's better to serve uncompressed than nothing at all.
                 FileHash.emplace(prefix + relPath,
@@ -1334,7 +1334,7 @@ void FileServerRequestHandler::readDirToHash(const std::string &basePath, const 
             const int deflateResult = deflate(&strm, Z_FINISH);
             if (deflateResult != Z_OK && deflateResult != Z_STREAM_END)
             {
-                LOG_ERR("Failed to deflate [" << basePath + relPath
+                LOG_ERR("Failed to deflate [" << basePath << relPath
                                               << "], result: " << deflateResult);
                 compressedFile.clear(); // Can't trust the compressed data, if any.
             }

--- a/wsd/ProxyProtocol.cpp
+++ b/wsd/ProxyProtocol.cpp
@@ -336,7 +336,7 @@ int ProxyProtocolHandler::sendMessage(const char *msg, const size_t len, bool te
 int ProxyProtocolHandler::sendTextMessage(const char *msg, const size_t len, bool flush) const
 {
     ASSERT_CORRECT_THREAD();
-    LOG_TRC("ProxyHack - send text msg " + std::string(msg, len));
+    LOG_TRC("ProxyHack - send text msg " << std::string(msg, len));
     return const_cast<ProxyProtocolHandler *>(this)->sendMessage(msg, len, true, flush);
 }
 

--- a/wsd/wopi/WopiProxy.cpp
+++ b/wsd/wopi/WopiProxy.cpp
@@ -197,7 +197,7 @@ void WopiProxy::checkFileInfo(const std::shared_ptr<TerminatingPoll>& poll, cons
                 }
                 catch (const std::exception& ex)
                 {
-                    LOG_ERR("Could not download document from WOPI FileUrl [" + fileUrlAnonym +
+                    LOG_ERR("Could not download document from WOPI FileUrl [" << fileUrlAnonym <<
                                 "]. Will use default URL. Error: "
                             << ex.what());
                     // Fall-through.
@@ -219,7 +219,7 @@ void WopiProxy::checkFileInfo(const std::shared_ptr<TerminatingPoll>& poll, cons
             catch (const std::exception& ex)
             {
                 LOG_ERR(
-                    "Cannot download document from WOPI storage uri [" + uriAnonym + "]. Error: "
+                    "Cannot download document from WOPI storage uri [" << uriAnonym << "]. Error: "
                     << ex.what());
                 // Fall-through.
             }

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -540,7 +540,7 @@ std::string WopiStorage::downloadStorageFileToLocal(const Authorization& auth,
         }
         catch (const std::exception& ex)
         {
-            LOG_ERR("Could not download template from [" + templateUriAnonym + "]. Error: "
+            LOG_ERR("Could not download template from [" << templateUriAnonym << "]. Error: "
                     << ex.what());
             throw; // Bubble-up the exception.
         }
@@ -562,7 +562,7 @@ std::string WopiStorage::downloadStorageFileToLocal(const Authorization& auth,
         }
         catch (const std::exception& ex)
         {
-            LOG_ERR("Could not download document from WOPI FileUrl [" + fileUrlAnonym +
+            LOG_ERR("Could not download document from WOPI FileUrl [" << fileUrlAnonym <<
                         "]. Will use default URL. Error: "
                     << ex.what());
         }
@@ -586,7 +586,7 @@ std::string WopiStorage::downloadStorageFileToLocal(const Authorization& auth,
     }
     catch (const std::exception& ex)
     {
-        LOG_ERR("Cannot download document from WOPI storage uri [" + uriAnonym + "]. Error: "
+        LOG_ERR("Cannot download document from WOPI storage uri [" << uriAnonym << "]. Error: "
                 << ex.what());
         throw; // Bubble-up the exception.
     }
@@ -905,7 +905,7 @@ std::size_t WopiStorage::uploadLocalFileToStorageAsync(
     }
     catch (const std::exception& ex)
     {
-        LOG_ERR(wopiLog << " cannot upload file to WOPI storage uri [" + uriAnonym + "]. Error: "
+        LOG_ERR(wopiLog << " cannot upload file to WOPI storage uri [" << uriAnonym << "]. Error: "
                         << ex.what());
         _uploadHttpSession.reset();
     }
@@ -1073,7 +1073,7 @@ WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
     }
     catch (const BadRequestException& exc)
     {
-        LOG_ERR("Cannot upload file to WOPI storage uri [" + details.uriAnonym + "]. Error: "
+        LOG_ERR("Cannot upload file to WOPI storage uri [" << details.uriAnonym << "]. Error: "
                 << exc.what());
         result.setResult(StorageBase::UploadResult::Result::FAILED);
     }


### PR DESCRIPTION
Change-Id: I7ac75450c7507f44bd37cfaeb4be895a397809f1


* Resolves: #13349
* Target version: master 

### Summary
Replaced string concatenation (`+`) with the stream operator (`<<`) in log statements to improve performance and match the project coding standards. This fixes the reported easy hack.


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

