### PR TITLE
CODA-M: Set the window icon based on what kind of file is currently open

### DIFF
--- a/macos/coda/coda/DocumentController.swift
+++ b/macos/coda/coda/DocumentController.swift
@@ -184,6 +184,7 @@ final class DocumentController: NSDocumentController {
 
             // mark it as new document (for better UI handling)
             doc.isNewDocument = true
+            doc.documentType = typeName  // Store the type explicitly for icon display
 
             try doc.read(from: data, ofType: typeName) // <- seeds tempDirectoryURL/tempFileURL exactly like a normal open
 


### PR DESCRIPTION
Uses document/spreadsheet/presentation icons to show the current document type in the window icon.
Unfortunately the AppKit tabs we are using don't support showing any icons but the window does so do that based on the current file's document type.


Change-Id: Ib761d7737040de8c38808f6eacf049ce6876e201


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

