### PR TITLE
Writer redlining: Fix polygon creation.

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -1410,19 +1410,7 @@ export class CommentSection extends CanvasSectionObject {
 		redline.anchorPix = this.numberArrayToCorePixFromTwips(redline.anchorPos, 0, 2);
 		redline.trackchange = true;
 		redline.text = redline.comment;
-		var rectangles = window.L.PolyUtil.rectanglesToPolygons(app.LOUtil.stringToRectangles(redline.textRange), app.map._docLayer);
-		if (rectangles.length > 0) {
-			redline.textSelected = window.L.polygon(rectangles, {
-				pointerEvents: 'all',
-				interactive: false,
-				fillOpacity: 0,
-				opacity: 0
-			});
-			redline.textSelected.addEventParent(this.map);
-			redline.textSelected.on('click', function() {
-				this.selectById(redline.id);
-			}, this);
-		}
+		redline.rectanglesOriginal = this.stringToRectangles(redline.textRange || redline.anchorPos || redline.rectangle); // This unmodified version will be kept for re-calculations.
 
 		return true;
 	}


### PR DESCRIPTION
Issue: It was referencing a deleted structure.

Use "rectanglesOriginal" variable for showing redlines as commnets. Normal comments is already using it. The purpose is the same for both.


Change-Id: Ifad4fa9bf49b2519e41594dfea4fb501d7fce34a


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

