### PR TITLE
a low level debugging thing to get tile data as an png data url

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -516,6 +516,21 @@ class TileManager {
 				imageData.byteLength,
 			);
 			const image = new ImageData(clampedData, this.tileSize, this.tileSize);
+
+			// uncomment to dump each image as a data url to console to see each
+			// tile snapshot
+			/*
+			const extremedebug = false;
+			if (extremedebug) {
+				const canvas = document.createElement('canvas');
+				canvas.width = image.width;
+				canvas.height = image.height;
+				canvas.getContext('2d').putImageData(image, 0, 0);
+				const pngDataUrl = canvas.toDataURL('image/png');
+				console.log(pngDataUrl);
+			}
+			*/
+
 			bitmaps.push(
 				createImageBitmap(image, {
 					premultiplyAlpha: 'none',


### PR DESCRIPTION
to visually verify what exactly is in the tile


Change-Id: I460056f225722061eb0ce8fbab79a7fdc29b9d9c


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

