### PR TITLE
Use GCC -mno-direct-extern-access when building an x86/x86_64 coda_qt…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,8 @@ AC_DEFINE_UNQUOTED([COOLWSD_BUILDCONFIG],[["$ac_configure_args"]],[Options passe
 # don't include config_unused.h anywhere!
 AC_CONFIG_HEADERS([config_unused.h])
 
+AM_CONDITIONAL([X86], [test "$host_cpu" = x86 || test "$host_cpu" = x86_64])
+
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC

--- a/qt/Makefile.am
+++ b/qt/Makefile.am
@@ -74,6 +74,11 @@ DBusService.moc.cpp: DBusService.hpp
 
 CLEANFILES = $(BUILT_SOURCES)
 
+coda_qt_CXXFLAGS = $(AM_CXXFLAGS)
+if X86
+coda_qt_CXXFLAGS += -mno-direct-extern-access
+endif
+
 coda_qt_SOURCES = coda-qt.cpp WebView.cpp DBusService.cpp RecentDocuments.cpp $(BUILT_SOURCES) $(cmake_list)
 
 metainfodir = $(datadir)/metainfo


### PR DESCRIPTION
… executable

...so that it wouldn't provide and export _ZN16QCoreApplication4selfE@Qt_6 when it would mention any use of e.g. the qApp macro, which could cause coda_qt to terminate with a SIGSEGV at start (cf. 9c8e658724fe39fb8a1088083332ba02d5c36f86 "avoid Crash on startup of CODA-Q").

See the mailing list thread starting at
<https://lists.qt-project.org/pipermail/development/2025-December/046791.html> "[Development] QT_FEATURE_reduce_relocations breaking executables that mention qApp?" for details.


Change-Id: Iee5bcf0e1507692a8a4d3f2753f75c362fe9777e


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

