### PR TITLE
Table Style: Add new Table tab for calc table styles

### DIFF
--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -70,10 +70,10 @@ window.L.Control.ContextMenu = window.L.Control.extend({
 				   'AddToWordbook'],
 
 			spreadsheet: ['MergeCells', 'SplitCell', 'InsertCell', 'DeleteCell',
-				      'RecalcPivotTable', 'DataDataPilotRun', 'DeletePivotTable', 'InsertCalcTable', 'RemoveCalcTable',
-				      'FormatCellDialog', 'DeleteNote', 'SetAnchorToCell', 'SetAnchorToCellResize',
-				      'FormatSparklineMenu', 'InsertSparkline', 'DeleteSparkline', 'DeleteSparklineGroup',
-				      'EditSparklineGroup', 'EditSparkline', 'GroupSparklines', 'UngroupSparklines', 'AutoFill'],
+					  'RecalcPivotTable', 'DataDataPilotRun', 'DeletePivotTable', 'InsertCalcTable', 'RemoveCalcTable',
+					  'DatabaseSettings', 'FormatCellDialog', 'DeleteNote', 'SetAnchorToCell', 'SetAnchorToCellResize',
+					  'FormatSparklineMenu', 'InsertSparkline', 'DeleteSparkline', 'DeleteSparklineGroup',
+					  'EditSparklineGroup', 'EditSparkline', 'GroupSparklines', 'UngroupSparklines', 'AutoFill'],
 
 			presentation: ['SetDefault'],
 			drawing: []

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -95,6 +95,13 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 				'accessibility': { focusBack: true,	combination: 'K', de: null }
 			},
 			{
+				'id': 'Table-tab-label',
+				'text': _('Table'),
+				'name': 'Table',
+				'context': 'Table',
+				'accessibility': { focusBack: true,	combination: 'T', de: null }
+			},
+			{
 				'id': 'Help-tab-label',
 				'text': _('Help'),
 				'name': 'Help',
@@ -117,6 +124,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 			this.getPictureTab(),
 			this.getViewTab(),
 			this.getSparklineTab(),
+			this.getCalcTableTab(),
 			this.getHelpTab()
 		]
 	},
@@ -1641,6 +1649,142 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 		return this.getTabPage('View', content);
 	},
 
+	getCalcTableTab: function() {
+		var content = [
+			{
+				'id': 'insert-remove-calc-table',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:RemoveCalcTable', 'spreadsheet'),
+				'command': '.uno:RemoveCalcTable',
+				'accessibility': { focusBack: true,	combination: 'DT', de: null }
+			},
+			{ type: 'separator', id: 'table-deletecalctable-break', orientation: 'vertical' },
+			{
+				'type': 'overflowgroup',
+				'id': 'table-style-options',
+				'name':_('Table Style Options'),
+				'accessibility': { focusBack: true,	combination: 'TO', de: null },
+				'children' : [
+					{
+						'type': 'container',
+						'children': [
+							{
+								'type': 'toolbox',
+								'children': [
+									{
+										'id': 'chk_header_row2',
+										'type': 'checkbox',
+										'command': '.uno:DatabaseSettings',
+										'text': _('Show Header Row'),
+										'accessibility': { focusBack: true,	combination: 'SH', de: null }
+									}
+								]
+							},
+							{
+								'type': 'toolbox',
+								'children': [
+									{
+										'id': 'chk_total_row2',
+										'type': 'checkbox',
+										'command': '.uno:DatabaseSettings',
+										'text': _('Show Total Row'),
+										'accessibility': { focusBack: true,	combination: 'ST', de: null }
+									}
+								]
+							}
+						],
+						'vertical': 'true'
+					},
+					{
+						'type': 'container',
+						'children': [
+							{
+								'type': 'toolbox',
+								'children': [
+									{
+										'id': 'chk_banded_rows2',
+										'type': 'checkbox',
+										'command': '.uno:DatabaseSettings',
+										'text': _('Banded Rows'),
+										'accessibility': { focusBack: true,	combination: 'BR', de: null }
+									}
+								]
+							},
+							{
+								'type': 'toolbox',
+								'children': [
+									{
+										'id': 'chk_banded_cols2',
+										'type': 'checkbox',
+										'command': '.uno:DatabaseSettings',
+										'text': _('Banded Columns'),
+										'accessibility': { focusBack: true,	combination: 'BC', de: null }
+									}
+								]
+							}
+						],
+						'vertical': 'true'
+					},
+					{
+						'type': 'container',
+						'children': [
+							{
+								'type': 'toolbox',
+								'children': [
+									{
+										'id': 'chk_first_column2',
+										'type': 'checkbox',
+										'command': '.uno:DatabaseSettings',
+										'text': _('First Column'),
+										'accessibility': { focusBack: true,	combination: 'FC', de: null }
+									}
+								]
+							},
+							{
+								'type': 'toolbox',
+								'children': [
+									{
+										'id': 'chk_last_column2',
+										'type': 'checkbox',
+										'command': '.uno:DatabaseSettings',
+										'text': _('Last Column'),
+										'accessibility': { focusBack: true,	combination: 'LC', de: null }
+									}
+								]
+							}
+						],
+						'vertical': 'true'
+					},
+					{
+						'type': 'container',
+						'children': [
+							{
+								'id': 'chk_filter_buttons2',
+								'type': 'checkbox',
+								'command': '.uno:DatabaseSettings',
+								'text': _('Show Filter Buttons'),
+								'accessibility': { focusBack: true,	combination: 'SF', de: null }
+							},
+							{
+								'id': 'tablestyles_cb2',
+								'type': 'listbox',
+								'selectedCount': '1',
+								'selectedEntries': [
+									'0'
+								],
+								'command': '.uno:DatabaseSettings',
+								'accessibility': { focusBack: true,	combination: 'TS', de: null }
+							}
+						],
+						'vertical': 'true'
+					},
+				]
+			}
+		];
+
+		return this.getTabPage('Table', content);
+	},
+
 	getSparklineTab: function() {
 		var content = [
 			{
@@ -1741,14 +1885,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 						'text': _UNO('.uno:InsertCalcTable', 'spreadsheet'),
 						'command': '.uno:InsertCalcTable',
 						'accessibility': { focusBack: true,	combination: 'IT', de: null }
-					},
-					{
-						'id': 'insert-remove-calc-table',
-						'type': 'bigtoolitem',
-						'text': _UNO('.uno:RemoveCalcTable', 'spreadsheet'),
-						'command': '.uno:RemoveCalcTable',
-						'accessibility': { focusBack: true,	combination: 'DT', de: null }
-					},
+					}
 				]
 			},
 			{ type: 'separator', id: 'insert-deletecalctable-break', orientation: 'vertical' },

--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -152,6 +152,7 @@ var unoCommandsArray = {
 	'Cut':{global:{menu:_('~Cut'),},},
 	'DataAreaRefresh':{spreadsheet:{menu:_('R~efresh Range'),},},
 	'DataBarFormatDialog':{spreadsheet:{menu:_('Data Bar...'),},},
+	'DatabaseSettings':{spreadsheet:{menu:_('~Table Style Options'),},},
 	'DataDataPilotRun':{spreadsheet:{context:_('~Properties...'),menu:_('Pi~vot Table...'),},},
 	'DataFilterAutoFilter':{spreadsheet:{menu:_('Auto~Filter'),},},
 	'DataFilterHideAutoFilter':{spreadsheet:{menu:_('~Hide AutoFilter'),},},


### PR DESCRIPTION
Add Remove Table and Table style options to the new tab. follow-up of 54762cc87ccf43b11ae0bfebe6dc9f03aa2ef20c

Patch will only work with this core changes:
8686517a4d3ca74edb1806ee19e129d0906567aa
(Table Styles: Add NoteBookBar implementation for table styles...)


Change-Id: Icb5ee0ada1b223812fa157d4413077fd94ea1d31


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

[Book1-edit.xlsx](https://github.com/user-attachments/files/23886101/Book1-edit.xlsx)
 For testing open the Book1-edit.xlsx file and select a cell inside the Table Style area.
A new Tab named 'Table' should be visible, with Table Style Options.

There are 8 UI element. (7 checkbox and 1 Listbox)
Unfortunatelly only the "Show Header Row", "Show Total Row", "Banded Rows", "Show Filter Button", and the Table Styles listbox works. They are nicely syncronised with Sidebar Table Style Options.

The "Banded Columns", "First Column", "Last Column" not working, unless the 										'command': '.uno:DatabaseSettings', is removed from getCalcTableTab() at ID chk_banded_cols2, chk_first_column2, chk_last_column2. (which is weird)

Also it is start working if I select these options from the Sidebar first.

I checked that in Online in case of these options we have an error on the console:
`docdispatcher.ts:867 unknown dispatch: ".uno:DatabaseSettings"`
The other options do not have this error.

### TODO

- [x] testing
- [x] fixing the above problem

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

