### PR TITLE
CODA-M: Set the window icon based on what kind of file is currently open.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ coolwsd.spec
 coolwsd.xml
 aclocal.m4
 autom4te.cache
+coda.xcarchive
 config.h
 config_unused.h
 config_unused.h.in
@@ -46,6 +47,7 @@ common/support-public-key.hpp
 compile_commands.json
 **/gdb.txt
 macos/coolwsd/gmake-wrapper.sh
+macos/coda/coda/Assets.xcassets
 
 # Test stuff
 systemplate

--- a/macos/coda/coda.xcodeproj/project.pbxproj
+++ b/macos/coda/coda.xcodeproj/project.pbxproj
@@ -447,9 +447,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = BECC4BD02CBD3FA400A120B3 /* Build configuration list for PBXNativeTarget "coda" */;
 			buildPhases = (
+				BEA82CDF2EC2201700CDC5A6 /* ShellScript */,
+				BE1234562CDA3024004111EF /* Generate Document Icons */,
 				BECC4BA72CBD3FA300A120B3 /* Sources */,
 				BECC4BA82CBD3FA300A120B3 /* Frameworks */,
-				BEA82CDF2EC2201700CDC5A6 /* ShellScript */,
 				BECC4BA92CBD3FA300A120B3 /* Resources */,
 				BEE076602CDA3024004111EF /* ShellScript */,
 			);
@@ -651,6 +652,33 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Make sure the JS bits are up-to-date: run make in the login shell (so that Homebrew etc. is set up)\nset -e\n\"${SHELL:-/bin/zsh}\" -lic 'make -C \"$SRCROOT/../..\" all'\n";
+		};
+		BE1234562CDA3024004111EF /* Generate Document Icons */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/../../browser/dist/images/x-office-document.svg",
+				"$(SRCROOT)/../../browser/dist/images/x-office-spreadsheet.svg",
+				"$(SRCROOT)/../../browser/dist/images/x-office-presentation.svg",
+				"$(SRCROOT)/../../browser/dist/images/x-office-drawing.svg",
+			);
+			name = "Generate Document Icons";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/coda/Assets.xcassets/DocumentIcon.imageset/DocumentIcon.png",
+				"$(SRCROOT)/coda/Assets.xcassets/SpreadsheetIcon.imageset/SpreadsheetIcon.png",
+				"$(SRCROOT)/coda/Assets.xcassets/PresentationIcon.imageset/PresentationIcon.png",
+				"$(SRCROOT)/coda/Assets.xcassets/DrawingIcon.imageset/DrawingIcon.png",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"$SRCROOT/generate-document-icons.sh\"\n";
 		};
 		BEE076602CDA3024004111EF /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/macos/coda/coda/Document.swift
+++ b/macos/coda/coda/Document.swift
@@ -46,6 +46,9 @@ class Document: NSDocument {
     /// This is a newly created document (from a template).
     var isNewDocument = false
 
+    /// The document type (UTI) for this document, set explicitly for new documents
+    var documentType: String?
+
     /** Parameters for a deferred Save / Save As… request. */
     private struct PendingSave {
         let url: URL
@@ -220,6 +223,38 @@ class Document: NSDocument {
             }
             else if !win.setFrameUsingName(initialName) {
                 FrameAutosaveHelper.applyDefaultFrame(win, widthFraction: 0.95, heightFraction: 0.95)
+            }
+
+            // Set window icon based on document type
+            let type = self.documentType ?? self.fileType ?? "org.oasis-open.opendocument.text"
+
+            // For new/untitled documents, we need to set a represented URL to make the icon button appear
+            if self.fileURL == nil && win.representedURL == nil {
+                // Create a temporary represented URL so the icon button appears
+                // Use the temp file URL if available, otherwise create a dummy one
+                if let tempURL = self.tempFileURL {
+                    win.representedURL = tempURL
+                } else {
+                    // Create a dummy URL with the appropriate extension
+                    let ext: String
+                    switch type {
+                    case let t where t.contains("spreadsheet"):
+                        ext = "ods"
+                    case let t where t.contains("presentation"):
+                        ext = "odp"
+                    case let t where t.contains("text"):
+                        ext = "odt"
+                    default:
+                        ext = "odt"
+                    }
+                    let dummyURL = URL(fileURLWithPath: "/tmp/Untitled.\(ext)")
+                    win.representedURL = dummyURL
+                }
+            }
+
+            // Set branded icon based on document type
+            if let icon = Document.iconForType(typeName: type) {
+                win.standardWindowButton(.documentIconButton)?.image = icon
             }
         }
 
@@ -529,6 +564,54 @@ class Document: NSDocument {
                 }
             }
         }
+    }
+
+    /// Returns the correct icon for a document type
+    static func iconForType(typeName: String) -> NSImage? {
+        // Use branded icons from Assets catalog
+        let iconName: String?
+        switch typeName {
+        case "org.oasis-open.opendocument.text",
+             "org.openoffice.text",
+             "com.microsoft.word.doc",
+             "org.openxmlformats.wordprocessingml.document",
+             "org.openxmlformats.wordprocessingml.document.macroEnabled",
+             "org.openxmlformats.wordprocessingml.template",
+             "org.openxmlformats.wordprocessingml.template.macroEnabled",
+             "public.rtf":
+            iconName = "DocumentIcon"
+        case "org.oasis-open.opendocument.spreadsheet",
+             "org.openoffice.spreadsheet",
+             "com.microsoft.excel.xls",
+             "org.openxmlformats.spreadsheetml.sheet",
+             "org.openxmlformats.spreadsheetml.sheet.macroEnabled",
+             "com.microsoft.excel.sheet.binary.macroEnabled",
+             "org.openxmlformats.spreadsheetml.template",
+             "org.openxmlformats.spreadsheetml.template.macroEnabled":
+            iconName = "SpreadsheetIcon"
+        case "org.oasis-open.opendocument.presentation",
+             "org.openoffice.presentation",
+             "com.microsoft.powerpoint.ppt",
+             "org.openxmlformats.presentationml.presentation",
+             "org.openxmlformats.presentationml.presentation.macroEnabled",
+             "org.openxmlformats.presentationml.template",
+             "org.openxmlformats.presentationml.template.macroEnabled":
+            iconName = "PresentationIcon"
+        case "org.oasis-open.opendocument.graphics",
+             "org.openoffice.graphics",
+             "org.libreoffice.visio-document":
+            iconName = "DrawingIcon"
+        default:
+            iconName = nil
+        }
+
+        // Load from Assets catalog
+        if let name = iconName, let image = NSImage(named: name) {
+            return image
+        }
+
+        // Fallback to app icon
+        return NSApp.applicationIconImage
     }
 }
 

--- a/macos/coda/coda/DocumentController.swift
+++ b/macos/coda/coda/DocumentController.swift
@@ -184,6 +184,7 @@ final class DocumentController: NSDocumentController {
 
             // mark it as new document (for better UI handling)
             doc.isNewDocument = true
+            doc.documentType = typeName  // Store the type explicitly for icon display
 
             try doc.read(from: data, ofType: typeName) // <- seeds tempDirectoryURL/tempFileURL exactly like a normal open
 

--- a/macos/coda/generate-document-icons.sh
+++ b/macos/coda/generate-document-icons.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Generate document type icons from SVGs
+set -e
+
+ASSETS="$SRCROOT/coda/Assets.xcassets"
+SVGS="$SRCROOT/../../browser/dist/images"
+
+# Create image sets if they don't exist
+for iconset in DocumentIcon SpreadsheetIcon PresentationIcon DrawingIcon; do
+  mkdir -p "$ASSETS/${iconset}.imageset"
+
+  # Create Contents.json if it doesn't exist
+  if [ ! -f "$ASSETS/${iconset}.imageset/Contents.json" ]; then
+    cat > "$ASSETS/${iconset}.imageset/Contents.json" <<EOF
+{
+  "images" : [
+    {
+      "filename" : "${iconset}.png",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+EOF
+  fi
+done
+
+# Convert SVGs to PNGs using sips (no external dependencies needed)
+# sips can read SVG and convert to PNG
+sips -s format png -z 512 512 "$SVGS/x-office-document.svg" --out "$ASSETS/DocumentIcon.imageset/DocumentIcon.png" >/dev/null 2>&1
+sips -s format png -z 512 512 "$SVGS/x-office-spreadsheet.svg" --out "$ASSETS/SpreadsheetIcon.imageset/SpreadsheetIcon.png" >/dev/null 2>&1
+sips -s format png -z 512 512 "$SVGS/x-office-presentation.svg" --out "$ASSETS/PresentationIcon.imageset/PresentationIcon.png" >/dev/null 2>&1
+sips -s format png -z 512 512 "$SVGS/x-office-drawing.svg" --out "$ASSETS/DrawingIcon.imageset/DrawingIcon.png" >/dev/null 2>&1
+
+echo "Document type icons generated successfully"


### PR DESCRIPTION
Uses document/spreadsheet/presentation icons to show the current document type in the window icon.
Unfortunately the AppKit tabs we are using don't support showing any icons but the window does so do that based on the current file's document type.


Change-Id: Ib761d7737040de8c38808f6eacf049ce6876e201


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

