### PR TITLE
show "Reorder Pages" snackbar on selecting previews on Overview page

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1302,7 +1302,6 @@ window.L.Control.NotebookbarImpress = window.L.Control.NotebookbarWriter.extend(
 	},
 
 	getFormatTab: function() {
-		const isODF = app.LOUtil.isFileODF(this.map);
 		var content = [
 			{
 				'type': 'overflowgroup',
@@ -1395,15 +1394,6 @@ window.L.Control.NotebookbarImpress = window.L.Control.NotebookbarWriter.extend(
 					}
 				],
 				'vertical': 'true'
-			},
-			{ type: 'separator', id: 'format-namedescription-break', orientation: 'vertical', 'visible': isODF && app.isExperimentalMode() },
-			{
-				'id': 'format-shuffle-pages',
-				'type': 'bigtoolitem',
-				'text': _UNO('.uno:ReshufflePages', 'presentation'),
-				'command': '.uno:ReshufflePages',
-				'visible': isODF && app.isExperimentalMode(),
-				'accessibility': { focusBack: true, combination: 'RP', de: null }
 			},
 		];
 

--- a/browser/src/map/handler/Map.StateChanges.js
+++ b/browser/src/map/handler/Map.StateChanges.js
@@ -124,6 +124,12 @@ window.L.Map.StateChangeHandler = window.L.Handler.extend({
 			app.activeDocument.activeLayout.scrollTo(scrollPoint.pX, scrollPoint.pY);
 		}
 
+		if (commandName == '.uno:ReshufflePagePopup') {
+			app.map.uiManager.showSnackbar('Reorder pages?', 'Yes', function () {
+				app.map.sendUnoCommand('.uno:ReshufflePages');
+			});
+		}
+
 		$('#document-container').removeClass('slide-master-mode');
 		$('#document-container').addClass('slide-normal-mode');
 		if (slideMasterPageItem) {


### PR DESCRIPTION
also, remove the button from the Format tab

Corresponding core patch: https://gerrit.libreoffice.org/c/core/+/195734

Change-Id: Ic6fd577c275988e5366a1859a034eea4eadd4cb9

* See: https://github.com/CollaboraOnline/online/pull/13434#issuecomment-3585037017
* Target version: master




### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

