### PR TITLE
js: fix: COOL UI doesn't follow UIDefault when no preference is set

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -760,7 +760,7 @@ function getInitializerClass() {
 				if (Object.prototype.hasOwnProperty.call(global.prefs._userBrowserSetting, key))
 					val = global.prefs._userBrowserSetting[key];
 
-				if(val !== undefined) {
+				if(val !== undefined && val !== '') {
 					global.prefs._localStorageCache[key] = val;
 					return val;
 				}


### PR DESCRIPTION
- for example, if `darkTheme` preference is not available and UIDefault has `darkTheme` set by integrator before this patch COOL didn't follow the UIDefault.
- problem was that localStorageCache was setting garbage empty values which were getting used by UIManager.

Change-Id: I53381243ad6f55aee696e57cd677bb8669be761a

* Target version: master 
