### PR TITLE
CODA(backstage): Fix Backstage view not visible for File tab

### DIFF
--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -224,11 +224,11 @@ window.L.Control.NotebookbarBuilder = window.L.Control.JSDialogBuilder.extend({
 		const isDesktop = window.mode.isDesktop();
 		const tooltipCollapsed = isDesktop ? _('Click to expand') : _('Tap to expand');
 		const tooltipExpanded = isDesktop ? _('Click to collapse') : _('Tap to collapse');
-		if ($(tabs[t]).hasClass('selected'))
 		var isFileTab = tabIds[t] === 'File-tab-label' || tabIds[t] === 'File';
 		var isFileTabForCoda = isFileTab && window.mode.isCODesktop();
 		if (!isFileTabForCoda) {
-			tabs[t].setAttribute('data-cooltip', tooltipExpanded);
+			if ($(tabs[t]).hasClass('selected'))
+				tabs[t].setAttribute('data-cooltip', tooltipExpanded);
 			window.L.control.attachTooltipEventListener(tabs[t], builder.map);
 		} else {
 			tabs[t].removeAttribute('data-cooltip');


### PR DESCRIPTION
CODA(backstage): Fix Backstage view not visible for File tab

Likely a rebase regression introduced in commit 265133f8e7d2c664654b6ba72c7ac2447b3775f0.

Change-Id: Iadea8e7034c958f0305b147649a09b8f30747c3b

