### PR TITLE
browser: a11y: Use accessibleDescription as image alt

### DIFF
--- a/browser/src/control/jsdialog/Widget.DrawingArea.js
+++ b/browser/src/control/jsdialog/Widget.DrawingArea.js
@@ -53,6 +53,8 @@ function _drawingAreaControl (parentContainer, data, builder) {
 	} else if (data.aria && data.aria.label) {
 		container.setAttribute('aria-label', data.aria.label);
 		image.alt = '';
+	} else if (data.accesibleDescription) {
+		image.alt = data.accesibleDescription;
 	}
 
 	// Line width dialog is affected from delay on image render.


### PR DESCRIPTION
Set accessibleDescription as image alt attribute.

Requires https://gerrit.libreoffice.org/c/core/+/195725

Change-Id: I6f01e08ae397bfa39e1f90270d380799c0e0891c
Signed-off-by: Henry Castro <hcastro@collabora.com>
