### PR TITLE
jsdialog: update non-persistent treeview entries

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2532,20 +2532,27 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 
 		case 'rendered_entry':
 		case 'rendered_combobox_entry':
+		{
 			if (!this.rendersCache[control.id])
 				this.rendersCache[control.id] = { persistent: false, images: [] };
+
+			const oldImage = this.rendersCache[control.id].images[data.pos];
+			if (oldImage === data.image) {
+					app.console.debug('rendered_entry: no change');
+					break;
+			}
 
 			this.rendersCache[control.id].images[data.pos] = data.image;
 
 			if (typeof control.updateRenders == 'function')
 				control.updateRenders(data.pos);
 			else
-				console.error('widget doesn\'t support custom entries');
-
-			break;
+				app.console.error('widget doesn\'t support custom entries');
+		}
+		break;
 
 		default:
-			console.error('unknown action: "' + data.action_type + '"');
+			app.console.error('unknown action: "' + data.action_type + '"');
 			break;
 		}
 	},

--- a/browser/src/control/jsdialog/Util.OnDemandRenderer.ts
+++ b/browser/src/control/jsdialog/Util.OnDemandRenderer.ts
@@ -30,12 +30,16 @@ function onDemandRenderer(
 		let requestRender = true;
 
 		if (cachedComboboxEntries && cachedComboboxEntries.images[entryId]) {
+			const originalClass = placeholder.classList;
 			window.L.DomUtil.remove(placeholder);
 			placeholder = window.L.DomUtil.create('img', '', parentContainer);
 			const placeholderImg = placeholder as HTMLImageElement;
 			placeholderImg.src = cachedComboboxEntries.images[entryId];
 			placeholderImg.alt = entryText;
 			placeholderImg.title = entryText;
+			originalClass.forEach((className: string) =>
+				placeholderImg.classList.add(className),
+			);
 			requestRender = !cachedComboboxEntries.persistent;
 		}
 


### PR DESCRIPTION
Fixes #13812
- for non-persistent entries we did render only once
- later we always used cached image and no request for new one
- it was visible while adding new style to the style sidebar
- we used wrong names for styles at that point
