### PR TITLE
Make window background dark so we don't get a flash of white during startup

### DIFF
--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -1,6 +1,6 @@
 :root {
 	/*LibreOffice Colors: https://wiki.documentfoundation.org/Marketing/Branding#Colors
-	 * this is the color prefab for light mode
+	 * Default to dark mode colors to prevent white flash on load
 	----------------------------------[to do]*/
 	--blue1-txt-primary-color: 3, 105, 163;
 	--green0-txt-primary-color: 16, 104, 2; /*green1 lacks contrast against white*/
@@ -15,7 +15,7 @@
 	--color-status-badge: #616161;
 	--color-slideshow: #A8A8A8;
 
-	--color-main-background: #F8F9FA;
+	--color-main-background: #121212;  /* Default to dark to prevent white flash */
 	--color-background-dark: #e8e8e8;  /* select */
 	--color-background-darker: #c0bfbc;  /* todo: apply to pressed (active), li:hover(top menu on classic mode)*/
 	--color-background-slideshow: #1a1a1a;
@@ -82,6 +82,10 @@
 	--color-treeview-highlight: #FFEE80;
 	--color-treeview-highlight-text: #222;
 	--color-quickfind-border: #e1dfdd;
+}
+
+[data-theme='light'] {
+	--color-main-background: #F8F9FA;
 }
 
 [data-bg-theme='light'] {

--- a/macos/coda/coda/ViewController.swift
+++ b/macos/coda/coda/ViewController.swift
@@ -64,6 +64,10 @@ class ViewController: NSViewController, WKScriptMessageHandlerWithReply, WKNavig
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        // Set dark background on the view to prevent white flash
+        self.view.wantsLayer = true
+        self.view.layer?.backgroundColor = NSColor(red: 0x12/255.0, green: 0x12/255.0, blue: 0x12/255.0, alpha: 1.0).cgColor
+
         // Setup jsHandler as the entry point co call back from JavaScript
         let contentController = WKUserContentController()
         contentController.addScriptMessageHandler(self, contentWorld: .page, name: "debug")
@@ -79,6 +83,12 @@ class ViewController: NSViewController, WKScriptMessageHandlerWithReply, WKNavig
         webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = self
         webView.uiDelegate = self
+
+        // Set dark background to prevent white flash during load - set to opaque dark
+        if #available(macOS 12.0, *) {
+            webView.underPageBackgroundColor = NSColor(red: 0x12/255.0, green: 0x12/255.0, blue: 0x12/255.0, alpha: 1.0)
+        }
+        webView.setValue(false, forKey: "drawsBackground")
 
 #if DEBUG
         // Enable possibility to debug the webview from Safari


### PR DESCRIPTION
Fixes flash of white background when darkTheme=true is set either by user or by user's selection of dark os theme.


Change-Id: I193e548975f75483d2879fe0a2c52b38463584ed


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Tested on macos and linux.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

