### PR TITLE
wsd/ClientRequestDispatcher: lower log priority in handleMessage

### DIFF
--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -994,7 +994,7 @@ ClientRequestDispatcher::MessageResult ClientRequestDispatcher::handleMessage(Po
                                                                               ssize_t headerSize)
 {
     const bool closeConnection = !request.getKeepAlive(); // HTTP/1.1: closeConnection true w/ "Connection: close" only!
-    LOG_DBG("Handling request: " << request.getURI() << ", closeConnection " << closeConnection);
+    LOG_TRC("Handling Message for request: " << request.getURI() << ", closeConnection " << closeConnection);
 
     // denotes whether the request has been served synchronously
     bool servedSync = false;


### PR DESCRIPTION
The same information is already logged by the function calling this one, handleFullMessage.

Also add a little context to the log message.

Change-Id: Ib86a51cb76c1271dda1a23c09e12bf35cb432537

* Target version: master 

### Summary


Our debug logs are full of:

```
wsd-00001-00021 2025-12-19 11:10:47.920631 +0000 [ websrv_poll ] DBG  #50: Handling request: /browser/e808afa229/images/lc_insertcontentcontrol.svg, closeConnection false| wsd/ClientRequestDispatcher.cpp:969
wsd-00001-00021 2025-12-19 11:10:47.920635 +0000 [ websrv_poll ] DBG  #50: Handling request: /browser/e808afa229/images/lc_insertcontentcontrol.svg, closeConnection false| wsd/ClientRequestDispatcher.cpp:991
```

Twice the same line for each request, this PR lowers this output and improves it when tracing.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

