### PR TITLE
Added read-only mode indicator button to the top toolbar.

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -19,7 +19,9 @@
 .unotoolbutton .unobutton.selected + .ui-content.unolabel {
 	color: var(--color-text-dark);
 }
-
+#viewMode {
+	margin: 0px 5px;
+}
 /* toolbuttons non selected */
 #clearFormatting,
 .hasnotebookbar .ui-content.unotoolbutton.has-label,
@@ -29,7 +31,8 @@
 .ui-overflow-group-more.unotoolbutton,
 .jsdialog.unotoolbutton,
 .notebookbar.unotoolbutton,
-#closebutton {
+#closebutton,
+#readonlyMode {
 	background-color: transparent;
 	border: 1px solid transparent;
 	color: var(--color-main-text);
@@ -37,12 +40,17 @@
 	height: max-content;
 }
 
+#readonlyMode {
+	border: 1px solid var(--color-btn-border);
+}
+
 /* toolbuttons non selected hover */
 .hasnotebookbar .ui-content.unotoolbutton.has-label:hover,
 .hasnotebookbar .ui-content.unotoolbutton.inline:hover,
 .hasnotebookbar .ui-content.unotoolbutton:not(.has-label):not(.inline):hover,
 .unotoolbutton:hover,
-.close-navigation-wrapper:hover {
+.close-navigation-wrapper:hover,
+#readonlyMode:hover {
 	border: 1px solid var(--color-btn-border);
 	color: var(--color-text-darker);
 	border-radius: var(--border-radius);

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -136,6 +136,11 @@ m4_ifelse(MOBILEAPP,[true],
           </div>
           <div id="userListSummaryBackground"><button id="userListSummary"></button></div>
         </div>
+        <div id="viewMode">
+          <div class="unotoolbutton notebookbar ui-content unospan readonly inline hidden" tabindex="-1" id="readonlyMode">
+              <span class="ui-content unolabel"></span>
+          </div>
+        </div>
         <div id="closebuttonwrapperseparator"></div>
         <div id="closebuttonwrapper">
           <button class="closebuttonimage" id="closebutton" accesskey="ZC"></button>

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -356,6 +356,17 @@ class UIManager extends window.L.Control {
 
 		if (!isMobile && !enableNotebookbar)
 			this.map.topToolbar = JSDialog.TopToolbar(this.map);
+
+		// this will execute only when UI get initialized
+		if (!isMobile) {
+			this.topReadonlyBtn = document.getElementById('readonlyMode');
+			const label = this.topReadonlyBtn.querySelector(
+				'.unolabel',
+			) as HTMLElement | null;
+			if (label) {
+				label.textContent = _('Read-only');
+			}
+		}
 	}
 
 	/**
@@ -1464,6 +1475,23 @@ class UIManager extends window.L.Control {
 				app.socket.sendMessage('uno .uno:SidebarHide');
 			}
 		}
+		this.updateReadonlyIndicator();
+	}
+
+	/**
+	 * Updates visibility of the Read-only badge/button in the top toolbar.
+	*/
+	updateReadonlyIndicator(): void {
+		app.layoutingService.appendLayoutingTask(() =>{
+			if (!this.topReadonlyBtn)
+				return;
+
+			if (app.isReadOnly()) {
+				this.topReadonlyBtn.classList.remove('hidden');
+			} else {
+				this.topReadonlyBtn.classList.add('hidden');
+			}
+		})
 	}
 
 	refreshTheme(): void {


### PR DESCRIPTION
- Before this patch we have this indicator only present in status bar but it may possible to hide status bar by deafult on document load.
- So for user to see the mode clearly we have now the label in top toolbar.
- Updated CSS to style the new indicator consistently.
- Improves clarity when the document is in read only mode.


<img width="1919" height="247" alt="image" src="https://github.com/user-attachments/assets/8388d4d9-439e-41c3-8000-374a697bc217" />

<img width="1919" height="247" alt="image" src="https://github.com/user-attachments/assets/9c71fb49-6618-4a47-9a59-7721939f15a8" />


Change-Id: If73b5b6e0c67e10bc5ae453b3d181de72fb7bf09


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

