### PR TITLE
CODA: Align template thumbnails to bottom for consistent layout

### DIFF
--- a/browser/css/backstage.css
+++ b/browser/css/backstage.css
@@ -332,7 +332,7 @@
 	padding: 0;
 	display: flex;
 	justify-content: center;
-	align-items: center;
+	align-items: end;
 	background: transparent;
 	flex: 1;
 	min-height: 120px;


### PR DESCRIPTION
Change-Id: Ic68b67e0eff309ca451cd63faaf1cc017a0232dd


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary
- Thumbnails vary in height, which caused some items to appear centered while others were not.
- Bottom alignment creates a more consistent and predictable layout.


### PREVIEW
<img width="1923" height="698" alt="2025-12-15_11-36" src="https://github.com/user-attachments/assets/afe29764-91f5-450a-8701-b56bd629335a" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

