### PR TITLE
enable a11y testing of character properties dialog

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
@@ -34,8 +34,7 @@ describe(['tagdesktop'], 'Accessibility Writer Tests', function () {
                     return;
                 }
                 // don't pass yet
-                if (command == '.uno:FontDialog' ||
-                    command == '.uno:InsertCaptionDialog' ||
+                if (command == '.uno:InsertCaptionDialog' ||
                     command == '.uno:PageDialog' ||
                     command == '.uno:ParagraphDialog' ||
                     command == '.uno:TableDialog' ||


### PR DESCRIPTION
get cypress to check that the dialog has the focus before sending 'esc'

The dialog is relatively sluggish to decide where to put focus.


Change-Id: If502466e1273c20f85dd5204376c118dbe1a1304


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

