### PR TITLE
Close style icon view popup on style list sidebar open

### DIFF
--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1280,9 +1280,9 @@ class UIManager extends window.L.Control {
 	 */
 	showStyleListDeck(): void {
 		const styleListDeck = document.querySelector('#StyleListDeck');
+		JSDialog.CloseAllDropdowns();
 		if (styleListDeck && (styleListDeck as any).checkVisibility())
 			return;
-
 		this._map.sendUnoCommand('.uno:SidebarDeck.StyleListDeck');
 	}
 


### PR DESCRIPTION
- before this patch the styles list popup stys open if user clicks and open the sidebar style-list
- this patch will close the popup on style-list open in sidebar


Before:

[Screencast from 2025-12-10 23-17-37.webm](https://github.com/user-attachments/assets/03c0a66b-bdcb-448a-8377-3435c2d93106)

After:

[Screencast from 2025-12-10 23-19-13.webm](https://github.com/user-attachments/assets/4b126162-57b7-4a97-941c-739a1b558be6)



Change-Id: Ia64263fb2a17fdeea472d22f6295c3b254120306


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

