### PR TITLE
wsd: fix language tool not working

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3482,12 +3482,14 @@ void lokit_main(
                 // ro bind-mount a replacement up-to-date /etc
                 if (sysTemplateIncomplete)
                 {
-                    LOG_INF("Mounting " << sysTemplateSubDir << " -> " << jailEtcDir);
-                    if (!JailUtil::bind(sysTemplateSubDir, jailEtcDir)
-                        || !JailUtil::remountReadonly(sysTemplateSubDir, jailEtcDir))
+                    const std::string sysTemplateSubDirEtc =
+                        Poco::Path(sysTemplateSubDir, "etc").toString();
+                    LOG_INF("Mounting " << sysTemplateSubDirEtc << " -> " << jailEtcDir);
+                    if (!JailUtil::bind(sysTemplateSubDirEtc, jailEtcDir) ||
+                        !JailUtil::remountReadonly(sysTemplateSubDirEtc, jailEtcDir))
                     {
-                        LOG_ERR("Failed to mount [" << sysTemplateSubDir << "] -> [" << jailEtcDir
-                                                    << "], will link/copy contents.");
+                        LOG_ERR("Failed to mount [" << sysTemplateSubDirEtc << "] -> ["
+                                                    << jailEtcDir << "], will link/copy contents.");
                         return false;
                     }
                 }


### PR DESCRIPTION
- In docker environment, `/opt/cool/systemplate` can't be updated
  because of `cool` user lacks permission

```
frk-00022-00022 2025-11-20 10:35:41.084056 +0000 [ forkit ] INF  Updating systemplate dynamic files in [/opt/cool/systemplate]| common/JailUtil.cpp:550
frk-00022-00022 2025-11-20 10:35:41.084086 +0000 [ forkit ] DBG  File contents mismatch: [/etc/passwd] exists, 885 bytes, modified at 1760645845 =/= [/opt/cool/systemplate//etc/passwd]: exists, 883 bytes, modified at 1760645831| common/FileUtil.hpp:328
frk-00022-00022 2025-11-20 10:35:41.084094 +0000 [ forkit ] INF  No write access to path [/opt/cool/systemplate]: Permission denied| common/FileUtil-unix.cpp:456
frk-00022-00022 2025-11-20 10:35:41.084103 +0000 [ forkit ] WRN  The systemplate directory [/opt/cool/systemplate] is read-only, and at least [/opt/cool/systemplate//etc/passwd] is out-of-date. Will have to clone dynamic elements of systemplate to the jails. To restore optimal performance, make sure the files in [/opt/cool/systemplate/etc] are up-to-date.| common/JailUtil.cpp:586
```

- When updating `/opt/cool/systemplate` fails we fallback to create
  `tmp/systempalte-id` and mount it on top of `jailEtcDir`. Implemented in commit https://github.com/CollaboraOnline/online/commit/852e8545af3f1807ff6619fe52a922f35bbd9da4

- Currently, the code mounts `sysTemplateSubDir` (which contains `etc/`)
onto `jailEtcDir` (the jail's `/etc`). This results in `/etc/etc/...`
inside the jail. The fix is to mount `sysTemplateSubDir/etc` onto
`jailEtcDir`.

Signed-off-by: Rashesh Padia <rashesh.padia@collabora.com>
Change-Id: I246cae7d8457f1f788a30730ecadc4f88ad05af7

* Resolves: #7880 

# TODO
- [ ] - Test in docker image