### PR TITLE
In CODA, if document is locked, hide the make-editable button

### DIFF
--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -1,4 +1,4 @@
-/* -*- js-indent-level: 8 -*- */
+/* -*- js-indent-level: 8; fill-column: 100 -*- */
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -390,8 +390,15 @@ class StatusBar extends JSDialog.Toolbar {
 		if (app.map['stateChangeHandler'].getItemValue('EditDoc') !== undefined) {
 			NotEditDocMode = app.map['stateChangeHandler'].getItemValue('EditDoc') === "false"; // can be true, false or disabled
 			if (NotEditDocMode) {
-				if (window.mode.isCODesktop())
+				if (window.mode.isCODesktop()) {
 					app.map.uiManager.showSnackbar(_('The document is probably locked and has been opened as view-only'));
+					// Don't let the user even try to make the document
+					// editable, as that will lead to things Online is not
+					// prepared to handle.
+					const button = document.querySelector('#mobile-edit-button');
+					if (button)
+						button.style.setProperty('display', 'none');
+				}
 				else
 					app.map.uiManager.showSnackbar(_('To prevent accidental changes, the author has set this file to open as view-only'));
 			}


### PR DESCRIPTION
Change-Id: Ie112bf1dd56811ff5aea4cbe0798f45bd83f46ac


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

