### PR TITLE
css: exclude modalpopup buttons from having default button size

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -123,7 +123,7 @@ button.jsdialog img {
 	width: max-content;
 }
 
-:not(.main-nav) > div:not(.toolbox) > button:not(.ui-tab):not(.ui-expander):not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.col):not(.arrowbackground):not(.ui-combobox-button).has-img {
+:not(.main-nav):not(.modalpopup *) > div:not(.toolbox) > button:not(.ui-tab):not(.ui-expander):not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.col):not(.arrowbackground):not(.ui-combobox-button).has-img {
 	width: var(--btn-size);
 }
 


### PR DESCRIPTION
Change-Id: Ia866c7c860dc7b7884317698451b61e0531f66d3

follow-up of : https://github.com/CollaboraOnline/online/pull/13695

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

