### PR TITLE
CODA-Q flatpak: offline npm build

### DIFF
--- a/qt/flatpak/README.md
+++ b/qt/flatpak/README.md
@@ -1,0 +1,15 @@
+# Offline build
+
+To build the flatpak offline like it is required in Flathub, `npm i`
+has to work offline.
+
+Due to an issue with `flatpak-builder-tool` generating a manifest to
+populate the npm cache doesn't work.
+
+The work around is to vendor the `node_modules` directory by running
+`npm install` on a clean tree and creating an archive of it. It is
+then extracted in place, in `browser/node_modules`.
+
+This versionned module tarball is attached to the assets "releases":
+
+https://github.com/CollaboraOnline/online/releases/tag/for-code-assets

--- a/qt/flatpak/com.collabora.Office.json
+++ b/qt/flatpak/com.collabora.Office.json
@@ -815,9 +815,11 @@
             "prepend-pkg-config-path": "/app/lib/aarch64-linux-gnu/pkgconfig"
           }
         },
-        "build-args": [
-          "--share=network"
-        ]
+        "env": {
+          "XDG_CACHE_HOME": "/run/build/collabora-online/flatpak-node/cache",
+          "npm_config_offline": "true",
+          "npm_config_cache": "/run/build/collabora-online/flatpak-node/npm-cache"
+        }
       },
       "config-opts": [
         "--enable-qtapp",
@@ -839,14 +841,16 @@
       ],
       "sources": [
         {
-          "type": "dir",
-          "path": "../../"
+          "type": "git",
+          "url": "https://github.com/CollaboraOnline/online.git",
+          "commit": "4e9ff688fcbf091da71535a63cc440e56ad151da",
+          "tag": "coda-2"
         },
         {
-          "type": "shell",
-          "commands": [
-            "autoreconf -vfi"
-          ]
+          "type": "archive",
+          "url": "https://github.com/CollaboraOnline/online/releases/download/for-code-assets/node_modules-25.04.7.tar.xz",
+          "sha256": "2ffa320633ef95679b22b3815ee628e61acaf00e68ae84245e2e0ab83b49c17b",
+          "dest": "browser/node_modules"
         }
       ]
     },


### PR DESCRIPTION
* Helps: #13644 
* Target version: coda-24.05 , on top of #13617 

### Summary

This implement the offline build by using a vendored node_modules tarball.

### TODO

- [x] publish the tarball for node modules
  - the current placeholder suggest uploading it to a tag/release on Github.
- [x] use a tagged git source for collabora office

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

