### PR TITLE
wsd: fix missing include

### DIFF
--- a/wsd/SenderQueue.hpp
+++ b/wsd/SenderQueue.hpp
@@ -17,6 +17,7 @@
 #include <Protocol.hpp>
 
 #include <Poco/JSON/Parser.h>
+#include <Poco/JSON/Object.h>
 
 #include <deque>
 #include <mutex>


### PR DESCRIPTION
	In file included from KitQueueTests.cpp:20:
	../wsd/SenderQueue.hpp:176:65: error: no member named 'Object' in namespace 'Poco::JSON'
	  176 |             const auto& newJson = newResult.extract<Poco::JSON::Object::Ptr>();
	      |                                                     ~~~~~~~~~~~~^
	../wsd/SenderQueue.hpp:187:71: error: no member named 'Object' in namespace 'Poco::JSON'
	  187 |                         const auto& json = result.extract<Poco::JSON::Object::Ptr>();
	      |                                                           ~~~~~~~~~~~~^

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I880a79a75b00f4acca704ca05670615c9215ab99
