### PR TITLE
CODA-q flatpak: remove add-build-extensions

### DIFF
--- a/qt/flatpak/com.collaboraoffice.Office.json
+++ b/qt/flatpak/com.collaboraoffice.Office.json
@@ -9,11 +9,6 @@
   "sdk-extensions": [
     "org.freedesktop.Sdk.Extension.node20"
   ],
-  "add-build-extensions": {
-    "org.freedesktop.Sdk.Extension.node20": {
-      "version": "25.08"
-    }
-  },
   "command": "coda-qt",
   "finish-args": [
     "--share=network",


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: coda-24.05 

### Summary

This is not in the flathub manifest
This doesn't do what you want. That's what `sdk-extensions` is for.

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

