### PR TITLE
CODA-Q flatpak: remove krb5 and gvfs

### DIFF
--- a/qt/flatpak/com.collabora.Office.json
+++ b/qt/flatpak/com.collabora.Office.json
@@ -29,7 +29,6 @@
     "--env=COOL_TOPSRCDIR=/app/share/coolwsd",
     "--env=LIBO_FLATPAK=1",
     "--talk-name=org.gtk.vfs.*",
-    "--talk-name=com.canonical.AppMenu.Registrar",
     "--device=dri"
   ],
   "cleanup-commands": [


### PR DESCRIPTION
krb5 is never used and also in the runtime.
gvfs is the GVFS daemon which doesn't belong here


Change-Id: I8352556026700a7e50c26d599acc83e83b892008

CODA-Q flatpak: remove dbus com.canonical.AppMenu.Registrar
    
Doesn't seem to be necessary
    
Change-Id: I845363b3cc3b52c801c15b5fa82ce1c21ab98439


* Resolves: # <!-- related github issue -->
* Target version: coda-25.04 

### Summary

Change 1
krb5 is never used and also in the runtime.
gvfs is the GVFS daemon whcih doesn't belong here

Change 2
remove dbus com.canonical.AppMenu.Registrar

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

