### PR TITLE
cool#7880: fix: kitbroker can't find CA bundle when bind mount is enabled

### DIFF
--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -220,6 +220,31 @@ namespace FileUtil
                           std::istreambuf_iterator<char>(lhs.rdbuf()));
     }
 
+    void copyDirectoryRecursive(const std::string& srcDir, const std::string& destDir, bool log)
+    {
+        namespace fs = std::filesystem;
+        try
+        {
+            for (const auto& entry : fs::recursive_directory_iterator(srcDir))
+            {
+                // Calculate relative path from source
+                const auto relativePath = fs::relative(entry.path(), srcDir);
+                const auto targetPath = fs::path(destDir) / relativePath;
+
+                // Create directory with writable permissions (default)
+                if (entry.is_directory())
+                    fs::create_directories(targetPath);
+                else if (entry.is_regular_file())
+                    FileUtil::copy(entry.path().string(), targetPath.string(), log, false);
+            }
+        }
+        catch (const std::exception& ex)
+        {
+            LOG_ERR("Failed to copy srcDir[" << srcDir << "to destDir[" << destDir
+                                             << "] with error[" << ex.what() << ']');
+        }
+    }
+
     std::unique_ptr<std::vector<char>> readFile(const std::string& path, int maxSize)
     {
         auto data = std::make_unique<std::vector<char>>(maxSize);

--- a/common/FileUtil.hpp
+++ b/common/FileUtil.hpp
@@ -237,6 +237,7 @@ namespace FileUtil
     /// Reads the whole file to memory. Only for small files.
     std::unique_ptr<std::vector<char>> readFile(const std::string& path, int maxSize = 256 * 1024);
 
+    void copyDirectoryRecursive(const std::string& srcDir, const std::string& destDir, bool log);
     /// File/Directory stat helper.
     class Stat
     {

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3454,7 +3454,13 @@ void lokit_main(
 
             if (sysTemplateIncomplete && JailUtil::isBindMountingEnabled())
             {
-                Poco::File(Poco::Path(sysTemplateSubDir, "etc").toString()).createDirectories();
+                const std::string sysTemplateEtcDir = Poco::Path(sysTemplate, "etc").toString();
+                const std::string sysTemplateSubEtcDir =
+                    Poco::Path(sysTemplateSubDir, "etc").toString();
+                Poco::File(sysTemplateSubEtcDir).createDirectories();
+
+                FileUtil::copyDirectoryRecursive(sysTemplateEtcDir, sysTemplateSubEtcDir, false);
+
                 if (!JailUtil::SysTemplate::updateDynamicFiles(sysTemplateSubDir))
                 {
                     LOG_WRN("Failed to update the dynamic files in ["


### PR DESCRIPTION
```
warn:linguistic:1151747:1151754:linguistic/source/gciterator.cxx:731:
GrammarCheckingIterator::DequeueAndCheck ignoring
com.sun.star.uno.RuntimeException message: "no OpenSSL CA certificate
bundle found at
/home/rashesh/collabora/core/co-2504/include/systools/curlinit.hxx:41"
```

- Steps to reproduce the problem locally:

1. Configure coolwsd with languagetool
2. Do `make` so it creates systemplate
3. Remove a file like `rm systemplate/etc/host.conf` to re-trigger
link/copy later
   when we start the coolwsd
4. Make the systemplate readonly `chmod -R -w systemplate/`

- we create `tmp/systemplate-*` when we don't have access to
`/opt/cool/systemplate` directory in environments like docker.
- when we create `tmp/systemplate-*` we don't copy/link
`opt/cool/systemplate/etc/ssl` directory
- This commit copies the `opt/cool/systemplate/etc` directory to
`tmp/systemplate/etc` which fixes the problem

For directory copy I tried `std::filesystem::copy(sysTemplateEtcDir, sysTemplateSubEtcDir, recursive, ec)`

`std::filesystem::copy` with recursive: Failed because it copied the read-only permissions (555/444) from source directories, then couldn't write files into those read-only destinations

Signed-off-by: Rashesh Padia <rashesh.padia@collabora.com>
Change-Id: I850e7f137173a8b57b0a18487b93c8e9fbdc65b9

* Resolves: #7880 
* Target version: master 


