### PR TITLE
browser: a11y: switch to global key events for shortcuts

### DIFF
--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -990,9 +990,6 @@ window.L.TextInput = window.L.Layer.extend({
 		if (this._map.uiManager.isUIBlocked())
 			return;
 
-		if (app.UI.notebookbarAccessibility)
-			app.UI.notebookbarAccessibility.onDocumentKeyDown(ev);
-
 		if (ev.keyCode === 8)
 			this._deleteHint = 'backspace';
 		else if (ev.keyCode === 46)
@@ -1173,9 +1170,6 @@ window.L.TextInput = window.L.Layer.extend({
 				}
 			}
 		}
-
-		if (app.UI.notebookbarAccessibility)
-			app.UI.notebookbarAccessibility.onDocumentKeyUp(ev);
 	},
 
 	// Used in the deleteContentBackward for deleting multiple characters with a single

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -313,11 +313,13 @@ window.L.Map.Keyboard = window.L.Handler.extend({
 
 		window.L.DomEvent.on(this._map.getContainer(), 'keydown keyup keypress', this._onKeyDown, this);
 		window.L.DomEvent.on(window.document, 'keydown', this._globalKeyEvent, this);
+		window.document.addEventListener('keyup', this._globalKeyUp.bind(this), true);
 	},
 
 	removeHooks: function () {
 		window.L.DomEvent.off(this._map.getContainer(), 'keydown keyup keypress', this._onKeyDown, this);
 		window.L.DomEvent.off(window.document, 'keydown', this._globalKeyEvent, this);
+		window.document.removeEventListener('keyup', this._globalKeyUp.bind(this));
 	},
 
 	_ignoreKeyEvent: function(ev) {
@@ -400,6 +402,10 @@ window.L.Map.Keyboard = window.L.Handler.extend({
 		if (this._map.uiManager.isUIBlocked())
 			return;
 
+		if (app.UI.notebookbarAccessibility) {
+			app.UI.notebookbarAccessibility.onDocumentKeyDown(ev);
+		}
+
 		if (ev.shortCutActivated === true) {
 			window.app.console.log('Shortcut for: ' + ev.code + ' already handled');
 			return;
@@ -453,6 +459,17 @@ window.L.Map.Keyboard = window.L.Handler.extend({
 				app.map._clip.clearSelection();
 				app.map.focus();
 			}
+		}
+	},
+
+	_globalKeyUp: function (ev) {
+		if (this._map.uiManager.isUIBlocked()) {
+			return;
+		}
+
+		if (app.UI.notebookbarAccessibility &&
+		    app.UI.notebookbarAccessibility.accessibilityInputElement !== document.activeElement) {
+			app.UI.notebookbarAccessibility.onDocumentKeyUp(ev);
 		}
 	},
 


### PR DESCRIPTION
Accessibility shortcuts are handled via a hidden input
that is activated by the document's text input cursor.
This approach only works when the document is focused.
However, the focused element could be the sidebar instead.

Change-Id: I49bf7bdda2632cc92cb051e8b1a9487444e28d90
Signed-off-by: Henry Castro <hcastro@collabora.com>
