### PR TITLE
css: change CSS to target specific iconview context menu for slid layout

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -640,7 +640,7 @@ algned to the bottom */
 	scrollbar-color: var(--scrollbar-color);
 }
 
-.modalpopup .ui-treeview {
+#__MENU__.ui-treeview {
 	min-height: min-content;
 }
 


### PR DESCRIPTION
Change-Id: I839ce665af7bb5c5ca36cbd7e0c04200c968085d

**Previews:**
<img width="320" height="172" alt="image" src="https://github.com/user-attachments/assets/0c167d78-a66e-4436-a228-bdd963283e88" />
<img width="1690" height="541" alt="image" src="https://github.com/user-attachments/assets/18c7237e-5082-48cc-919e-56349d062a35" />

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

