### PR TITLE
jsdialog: stop closing dropdown on reselection

### DIFF
--- a/browser/src/control/jsdialog/Util.Dropdown.js
+++ b/browser/src/control/jsdialog/Util.Dropdown.js
@@ -135,8 +135,11 @@ JSDialog.OpenDropdown = function (id, popupParent, entries, innerCallback, popup
 		return function(objectType, eventType, object, data) {
 			var pos = data ? parseInt(data.substr(0, data.indexOf(';'))) : null;
 			var entry = targetEntries && pos !== null ? targetEntries[pos] : null;
+			var subMenuId = object.id + '-' + pos;
 
 			if (eventType === 'selected' || eventType === 'showsubmenu') {
+				if (lastSubMenuOpened === subMenuId)
+					return;
 				if (entry && entry.items) {
 					if (lastSubMenuOpened) {
 						var submenu = JSDialog.GetDropdown(lastSubMenuOpened);
@@ -148,7 +151,6 @@ JSDialog.OpenDropdown = function (id, popupParent, entries, innerCallback, popup
 
 					// open submenu
 					var dropdown = JSDialog.GetDropdown(object.id);
-					var subMenuId = object.id + '-' + pos;
 					var targetEntry = dropdown.querySelectorAll('.ui-grid-cell')[pos + 1];
 					JSDialog.OpenDropdown(subMenuId, targetEntry, entry.items,
 						generateCallback(entry.items), 'top-end', true);


### PR DESCRIPTION
problem:
ie:
1. inside table tab in writer open the broder dropdown
2. hover over line color (opens the line color submenu)
3. hover back to any other entries in dropdown without submenu
4. hover back to line color menu it will close


Change-Id: I0ecb6da5223a55df9ff844b784e02f8f9d1a38cf


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

