### PR TITLE
fix(a11y): update aria-controls attribute handling for combobox dropdown

### DIFF
--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -204,11 +204,9 @@ JSDialog.combobox = function (parentContainer, data, builder) {
 
 	var dropDownId = JSDialog.CreateDropdownEntriesId(data.id);
 	content.setAttribute('aria-expanded', false);
-	content.setAttribute('aria-controls', dropDownId);
 
 	var button = window.L.DomUtil.create('button', 'ui-combobox-button ' + builder.options.cssClass, container);
 	button.setAttribute('aria-expanded', false);
-	button.setAttribute('aria-controls', dropDownId);
 
 	const dataAriaLabel = data.aria && data.aria.label ? data.aria.label : '';
 	const buttonARIALabel = dataAriaLabel
@@ -228,6 +226,15 @@ JSDialog.combobox = function (parentContainer, data, builder) {
 	container._onDropDown = function (open) {
 		content.setAttribute('aria-expanded', open);
 		button.setAttribute('aria-expanded', open);
+
+		// Only set aria-controls when dropdown is open to avoid screen reader confusion
+		if (open) {
+			content.setAttribute('aria-controls', dropDownId);
+			button.setAttribute('aria-controls', dropDownId);
+		} else {
+			content.removeAttribute('aria-controls');
+			button.removeAttribute('aria-controls');
+		}
 	};
 
 	if (data.selectedCount > 0)


### PR DESCRIPTION
Set aria-controls only when the dropdown is open to avoid screen reader confusion. Since the dropdown element is dynamically created and removed from the DOM, aria-controls would otherwise reference a non-existent element. This fix adds aria-controls when the dropdown is present in the DOM and removes it when the dropdown is removed

Change-Id: Ia4763bc342a53bec4054f7fc26f52821ab1c9ad8

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

