### PR TITLE
accessibility: use aria-haspopup instead of aria-pressed for more button in overflow group

### DIFF
--- a/browser/src/control/jsdialog/Widget.OverflowGroup.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowGroup.ts
@@ -61,7 +61,7 @@ function createMoreButton(
 	moreOptionsButton.className = 'ui-content unobutton';
 	moreOptionsButton.id = `${id}-more-button`;
 	moreOptionsButton.setAttribute('aria-label', `More options for ${id}`);
-	moreOptionsButton.setAttribute('aria-pressed', 'false');
+	moreOptionsButton.setAttribute('aria-haspopup', 'dialog');
 
 	const img = document.createElement('img');
 	img.alt = '';


### PR DESCRIPTION
Change-Id: I3ad09d43a8730936d369e8168925097e026f9aeb

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

