### PR TITLE
css: revert complex custom button sizing

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -123,10 +123,6 @@ button.jsdialog img {
 	width: max-content;
 }
 
-:not(.main-nav) > div:not(.toolbox) > button:not(.ui-tab):not(.ui-expander):not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.col):not(.arrowbackground):not(.ui-combobox-button).has-img {
-	width: var(--btn-size);
-}
-
 .button-primary {
 	height: 32px;
 	line-height: 0em;
@@ -186,11 +182,6 @@ button.jsdialog img {
 	display: flex;
 	justify-self: start;
 	margin-inline-start: -5px;
-}
-
-/* Eg: Sidebar -> Animation -> Effects buttons shouldn't overflow the content */
-button.has-img {
-	min-width: auto !important;
 }
 
 #container .ui-grid-cell button.jsdialog.has-img:not(.sidebar) {


### PR DESCRIPTION
- it reverts 2 patches:
  - commit 1f91a454c72f2b1a01be0ebd1e91632c56361044 Set the width of the effects buttons #6378
  - commit 0bb4aa42bb97c4446858d868a2a26abbbc6c6738 browser: a11y: fix push-button image size
- fix the sidebar panel .ui instead requires https://gerrit.libreoffice.org/c/core/+/196059
- affects:
  - Impress -> Sidebar -> Animation Deck
  - Writer -> References -> Table of Content -> Entries

BEFORE:
<img width="257" height="373" alt="Screenshot From 2025-12-22 06-05-50" src="https://github.com/user-attachments/assets/860bfa8c-9995-48c3-a02b-0790487e01ce" />

AFTER:

<img width="331" height="533" alt="Screenshot From 2025-12-22 06-43-39" src="https://github.com/user-attachments/assets/480265a4-7d9f-4371-abfb-02803e697f8f" />

<img width="331" height="533" alt="Screenshot From 2025-12-22 06-49-00" src="https://github.com/user-attachments/assets/ca8d6730-2cb8-4055-a772-c63914336c33" />
