### PR TITLE
browser/control/Notebookbar: remove trivial use of jquery and of var

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -54,7 +54,7 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 
 	// on show
 	create: function(container) {
-		var docType = this._map.getDocType();
+		const docType = this._map.getDocType();
 
 		if (document.documentElement.dir === 'rtl')
 			this._RTL = true;
@@ -82,11 +82,11 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 		document.getElementById('document-container').classList.add('notebookbar-active');
 
 		if (!window.logoURL || window.logoURL != "none") {
-			var docLogoHeader = window.L.DomUtil.create('div', '');
+			const docLogoHeader = window.L.DomUtil.create('div', '');
 			docLogoHeader.id = 'document-header';
 
-			var iconClass = 'document-logo';
-			var iconTooltip;
+			let iconClass = 'document-logo';
+			let iconTooltip;
 			if (!window.logoURL) {
 				if (docType === 'text') {
 					iconClass += ' writer-icon-img';
@@ -102,12 +102,12 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 					iconTooltip = 'Draw';
 				}
 			}
-			var docLogo = window.L.DomUtil.create('a', iconClass, docLogoHeader);
+			const docLogo = window.L.DomUtil.create('a', iconClass, docLogoHeader);
 
-			$(docLogo).data('id', 'document-logo');
-			$(docLogo).data('type', 'action');
-			docLogo.target = '_blank';
-			docLogo.tabIndex = 0;
+			docLogo.setAttribute('id', 'document-logo');
+			docLogo.setAttribute('type', 'action');
+			docLogo.setAttribute('target', '_blank');
+			docLogo.setAttribute('tabIndex', 0);
 
 			if (iconTooltip) {
 				docLogo.setAttribute('data-cooltip', iconTooltip);
@@ -120,7 +120,7 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 			}
 		}
 
-		var isDarkMode = window.prefs.getBoolean('darkTheme');
+		const isDarkMode = window.prefs.getBoolean('darkTheme');
 		if (!isDarkMode)
 			$('#invertbackground').hide();
 


### PR DESCRIPTION
Change-Id: I53d6649dda0a09d62ef267aa9bf66b0c0d9d8a11


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Remove very unncessary jquery use and some `var` use along the way.

Since I touched this file in https://github.com/CollaboraOnline/online/pull/12410/files#diff-440d1d5e71a7c77724a7b79b975ce9d0ca838a0e8af9fee1c584a07913cd4263

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

