### PR TITLE
wsd: include Poco/JSON/Object.h to fix compiler error

### DIFF
--- a/wsd/SenderQueue.hpp
+++ b/wsd/SenderQueue.hpp
@@ -17,6 +17,7 @@
 #include <Protocol.hpp>
 
 #include <Poco/JSON/Parser.h>
+#include <Poco/JSON/Object.h>
 
 #include <deque>
 #include <mutex>


### PR DESCRIPTION
In file included from KitQueueTests.cpp:20:
../wsd/SenderQueue.hpp: In member function ‘bool SenderQueue<Item>::deduplicate(const Item&)’: ../wsd/SenderQueue.hpp:176:65: error: ‘Object’ is not a member of ‘Poco::JSON’
  176 |             const auto& newJson = newResult.extract<Poco::JSON::Object::Ptr>();
      |                                                                 ^~~~~~
../wsd/SenderQueue.hpp:176:45: error: parse error in template argument list
  176 |             const auto& newJson = newResult.extract<Poco::JSON::Object::Ptr>();
      |                                             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../wsd/SenderQueue.hpp: In lambda function:
../wsd/SenderQueue.hpp:187:71: error: ‘Object’ is not a member of ‘Poco::JSON’
  187 |                         const auto& json = result.extract<Poco::JSON::Object::Ptr>();
      |                                                                       ^~~~~~
../wsd/SenderQueue.hpp:187:51: error: parse error in template argument list
  187 |                         const auto& json = result.extract<Poco::JSON::Object::Ptr>();
      |                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Change-Id: I111adce4b8320f43fd73a363ed7b0f417811cffd


* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

