### PR TITLE
fix jpg files not visible in file picker

### DIFF
--- a/browser/src/app/LOUtil.ts
+++ b/browser/src/app/LOUtil.ts
@@ -57,7 +57,7 @@ class LOUtil {
 		'image/emz',
 		'image/eps',
 		'image/gif',
-		'image/jpg',
+		'image/jpeg',
 		'image/met',
 		'image/pbm',
 		'image/pcd',


### PR DESCRIPTION
problem:
regression from 02a5c8904115da11a403c80c64c3b79a89825353 .jpg or .jpeg files were not visible when tried to insert the image


Change-Id: Ieb53745f38c2f49e3fa6bb69d404b0e70a5b3410


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

