### PR TITLE
Impress: Use doc-type color for selected slides in the slide preview sidebar #13416

### DIFF
--- a/browser/css/partsPreviewControl.css
+++ b/browser/css/partsPreviewControl.css
@@ -43,13 +43,14 @@
 
 /* The current part the user is on. */
 .preview-img-currentpart {
-	border-color: var(--color-background-lighter) !important;
-	outline-color: var(--color-primary-dark);
+	border-color: transparent !important;
+	outline-color: rgba(var(--doc-type), 1);
 }
 
 /* One of (potentially many) selected parts, but not the current. */
 .preview-img-selectedpart {
-	border-color: var(--color-primary) !important;
+	border-color: transparent !important;
+	outline-color: rgba(var(--doc-type), 0.65);
 }
 
 /* Highlight where a slide can be dropped when reordering by drag-and-drop. */


### PR DESCRIPTION
* Resolves: #13416

### Summary
Standardizes the slide selection highlight color in the Impress sidebar to align with the **Impress doc-type color (orange)**. This removes the inconsistent blue highlight and updates the multi-selection styling (Ctrl+click) to use a consistent fill/outline style with reduced opacity (approx. 0.65).

### Key Changes
- Single selected slide highlight changed from default blue to primary Impress orange.
- Multi-selected slides use Impress orange with lower opacity (approx. 0.65).
- Multi-selection styling updated from a border to a consistent fill/outline to match the active/single selection appearance.


### Checklist
- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

