### PR TITLE
Respect darkTheme=true query parameter in loading screen.

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -220,6 +220,9 @@ body {
 	left: 50%;
 	transform: translate(-50%, -50%);
 	z-index: 1000;
+	background-color: var(--color-main-background);
+	padding: 20px;
+	border-radius: 8px;
 }
 
 .bucket-cursor {

--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -826,6 +826,10 @@ input.clipboard {
 	font: var(--default-font-size)/1.5 var(--cool-font);
 }
 
+[data-theme='dark'] .leaflet-progress-label {
+	color: white !important;
+}
+
 .leaflet-progress-label.brand-label {
 	font-size: 0.875rem;
 	font-weight: bold;

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -103,6 +103,19 @@ m4_ifelse(MOBILEAPP,[true],
    <link rel="localizations" href="%SERVICE_ROOT%/browser/%VERSION%/l10n/help-localizations.json" type="application/vnd.oftn.l10n+json"/>
    <link rel="localizations" href="%SERVICE_ROOT%/browser/%VERSION%/l10n/uno-localizations.json" type="application/vnd.oftn.l10n+json"/>]
 )m4_dnl
+<script>
+// Apply dark theme immediately if darkTheme query parameter is present
+(function() {
+	var params = new URLSearchParams(window.location.search);
+	if (params.get('darkTheme') === 'true') {
+		document.documentElement.setAttribute('data-theme', 'dark');
+		var link = document.createElement('link');
+		link.setAttribute('rel', 'stylesheet');
+		link.setAttribute('href', 'm4_ifelse(MOBILEAPP,[],[%SERVICE_ROOT%/browser/%VERSION%/])color-palette-dark.css');
+		document.head.appendChild(link);
+	}
+})();
+</script>
 </head>
 
   <body>

--- a/macos/coda/coda/Document.swift
+++ b/macos/coda/coda/Document.swift
@@ -450,6 +450,11 @@ class Document: NSDocument {
             // TODO: add "dir" if needed
         ]
 
+        // Add darkTheme parameter if user has dark mode enabled
+        if NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
+            components.queryItems?.append(URLQueryItem(name: "darkTheme", value: "true"))
+        }
+
         if isNewDocument {
             components.queryItems?.append(URLQueryItem(name: "isnewdocument", value: "true"))
         }


### PR DESCRIPTION
Detect darkTheme early and if set use dark css content. Also force text in loading screen to be white if darkTheme is in use.
Also added darkTheme=true query argument on macos when using a dark theme.


Change-Id: I0fb5fd844c47c5cb7a73f338f95efb2d0114f287


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

