### PR TITLE
Fix initial font size when switching to compact view.

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -189,6 +189,12 @@ window.L.Map.include({
 
 		this.off('commandstatechanged', onCommandStateChanged);
 		this.on('commandstatechanged', onCommandStateChanged);
+
+		// Initialize with current state value if available
+		var currentState = this['stateChangeHandler'].getItemValue('.uno:FontHeight');
+		if (currentState) {
+			onCommandStateChanged.call(this, {commandName: '.uno:FontHeight', state: currentState});
+		}
 	},
 
 	applyFont: function (fontName) {


### PR DESCRIPTION
When switching from tabbed view to compact view the font size is uninitialized and shows 6 even though the current selected text is likely not 6pt.
Initialize the font size correctly.


Change-Id: I5d04f5f3dc343288a79c176021e1df11bcde344b (cherry picked from commit c08189d055026fde950d74a33e12874122faf95a)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

This fix was added to coda-25.04 branch here: https://github.com/CollaboraOnline/online/pull/13749
