### PR TITLE
Add Escape key handling to exit selected comments

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -120,6 +120,7 @@ export class CommentSection extends CanvasSectionObject {
 
 	private annotationMinSize: number;
 	private annotationMaxSize: number;
+	escapeListener: (e: KeyboardEvent) => void;
 
 	constructor () {
 		super(app.CSections.CommentList.name);
@@ -183,6 +184,8 @@ export class CommentSection extends CanvasSectionObject {
 			this.setShowSection(false);
 			this.size[0] = 0;
 		}
+
+		this.escapeSelectedComment();
 	}
 
 	public navigateAndFocusComment(annotation: any): void {
@@ -998,8 +1001,10 @@ export class CommentSection extends CanvasSectionObject {
 
 	public unselect (): void {
 		if (this.sectionProperties.selectedComment && this.sectionProperties.selectedComment.sectionProperties.data.id != 'new') {
-			if (this.sectionProperties.selectedComment && $(this.sectionProperties.selectedComment.sectionProperties.container).hasClass('annotation-active'))
-				$(this.sectionProperties.selectedComment.sectionProperties.container).removeClass('annotation-active');
+			for (const comment of this.sectionProperties.commentList) {
+				if ($(comment.sectionProperties.container).hasClass('annotation-active'))
+					$(comment.sectionProperties.container).removeClass('annotation-active');
+			}
 
 			if (app.map._docLayer._docType === 'spreadsheet')
 				this.sectionProperties.selectedComment.hide();
@@ -1016,6 +1021,18 @@ export class CommentSection extends CanvasSectionObject {
 
 			this.update();
 		}
+	}
+
+
+	// Escape selected comment and also comment in full view mode.
+	private escapeSelectedComment() {
+		this.escapeListener = (e: KeyboardEvent) => {
+			if (e.key !== 'Escape') return;
+			this.unselect();
+			this.map.focus();
+		};
+
+		document.addEventListener('keydown', this.escapeListener);
 	}
 
 	private setThreadPopup (comment: Comment, popup: boolean) {

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -1019,8 +1019,14 @@ export class Comment extends CanvasSectionObject {
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	private onEscKey (e: any): void {
 		if ((<any>window).mode.isDesktop()) {
+			// When a comment is being edited and focus is in comment textbox, 
+			// Esc should not close the comment being edited, but should just mark it with an attention.
 			if (e.keyCode === 27) {
-				this.onCancelClick(e);
+				const editingComment = Comment.isAnyEdit();
+				if (editingComment) {
+					this.sectionProperties.commentListSection.addCommentAttention(editingComment);
+					return;
+				}
 			} else if (e.keyCode === 33 /*PageUp*/ || e.keyCode === 34 /*PageDown*/) {
 				// work around for a chrome issue https://issues.chromium.org/issues/41417806
 				window.L.DomEvent.preventDefault(e);


### PR DESCRIPTION
Change-Id: I03750e63dad3a0a1f1e0e308cf02c60e7c2976b9


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Pressing Escape now unselects the active comment, regardless of whether it is in full-view mode or in its normal (collapsed/expanded) state.
- 
- This improves navigation by allowing users to quickly dismiss a selected comment without needing to click outside the comment thread or in the canvas.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

