### PR TITLE
jsdialog: allow treeview to render on demand

### DIFF
--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -332,6 +332,7 @@ interface TreeWidgetJSON extends WidgetJSON {
 	headers: Array<TreeHeaderJSON>; // header columns
 	highlightTerm?: string; // what, if any, entries are we highlighting?
 	ignoreFocus?: boolean; // When true, does't focus to selected item automatically.
+	customEntryRenderer?: boolean;
 }
 
 interface IconViewEntry {

--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -500,7 +500,9 @@ class TreeViewControl {
 			builder._cleanText(entry.columns[index].text) ||
 			builder._cleanText(entry.text);
 
-		const hasRenderer = entry.columns[index].customEntryRenderer;
+		const hasRenderer =
+			entry.columns[index].customEntryRenderer ||
+			treeViewData.customEntryRenderer;
 		const hasCache = hasRenderer && builder.rendersCache[treeViewData.id];
 		const hasCachedImage =
 			hasCache && builder.rendersCache[treeViewData.id].images[entry.row];


### PR DESCRIPTION
now treeview list box is updated when user scrolls and new entries are visible


Change-Id: Id01f4f4017f63ca791d8d6719766ef7bb8312ae2


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

