### PR TITLE
It is better to set just the FONTCONFIG_PATH env var

### DIFF
--- a/macos/coda/coda/AppDelegate.swift
+++ b/macos/coda/coda/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         setUserName();
 
-        setenv("FONTCONFIG_FILE", Bundle.main.resourcePath! + "/fontconfig/fonts.conf", 1)
+        setenv("FONTCONFIG_PATH", Bundle.main.resourcePath! + "/fontconfig", 1)
 
         // Initialize the COOLWSD
         COWrapper.startServer()


### PR DESCRIPTION
Then fontconfig will also find the conf.d directory and the files in it.


Change-Id: Ieeed37f6175afce847c329b3eb76b3ec7ae91070


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

