### PR TITLE
 HostUtil: properly handle alias using regex 

### DIFF
--- a/test/HostUtilTests.cpp
+++ b/test/HostUtilTests.cpp
@@ -1,0 +1,54 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include "HostUtil.hpp"
+
+#include <test/lokassert.hpp>
+
+#include <cppunit/extensions/HelperMacros.h>
+
+/// HostUtilTests unit-tests.
+class HostUtilTests : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE(HostUtilTests);
+
+    CPPUNIT_TEST(testParseAlias);
+
+    CPPUNIT_TEST_SUITE_END();
+
+    void testParseAlias();
+};
+
+void HostUtilTests::testParseAlias()
+{
+    constexpr std::string_view testname = __func__;
+
+    LOK_ASSERT_EQUAL_STR("test2\\.local", HostUtil::parseAlias("test2.local"));
+    LOK_ASSERT_EQUAL_STR("test3\\.local", HostUtil::parseAlias("https://test3.local"));
+    LOK_ASSERT_EQUAL_STR("test4\\.local", HostUtil::parseAlias("https://test4.local:8080"));
+    LOK_ASSERT_EQUAL_STR("test5\\.local", HostUtil::parseAlias("https://test5.local:8080/"));
+    LOK_ASSERT_EQUAL_STR("test6\\.local", HostUtil::parseAlias("https://test6.local:8080/path"));
+    LOK_ASSERT_EQUAL_STR("test7\\.local", HostUtil::parseAlias("test7.local/path"));
+
+    LOK_ASSERT_EQUAL_STR("test", HostUtil::parseAlias("test")); // invalid hostname, interpret as regex
+    LOK_ASSERT_EQUAL_STR("test[1-3]", HostUtil::parseAlias("test[1-3]"));
+    LOK_ASSERT_EQUAL_STR("test[0-9].local", HostUtil::parseAlias("test[0-9].local"));
+    LOK_ASSERT_EQUAL_STR("test[0-9]+.local", HostUtil::parseAlias("test[0-9]+.local"));
+    LOK_ASSERT_EQUAL_STR("", HostUtil::parseAlias("test[0-9.local")); // invalid regex
+
+    LOK_ASSERT_EQUAL_STR("https://aliasname[0-9]{1}:443", HostUtil::parseAlias("https://aliasname[0-9]{1}:443"));
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION(HostUtilTests);
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -158,6 +158,7 @@ test_base_sources = \
 	WopiProofTests.cpp \
 	UriTests.cpp \
 	TestGlobals.cpp \
+	HostUtilTests.cpp \
 	$(wsd_sources)
 
 common_sources = \
@@ -187,7 +188,8 @@ common_sources = \
 	../net/HttpRequest.cpp \
 	../net/Socket.cpp \
 	../net/NetUtil.cpp \
-	../wsd/Auth.cpp
+	../wsd/Auth.cpp \
+	../wsd/HostUtil.cpp
 
 globals_sources = ../common/Globals.cpp
 

--- a/wsd/HostUtil.hpp
+++ b/wsd/HostUtil.hpp
@@ -69,8 +69,18 @@ public:
     static bool allowedWSOrigin(const std::string& origin);
 
 private:
+    /// parse a single alias from groups of alias_groups, return an empty string if the pattern was invalid
+    ///
+    /// valid shared.*\.com
+    /// valid my-domain-(sub1|sub2).com
+    /// valid my-domain.com
+    /// invalid my-domain[1
+    static std::string parseAlias(const std::string& aliasPattern);
+
     /// add host to WopiHosts
     static void addWopiHost(const std::string& host, bool allow);
+
+    friend class HostUtilTests;
 };
 #endif // !MOBILEAPP
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

The aliasString was used to construct a POCO::URI then used the uri
authority as a regex. Except an authority does not accept caracters
typically found in regex: +[]()... Making regex interpretation invalid.

This PR checks whether the pattern passed in is a regex or not, if not
transforms the hostname passed-in into a regex.

If it is a regex and since Regex validity is now checked, we can add the
aliasPattern to the AliasHost and WopiHosts.

Also adds warnings when | may have been used as alias separator before
multiple <alias> were posssible, except this prevnts regex handling to

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

