### PR TITLE
CODA-M: Fix copying of templates and generating json for them on MacOS.

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -887,7 +887,11 @@ endif
 if ENABLE_WINDOWSAPP
 LOPATHFORTEMPLATES=$(LOBUILDDIR)/instdir
 else
+if ENABLE_MACOS
+LOPATHFORTEMPLATES=$(LO_PATH)/Contents/Resources
+else
 LOPATHFORTEMPLATES=$(LO_PATH)
+endif
 endif
 
 $(TEMPLATE_MANIFEST): $(srcdir)/util/generate-templates-manifest.js

--- a/browser/util/generate-templates-manifest.js
+++ b/browser/util/generate-templates-manifest.js
@@ -156,9 +156,22 @@ function writeManifest(outPath, templates) {
 		process.exit(1);
 	}
 
-	const templateRoot = loPath ? path.join(loPath, 'share', 'template', 'common') : null;
+	// On macOS, templates are in Contents/Resources/template/common
+	// On other platforms, they're in share/template/common
+	let templateRoot = null;
+	if (loPath) {
+		const macOSPath = path.join(loPath, 'template', 'common');
+		const standardPath = path.join(loPath, 'share', 'template', 'common');
+
+		if (fs.existsSync(macOSPath)) {
+			templateRoot = macOSPath;
+		} else if (fs.existsSync(standardPath)) {
+			templateRoot = standardPath;
+		}
+	}
+
 	if (!templateRoot || !fs.existsSync(templateRoot)) {
-		console.warn(`Template root not found: ${templateRoot}`);
+		console.warn(`Template root not found: ${templateRoot || 'no LO path specified'}`);
 		writeManifest(outPath, []);
 		return;
 	}
@@ -166,7 +179,7 @@ function writeManifest(outPath, templates) {
 	const manifestDir = path.dirname(outPath);
 	const previewsRoot = path.join(manifestDir, 'previews');
 	const distTemplatesRoot = path.join(manifestDir, 'files');
-	
+
 	try {
 		fs.rmSync(previewsRoot, { recursive: true, force: true });
 		fs.rmSync(distTemplatesRoot, { recursive: true, force: true });

--- a/macos/coda/coda.xcodeproj/project.pbxproj
+++ b/macos/coda/coda.xcodeproj/project.pbxproj
@@ -121,7 +121,7 @@
 		BE5A7A282D2BE28200FE7D60 /* FileUtil.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = FileUtil.hpp; path = ../../../../common/FileUtil.hpp; sourceTree = "<group>"; };
 		BE5FDE352DAD3DCF00C48DB2 /* LogUI.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = LogUI.hpp; path = ../../../../kit/LogUI.hpp; sourceTree = "<group>"; };
 		BE5FDE362DAD3DCF00C48DB2 /* LogUI.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = LogUI.cpp; path = ../../../../kit/LogUI.cpp; sourceTree = "<group>"; };
-		BE862C4C2EB9066E0061664E /* templates */ = {isa = PBXFileReference; lastKnownFileType = folder; name = templates; path = ../../../browser/templates; sourceTree = "<group>"; };
+		BE862C4C2EB9066E0061664E /* templates */ = {isa = PBXFileReference; lastKnownFileType = folder; name = templates; path = ../../../browser/dist/templates; sourceTree = "<group>"; };
 		BE9115AD2CECBD3100C597B2 /* FileUtil-unix.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "FileUtil-unix.cpp"; path = "../../../../common/FileUtil-unix.cpp"; sourceTree = "<group>"; };
 		BE9115AF2CECBECF00C597B2 /* Util-unix.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = "Util-unix.cpp"; path = "../../../../common/Util-unix.cpp"; sourceTree = "<group>"; };
 		BEA263522CBE38E20007435A /* Authorization.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; name = Authorization.hpp; path = ../../../../common/Authorization.hpp; sourceTree = "<group>"; };

--- a/macos/coda/coda/DocumentController.swift
+++ b/macos/coda/coda/DocumentController.swift
@@ -148,11 +148,23 @@ final class DocumentController: NSDocumentController {
     /**
      * Copy content of the template (based on "kind") to NSDocument and trigger its editing.
      */
-    func createDocument(fromTemplateFor kind: NewKind) {
+    func createDocument(fromTemplateFor kind: NewKind, templatePath: String? = nil) {
         // Pick the template file in your bundle
-        guard let (resName, ext) = templateNameAndExt(for: kind),
-              let templatesURL = Bundle.main.url(forResource: resName, withExtension: ext, subdirectory: "templates")
-        else {
+        let templatesURL: URL?
+
+        if let templatePath = templatePath {
+            // Use the provided template path from the backstage view
+            templatesURL = Bundle.main.resourceURL?.appendingPathComponent(templatePath)
+        } else {
+            // Use the default blank template
+            guard let (resName, ext) = templateNameAndExt(for: kind) else {
+                NSApp.presentError(NSError(domain: "NewDoc", code: 1, userInfo: [NSLocalizedDescriptionKey: "Template not found."]))
+                return
+            }
+            templatesURL = Bundle.main.url(forResource: resName, withExtension: ext, subdirectory: "templates")
+        }
+
+        guard let templatesURL = templatesURL else {
             NSApp.presentError(NSError(domain: "NewDoc", code: 1, userInfo: [NSLocalizedDescriptionKey: "Template not found."]))
             return
         }

--- a/macos/coda/coda/ViewController.swift
+++ b/macos/coda/coda/ViewController.swift
@@ -376,10 +376,13 @@ class ViewController: NSViewController, WKScriptMessageHandlerWithReply, WKNavig
         if body.hasPrefix("newdoc ") {
             let messageBodyItems = body.components(separatedBy: " ")
             var type: String?
+            var templatePath: String?
             if messageBodyItems.count >= 2 {
                 for item in messageBodyItems[1...] {
                     if item.hasPrefix("type=") {
                         type = String(item.dropFirst("type=".count))
+                    } else if item.hasPrefix("template=") {
+                        templatePath = String(item.dropFirst("template=".count)).removingPercentEncoding
                     }
                 }
 
@@ -390,7 +393,7 @@ class ViewController: NSViewController, WKScriptMessageHandlerWithReply, WKNavig
                     default : kind = .text
                 }
 
-                (NSDocumentController.shared as? DocumentController)?.createDocument(fromTemplateFor: kind)
+                (NSDocumentController.shared as? DocumentController)?.createDocument(fromTemplateFor: kind, templatePath: templatePath)
             }
 
             return true


### PR DESCRIPTION
Since the templates are in the Contents/Resources we needed to adjust the generate-templates-manifest.js to look there instead. Also fixed loading template files by passing a templatePath to createDocument.


Change-Id: If08dc03323a371b5565465fc2f9b2a46f113fdc0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

