### PR TITLE
Missing doc-type when on compact view

### DIFF
--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -2396,6 +2396,7 @@ class Menubar extends window.L.Control {
 	 */
 	private _createFileIcon(): void {
 		if (!(window.logoURL && window.logoURL == "none")) {
+			var docType = this._map.getDocType();
 			var liItem = window.L.DomUtil.create('li', '');
 			liItem.id = 'document-header';
 			liItem.setAttribute('role', 'menuitem');
@@ -2405,7 +2406,23 @@ class Menubar extends window.L.Control {
 			aItem.setAttribute('role', 'img');
 			aItem.setAttribute('aria-label', _('file type icon'));
 
-			if (window.logoURL) {
+			var iconClass = 'document-logo';
+			var iconTooltip;
+			if (!window.logoURL) {
+				if (docType === 'text') {
+					iconClass += ' writer-icon-img';
+					iconTooltip = 'Writer';
+				} else if (docType === 'spreadsheet') {
+					iconClass += ' calc-icon-img';
+					iconTooltip = 'Calc';
+				} else if (docType === 'presentation') {
+					iconClass += ' impress-icon-img';
+					iconTooltip = 'Impress';
+				} else if (docType === 'drawing') {
+					iconClass += ' draw-icon-img';
+					iconTooltip = 'Draw';
+				}
+			} else {
 				aItem.style.backgroundImage = "url(" + window.logoURL + ")";
 			}
 
@@ -2413,6 +2430,10 @@ class Menubar extends window.L.Control {
 				this._menubarCont.insertBefore(liItem, this._menubarCont.firstChild);
 
 			var $docLogo = $(aItem);
+			$docLogo.addClass(iconClass);
+			if (iconTooltip) {
+				$docLogo.attr('data-cooltip', iconTooltip);
+			}
 			$docLogo.bind('click', {self: this}, this._createDocument);
 			$docLogo.bind('click', this._createDocument.bind(this));
 		}


### PR DESCRIPTION
Add tooltip and icon class in compact mode as well.

Possible Follow Up:
I don't see any reason why we need those CSS Class, we should instead
rely on existing html (that we already add to the body element per
doc-type) instead adding these css classes.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ibdc00335993b9d81db724cda8b237e490d4d5616

---

Bug:

[doc-type-goneactons-2025-11-24_13.28.08.webm](https://github.com/user-attachments/assets/33bc921e-711b-4526-8990-16b1a702a050)

