### PR TITLE
Sort and group #include headers

### DIFF
--- a/common/Authorization.cpp
+++ b/common/Authorization.cpp
@@ -19,6 +19,7 @@
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/URI.h>
 
+
 void Authorization::authorizeURI(Poco::URI& uri) const
 {
     if (_type == Authorization::Type::Token)

--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -12,16 +12,16 @@
 #include <config.h>
 
 #include <ConfigUtil.hpp>
-
 #include <Util.hpp>
+
+#include <Poco/Util/AbstractConfiguration.h>
+#include <Poco/Util/XMLConfiguration.h>
 
 #include <cassert>
 #include <string>
 #include <sstream>
 #include <unordered_map>
 
-#include <Poco/Util/AbstractConfiguration.h>
-#include <Poco/Util/XMLConfiguration.h>
 
 namespace ConfigUtil
 {

--- a/common/Crypto.cpp
+++ b/common/Crypto.cpp
@@ -11,17 +11,18 @@
 
 #include <config.h>
 
-#include <Poco/DigestStream.h>
+#include "Crypto.hpp"
+#include "Log.hpp"
+
 #include <Poco/Base64Decoder.h>
-#include <Poco/DateTimeParser.h>
 #include <Poco/Crypto/RSADigestEngine.h>
+#include <Poco/DateTimeParser.h>
+#include <Poco/DigestStream.h>
 
 #include <fstream>
-#include <sstream>
 #include <iostream>
+#include <sstream>
 
-#include "Log.hpp"
-#include "Crypto.hpp"
 #if ENABLE_SUPPORT_KEY
 #include "support-public-key.hpp"
 #endif

--- a/common/FileUtil-unix.cpp
+++ b/common/FileUtil-unix.cpp
@@ -13,15 +13,13 @@
 
 #include <common/Anonymizer.hpp>
 #include <common/FileUtil.hpp>
-
-#include <filesystem>
-#include <iostream>
-#include <string>
-
 #include <dirent.h>
+#include <filesystem>
 #include <ftw.h>
 #include <grp.h>
+#include <iostream>
 #include <pwd.h>
+#include <string>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <unistd.h>

--- a/common/FileUtil.cpp
+++ b/common/FileUtil.cpp
@@ -11,29 +11,28 @@
 
 #include <config.h>
 
-#include "FileUtil.hpp"
-
 #include <common/Anonymizer.hpp>
 #include <common/Log.hpp>
 #include <common/Unit.hpp>
 #include <common/Util.hpp>
 
-#include <exception>
-#include <stdexcept>
+#include "FileUtil.hpp"
 
-#include <fcntl.h>
+#include <Poco/File.h>
+#include <Poco/Path.h>
+
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
+#include <fcntl.h>
 #include <filesystem>
 #include <fstream>
 #include <mutex>
 #include <set>
+#include <stdexcept>
 #include <string>
-
-#include <Poco/File.h>
-#include <Poco/Path.h>
 
 namespace FileUtil
 {

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -13,26 +13,25 @@
 
 #include "FileUtil.hpp"
 #include "JailUtil.hpp"
+#include "Log.hpp"
 
+#include <SigUtil.hpp>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h>
+#include <fstream>
+#include <string>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sysexits.h>
 #include <unistd.h>
+
 #ifdef __linux__
 #include <sys/sysmacros.h>
 #endif
-
-#include <csignal>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <fstream>
-#include <string>
-
-#include "Log.hpp"
-#include <SigUtil.hpp>
 
 extern int domount(int argc, const char* const* argv);
 

--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -11,6 +11,15 @@
 
 #include <config.h>
 
+#include "Log.hpp"
+#include "StaticLogHelper.hpp"
+#include "Util.hpp"
+
+#include <Poco/AutoPtr.h>
+#include <Poco/FileChannel.h>
+#include <Poco/Logger.h>
+#include <Poco/Version.h>
+
 #include <atomic>
 #include <cassert>
 #include <cstdint>
@@ -20,18 +29,8 @@
 #include <iostream>
 #include <sstream>
 #include <string>
-#include <unordered_map>
-
 #include <unistd.h>
-
-#include <Poco/AutoPtr.h>
-#include <Poco/FileChannel.h>
-#include <Poco/Logger.h>
-#include <Poco/Version.h>
-
-#include "Log.hpp"
-#include "StaticLogHelper.hpp"
-#include "Util.hpp"
+#include <unordered_map>
 
 namespace
 {

--- a/common/Seccomp.cpp
+++ b/common/Seccomp.cpp
@@ -15,11 +15,19 @@
 
 #include <config.h>
 
-#include <sysexits.h>
 #include "Seccomp.hpp"
+
+#include <common/Log.hpp>
+#include <common/SigUtil.hpp>
 
 #include <dlfcn.h>
 #include <ftw.h>
+#include <sys/resource.h>
+#include <sys/time.h>
+#include <sysexits.h>
+#include <unistd.h>
+#include <utime.h>
+
 #ifdef __linux__
 #include <linux/audit.h>
 #include <linux/filter.h>
@@ -31,13 +39,6 @@
 #include <sys/prctl.h>
 #include <sys/syscall.h>
 #endif // __linux__
-#include <sys/resource.h>
-#include <sys/time.h>
-#include <unistd.h>
-#include <utime.h>
-
-#include <common/Log.hpp>
-#include <common/SigUtil.hpp>
 
 #if DISABLE_SECCOMP == 0
 #ifndef SYS_SECCOMP

--- a/common/SigUtil-dummy.cpp
+++ b/common/SigUtil-dummy.cpp
@@ -11,11 +11,11 @@
 
 #include <config.h>
 
+#include "Log.hpp"
 #include "SigUtil.hpp"
 
 #include <string>
 
-#include "Log.hpp"
 
 namespace SigUtil
 {

--- a/common/SigUtil-mobile.cpp
+++ b/common/SigUtil-mobile.cpp
@@ -10,12 +10,13 @@
  */
 
 #include <config.h>
-#include <Socket.hpp>
+
+#include "Log.hpp"
 #include "SigUtil.hpp"
+#include <Socket.hpp>
 
 #include <string>
 
-#include "Log.hpp"
 
 namespace
 {

--- a/common/SigUtil-server.cpp
+++ b/common/SigUtil-server.cpp
@@ -11,21 +11,39 @@
 
 #include <config.h>
 
-#include "SigUtil.hpp"
+#include "Common.hpp"
+#include "Log.hpp"
 #include "SigHandlerTrap.hpp"
+#include "SigUtil.hpp"
+#include <Socket.hpp>
+#include <test/testlog.hpp>
 #include "Util.hpp"
 
-#if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
-#  include <execinfo.h>
-#endif
+#include <array>
+#include <atomic>
+#include <cassert>
+#include <chrono>
 #include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
 #include <poll.h>
+#include <sstream>
+#include <string>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <sys/wait.h>
+#include <thread>
 #include <unistd.h>
+
+#if !defined(__ANDROID__) && !defined(__EMSCRIPTEN__)
+#  include <execinfo.h>
+#endif
 
 #if !defined(ANDROID) && !defined(IOS) && !defined(__FreeBSD__)
 #  include <sys/prctl.h>
@@ -34,24 +52,6 @@
 #  include <sys/procctl.h>
 #endif
 
-#include <atomic>
-#include <cassert>
-#include <chrono>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <fstream>
-#include <iomanip>
-#include <iostream>
-#include <sstream>
-#include <string>
-#include <thread>
-#include <array>
-
-#include <Socket.hpp>
-#include "Common.hpp"
-#include "Log.hpp"
-#include <test/testlog.hpp>
 
 namespace
 {

--- a/common/TraceEvent.cpp
+++ b/common/TraceEvent.cpp
@@ -8,13 +8,14 @@
 // To build a freestanding test executable for just TraceEvent:
 // clang++ -Wall -Wextra -DTEST_TRACEEVENT_EXE TraceEvent.cpp -o TraceEvent -pthread
 
-#include "config.h"
+#include <config.h>
+
+#include "TraceEvent.hpp"
 
 #include <cassert>
 #include <mutex>
 #include <sstream>
 
-#include "TraceEvent.hpp"
 
 std::atomic<bool> TraceEvent::recordingOn(false);
 

--- a/common/Unit-server.cpp
+++ b/common/Unit-server.cpp
@@ -7,14 +7,14 @@
 
 #include <config.h>
 
+#include "Log.hpp"
 #include "Unit.hpp"
+#include "Util.hpp"
 
 // A "server" COOL is always running on a Unixish OS, so we can
 // include this unconditionally.
 #include <dlfcn.h>
 
-#include "Log.hpp"
-#include "Util.hpp"
 #include <test/testlog.hpp>
 
 UnitBase** UnitBase::linkAndCreateUnit([[maybe_unused]] UnitType type,

--- a/common/Uri.cpp
+++ b/common/Uri.cpp
@@ -7,11 +7,14 @@
 
 #include <config.h>
 
-#include "Uri.hpp"
-#include <common/Util.hpp>
 #include <common/Log.hpp>
+#include <common/Util.hpp>
+
+#include "Uri.hpp"
 
 #include <Poco/URI.h>
+
+
 
 const std::string Uri::Reserved = ",/?:@&=+$#";
 

--- a/common/Util-server.cpp
+++ b/common/Util-server.cpp
@@ -14,6 +14,13 @@
 #include "StringVector.hpp"
 #include "Util.hpp"
 
+#include <Poco/Exception.h>
+
+#include <dirent.h>
+#include <fstream>
+#include <iomanip>
+#include <spawn.h>
+
 #ifdef __linux__
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -23,14 +30,6 @@
 #include <unistd.h>
 extern char** environ;
 #endif
-
-#include <dirent.h>
-#include <spawn.h>
-
-#include <fstream>
-#include <iomanip>
-
-#include <Poco/Exception.h>
 
 namespace
 {

--- a/common/Util-unix.cpp
+++ b/common/Util-unix.cpp
@@ -11,12 +11,12 @@
 
 #include <config.h>
 
+#include <common/Log.hpp>
+#include <common/Util.hpp>
+
 #include <fcntl.h>
 #include <time.h>
 #include <unistd.h>
-
-#include <common/Log.hpp>
-#include <common/Util.hpp>
 
 namespace Util
 {

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -12,12 +12,48 @@
 #include <config.h>
 #include <config_version.h>
 
+#include "Log.hpp"
+#include "Protocol.hpp"
+#include "Rectangle.hpp"
+#include "TraceEvent.hpp"
+#include "Util.hpp"
+#include "common/Common.hpp"
+
+#include <Poco/Base64Encoder.h>
+#include <Poco/ConsoleChannel.h>
+#include <Poco/Exception.h>
+#include <Poco/Format.h>
+#include <Poco/HexBinaryEncoder.h>
+#include <Poco/TemporaryFile.h>
+#include <Poco/URI.h>
+#include <Poco/Util/Application.h>
+
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <dirent.h>
+#include <fcntl.h>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <mutex>
+#include <random>
+#include <spawn.h>
+#include <sstream>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <thread>
+#include <unistd.h>
+
 #ifndef COOLWSD_BUILDCONFIG
 #define COOLWSD_BUILDCONFIG
 #endif
-
-#include "Util.hpp"
-#include "Rectangle.hpp"
 
 #if !MOBILEAPP
 #include "SigHandlerTrap.hpp"
@@ -38,14 +74,6 @@
 #elif defined IOS
 #import <Foundation/Foundation.h>
 #endif
-#include <sys/stat.h>
-#include <sys/types.h>
-
-#include <sys/uio.h>
-#include <unistd.h>
-#include <dirent.h>
-#include <fcntl.h>
-#include <spawn.h>
 
 #if defined __GLIBC__
 #include <malloc.h>
@@ -58,32 +86,6 @@
 #include <emscripten/console.h>
 #endif
 
-#include <atomic>
-#include <cassert>
-#include <chrono>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <ctime>
-#include <iomanip>
-#include <iostream>
-#include <mutex>
-#include <random>
-#include <sstream>
-#include <string>
-#include <thread>
-#include <limits>
-
-#include <Poco/Base64Encoder.h>
-#include <Poco/HexBinaryEncoder.h>
-#include <Poco/ConsoleChannel.h>
-#include <Poco/Exception.h>
-#include <Poco/Format.h>
-
-#include <Poco/TemporaryFile.h>
-#include <Poco/Util/Application.h>
-#include <Poco/URI.h>
-
 // for version info
 #include <Poco/Version.h>
 #if ENABLE_SSL
@@ -94,10 +96,6 @@
 #include <png.h>
 #undef PNG_VERSION_INFO_ONLY
 
-#include "Log.hpp"
-#include "Protocol.hpp"
-#include "TraceEvent.hpp"
-#include "common/Common.hpp"
 
 namespace Util
 {


### PR DESCRIPTION
Change-Id: I98ab07bace916b0978249fcf78839c0ce9c98a4c

* Resolves: #13336 
* Target version: master 

Grouped `#include` headers in 3 alphabetically sorted groups: `Internal headers`, `Poco headers` and `standard C/C++ headers`