### PR TITLE
cool#13770 windows: use LOK's new registerFileSaveDialogCallback()

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3303,6 +3303,9 @@ void startMainLoop(const LibreOfficeKit* kit, const std::shared_ptr<lok::Office>
     }
 
     loKit->registerAnyInputCallback(anyInputCallback, mainKit.get());
+#if defined(_WIN32)
+    loKit->registerFileSaveDialogCallback(output_file_dialog_from_core);
+#endif
 
     LOG_INF("Kit unipoll loop run");
 

--- a/windows/coda/CODA/CODA.cpp
+++ b/windows/coda/CODA/CODA.cpp
@@ -283,12 +283,10 @@ static void send2JS(const HWND hWnd, const char* buffer, int length)
     PostMessageW(hWnd, CODA_WM_EXECUTESCRIPT, (WPARAM)wparam, 0);
 }
 
-// FIXME: This function is *exported* on purpose and called by SfxStoringHelper::FinishGUIStoreModel() in
-// sfx2/source/doc/guisaveas.cxx in core. Yes, this is an awful hack.
-
-__declspec(dllexport) void output_file_dialog_from_core(const std::wstring& suggestedURI, std::string& result)
+// LOK file save dialog callback.
+void output_file_dialog_from_core(const char* suggestedURI, char* result, size_t resultLen)
 {
-    auto URI = Poco::URI(Util::wide_string_to_string(suggestedURI));
+    auto URI = Poco::URI(suggestedURI);
     auto path = URI.getPath();
     if (path.size() > 4 && path[0] == '/' && path[2] == ':' && path[3] == '/')
         path = path.substr(1);
@@ -298,7 +296,10 @@ __declspec(dllexport) void output_file_dialog_from_core(const std::wstring& sugg
     auto lastPeriod = filename.find_last_of('.');
     auto extension = filename.substr(lastPeriod + 1);
     auto filenameAndUri = fileSaveDialog(filename, folder, extension);
-    result = filenameAndUri.uri;
+    if (filenameAndUri.uri.size() < resultLen)
+    {
+        strcpy(result, filenameAndUri.uri.c_str());
+    }
 }
 
 static void stopServer()

--- a/windows/coda/windows.hpp
+++ b/windows/coda/windows.hpp
@@ -16,5 +16,6 @@ extern std::string app_installation_path;
 extern std::string app_installation_uri;
 
 extern void load_next_document();
+void output_file_dialog_from_core(const char* suggestedURI, char* result, size_t resultLen);
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
This is cleaner and more importantly something that CODA-M and CODA-Q
can implement in the future.

Requires core.git <https://gerrit.libreoffice.org/c/core/+/195294>.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I391910718b7cb7bd797c85968a2b1a750cdd1a8a
