### PR TITLE
attempted fix to have correct file picker filters, cross-platform

### DIFF
--- a/browser/src/app/LOUtil.ts
+++ b/browser/src/app/LOUtil.ts
@@ -51,41 +51,50 @@ class LOUtil {
 	// This list is based on supported filters defined in core in
 	// filter/Configuration_filter.mk
 	public static graphicMimeFilter = [
+		// bitmaps (well-defined)
 		'image/bmp',
-		'image/dxf',
-		'image/emf',
-		'image/emz',
-		'image/eps',
 		'image/gif',
 		'image/jpeg',
-		'image/met',
-		'image/pbm',
-		'image/pcd',
-		'image/pcd',
-		'image/pcd',
-		'image/pct',
-		'image/pcx',
-		'image/pdf',
-		'image/pgm',
 		'image/png',
-		'image/ppm',
-		'image/psd',
-		'image/ras',
-		'image/svg',
-		'image/svgz',
-		'image/svm',
-		'image/tga',
-		'image/tif',
 		'image/webp',
-		'image/wmf',
-		'image/wmz',
-		'image/xbm',
-		'image/xpm',
-		'image/mov',
+		'image/tiff',
+
+		// vector graphics (canonical MIME)
+		'image/svg+xml',
+		'image/x-emf',
+		'image/x-wmf',
+
+		// PDF as image
+		'application/pdf',
+
+		// extensions for everything else (or as fallback)
+		// file pickers don't recognize them by MIME type
+		// Windows file picker doesn't recognize vector images by MIME type
+		'.svg',
+		'.svgz',
+		'.emf',
+		'.emz',
+		'.wmf',
+		'.wmz',
+		'.eps',
+		'.dxf',
+		'.pct',
+		'.pcx',
+		'.pcd',
+		'.psd',
+		'.tga',
+		'.ras',
+		'.svm',
+		'.met',
+		'.pbm',
+		'.pgm',
+		'.ppm',
+		'.xbm',
+		'.xpm',
 	];
 
 	public static mediaMimeFilter = [
-		'video/MP2T',
+		'video/mp2t',
 		'video/mp4',
 		'video/mpeg',
 		'video/ogg',
@@ -99,7 +108,7 @@ class LOUtil {
 		'audio/mp4',
 		'audio/mpeg',
 		'audio/ogg',
-		'audio/x-wav',
+		'audio/wav',
 	];
 
 	public static onRemoveHTMLElement(


### PR DESCRIPTION
Change-Id: Idadf6c735149fe1cc6a679042e77e5ecf7bf1806

This fixes at least the bug that was reported on https://hup.hu/comment/3244922#comment-3244922, i.e. svg and emf files were missing from the custom filter.

PR #13646 is related. At least that added the non-standard MIME-types. Probably svg and emf files were missing even before that.