### PR TITLE
follow me slideshow: use wopi property to define the leader

### DIFF
--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -562,6 +562,10 @@ class UIManager extends window.L.Control {
 		var startFolloMePresntationGet = this.map.isPresentationOrDrawing() && window.coolParams.get('startFollowMePresentation');
 		var presentationLeaderIdGet = this.map.isPresentationOrDrawing() && window.coolParams.get('presentationLeaderId');
 		var startPresentationGet = this.map.isPresentationOrDrawing() && window.coolParams.get('startPresentation');
+		if (this.map.wopi.PresentationLeader)
+		{
+			presentationLeaderIdGet = this.map.wopi.PresentationLeader;
+		}
 		// check for "presentation" dispatch event only after document gets fully loaded
 		// in case if the leader is defined we have to wait a little longer to get the viewer info
 		const startPresentation = () => {

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -44,6 +44,7 @@ window.L.Map.WOPI = window.L.Handler.extend({
 	UserCanRename: false,
 	UserCanWrite: false,
 	DisablePresentation: false,
+	PresentationLeader: '',
 
 	_appLoadedConditions: {
 		docloaded: false,
@@ -155,6 +156,7 @@ window.L.Map.WOPI = window.L.Handler.extend({
 		this.EnableShare = !!wopiInfo['EnableShare'];
 		this.UserCanWrite = !!wopiInfo['UserCanWrite'];
 		this.DisablePresentation = wopiInfo['DisablePresentation'];
+		this.PresentationLeader = wopiInfo['PresentationLeader'];
 
 		if (this.UserCanWrite && !app.isReadOnly()) // There are 2 places that set the file permissions, WOPI and URI. Don't change permission if URI doesn't allow.
 			app.setPermission('edit');

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1506,6 +1506,9 @@ DocumentBroker::updateSessionWithWopiInfo(const std::shared_ptr<ClientSession>& 
                                                         WopiStorage::WOPIFileInfo::TriState::True);
     wopiInfo->set("IsOwner", session->isDocumentOwner());
 
+    if (!wopiFileInfo->getPresentationLeader().empty())
+        wopiInfo->set("PresentationLeader", wopiFileInfo->getPresentationLeader());
+
     bool disablePresentation = wopiFileInfo->getDisableExport() || wopiFileInfo->getHideExportOption();
     // the new slideshow supports watermarking, anyway it's still an experimental features
     disablePresentation = disablePresentation || (!ConfigUtil::getBool("canvas_slideshow_enabled", true) && !watermarkText.empty());

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -235,6 +235,7 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo, Poco::JSON::Ob
     JsonUtil::findJSONValue(object, "FileUrl", _fileUrl);
     JsonUtil::findJSONValue(object, "UserCanOnlyComment", _userCanOnlyComment);
     JsonUtil::findJSONValue(object, "UserCanOnlyManageRedlines", _userCanOnlyManageRedlines);
+    JsonUtil::findJSONValue(object, "PresentationLeader", _presentationLeader);
 
     // check if user is admin on the integrator side
     bool isAdminUser = false;

--- a/wsd/wopi/WopiStorage.hpp
+++ b/wsd/wopi/WopiStorage.hpp
@@ -61,6 +61,7 @@ public:
         const std::string& getFileUrl() const { return _fileUrl; }
         const std::string& getPostMessageOrigin() { return _postMessageOrigin; }
         const std::string& getHideUserList() { return _hideUserList; }
+        const std::string& getPresentationLeader() const { return _presentationLeader; }
 
         bool getUserCanWrite() const { return _userCanWrite; }
         void setHidePrintOption(bool hidePrintOption) { _hidePrintOption = hidePrintOption; }
@@ -185,6 +186,8 @@ public:
         bool _userCanOnlyComment = false;
         /// If user is limited to only managing redlines (accept/reject)
         bool _userCanOnlyManageRedlines = false;
+        /// Used for directly starting follow me presentation
+        std::string _presentationLeader;
     };
 
     WopiStorage(const Poco::URI& uri, const std::string& localStorePath,


### PR DESCRIPTION
if the wopi property had presentation leader defined, use that over leader specified by the url parameter this provides more security than using just url parameter


Change-Id: Ifc5825294ead0307aef33552e3eb93574ff1026a

* Target version: master 



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

