### PR TITLE
fix: update disabled attribute handling for improved accessibility in _pushbuttonControl

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1312,8 +1312,11 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 
 		const isDisabled = data.enabled === false;
 		if (isDisabled) {
-			wrapper.setAttribute('disabled', 'disabled');
+			wrapper.setAttribute('disabled', 'true');
 			wrapper.setAttribute('aria-disabled', true);
+			pushbutton.setAttribute('disabled', 'true');
+			pushbutton.setAttribute('aria-disabled', true);
+			
 		}
 
 		JSDialog.SynchronizeDisabledState(wrapper, [pushbutton]);


### PR DESCRIPTION
Change-Id: Iea21d41605063b88770aa255f061af881bfb535f

Relevant core patch: https://gerrit.libreoffice.org/c/core/+/194476

Changes:
1. fix disabled state for wrapper
2. add initial disable state sync behavior for pushbutton

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

