### PR TITLE
Writer: Fix Comment's width when in full view: polishing

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -593,6 +593,15 @@ body {
 	max-height: 95%;
 	width: 66ch;
 	/* Centered align comment in TS, we cannot align it here with positon relative */
+	z-index: 1000;
+}
+.cool-annotation.annotation-pop-up:not(.annotation-active) > .cool-annotation-content-wrapper {
+	margin-right: 8px;
+}
+.cool-annotation.annotation-pop-up.annotation-active {
+	transition: transform 400ms cubic-bezier(0.2,0,0,1), box-shadow 400ms cubic-bezier(0.2,0,0,1);
+	will-change: transform, box-shadow;
+	box-shadow: 0 0 0 1000px rgba(var(--doc-type),0.15);
 }
 
 .cool-annotation.tracked-deleted-comment-show {


### PR DESCRIPTION
Follow up of https://github.com/CollaboraOnline/online/pull/13569

---

<img width="1920" height="928" alt="image" src="https://github.com/user-attachments/assets/3e453c75-f890-4f39-8c9b-b5f2b48f0dd4" />

<img width="1920" height="529" alt="image" src="https://github.com/user-attachments/assets/ea8969a0-7414-458f-bbf0-a4b0d524554d" />


commit db765b392564ace027e35243f124f1ab37e8ce11 (HEAD -> private/pedro/fullview-part2-testing, origin/private/pedro/fullview-part2-testing)
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Thu Nov 27 14:28:21 2025 +0100

    Writer: Fix Comment's width when in full view: animation & z-index
    
    Before this commit the line that connects the normal comment would
    still be visible when the card switched to full view mode -> result:
    the line was connect to nothing. Hide that line.
    
    When in full view mode the card the card is centered, user wants to
    see the comment in a more focused way so, better to add an overlay
    - It helps to distinguish the comment from the document page
    - It helps the user to understand that clicking anywhere in the
    document or in the sidebars will close the Full view mode of the
    comment
      - While doing this I discovered that the z-index was very low making
      some parts of the sidebars being above the comment overlay (and the
      comment in full view when in super narrow screens).
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: I13b382426bdceb1b3daa60a1a4d60647ebeb5626

commit 2ad8ce16629133b83ca5194d1a4b2fd8c7addbdd
Author: Pedro Pinto Silva <pedro.silva@collabora.com>
Date:   Thu Nov 27 09:48:51 2025 +0100

    Writer: Fix Comment's width when in full view: polishing
    
    Follow up of 13639417ff80eb3fd64e384501768abdd84827f8.
    
    - Remove of left position in css. This was a nice try to attempt to
    run away from absolute values, but this needs to be done
    in a better way. Otherwise, sidebars are note taken into account. The
    position that is set in the TS section is enough for now
      - Would be nice in the future to be able to simply align this popup
      via flex box
    - Add also max-heigh to make sure the card will never be taller then
    the window
    - Increase font-size to add a bit more value to this feature
    
    Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
    Change-Id: Id23c40e369fef9fdc53ccf4d34b3def07ba96284
