### PR TITLE
toolbar: avoid updating mobile buttons on desktop

### DIFF
--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -1014,6 +1014,9 @@ function onUpdatePermission(e) {
 			}
 		}
 
+		if (window.mode.isDesktop())
+			return;
+
 		if (e.detail.perm === 'edit') {
 			$('#toolbar-mobile-back').removeClass('editmode-off');
 			$('#toolbar-mobile-back').addClass('editmode-on');


### PR DESCRIPTION
saves unnecessary updates

problem:
closemobile("check mark" button besides save icon) button used to appear in desktop after disconnect and reconnection with the server


Change-Id: I0750f4e884a1efa835affa408e9b79a1457f1ad2


* Target version: master 


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

