### PR TITLE
Removed unused includes

### DIFF
--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -68,7 +68,6 @@
 #include <iomanip>
 #include <iostream>
 #include <mutex>
-#include <unordered_map>
 #include <random>
 #include <sstream>
 #include <string>

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -62,10 +62,8 @@
 
 #include <climits>
 #include <fstream>
-#include <memory>
 #include <sstream>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <zlib.h>
 #include <zstd.h>

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -56,7 +56,6 @@
 #include <chrono>
 #include <ctime>
 #include <fstream>
-#include <ios>
 #include <memory>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
* Resolves: #13335 
* Target version: master 

### Summary
The kit/KitHelper.cpp file doesn't exist in the repository.
I have removed unused includes in:
- wsd/DocumentBrocker.cpp
- kit/ChildSession.cpp
- common/Util.cpp
- common/FileUtil.cpp
I didn't find unused includes in the other mentioned files.

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

