### PR TITLE
kit, delta: rename 'le' back to 'rle'

### DIFF
--- a/kit/Delta.hpp
+++ b/kit/Delta.hpp
@@ -190,7 +190,7 @@ class DeltaGenerator {
 
     private:
         void initPixRowCpu(const uint32_t *from, uint32_t *scratch,
-                           size_t *scratchLen, uint64_t *leMaskBlock,
+                           size_t *scratchLen, uint64_t *rleMaskBlock,
                            unsigned int width)
         {
             uint32_t lastPix = 0x00000000; // transparency
@@ -229,7 +229,7 @@ class DeltaGenerator {
                         }
                     }
                 }
-                leMaskBlock[mask] = rleMask;
+                rleMaskBlock[mask] = rleMask;
             }
 
             if (x < width)


### PR DESCRIPTION
This went wrong in commit 805e2f82fb9f4ed0370742e403158c6c683a5633
(Removed the hungarian notation in this files:, 2025-11-21), which was
mostly fine, but this 'r' prefix was a reference to run-length encoding
(RLE), not the unwanted 'reference' prefix, so restore it.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I2d85d6bff0516d0377c3209159dd48d1464e3757
