### PR TITLE
[UI] Fix context menu delay on right click (#13685)

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1178,7 +1178,7 @@ class CanvasSectionContainer {
 	}
 
 	public onMouseDown (e: MouseEvent) { // Ignore this event, just rely on this.draggingSomething variable.
-		if (e.button === 0 && !this.touchEventInProgress) { // So, we only handle left button.
+		if ((e.button === 0 || e.button === 2) && !this.touchEventInProgress) { // So, we only handle left button.
 			this.clearMousePositions();
 			this.positionOnMouseDown = this.convertPositionToCanvasLocale(e);
 
@@ -1197,7 +1197,7 @@ class CanvasSectionContainer {
 			return;
 		}
 
-		if (e.button === 0 && !this.touchEventInProgress) {
+		if ((e.button === 0 || e.button === 2) && !this.touchEventInProgress) {
 			this.positionOnMouseUp = this.convertPositionToCanvasLocale(e);
 			var section: CanvasSectionObject;
 			if (!this.draggingSomething) {

--- a/browser/src/canvas/sections/MouseControl.ts
+++ b/browser/src/canvas/sections/MouseControl.ts
@@ -122,7 +122,7 @@ class MouseControl extends CanvasSectionObject {
 		const buttons = app.LOButtons.right;
 		const modifier = this.readModifier(e);
 
-		if (modifier === 0) {
+		if (modifier === 0 && !this.mouseDownSent) {
 			this.postCoreMouseEvent(
 				'buttondown',
 				this.currentPosition,
@@ -130,6 +130,8 @@ class MouseControl extends CanvasSectionObject {
 				buttons,
 				modifier,
 			);
+		} else if (this.mouseDownSent) {
+			this.mouseDownSent = false;
 		}
 	}
 
@@ -343,6 +345,19 @@ class MouseControl extends CanvasSectionObject {
 	onMouseDown(point: cool.SimplePoint, e: MouseEvent): void {
 		this.refreshPosition(point);
 		this.positionOnMouseDown = this.currentPosition.clone();
+
+		if (e.button === 2) {
+			const buttons = app.LOButtons.right;
+			const modifier = this.readModifier(e);
+			this.postCoreMouseEvent(
+				'buttondown',
+				this.currentPosition,
+				1,
+				buttons,
+				modifier,
+			);
+			this.mouseDownSent = true;
+		}
 
 		if (e.type === 'touchstart') {
 			// For swipe action.


### PR DESCRIPTION

* Resolves: #13685
* Target version: master  
## Summary

This PR fixes the **context menu delay issue** in Collabora Online. Instead of waiting for the browser's `contextmenu` event, the right-click `mousedown` event is handled immediately, ensuring that the context menu appears instantly across all file types (Writer, Calc, Impress).

## Changes Made

**Browser**

- **`CanvasSectionContainer.ts`**  
  - Updated `onMouseDown` and `onMouseUp` to propagate right-click events (button 2).

- **`MouseControl.ts`**  
  - Updated `onMouseDown` to detect right-clicks and send the `buttondown` command immediately.  
  - Updated `onContextMenu` to prevent duplicate `buttondown` commands if one was already sent by `onMouseDown`.

---

## Verification Steps

1. Build the project using the browser package commands.  
2. Run the Collabora Online server.  
3. Open any document (Writer, Calc, or Impress).  
4. **Right-click** → Context menu should appear immediately (no ~1-second delay).  
5. **Drag test** → Right-click + drag should work without issues.  
6. **Double right-click** → Ensure no unexpected behavior.

---

## Technical Details

- The fix bypasses the browser’s potential delay in firing the `contextmenu` event.  
- By catching the `mousedown` event for the right mouse button, the core is signaled to show the menu instantly.  
- Added a flag `mouseDownSent` to avoid sending the signal twice (once for `mousedown` and once for `contextmenu`).

---

## Checklist

- [✔] Code formatted with `make prettier-write`  
- [✔] All commits have Change-Id  
- [✔] Tests run successfully (`make check`)  
- [✔] Manual verification completed (`make run`)  
- [✔] Documentation updated or not required
