### PR TITLE
Colabora Office: Add about tab in backstage sidebar

### DIFF
--- a/browser/css/backstage.css
+++ b/browser/css/backstage.css
@@ -97,6 +97,9 @@
 	padding: 16px 0;
 	overflow-y: auto;
 	box-shadow: 1px 0 3px rgba(0, 0, 0, 0.05);
+	display: flex;
+	flex-direction: column;
+	height: 100%;
 }
 
 .backstage-sidebar-back {
@@ -118,7 +121,10 @@
 .backstage-sidebar-tabs {
 	display: flex;
 	flex-direction: column;
+	flex: 1;
 	gap: 4px;
+	min-height: 0;
+	margin-bottom: 30px;
 }
 
 .backstage-sidebar-item {
@@ -159,6 +165,23 @@
 
 .backstage-sidebar-item img {
 	display: none;
+}
+
+#backstage-sidebar-horizonatal-break.backstage-sidebar-item {
+	height: 2px;
+	background-color: var(--color-toolbar-border);
+	padding: 0;
+	margin-bottom: 8px;
+	margin-top: auto;
+	margin-inline-start: 20px;
+	margin-inline-end: 20px;
+}
+
+#backstage-about.backstage-sidebar-item {
+	justify-content: center;
+	margin-top: 0 !important;
+	margin-bottom: 0 !important;
+	padding: 4px 16px;
 }
 
 /* Starter mode: vertical layout with big centered icons */

--- a/browser/src/control/Control.BackstageView.ts
+++ b/browser/src/control/Control.BackstageView.ts
@@ -14,7 +14,7 @@
 interface BackstageTabConfig {
 	id: string;
 	label: string;
-	type: 'view' | 'action';
+	type: 'view' | 'action' | 'separator';
 	icon?: string;
 	visible?: boolean;
 	viewType?: 'home' | 'templates' | 'info' | 'export';
@@ -26,7 +26,8 @@ interface BackstageTabConfig {
 		| 'share'
 		| 'repair'
 		| 'properties'
-		| 'history';
+		| 'history'
+		| 'about';
 }
 
 interface TemplateTypeMap {
@@ -104,6 +105,7 @@ class BackstageView extends window.L.Class {
 		repair: () => this.executeRepair(),
 		properties: () => this.executeDocumentProperties(),
 		history: () => this.executeRevisionHistory(),
+		about: () => this.executeAbout(),
 	};
 
 	constructor(map: any) {
@@ -336,6 +338,14 @@ class BackstageView extends window.L.Class {
 				viewType: 'export',
 				icon: 'lc_exportto.svg',
 				visible: !this.isStarterMode,
+			},
+			{ type: 'separator', id: 'sidebar-horizonatal-break', label: '' },
+			{
+				id: 'about',
+				label: _UNO('.uno:About'),
+				type: 'action',
+				actionType: 'about',
+				visible: true,
 			},
 		];
 	}
@@ -1073,6 +1083,10 @@ class BackstageView extends window.L.Class {
 		} else {
 			this.sendUnoCommand('.uno:Open');
 		}
+	}
+
+	private executeAbout(): void {
+		this.map.showLOAboutDialog();
 	}
 
 	private executeSave(): void {


### PR DESCRIPTION
Change-Id: I6dfd6555e68e7f3a200f93ee843073a675633174


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Added a new "About" entry at the bottom of the backstage sidebar
- Clicking the entry now opens the About dialog
- Introduced a centered horizontal separator above the bottom section

### PREVIEW
<img width="1922" height="1152" alt="2025-12-11_14-07" src="https://github.com/user-attachments/assets/898cf399-98df-4723-8de3-43b086d46b86" />

<img width="1909" height="1152" alt="2025-12-11_14-08" src="https://github.com/user-attachments/assets/6fd9d47f-990c-4c2b-aaaf-18374237bc13" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

