### PR TITLE
graphic filter: hide unsupported image file types in insert dialog

### DIFF
--- a/browser/src/app/LOUtil.ts
+++ b/browser/src/app/LOUtil.ts
@@ -48,6 +48,60 @@ class LOUtil {
 		[209, 118, 0],
 	];
 
+	// This list is based on supported filters defined in core in
+	// filter/Configuration_filter.mk
+	public static graphicMimeFilter = [
+		'image/bmp',
+		'image/dxf',
+		'image/emf',
+		'image/emz',
+		'image/eps',
+		'image/gif',
+		'image/jpg',
+		'image/met',
+		'image/pbm',
+		'image/pcd',
+		'image/pcd',
+		'image/pcd',
+		'image/pct',
+		'image/pcx',
+		'image/pdf',
+		'image/pgm',
+		'image/png',
+		'image/ppm',
+		'image/psd',
+		'image/ras',
+		'image/svg',
+		'image/svgz',
+		'image/svm',
+		'image/tga',
+		'image/tif',
+		'image/webp',
+		'image/wmf',
+		'image/wmz',
+		'image/xbm',
+		'image/xpm',
+		'image/mov',
+	];
+
+	public static mediaMimeFilter = [
+		'video/MP2T',
+		'video/mp4',
+		'video/mpeg',
+		'video/ogg',
+		'video/quicktime',
+		'video/webm',
+		'video/x-matroska',
+		'video/x-ms-wmv',
+		'video/x-msvideo',
+		'audio/aac',
+		'audio/flac',
+		'audio/mp4',
+		'audio/mpeg',
+		'audio/ogg',
+		'audio/x-wav',
+	];
+
 	public static onRemoveHTMLElement(
 		element: Element,
 		onDetachCallback: () => void,

--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -2228,23 +2228,7 @@ class Menubar extends window.L.Control {
 		} else if (id === 'remotemultimedia') {
 			this._map.fire('postMessage', {
 				msgId: 'UI_InsertFile', args: {
-					callback: 'Action_InsertMultimedia', mimeTypeFilter: [
-						'video/MP2T',
-						'video/mp4',
-						'video/mpeg',
-						'video/ogg',
-						'video/quicktime',
-						'video/webm',
-						'video/x-matroska',
-						'video/x-ms-wmv',
-						'video/x-msvideo',
-						'audio/aac',
-						'audio/flac',
-						'audio/mp4',
-						'audio/mpeg',
-						'audio/ogg',
-						'audio/x-wav',
-					]
+					callback: 'Action_InsertMultimedia', mimeTypeFilter: app.LOUtil.MediaMimeFilter
 				}
 			});
 		} else if (id === 'selectbackground') {

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -1044,9 +1044,27 @@ global.editorUpdate = editorUpdate;
 
 $(document).ready(function() {
 	// Attach insert file action
-	$('#insertgraphic').on('change', onInsertGraphic);
-	$('#insertmultimedia').on('change', onInsertMultimedia);
-	$('#selectbackground').on('change', onInsertBackground);
+	// Update supported media mime type insertion
+	const supportedGraphicMime = app.LOUtil.graphicMimeFilter.join(",");
+	const supportedMediaMime = app.LOUtil.mediaMimeFilter.join(",");
+
+	const insertgraphic = window.L.DomUtil.get('insertgraphic');
+	if (insertgraphic) {
+		insertgraphic.accept = supportedGraphicMime;
+		insertgraphic.addEventListener('change', onInsertGraphic);
+	}
+
+	const insertmultimedia = window.L.DomUtil.get('insertmultimedia');
+	if (insertmultimedia) {
+		insertmultimedia.accept = supportedMediaMime;
+		insertmultimedia.addEventListener('change', onInsertMultimedia);
+	}
+
+	const selectbackground = window.L.DomUtil.get('selectbackground');
+	if (selectbackground) {
+		selectbackground.accept = supportedGraphicMime;
+		selectbackground.addEventListener('change', onInsertBackground);
+	}
 });
 
 function setupToolbar(e) {

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -127,23 +127,7 @@ class Dispatcher {
 				msgId: 'UI_InsertFile',
 				args: {
 					callback: 'Action_InsertMultimedia',
-					mimeTypeFilter: [
-						'video/MP2T',
-						'video/mp4',
-						'video/mpeg',
-						'video/ogg',
-						'video/quicktime',
-						'video/webm',
-						'video/x-matroska',
-						'video/x-ms-wmv',
-						'video/x-msvideo',
-						'audio/aac',
-						'audio/flac',
-						'audio/mp4',
-						'audio/mpeg',
-						'audio/ogg',
-						'audio/x-wav',
-					],
+					mimeTypeFilter: app.LOUtil.MediaMimeFilter,
 				},
 			});
 		};


### PR DESCRIPTION
problem:
when user tried to select the image to insert from local, unsupported file types (i.e: heic) files were also visible. Inserting them did nothing in doc.


Change-Id: I2d1addd4809b2f233a3ff856370671699aa4807d


* Target version: master 



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

