### PR TITLE
fix(slideshow): improve error logging and null safety in animation engine

### DIFF
--- a/browser/src/slideshow/engine/AnimationFactory.ts
+++ b/browser/src/slideshow/engine/AnimationFactory.ts
@@ -184,8 +184,33 @@ function createPropertyAnimation(
 	}
 
 	// nWidth, nHeight are used here
-	const aGetModifier = eval(aFunctorSet.getmod);
-	const aSetModifier = eval(aFunctorSet.setmod);
+	// getmod and setmod are optional - only some properties use them
+	let aGetModifier: SetterType | undefined;
+	let aSetModifier: SetterType | undefined;
+
+	if (aFunctorSet.getmod) {
+		aGetModifier = eval(aFunctorSet.getmod);
+		// Validate modifier - makeScaler can return null for invalid parameters
+		if (!aGetModifier) {
+			window.app.console.error(
+				'createPropertyAnimation: failed to create get modifier for attribute: ' +
+					sAttrName,
+			);
+			return null;
+		}
+	}
+
+	if (aFunctorSet.setmod) {
+		aSetModifier = eval(aFunctorSet.setmod);
+		// Validate modifier - makeScaler can return null for invalid parameters
+		if (!aSetModifier) {
+			window.app.console.error(
+				'createPropertyAnimation: failed to create set modifier for attribute: ' +
+					sAttrName,
+			);
+			return null;
+		}
+	}
 
 	const aGetValueMethod =
 		aAnimatedElement[sGetValueMethod as keyof typeof aAnimatedElement];

--- a/browser/src/slideshow/engine/tools.ts
+++ b/browser/src/slideshow/engine/tools.ts
@@ -416,7 +416,7 @@ class HSLColor {
 // eslint-disable-next-line no-unused-vars
 function makeScaler(nScale: number) {
 	if (typeof nScale !== typeof 0 || !isFinite(nScale)) {
-		window.app.console.log('makeScaler: not valid param passed: ' + nScale);
+		window.app.console.error('makeScaler: not valid param passed: ' + nScale);
 		return null;
 	}
 


### PR DESCRIPTION
# Fix error logging and null safety in slideshow animation engine

## Summary

This PR fixes two related issues in the slideshow animation engine:
1. **Error logging improvement**: Changes `makeScaler()` to use `app.console.error()` instead of `app.console.log()` for invalid parameter errors, improving error visibility in debugging scenarios.
2. **Null safety check**: Adds defensive null checks after `eval()` calls in `AnimationFactory.ts` to prevent potential runtime errors when `makeScaler()` returns `null` for invalid parameters.

## Problem

### Root Cause

1. **Incorrect error logging level**: The `makeScaler()` function in `browser/src/slideshow/engine/tools.ts` uses `window.app.console.log()` for error conditions (invalid parameters), which makes errors less visible compared to using `app.console.error()`.

2. **Missing null safety**: In `browser/src/slideshow/engine/AnimationFactory.ts`, the `createPropertyAnimation()` function evaluates `getmod` and `setmod` strings via `eval()` to create modifier functions. When `makeScaler()` is called with invalid parameters (e.g., `NaN`, `Infinity`, or non-numeric values), it returns `null`. These `null` values are then passed to `GenericAnimation` constructor without validation, which could lead to runtime errors if the modifiers are used without proper null checks elsewhere.

### Impact

- **Error visibility**: Invalid parameter errors in `makeScaler()` are logged at the wrong level, making them harder to spot during debugging.
- **Potential crashes**: If `makeScaler()` returns `null` due to invalid parameters (e.g., when `nWidth` or `nHeight` are invalid), the animation creation could fail silently or cause runtime errors when modifiers are used.

## Solution

1. **Changed error logging**: Updated `makeScaler()` to use `window.app.console.error()` instead of `window.app.console.log()` for invalid parameter errors, aligning with the logging pattern used elsewhere in the slideshow engine (e.g., `SlideShowHandler.ts`).

2. **Added null safety checks**: 
   - Added conditional evaluation of `getmod` and `setmod` (they are optional properties)
   - Added validation after `eval()` to ensure modifiers are not `null` before passing them to `GenericAnimation`
   - Added appropriate error logging when modifier creation fails
   - Return `null` early if modifier creation fails, preventing invalid animation objects

## Files Changed

- `browser/src/slideshow/engine/tools.ts`: Changed error logging from `console.log` to `console.error`
- `browser/src/slideshow/engine/AnimationFactory.ts`: Added null safety checks for modifier evaluation

## Before vs After

### Before

```typescript
// tools.ts
function makeScaler(nScale: number) {
	if (typeof nScale !== typeof 0 || !isFinite(nScale)) {
		window.app.console.log('makeScaler: not valid param passed: ' + nScale);
		return null;
	}
	// ...
}

// AnimationFactory.ts
const aGetModifier = eval(aFunctorSet.getmod);
const aSetModifier = eval(aFunctorSet.setmod);
// No validation - null values could be passed to GenericAnimation
return new GenericAnimation(..., aGetModifier, aSetModifier);
```

### After

```typescript
// tools.ts
function makeScaler(nScale: number) {
	if (typeof nScale !== typeof 0 || !isFinite(nScale)) {
		window.app.console.error('makeScaler: not valid param passed: ' + nScale);
		return null;
	}
	// ...
}

// AnimationFactory.ts
let aGetModifier: SetterType | undefined;
let aSetModifier: SetterType | undefined;

if (aFunctorSet.getmod) {
	aGetModifier = eval(aFunctorSet.getmod);
	if (!aGetModifier) {
		window.app.console.error('createPropertyAnimation: failed to create get modifier...');
		return null;
	}
}

if (aFunctorSet.setmod) {
	aSetModifier = eval(aFunctorSet.setmod);
	if (!aSetModifier) {
		window.app.console.error('createPropertyAnimation: failed to create set modifier...');
		return null;
	}
}
// Safe to pass modifiers to GenericAnimation
return new GenericAnimation(..., aGetModifier, aSetModifier);
```

## Testing

### Manual Testing

1. **Error logging verification**: 
   - Trigger `makeScaler()` with invalid parameters (e.g., `NaN`, `Infinity`, non-numeric)
   - Verify errors appear in browser console with error level (red/error styling)
   - Previously they appeared as regular log messages

2. **Null safety verification**:
   - Test animation creation with invalid width/height values that would cause `makeScaler()` to return `null`
   - Verify that `createPropertyAnimation()` returns `null` gracefully instead of creating invalid animation objects
   - Verify error messages are logged appropriately

### Test Coverage Notes

- The slideshow engine currently doesn't have unit tests in the mocha test suite
- Manual testing should cover:
  - Valid animation creation (regression test)
  - Invalid parameter handling in `makeScaler()`
  - Animation creation failure scenarios

## Why This Is Safe and Should Be Merged

1. **Low risk**: 
   - Only changes error logging level and adds defensive null checks
   - No changes to public APIs or core logic
   - Backward compatible - existing valid code paths unchanged

2. **Follows project patterns**:
   - Uses `app.console.error()` consistent with other error logging in slideshow engine
   - Defensive programming approach aligns with existing null checks in codebase

3. **Improves robustness**:
   - Prevents potential runtime errors from null modifiers
   - Better error visibility for debugging

4. **Small, focused change**:
   - Easy to review
   - Clear purpose and impact
   - No unnecessary changes

## Conventional Commit Message

```
fix(slideshow): improve error logging and null safety in animation engine

- Change makeScaler() to use console.error instead of console.log for invalid parameters
- Add null safety checks for modifier evaluation in AnimationFactory
- Prevent potential runtime errors when makeScaler returns null

Fixes error visibility issues and adds defensive null checks to prevent
crashes when invalid animation parameters are provided.

Signed-off-by: [Your Name] <[your.email@example.com]>
```

## Git Commands

```bash
# Create a new branch
git checkout -b fix/slideshow-error-logging-null-safety

# Stage the changes
git add browser/src/slideshow/engine/tools.ts browser/src/slideshow/engine/AnimationFactory.ts

# Commit with DCO sign-off
git commit -s -m "fix(slideshow): improve error logging and null safety in animation engine

- Change makeScaler() to use console.error instead of console.log for invalid parameters
- Add null safety checks for modifier evaluation in AnimationFactory
- Prevent potential runtime errors when makeScaler returns null

Fixes error visibility issues and adds defensive null checks to prevent
crashes when invalid animation parameters are provided."

# Push to your fork
git push origin fix/slideshow-error-logging-null-safety
```

## Reviewer Checklist

### Code Quality
- [ ] Code follows Collabora Online TypeScript/JavaScript style guidelines
- [ ] No linter errors introduced
- [ ] Changes are minimal and focused

### Functionality
- [ ] Error logging uses appropriate level (`console.error` for errors)
- [ ] Null checks prevent potential runtime errors
- [ ] Existing functionality not broken (regression test)

### Safety
- [ ] No memory leaks introduced
- [ ] No breaking changes to public APIs
- [ ] Defensive programming approach is appropriate

### Documentation
- [ ] Code comments are clear (if needed)
- [ ] Commit message follows conventional commit format
- [ ] PR description explains problem and solution clearly

### Testing
- [ ] Manual testing performed for error scenarios
- [ ] Valid animation creation still works (regression)
- [ ] Error messages are visible and helpful

## Related Issues

This fix addresses potential issues that could occur when:
- Invalid width/height values are passed to animation creation
- `makeScaler()` receives non-numeric or infinite values
- Animation modifiers fail to create but errors are not visible

## Additional Notes

- The `GenericAnimation` constructor already accepts optional modifiers, so the null checks are defensive rather than strictly required, but they improve error handling and debugging
- This change aligns with the project's pattern of using `app.console.error()` for error conditions (as seen in `SlideShowHandler.ts`, `Transition2d.ts`, etc.)

