### PR TITLE
[UI] Fix context menu delay on right click (#13685)

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1178,7 +1178,7 @@ class CanvasSectionContainer {
 	}
 
 	public onMouseDown (e: MouseEvent) { // Ignore this event, just rely on this.draggingSomething variable.
-		if (e.button === 0 && !this.touchEventInProgress) { // So, we only handle left button.
+		if ((e.button === 0 || e.button === 2) && !this.touchEventInProgress) { // So, we only handle left button.
 			this.clearMousePositions();
 			this.positionOnMouseDown = this.convertPositionToCanvasLocale(e);
 
@@ -1197,7 +1197,7 @@ class CanvasSectionContainer {
 			return;
 		}
 
-		if (e.button === 0 && !this.touchEventInProgress) {
+		if ((e.button === 0 || e.button === 2) && !this.touchEventInProgress) {
 			this.positionOnMouseUp = this.convertPositionToCanvasLocale(e);
 			var section: CanvasSectionObject;
 			if (!this.draggingSomething) {

--- a/browser/src/canvas/sections/MouseControl.ts
+++ b/browser/src/canvas/sections/MouseControl.ts
@@ -122,7 +122,7 @@ class MouseControl extends CanvasSectionObject {
 		const buttons = app.LOButtons.right;
 		const modifier = this.readModifier(e);
 
-		if (modifier === 0) {
+		if (modifier === 0 && !this.mouseDownSent) {
 			this.postCoreMouseEvent(
 				'buttondown',
 				this.currentPosition,
@@ -130,6 +130,8 @@ class MouseControl extends CanvasSectionObject {
 				buttons,
 				modifier,
 			);
+		} else if (this.mouseDownSent) {
+			this.mouseDownSent = false;
 		}
 	}
 
@@ -343,6 +345,19 @@ class MouseControl extends CanvasSectionObject {
 	onMouseDown(point: cool.SimplePoint, e: MouseEvent): void {
 		this.refreshPosition(point);
 		this.positionOnMouseDown = this.currentPosition.clone();
+
+		if (e.button === 2) {
+			const buttons = app.LOButtons.right;
+			const modifier = this.readModifier(e);
+			this.postCoreMouseEvent(
+				'buttondown',
+				this.currentPosition,
+				1,
+				buttons,
+				modifier,
+			);
+			this.mouseDownSent = true;
+		}
 
 		if (e.type === 'touchstart') {
 			// For swipe action.


### PR DESCRIPTION
Resolves: #13685
Target version: master

### Summary
This PR fixes the ~1-second delay observed when right-clicking in Collabora Online. The context menu now appears immediately.

### Changes Made
**Browser**
- **CanvasSectionContainer.ts**: Updated `onMouseDown` and `onMouseUp` to propagate right-click events (button 2).
- **MouseControl.ts**: 
  - `onMouseDown` detects right-clicks and sends the buttondown command immediately.
  - `onContextMenu` prevents duplicate buttondown commands if already sent by `onMouseDown`.

### Verification Steps
1. Build the project (browser package).  
2. Run the application.  
3. Open any document (Writer, Calc, Impress).  
4. Right-click on the document canvas. Context menu should appear immediately.  
5. Test drag and double right-click to ensure normal behavior.

### Technical Details
By handling the right-click `mousedown` event immediately, we bypass the browser’s potential delay for the `contextmenu` event. A flag `mouseDownSent` ensures the signal isn’t sent twice.

