### PR TITLE
impress: fix comments appearing on wrong slide

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -1692,7 +1692,10 @@ export class Comment extends CanvasSectionObject {
 		|| this.sectionProperties.data.resolved === 'false'
 		|| this.sectionProperties.commentListSection.sectionProperties.showResolved) {
 			this.sectionProperties.container.style.display = '';
-			this.sectionProperties.container.style.visibility = '';
+			// For presentations, only expand if the comment is on the active slide.
+			if ((app.map.getDocType() !== 'presentation' && app.map.getDocType() !== 'drawing') || this.isInsideActivePart()) {
+				this.sectionProperties.container.style.visibility = '';
+			}
 		}
 		if (app.map._docLayer._docType === 'text')
 			this.sectionProperties.collapsedInfoNode.style.display = 'none';


### PR DESCRIPTION
Change-Id: I13804dfcd513a67affa7381d0689069f85e46c80


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- When the sidebar was hidden or the window resized, comment cards from other slides became visible on the current slide.
- This patch updates to show a comment only when it belongs to the active slide

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

