### PR TITLE
accessibility: remove incorrect usage of aria-pressed attribute on navigator button

### DIFF
--- a/browser/src/control/Control.NavigatorPanel.ts
+++ b/browser/src/control/Control.NavigatorPanel.ts
@@ -293,7 +293,6 @@ class NavigatorPanel extends SidebarBase {
 		button.className = 'ui-content unobutton';
 		button.id = 'floating-navigator';
 		button.accessKey = 'ZN';
-		button.setAttribute('aria-pressed', 'false');
 
 		// Create the image inside the button
 		const img = document.createElement('img');


### PR DESCRIPTION
Change-Id: Ib276d64a4135baf3097250be9be958b378f6a784

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

