### PR TITLE
kit: use more LOKitHelper::ScopedString

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3339,10 +3339,8 @@ bool ChildSession::getPresentationInfo()
 {
     getLOKitDocument()->setView(_viewId);
 
-    char* info = nullptr;
-    info = getLOKitDocument()->getPresentationInfo();
-    std::string data(info);
-    free(info);
+    LOKitHelper::ScopedString info(getLOKitDocument()->getPresentationInfo());
+    std::string data(info.get());
     sendTextFrame("presentationinfo: " + data);
     return true;
 }

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3863,8 +3863,8 @@ void lokit_main(
         }
         if (queryVersion)
         {
-            char* versionInfo = loKit->getVersionInfo();
-            std::string versionString(versionInfo);
+            LOKitHelper::ScopedString versionInfo(loKit->getVersionInfo());
+            std::string versionString(versionInfo.get());
             if (displayVersion)
                 std::cout << "office version details: " << versionString << std::endl;
 
@@ -3901,7 +3901,6 @@ void lokit_main(
             Poco::URI::encode(versionString, "?#/", encodedVersion);
             pathAndQuery.append("&version=");
             pathAndQuery.append(encodedVersion);
-            free(versionInfo);
         }
 
         // Admin settings bits:


### PR DESCRIPTION
Similar to commit f2ffe50da4d6399125d7c3eb7d6f5722284ba88e (kit: use
more LOKitHelper::ScopedString, 2025-12-12).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I109c1c799e2650c7e0f3a8b8559faa972a211469
