### PR TITLE
Table Styles: rename new tab from Table to Table Design

### DIFF
--- a/browser/src/app/LOUtil.ts
+++ b/browser/src/app/LOUtil.ts
@@ -420,6 +420,7 @@ class LOUtil {
 			tabledeletemenu: 'deletetable',
 			insertcalctable: 'inserttable',
 			removecalctable: 'deletetable',
+			databasesettings: 'tabledesign',
 			tracechangemode: 'trackchanges',
 			deleteallannotation: 'deleteallnotes',
 			sdtabledesignpanel: 'tabledesign',

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -96,7 +96,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 			},
 			{
 				'id': 'Table-tab-label',
-				'text': _('Table'),
+				'text': _('Table Design'),
 				'name': 'Table',
 				'context': 'Table',
 				'accessibility': { focusBack: true,	combination: 'T', de: null }
@@ -1675,7 +1675,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 										'id': 'chk_header_row2',
 										'type': 'checkbox',
 										'command': '.uno:DatabaseSettings',
-										'text': _('Show Header Row'),
+										'text': _('Header Row'),
 										'accessibility': { focusBack: true,	combination: 'SH', de: null }
 									}
 								]
@@ -1687,7 +1687,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 										'id': 'chk_total_row2',
 										'type': 'checkbox',
 										'command': '.uno:DatabaseSettings',
-										'text': _('Show Total Row'),
+										'text': _('Total Row'),
 										'accessibility': { focusBack: true,	combination: 'ST', de: null }
 									}
 								]
@@ -1762,7 +1762,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 								'id': 'chk_filter_buttons2',
 								'type': 'checkbox',
 								'command': '.uno:DatabaseSettings',
-								'text': _('Show Filter Buttons'),
+								'text': _('Filter Buttons'),
 								'accessibility': { focusBack: true,	combination: 'SF', de: null }
 							},
 							{

--- a/browser/src/control/jsdialog/Widget.OverflowGroup.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowGroup.ts
@@ -291,7 +291,8 @@ function findFirstToolitem(
 		if (
 			item.type.indexOf('toolitem') >= 0 ||
 			item.type.indexOf('colorlistbox') >= 0 ||
-			item.type.indexOf('menubutton') >= 0
+			item.type.indexOf('menubutton') >= 0 ||
+			item.type.indexOf('checkbox') >= 0
 		)
 			return item;
 		else if (item.children && item.children.length) {


### PR DESCRIPTION
follow-up of: e7a1212615bebfc52ec52e0422c96ce4f1f21964


Change-Id: Ia0ac5538a9debe21136084364238c3f928049ce0


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
Just rename new Calc `Table` tab to `Table Design` tab.
Also there was some update in the core to check the context change more effectivly,
So it should work fine with the core patch: 9ee7c57308bbaddd5dec80ab5c9b2bbd8db6bac1
Also some UI cosmetics will be available in this core change: 27c37b84c0f522551caf8fc81ad3b1b6d0f0a9b4

### TODO

- [ ] review

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

