### PR TITLE
CODA-Q flatpak: Added script to add a release

### DIFF
--- a/qt/Makefile.am
+++ b/qt/Makefile.am
@@ -103,6 +103,8 @@ nobase_dist_icons_DATA = \
 	hicolor/512x512/apps/com.collaboraoffice.Office.startcenter.png \
 	hicolor/scalable/apps/com.collaboraoffice.Office.startcenter.svg
 
+EXTRA_DIST = tools/add-release.py
+
 ### --- Qt translations integration begin ---
 
 # List of translation languages
@@ -133,7 +135,7 @@ translationsdir = $(datadir)/coda-qt/translations
 translations_DATA = $(QM_FILES)
 
 # Distribute sources and clean up generated files
-EXTRA_DIST = $(TS_FILES) run-from-build.in
+EXTRA_DIST += $(TS_FILES) run-from-build.in
 CLEANFILES += $(QM_FILES) run-from-build
 
 ### --- Qt translations integration end ---

--- a/qt/README.md
+++ b/qt/README.md
@@ -1,1 +1,32 @@
-Moved to https://collaboraonline.github.io/post/build-co-linux/
+Build instruction have moved to https://collaboraonline.github.io/post/build-co-linux/
+
+# Release helpers
+
+`tools/add-release.py` is a script that allow adding a release to the
+appstream file prior to tagging.
+
+Usage
+
+```shell
+$ ./tools/add-release.py 25.04.7.8.1 com.collaboraoffice.Office.metainfo.xml
+```
+
+This will add release `25.04.7.8.1` with today's date in the appstream
+file `com.collaboraoffice.Office.metainfo.xml`
+
+Options are:
+
+- `-d` or `--date` to pass the date string to use.
+- `-c` or `--changelog` to use the changelog entry from a file.
+
+The expected changelog data should follow appstream `description`
+element.
+
+```xml
+<description>
+<p>Foo</p>
+<ul>
+<li>Something</li>
+</ul>
+</description>
+```

--- a/qt/tools/add-release.py
+++ b/qt/tools/add-release.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+#
+# Usage:
+# ./tools/add-release.py 25.04.7.8.1 com.collaboraoffice.Office.metainfo.xml
+#
+
+import argparse
+from datetime import datetime
+import sys
+import xml.etree.ElementTree as ET
+
+parser = argparse.ArgumentParser(
+                    prog='Add Release',
+                    description='Add a release to the appstream file')
+parser.add_argument('version', help='Version string to use.')
+parser.add_argument('appstream', help='Appstream file to modify.')
+parser.add_argument('-d', '--date', help='Date of the release. If missing, now is used.')
+parser.add_argument('-c', '--changelog', help='XML file containing the markup for the changelog.')
+
+args = parser.parse_args()
+
+tree = ET.parse(args.appstream)
+root = tree.getroot()
+
+releases = root.find('./releases');
+
+if args.date:
+    date = args.date
+else:
+    date = datetime.now().strftime('%Y-%m-%d')
+
+release = ET.Element('release', attrib={
+    'version': args.version,
+    'date': date,
+})
+releases.insert(0, release)
+if args.changelog:
+    changelog = ET.parse(args.changelog)
+    release.append(changelog.getroot())
+
+ET.indent(tree, ' ', level=0)
+tree.write(args.appstream, xml_declaration=True, encoding='unicode')


### PR DESCRIPTION
This is meant to be called before tagging to add to the appstream file


Change-Id: I1e0c870eee61832af44acf133ab1a959e0f23512


* Resolves: # <!-- related github issue -->
* Target version: coda-25.04 

### Summary

This is a tool to add a release to the appstream file.
Current caveat: the first run will reformat the file a bit because of inconsistent indentation.

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

