### PR TITLE
private/printfdebugging/rows-backport

### DIFF
--- a/browser/src/control/Control.RowHeader.ts
+++ b/browser/src/control/Control.RowHeader.ts
@@ -102,7 +102,11 @@ export class RowHeader extends cool.Header {
 	isMouseOverResizeArea(start: number, end:number, position: number, entryIsCurrent: boolean) : boolean {
 		let resizeAreaStart = Math.max(start, end - this.borderResizeHandle * app.dpiScale);
 		if (entryIsCurrent || (window as any).mode.isMobile()) {
-			resizeAreaStart =  end - this.resizeHandleSize;
+			if (this.resizeHandleSize > (end - start) / 4) {
+				resizeAreaStart = end - ((end - start) / 4);
+			} else {
+				resizeAreaStart =  end - this.resizeHandleSize;
+			}
 		}
 		return position > resizeAreaStart;
 	}


### PR DESCRIPTION
Resize handle has fixed size 15px, whereas row heights vary with the document zoom. There comes a point where the row height is smaller than or close to 15px and at that point it's impossible to select the current row because hovering on the current row's header moves the resizeAreaStart up by resizeHandleSize (which is greater than the row height).

This fix adds an assumption that the resizeHandleSize cannot be greater than rowHeight/4 and if it is then that means that the rowHeight is very small, in which case it sets the resizeArea to be the bottom 1/4th part of the row. This way if the user hovers the cursor around the center of the row, they will get a selection cursor and not the resize cursor.


Change-Id: Ibd3683f3572c685a76ec3370a44c31d4a2db9ff2 (cherry picked from commit cfec0c3b613868e1d7e861aa7ec482a35ac4cbeb)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

