### PR TITLE
jsdialog: propagate events in menubutton

### DIFF
--- a/browser/src/control/jsdialog/Widget.MenuButton.js
+++ b/browser/src/control/jsdialog/Widget.MenuButton.js
@@ -98,7 +98,7 @@ function _menubuttonControl (parentContainer, data, builder) {
 			if (control.container.hasAttribute('disabled'))
 				return;
 
-			var callback = function(objectType, eventType, object, data, entry) {
+			var callback = function(objectType, eventType, object, data, entry /* : MenuDefinition | JSBuilder */) {
 				if ((eventType === 'selected' && entry.items) || eventType === 'showsubmenu') {
 					return true;
 				} else if (eventType === 'selected' && entry.uno) {
@@ -110,18 +110,16 @@ function _menubuttonControl (parentContainer, data, builder) {
 					app.dispatcher.dispatch(entry.action);
 					JSDialog.CloseDropdown(dropdownId);
 					return true;
-				} else if (eventType === 'selected') {
+				} else if (eventType === 'selected' && entry.id) {
 					builder.callback('menubutton', 'select', control.container, entry.id, builder);
 					JSDialog.CloseDropdown(dropdownId);
 					return true;
-				} else if (!entry){
+				} else /* note: entry can be a builder instance as in regular JSDialog callback */ {
 					// custom popup - execute generic action
 					builder.callback(objectType, eventType, object, data, builder);
 					JSDialog.CloseDropdown(dropdownId);
 					return true;
 				}
-
-				return false;
 			};
 
 			var freshMenu = builder._menus.get(menuId); // refetch to apply dynamic changes


### PR DESCRIPTION
- this fixes the regression from commit 29252bf029df8aed3934e3bcad70f9e5081dc59f jsdialog: allow to use regular callback in dropdowns
- when using in Impress the Layout dropdown in the notebookbar it wasn't doing anything with error: unhandled click event
- we should do a fallback with event propagation in custom callback so we can properly intercept in decorator widgets