### PR TITLE
remoteConfig: reload lokit environment variables

### DIFF
--- a/common/RegexUtil.cpp
+++ b/common/RegexUtil.cpp
@@ -14,6 +14,7 @@
 
 #include "RegexUtil.hpp"
 
+#include <regex>
 #include <Poco/RegularExpression.h>
 
 namespace RegexUtil
@@ -119,14 +120,12 @@ bool isRegexValid(const std::string& regex)
 {
     try
     {
-        // Not performance critical to warrant caching.
-        Poco::RegularExpression re(regex, Poco::RegularExpression::RE_CASELESS);
+        std::regex re(regex, std::regex_constants::icase);
         return true;
     }
-    catch (const std::exception& exc)
-    {
-        return false;
-    }
+    catch (const std::regex_error&){}
+
+    return false;
 }
 
 } // namespace RegexUtil

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -52,7 +52,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <regex>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -89,6 +88,7 @@
 #include <common/FileUtil.hpp>
 #include <common/JailUtil.hpp>
 #include <common/JsonUtil.hpp>
+#include <common/RegexUtil.hpp>
 
 #include <common/Log.hpp>
 #include <MobileApp.hpp>
@@ -183,7 +183,7 @@ extern "C"
     void forwardSigUsr2();
 }
 
-void COOLWSD::appendAllowedHostsFrom(LayeredConfiguration& conf, const std::string& root, std::vector<std::string>& allowed)
+void COOLWSD::appendAllowedHostsFrom(const LayeredConfiguration& conf, const std::string& root, std::vector<std::string>& allowed)
 {
     for (size_t i = 0; ; ++i)
     {
@@ -225,21 +225,9 @@ std::string removeProtocolAndPort(const std::string& host)
 
     return result;
 }
-
-bool isValidRegex(const std::string& expression)
-{
-    try
-    {
-        std::regex regex(expression);
-        return true;
-    }
-    catch (const std::regex_error& e) {}
-
-    return false;
-}
 }
 
-void COOLWSD::appendAllowedAliasGroups(LayeredConfiguration& conf, std::vector<std::string>& allowed)
+void COOLWSD::appendAllowedAliasGroups(const LayeredConfiguration& conf, std::vector<std::string>& allowed)
 {
     for (size_t i = 0;; i++)
     {
@@ -2172,41 +2160,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
                                                         takeSnapshot, filters);
     }
 
-    // Allowed hosts for being external data source in the documents
-    std::vector<std::string> lokAllowedHosts;
-    appendAllowedHostsFrom(conf, "net.lok_allow", lokAllowedHosts);
-    // For backward compatibility post_allow hosts are also allowed
-    bool postAllowed = conf.getBool("net.post_allow[@allow]", false);
-    if (postAllowed)
-        appendAllowedHostsFrom(conf, "net.post_allow", lokAllowedHosts);
-    // For backward compatibility wopi hosts are also allowed
-    bool wopiAllowed = conf.getBool("storage.wopi[@allow]", false);
-    if (wopiAllowed)
-    {
-        appendAllowedHostsFrom(conf, "storage.wopi", lokAllowedHosts);
-        appendAllowedAliasGroups(conf, lokAllowedHosts);
-    }
-
-    if (lokAllowedHosts.size())
-    {
-        std::string allowedRegex;
-        for (size_t i = 0; i < lokAllowedHosts.size(); i++)
-        {
-            if (isValidRegex(lokAllowedHosts[i]))
-                allowedRegex += (i != 0 ? "|" : "") + lokAllowedHosts[i];
-            else
-                LOG_ERR("Invalid regular expression for allowed host: \"" << lokAllowedHosts[i] << "\"");
-        }
-
-        setenv("LOK_HOST_ALLOWLIST", allowedRegex.c_str(), true);
-
-#if !MOBILEAPP
-        if (!ConfigUtil::getConfigValue<bool>(conf, "ssl.ssl_verification", true)) {
-            // also disable host verification for allowed hosts
-            ::setenv("LOK_HOST_ALLOWLIST_EXEMPT_VERIFY_HOST", "1", true);
-        }
-#endif
-    }
+    setLokitEnvironmentVariables(conf);
 
 #if !MOBILEAPP
     SavedClipboards = std::make_unique<ClipboardCache>();
@@ -2287,6 +2241,46 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
 #else
     (void) self;
 #endif
+}
+
+void COOLWSD::setLokitEnvironmentVariables(const Poco::Util::LayeredConfiguration& conf)
+{
+    // Allowed hosts for being external data source in the documents
+    std::vector<std::string> lokAllowedHosts;
+    appendAllowedHostsFrom(conf, "net.lok_allow", lokAllowedHosts);
+    // For backward compatibility post_allow hosts are also allowed
+    bool postAllowed = conf.getBool("net.post_allow[@allow]", false);
+    if (postAllowed)
+        appendAllowedHostsFrom(conf, "net.post_allow", lokAllowedHosts);
+    // For backward compatibility wopi hosts are also allowed
+    bool wopiAllowed = conf.getBool("storage.wopi[@allow]", false);
+    if (wopiAllowed)
+    {
+        appendAllowedHostsFrom(conf, "storage.wopi", lokAllowedHosts);
+        appendAllowedAliasGroups(conf, lokAllowedHosts);
+    }
+
+    if (lokAllowedHosts.size())
+    {
+        std::string allowedRegex;
+        for (size_t i = 0; i < lokAllowedHosts.size(); i++)
+        {
+            if (RegexUtil::isRegexValid(lokAllowedHosts[i]))
+                allowedRegex += (i != 0 ? "|" : "") + lokAllowedHosts[i];
+            else
+                LOG_ERR("Invalid regular expression for allowed host: \"" << lokAllowedHosts[i] << "\"");
+        }
+
+        setenv("LOK_HOST_ALLOWLIST", allowedRegex.c_str(), true);
+
+#if !MOBILEAPP
+        if (!ConfigUtil::getConfigValue<bool>(conf, "ssl.ssl_verification", true))
+        {
+            // also disable host verification for allowed hosts
+            ::setenv("LOK_HOST_ALLOWLIST_EXEMPT_VERIFY_HOST", "1", true);
+        }
+#endif
+    }
 }
 
 void COOLWSD::initializeSSL()

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -250,6 +250,8 @@ public:
                                          const std::string& json);
 #endif
 
+    static void setLokitEnvironmentVariables(const Poco::Util::LayeredConfiguration& conf);
+
 #if ENABLE_DEBUG
     /// get correct server URL with protocol + port number for this running server
     static std::string getServerURL();
@@ -300,8 +302,8 @@ private:
     /// The actual main implementation.
     void innerMain();
 
-    static void appendAllowedHostsFrom(Poco::Util::LayeredConfiguration& conf, const std::string& root, std::vector<std::string>& allowed);
-    static void appendAllowedAliasGroups(Poco::Util::LayeredConfiguration& conf, std::vector<std::string>& allowed);
+    static void appendAllowedHostsFrom(const Poco::Util::LayeredConfiguration& conf, const std::string& root, std::vector<std::string>& allowed);
+    static void appendAllowedAliasGroups(const Poco::Util::LayeredConfiguration& conf, std::vector<std::string>& allowed);
 
 private:
     /// UnitWSDInterface

--- a/wsd/RemoteConfig.cpp
+++ b/wsd/RemoteConfig.cpp
@@ -174,6 +174,8 @@ void RemoteConfigPoll::handleJSON(const Poco::JSON::Object::Ptr& remoteJson)
 
     HostUtil::parseAllowedWSOrigins(_conf);
 
+    COOLWSD::setLokitEnvironmentVariables(_conf);
+
     COOLWSD::IndirectionServerEnabled =
         !ConfigUtil::getConfigValue<std::string>(_conf, "indirection_endpoint.url", "").empty();
     COOLWSD::GeolocationSetup =


### PR DESCRIPTION
When the remote config changes.
This will allow subsequent lokit to use the updated hosts and alias_groups.

Share the implementation in COOLWSD through static access.

Reuse RegexUtil::isRegexValid in COOLWSD.

Change-Id: I24011e514799fd34bf6d5a6514748fed8046726f


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary

Fixes #13727

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

