### PR TITLE
If the desktop theme is dark, use a dark background for windows in CO…

### DIFF
--- a/windows/coda/CODA/CODA.cpp
+++ b/windows/coda/CODA/CODA.cpp
@@ -1912,7 +1912,10 @@ int APIENTRY wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR, int showWindowMode)
         wcex.hInstance = hInstance;
         wcex.hIcon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_CODA));
         wcex.hCursor = LoadCursor(NULL, IDC_ARROW);
-        wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+        if (isLightTheme())
+            wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+        else
+            wcex.hbrBackground = CreateSolidBrush(RGB(0x12, 0x12, 0x12));
         wcex.lpszMenuName = NULL;
         wcex.lpszClassName = windowClass;
         wcex.hIconSm = NULL;


### PR DESCRIPTION
…DA-W

It is simplest and most effective to handle this already in the window class. Set the class background brush to a dak one if the desktop theme is dark.

Making CODA-W adapt to desktop theme changes while it is running is left for the future.

Trying to fix this through CSS did not work well enough, the window still flashed white before it turned dark.


Change-Id: I4affe4702b9ed2913de9c34c8d54d8c51c28ee0d


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

