### PR TITLE
Set FONTCONFIG_FILE so that fontconfig finds fonts.conf

### DIFF
--- a/macos/coda/coda/AppDelegate.swift
+++ b/macos/coda/coda/AppDelegate.swift
@@ -21,6 +21,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         setUserName();
 
+        setenv("FONTCONFIG_FILE", Bundle.main.resourcePath! + "/fontconfig/fonts.conf", 1)
+
         // Initialize the COOLWSD
         COWrapper.startServer()
 


### PR DESCRIPTION
One line from a patch by Andras that he already reverted.


Change-Id: Ie62906889fea2409ea84aab125f3a29e641a96ef


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

