### PR TITLE
iconview entry selection enhancement

### DIFF
--- a/browser/src/control/jsdialog/Widget.IconView.ts
+++ b/browser/src/control/jsdialog/Widget.IconView.ts
@@ -185,9 +185,36 @@ function _iconViewEntry(
 		}
 		builder._preventDocumentLosingFocusOnClick(entryContainer);
 
-		entryContainer.addEventListener('keydown', function (e: KeyboardEvent) {
-			if (e.key !== 'Enter' && e.key !== ' ' && e.code !== 'Space') return;
+		const getUNOKeyCodeWithModifiers = function (
+			e: KeyboardEvent,
+			builder: any,
+			app: any,
+		): number {
+			let keyCode = e.keyCode;
 
+			const shift =
+				keyCode === builder.map.keyboard.keyCodes.SHIFT
+					? app.UNOModifier.SHIFT
+					: 0;
+			const ctrl =
+				keyCode === builder.map.keyboard.keyCodes.CTRL || e.metaKey
+					? app.UNOModifier.CTRL
+					: 0;
+			const alt =
+				keyCode === builder.map.keyboard.keyCodes.ALT ? app.UNOModifier.ALT : 0;
+
+			const modifier = shift | ctrl | alt;
+
+			if (modifier) {
+				keyCode = e.key.toUpperCase().charCodeAt(0);
+				keyCode = builder.map.keyboard._toUNOKeyCode(keyCode);
+				keyCode |= modifier;
+			}
+
+			return keyCode;
+		};
+
+		entryContainer.addEventListener('keydown', function (e: KeyboardEvent) {
 			if (e.key === ' ' || e.code === 'Space')
 				parentContainer.builderCallback(
 					'iconview',
@@ -202,6 +229,23 @@ function _iconViewEntry(
 					entry.row,
 					builder,
 				);
+			else {
+				parentContainer.builderCallback(
+					'iconview',
+					'keypress',
+					getUNOKeyCodeWithModifiers(e, builder, app),
+					builder,
+				);
+			}
+		});
+
+		entryContainer.addEventListener('keyup', function (e: KeyboardEvent) {
+			parentContainer.builderCallback(
+				'iconview',
+				'keyrelease',
+				getUNOKeyCodeWithModifiers(e, builder, app),
+				builder,
+			);
 		});
 	}
 }


### PR DESCRIPTION
- Intoduces icon-view entry selection json to send along with selection/activation instead of just selected index
- This information can be helpful in core side to know if any mouse key was pressed along with selection of item to execute relevant logic if exist.
- i.e sidebar->border popup dialog allows to overwrite borders if shift key was pressed along border item selection


Change-Id: I09ced62b58fb906abc7279fa2c77ba06a0743eab

This is follow-up of #13637
core patch require: https://gerrit.libreoffice.org/c/core/+/194688

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

