### PR TITLE
Fix Misaligned Text Orientations Buttons on Calc

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -489,14 +489,6 @@ algned to the bottom */
 	color: var(--color-text-darker) !important;
 }
 
-
-.jsdialog.sidebar #textorientbox button {
-	padding: 0 5px !important;
-	min-width: 0 !important;
-	margin-inline-end: 2px !important;
-	margin-inline-start: -8px !important;
-}
-
 /* Sub Tabs: example Format Cells: Font */
 
 .ui-tabs-content .ui-tabs.jsdialog.ui-widget {

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -286,10 +286,12 @@ button#button2.ui-pushbutton.jsdialog.sidebar {
 	grid-gap: inherit;
 }
 #textorientbox button {
-	min-width: auto;
+	padding: 0 5px !important;
+	min-width: 0 !important;
+	margin-inline-end: 2px !important;
+	margin-inline-start: -8px !important;
 	width: auto;
 }
-
 
 /* Charts */
 


### PR DESCRIPTION
Resolves: #13486

Fix Misaligned Text Orientations Buttons on Calc
modified:   browser/css/jsdialogs.css

Change-Id: I07d6c79f6730c7ce8f9b37cb0dc018e2d8dfd978

* Resolves: # <!-- 13486 -->
* Target version: master 

### Summary

Added a CSS rule targeting the three text extension buttons (#top-button, #bottom-button, #standard-button) in the sidebar to reduce padding, remove minimum width constraints, and adjust spacing/alignment.

### Checklist

- [ x] I have run `make prettier-write` and formatted the code.
- [ x] All commits have Change-Id
- [ x] I have run tests with `make check`
- [ x] I have issued `make run` and manually verified that everything looks okay
- [ x] Documentation (manuals or wiki) is not required

