### PR TITLE
CODA-Q flatpak: Run make clean on collabora-office

### DIFF
--- a/qt/flatpak/com.collaboraoffice.Office.json
+++ b/qt/flatpak/com.collaboraoffice.Office.json
@@ -827,6 +827,9 @@
       "ensure-writable": [
         "/collaboraoffice/LICENSE.html"
       ],
+      "make-args": [
+        "clean"
+      ],
       "post-install": [
         "python3 scripts/insert-coda-license.py /app/collaboraoffice/LICENSE.html CODA-THIRDPARTYLICENSES.html"
       ],


### PR DESCRIPTION
This because we use dir source
And the frontend code can be stale


Change-Id: I90c10edaee7c847aa0dc2d37eda35c71a92a6bb0


* Resolves: # <!-- related github issue -->
* Target version: coda-25.04 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

