### PR TITLE
Impress: Remove focus from slide sorter when clicked outside.

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -44,6 +44,11 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 		this._width = 0;
 		this._height = 0;
 		this.scrollTimer = null;
+
+		document.body.addEventListener('click', (e) => {
+			if (!e.partsFocusedApplied && this.partsFocused)
+				this.partsFocused = false;
+		});
 	},
 
 	onAdd: function (map) {
@@ -230,10 +235,11 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 		}, this);
 
 		var that = this;
-		img.onfocus = function () {
+		img.onfocus = function (e) {
 			that._map._clip.clearSelection();
 			that._map._clip.setTextSelectionType('slide');
 			that.partsFocused = true;
+			e.partsFocusedApplied = true;
 		};
 
 		var that = this;

--- a/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
@@ -53,6 +53,13 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', functio
 			const app = win['0'].app;
 			cy.expect(app.map._docLayer._preview.partsFocused).to.be.equal(true);
 		});
+
+		cy.cGet('#toolbar-up').click();
+		// Slide sorter should have lost the focus after user clicked somewhere.
+		cy.window().then(win => {
+			const app = win['0'].app;
+			cy.expect(app.map._docLayer._preview.partsFocused).to.be.equal(false);
+		});
 	});
 
 	it('Duplicate slide', function() {


### PR DESCRIPTION
Also added a test.

Test doesn't pass without the fix.


Change-Id: Ia0b47a0144c3fd83d3350e403eea76661f70275b
