### PR TITLE
browser: a11y: fix logo link in document

### DIFF
--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -2397,7 +2397,6 @@ class Menubar extends window.L.Control {
 			$(aItem).data('type', 'action');
 			aItem.setAttribute('role', 'img');
 			aItem.setAttribute('aria-label', _('file type icon'));
-			aItem.href = '#';
 			aItem.target = '_blank';
 
 			if (window.logoURL) {

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -106,8 +106,8 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 
 			$(docLogo).data('id', 'document-logo');
 			$(docLogo).data('type', 'action');
-			docLogo.href = '#';
 			docLogo.target = '_blank';
+			docLogo.tabIndex = 0;
 
 			if (iconTooltip) {
 				docLogo.setAttribute('data-cooltip', iconTooltip);


### PR DESCRIPTION
The href attribute is not set. It should be customized,
but ensure the element is focusable.

Change-Id: Ia63e77047e8e46147886fb94e4f9eb561a463579
Signed-off-by: Henry Castro <hcastro@collabora.com>
