### PR TITLE
process and install only help-*.po and ui-*.po

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -13,7 +13,8 @@ TYPESCRIPT_JS_DIR = $(builddir)/typescript_js
 export NODE_PATH=$(abs_builddir)/node_module
 
 if !ENABLE_MOBILEAPP
-L10N_JSON = $(patsubst $(srcdir)/po/%.po,$(DIST_FOLDER)/l10n/%.json,$(L10N_PO))
+L10N_JSON = $(patsubst $(srcdir)/po/help-%.po,$(DIST_FOLDER)/l10n/help-%.json,$(L10N_PO))
+L10N_JSON += $(patsubst $(srcdir)/po/ui-%.po,$(DIST_FOLDER)/l10n/ui-%.json,$(L10N_PO))
 else
 L10N_IOS_ALL_JS = $(DIST_FOLDER)/l10n-all.js
 L10N_JSON = $(L10N_IOS_ALL_JS)
@@ -998,7 +999,10 @@ $(DIST_FOLDER)/l10n/%: $(srcdir)/l10n/%
 	@mkdir -p $(dir $@)
 	@cp $< $@
 
-$(DIST_FOLDER)/l10n/%.json: $(srcdir)/po/%.po
+$(DIST_FOLDER)/l10n/help-%.json: $(srcdir)/po/help-%.po
+	@$(srcdir)/util/po2json.py --quiet $< -o $@
+
+$(DIST_FOLDER)/l10n/ui-%.json: $(srcdir)/po/ui-%.po
 	@$(srcdir)/util/po2json.py --quiet $< -o $@
 
 $(DIST_FOLDER)/admin/%: $(srcdir)/admin/%


### PR DESCRIPTION
The `core-*.po` are kept in this repo for convenience, and are merged back to core's translation module manually. The `description-*.po` are for the Play Store, not for the product itself.
It makes no sense to convert them to json, and package and install the result.


Change-Id: Id6af047915a639aabf07f934c291b764f9e6c8da

