### PR TITLE
refactor!: remove more dead GTK app code

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -10,7 +10,6 @@ m4_dnl# Define MOBILEAPP as true if this is either for the iOS/Android app or fo
 m4_define([MOBILEAPP],[])m4_dnl
 m4_ifelse(IOSAPP,[true],[m4_define([MOBILEAPP],[true])])m4_dnl
 m4_ifelse(MACOSAPP,[true],[m4_define([MOBILEAPP],[true])])m4_dnl
-m4_ifelse(GTKAPP,[true],[m4_define([MOBILEAPP],[true])])m4_dnl
 m4_ifelse(WINDOWSAPP,[true],[m4_define([MOBILEAPP],[true])])m4_dnl
 m4_ifelse(ANDROIDAPP,[true],[m4_define([MOBILEAPP],[true])])m4_dnl
 m4_ifelse(QTAPP,[true],[m4_define([MOBILEAPP],[true])])m4_dnl
@@ -68,7 +67,6 @@ m4_ifelse(MOBILEAPP, [true],
 m4_dnl# For use in conditionals in JS:
 m4_ifelse(IOSAPP, [true], [<input type="hidden" id="init-mobile-app-os-type" value="IOS" />])
 m4_ifelse(MACOSAPP, [true], [<input type="hidden" id="init-mobile-app-os-type" value="MACOS" />])
-m4_ifelse(GTKAPP, [true], [<input type="hidden" id="init-mobile-app-os-type" value="GTK" />])
 m4_ifelse(WINDOWSAPP, [true], [<input type="hidden" id="init-mobile-app-os-type" value="WINDOWS" />])
 m4_ifelse(ANDROIDAPP, [true], [<input type="hidden" id="init-mobile-app-os-type" value="ANDROID" />])
 m4_ifelse(EMSCRIPTENAPP, [true], [<input type="hidden" id="init-mobile-app-os-type" value="EMSCRIPTEN" />])

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -288,7 +288,6 @@ class InitializerBase {
 
 		window.ThisIsAMobileApp = false;
 		window.ThisIsTheiOSApp = false;
-		window.ThisIsTheGtkApp = false;
 		window.ThisIsTheAndroidApp = false;
 		window.ThisIsTheEmscriptenApp = false;
 		window.ThisIsTheQtApp = false;
@@ -515,17 +514,6 @@ class MacOSAppInitializer extends MobileAppInitializer {
 	}
 }
 
-class GTKAppInitializer extends MobileAppInitializer {
-	constructor() {
-		super();
-
-		window.ThisIsTheGtkApp = true;
-		window.postMobileMessage = function(msg) { window.webkit.messageHandlers.cool.postMessage(msg, '*'); };
-		window.postMobileError   = function(msg) { window.webkit.messageHandlers.error.postMessage(msg, '*'); };
-		window.postMobileDebug   = function(msg) { window.webkit.messageHandlers.debug.postMessage(msg, '*'); };
-	}
-}
-
 class WindowsAppInitializer extends MobileAppInitializer {
 	constructor() {
 		super();
@@ -625,8 +613,6 @@ function getInitializerClass() {
 				return new IOSAppInitializer();
 			else if (osType === "MACOS")
 				return new MacOSAppInitializer();
-			else if (osType === "GTK")
-				return new GTKAppInitializer();
 			else if (osType === "WINDOWS")
 				return new WindowsAppInitializer();
 			else if (osType === "ANDROID")

--- a/browser/src/core/Socket.js
+++ b/browser/src/core/Socket.js
@@ -269,7 +269,7 @@ app.definitions.Socket = class Socket extends SocketBase {
 		if (!logMessage)
 			return;
 
-		if (window.ThisIsTheGtkApp || window.ThisIsTheQtApp)
+		if (window.ThisIsTheQtApp)
 			window.postMobileDebug(type + ' ' + msg);
 
 		var debugOn = this._map._debug.debugOn;

--- a/browser/src/global.d.ts
+++ b/browser/src/global.d.ts
@@ -315,7 +315,6 @@ interface Window {
 	userInterfaceMode: string;
 	ThisIsAMobileApp: boolean;
 	ThisIsTheEmscriptenApp: boolean;
-	ThisIsTheGtkApp: boolean;
 	wopiSrc: string;
 	zoteroEnabled: boolean;
 	accessToken: string;

--- a/common/ThreadPool.hpp
+++ b/common/ThreadPool.hpp
@@ -46,7 +46,7 @@ public:
     {
 #if WASMAPP
         // Leave it at that.
-#elif MOBILEAPP && (!defined(GTKAPP) || !defined(QTAPP))
+#elif MOBILEAPP
         _maxConcurrency = std::max<int>(std::thread::hardware_concurrency(), 2);
 #else
         // coverity[tainted_data_return] - we trust the contents of this variable

--- a/wsd/PlatformMobile.hpp
+++ b/wsd/PlatformMobile.hpp
@@ -16,8 +16,6 @@
 #include "ios.h"
 #elif defined(_WIN32)
 #include "windows.hpp"
-#elif defined(GTKAPP)
-#include "gtk.hpp"
 #elif defined(QTAPP)
 #include "qt.hpp"
 #elif defined(__ANDROID__)

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -57,8 +57,6 @@
 #include "androidapp.hpp"
 #elif defined(_WIN32)
 #include "windows.hpp"
-#elif defined(GTKAPP)
-#include "gtk.hpp"
 #elif defined(QTAPP)
 #include "qt.hpp"
 #elif WASMAPP


### PR DESCRIPTION
I did this before, but I missed a bit ... most of this is trivially removing conditions that can no longer be met. Indeed, the only part which might be likely to cause you any concern is this line here in `common/ThreadPool.hpp`:

-#elif MOBILEAPP && (!defined(GTKAPP) || !defined(QTAPP)) +#elif MOBILEAPP

I've done this because I find it extremely likely that this condition was made in error. GTKAPP and QTAPP won't be defined at the same time, so the second half of this condition will always be true. The condition started as

#elif MOBILEAPP && !defined(GTKAPP)

and was changed in Ib05893c058cb9db29485aacd5673ed1bb9fc2d42 to read

#elif MOBILEAPP && !defined(GTKAPP) || !defined(QTAPP)

I suspect the change should actually have been to

#elif MOBILEAPP && !(defined(GTKAPP) || defined(QTAPP))

but that hasn't been how CODA-QT has worked since the start. A later change, I0514e223fc687839bc601bc8ac3cfbb2379fb551, sealed this as

#elif MOBILAPP && (!defined(GTKAPP) || !defined(QTAPP))

to fix a failing test. The condition as it is, therefore, is roughly equivalent to

#elif MOBILEAPP

I don't feel comfortable fixing the condition, as this has been tested with it as-is for months now. Perhaps @quwex, @tml1024 or @kendy might be able to advise on whether this matters and should be changed...

Follow-Up-To: I8244661f73cfccd875e720b86495c4016a6a6964

Change-Id: I7d4da771ed55367e0f637dd3dadc46836a6a6964


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

