### PR TITLE
accessibility: remove duplicate aria-expanded state control logic

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -767,8 +767,6 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 					else
 						builder.callback('expander', 'toggle', data, null, builder);
 
-					var state = expander.getAttribute('aria-expanded') === 'true';
-					expander.setAttribute('aria-expanded', !state);
 					$(label).toggleClass('expanded');
 					$(expander).siblings().toggleClass('expanded');
 


### PR DESCRIPTION
This fixes a regression introduced in 1e13b3bf9a473a963269efab66565a46678692bd where duplicate logic controlling aria-expanded caused the attribute to remain permanently set to true


Change-Id: Ie971a9dc30d60f63531a52c7fdf89173f8aac06e

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

