### PR TITLE
make ENABLE_CONSOLE_LOG work

### DIFF
--- a/cypress_test/README
+++ b/cypress_test/README
@@ -255,7 +255,7 @@ Unfortunately this does not work for multi-user tests.
 2. ENABLE_CONSOLE_LOG
 
 With this flag we can enable logging for console.error() messages and so they
-will be displayed in the command line. It's useful when we can reproduce a test
+will be displayed in the terminal. It's useful when we can reproduce a test
 failure only in headless mode and we need to debug the client-side JS code.
 
     ENABLE_CONSOLE_LOG="1" make check-mobile spec=writer/apply_font_spec.js

--- a/cypress_test/package.json
+++ b/cypress_test/package.json
@@ -20,6 +20,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-cypress-rules": "file:eslint_plugin",
     "get-port-cli": "2.0.0",
+    "patch-package": "^8.0.1",
     "semver": "^7.5.4",
     "typescript": "5.0.4",
     "wait-on": "7.0.1",
@@ -32,5 +33,8 @@
   "dependencies": {
     "cypress-tags": "^1.2.2",
     "cypress-visual-regression": "^5.2.2"
+  },
+  "scripts": {
+    "postinstall": "patch-package"
   }
 }

--- a/cypress_test/patches/cypress-log-to-output+1.1.2.patch
+++ b/cypress_test/patches/cypress-log-to-output+1.1.2.patch
@@ -1,0 +1,41 @@
+diff --git a/node_modules/cypress-log-to-output/src/log-to-output.js b/node_modules/cypress-log-to-output/src/log-to-output.js
+index 00cb486..3f38ace 100644
+--- a/node_modules/cypress-log-to-output/src/log-to-output.js
++++ b/node_modules/cypress-log-to-output/src/log-to-output.js
+@@ -138,6 +138,16 @@ function ensureRdpPort(args) {
+   return port
+ }
+ 
++function getRdpHost(args) {
++  const existing = args.find(arg => arg.slice(0, 26) === '--remote-debugging-address')
++
++  if (existing) {
++    return existing.split('=')[1]
++  }
++
++  return nil
++}
++
+ function browserLaunchHandler(browser = {}, launchOptions) {
+   const args = launchOptions.args || launchOptions
+ 
+@@ -146,13 +156,16 @@ function browserLaunchHandler(browser = {}, launchOptions) {
+   }
+ 
+   const rdp = ensureRdpPort(args)
++  const host = getRdpHost(args)
+ 
+   debugLog('Attempting to connect to Chrome Debugging Protocol')
+ 
+   const tryConnect = () => {
+-    new CDP({
+-      port: rdp
+-    })
++    const options = { port: rdp }
++    if (host) {
++        options.host = host
++    }
++    new CDP(options)
+     .then((cdp) => {
+       debugLog('Connected to Chrome Debugging Protocol')
+ 

--- a/cypress_test/plugins/index.js
+++ b/cypress_test/plugins/index.js
@@ -19,17 +19,21 @@ function plugin(on, config) {
 		config.video = true;
 	}
 
-	if (process.env.ENABLE_CONSOLE_LOG) {
-		require('cypress-log-to-output').install(on, function(type, event) {
-			if (event.level === 'error' || event.type === 'error') {
-				return true;
-			}
-
-			return false;
-		});
-	}
-
 	on('before:browser:launch', function(browser, launchOptions) {
+
+		if (process.env.ENABLE_CONSOLE_LOG) {
+			const logToOutput = require('cypress-log-to-output')
+
+			logToOutput.install(on, function(type, event) {
+				if (event.level === 'error' || event.type === 'error') {
+					return true;
+				}
+				return false;
+			});
+
+			launchOptions = logToOutput.browserLaunchHandler(browser, launchOptions);
+		}
+
 		if (browser.family === 'chromium') {
 			if (process.env.ENABLE_LOGGING) {
 				launchOptions.args.push('--enable-logging=stderr');


### PR DESCRIPTION
use the browserLaunchHandler pattern mentioned at: https://github.com/flotwig/cypress-log-to-output/issues/5

avoid the --remote-debugging-address arg mismatch vs default host using the patch upstreamed as:
https://github.com/flotwig/cypress-log-to-output/pull/28


Change-Id: Ie695b5fd85882932d42bfc83ba3b6da741a7233d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

