### PR TITLE
browser: a11y: use <a> tag for document logo

### DIFF
--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -2392,11 +2392,13 @@ class Menubar extends window.L.Control {
 			var liItem = window.L.DomUtil.create('li', '');
 			liItem.id = 'document-header';
 			liItem.setAttribute('role', 'menuitem');
-			var aItem = window.L.DomUtil.create('div', 'document-logo', liItem);
+			var aItem = window.L.DomUtil.create('a', 'document-logo', liItem);
 			$(aItem).data('id', 'document-logo');
 			$(aItem).data('type', 'action');
 			aItem.setAttribute('role', 'img');
 			aItem.setAttribute('aria-label', _('file type icon'));
+			aItem.href = '#';
+			aItem.target = '_blank';
 
 			if (window.logoURL) {
 				aItem.style.backgroundImage = "url(" + window.logoURL + ")";

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -102,10 +102,12 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 					iconTooltip = 'Draw';
 				}
 			}
-			var docLogo = window.L.DomUtil.create('div', iconClass, docLogoHeader);
+			var docLogo = window.L.DomUtil.create('a', iconClass, docLogoHeader);
+
 			$(docLogo).data('id', 'document-logo');
 			$(docLogo).data('type', 'action');
-			docLogo.tabIndex = 0;
+			docLogo.href = '#';
+			docLogo.target = '_blank';
 
 			if (iconTooltip) {
 				docLogo.setAttribute('data-cooltip', iconTooltip);


### PR DESCRIPTION
Use default focusable and clickable <a> tag to open links
in a new window.

Change-Id: Ie0a6be748a0410c7da9671397232d635fec1c997
Signed-off-by: Henry Castro <hcastro@collabora.com>
