### PR TITLE
Docker: code-nightly fails to start in unpriviledged env

### DIFF
--- a/docker/from-source-gh-action/Dockerfile
+++ b/docker/from-source-gh-action/Dockerfile
@@ -68,7 +68,9 @@ RUN chmod +x /start-collabora-online.sh
 
 # set up Collabora Online (normally done by postinstall script of package)
 # Fix permissions
-RUN adduser --quiet --system --group --home /opt/cool cool && \
+RUN setcap cap_fowner,cap_chown,cap_sys_chroot=ep /usr/bin/coolforkit-caps && \
+    setcap cap_sys_admin=ep /usr/bin/coolmount && \
+    adduser --quiet --system --group --home /opt/cool cool && \
     rm -rf /opt/cool || true && \
     mkdir -p /opt/cool/child-roots /opt/cool/cache && \
     chown cool: /opt/cool && \


### PR DESCRIPTION
- looks like we still need caps for the hosts who don't allow userns
  call

```
frk-00026-00026 2025-11-27 12:27:59.405532 +0000 [ coolforkit-caps ] ERR  Capability cap_sys_chroot is not set for the coolforkit program.| kit/ForKit.cpp:259
frk-00026-00026 2025-11-27 12:27:59.405534 +0000 [ coolforkit-caps ] ERR  Capability cap_fowner is not set for the coolforkit program.| kit/ForKit.cpp:259
frk-00026-00026 2025-11-27 12:27:59.405536 +0000 [ coolforkit-caps ] ERR  Capability cap_chown is not set for the coolforkit program.| kit/ForKit.cpp:259
Capabilities are not set for the coolforkit program.
frk-00026-00026 2025-11-27 12:27:59.405538 +0000 [ coolforkit-caps ] FTL  Capabilities are not set for the coolforkit program.| kit/ForKit.cpp:1006
Please make sure that the current partition was *not* mounted with the 'nosuid' option.
frk-00026-00026 2025-11-27 12:27:59.405540 +0000 [ coolforkit-caps ] FTL  Please make sure that the current partition was *not* mounted with the 'nosuid' option.| kit/ForKit.cpp:1007
If you are on SLES11, please set 'file_caps=1' as kernel boot option.
frk-00026-00026 2025-11-27 12:27:59.405542 +0000 [ coolforkit-caps ] FTL  If you are on SLES11, please set 'file_caps=1' as kernel boot option.| kit/ForKit.cpp:1008
```

Change-Id: I0034f9658475c896243acfdfefcdb25aad8f754b

* Target version: master 