### PR TITLE
accessibility: fix escape panel id when selecting active tab panel

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
@@ -171,7 +171,8 @@ describe(['tagdesktop'], 'Accessibility Writer Tests', function () {
         const panelId = $activeTab.attr('aria-controls');
         if (!panelId) return null;
 
-        return $container.find(`#${panelId}[role="tabpanel"]`);
+        const panelSelector = `#${CSS.escape(panelId)}[role="tabpanel"]`;
+        return $container.find(panelSelector);
     }
 
     function closeActiveDialog() {


### PR DESCRIPTION
Change-Id: Ie6f2b7e617b1daceb0a8a3c66d1faba8cdfd266c

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

