### PR TITLE
uno:SpellingAndGrammarDialog stopped working

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
@@ -38,6 +38,7 @@ describe(['tagdesktop'], 'Accessibility Writer Tests', function () {
                     command == '.uno:InsertCaptionDialog' ||
                     command == '.uno:PageDialog' ||
                     command == '.uno:ParagraphDialog' ||
+                    command == '.uno:SpellingAndGrammarDialog' ||
                     command == '.uno:TableDialog' ||
                     command == '.uno:TableNumberFormatDialog') {
                     cy.log(`Skipping buggy dialog: ${command}`);


### PR DESCRIPTION
Change-Id: I65ce4143c8fc3ffcadfe634a0629e2fbe7c66b68


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

