### PR TITLE
CODA-Q flatpak: Use resolved URL for screenshots

### DIFF
--- a/qt/com.collaboraoffice.Office.metainfo.xml
+++ b/qt/com.collaboraoffice.Office.metainfo.xml
@@ -14,20 +14,20 @@
  <url type="vcs-browser">https://github.com/CollaboraOnline/online</url>
  <screenshots>
   <screenshot type="default">
-   <image>https://www.collaboraoffice.com/downloads/CODA-Hd7wwbJWxm/writer.png</image>
-   <caption>Sample Writer document</caption>
+   <image>https://www.collaboraoffice.com/downloads/collabora-office-screenshots/writer-calc-impress-2025-11-26.png</image>
+   <caption>Spreadsheets, documents, and presentations</caption>
   </screenshot>
   <screenshot>
-   <image>https://www.collaboraoffice.com/downloads/CODA-Hd7wwbJWxm/calc.png</image>
-   <caption>Sample Calc document</caption>
+   <image>https://www.collaboraoffice.com/downloads/collabora-office-screenshots/calc-2025-11-26.png</image>
+   <caption>Sample spreadsheet document</caption>
   </screenshot>
   <screenshot>
-   <image>https://www.collaboraoffice.com/downloads/CODA-Hd7wwbJWxm/impress.png</image>
-   <caption>Sample Impress document</caption>
+   <image>https://www.collaboraoffice.com/downloads/collabora-office-screenshots/writer-2025-11-26.png</image>
+   <caption>Sample text document</caption>
   </screenshot>
   <screenshot>
-   <image>https://www.collaboraoffice.com/downloads/CODA-Hd7wwbJWxm/draw.png</image>
-   <caption>Sample Draw document</caption>
+   <image>https://www.collaboraoffice.com/downloads/collabora-office-screenshots/backstage-2025-11-26.png</image>
+   <caption>The Backstage View</caption>
   </screenshot>
  </screenshots>
  <developer id="com.collaboraoffice">


### PR DESCRIPTION
Flathub in the backend will not refresh the cache if the URL doesn't change Therefor using an URL shortener for permalink is an anti-pattern


Change-Id: I1a1552b87be99d62c1920495490c2090e80ade24


* Resolves: # <!-- related github issue -->
* Target version: coda-25.04 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

