### PR TITLE
CODA-Q: Fix makefile warning

### DIFF
--- a/qt/Makefile.am
+++ b/qt/Makefile.am
@@ -106,6 +106,6 @@ translations_DATA = $(QM_FILES)
 
 # Distribute sources and clean up generated files
 EXTRA_DIST = $(TS_FILES)
-CLEANFILES = $(QM_FILES)
+CLEANFILES += $(QM_FILES)
 
 ### --- Qt translations integration end ---


### PR DESCRIPTION
CLEANFILES is already defined


Change-Id: Ia5dec5a4bd9f8f0174d75ccf53c32e756be7ee73


* Resolves: # <!-- related github issue -->
* Target version: coda-25.04 

### Summary

This fix a make warning. Possibly fix `make clean`

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

