### PR TITLE
browser: a11y: fix logo link in document

### DIFF
--- a/browser/src/control/jsdialog/Widget.DrawingArea.js
+++ b/browser/src/control/jsdialog/Widget.DrawingArea.js
@@ -53,6 +53,8 @@ function _drawingAreaControl (parentContainer, data, builder) {
 	} else if (data.aria && data.aria.label) {
 		container.setAttribute('aria-label', data.aria.label);
 		image.alt = '';
+	} else if (data.aria && data.aria.description) {
+		image.alt = data.aria.description;
 	}
 
 	// Line width dialog is affected from delay on image render.


### PR DESCRIPTION
The default is set to the branding product URL
upon initialization. This setting can be customized.

Change-Id: Ia63e77047e8e46147886fb94e4f9eb561a463579
Signed-off-by: Henry Castro <hcastro@collabora.com>
