### PR TITLE
sidebar: make style list scrollable

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -794,6 +794,8 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	height: 100%;
 }
 
+#sidebar-container,
+#sidebar-container > div,
 #StyleListDeck,
 #StyleListDeck .root-container.jsdialog.sidebar,
 #StyleListDeck .vertical.jsdialog.sidebar,
@@ -803,6 +805,10 @@ span.jsdialog.sidebar.ui-treeview-notexpandable {
 	height: 100%;
 	display: flex;
 	flex-direction: column;
+}
+
+#sidebar-container > div {
+	display: flex !important;
 }
 
 .StyleListPanel .ui-expander-content.jsdialog.sidebar.expanded {


### PR DESCRIPTION
- it was scrollable in the past
- we have new containers in the structure which didn't get height properties set

AFTER:
<img width="373" height="776" alt="Screenshot From 2025-12-09 17-36-20" src="https://github.com/user-attachments/assets/8ed261a0-afc6-4b62-8c0a-a2748cc0821f" />
