### PR TITLE
define separate `header-height` variable for sidebar expander labels

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -48,6 +48,7 @@
 	--default-height: 24px;
 	--default-width: 24px;
 	--header-height: 34px;
+	--sidebar-header-height: 34px;
 
 	/* Annotations */
 	--annotation-input-size: 100px;

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -68,7 +68,7 @@ img.sidebar.ui-image {
 .sidebar.ui-expander-label {
 	color: var(--color-main-text);
 	font-size: var(--header-font-size);
-	line-height: var(--header-height);
+	line-height: var(--sidebar-header-height);
 	padding-inline: 8px;
 	flex: 1;
 	display: flex;


### PR DESCRIPTION
Change-Id: Ie31e73f380a0656e6f94efbeb8368364ea2fa5d6 (cherry picked from commit efb17e6a1e90786078cdf359e8c3486997fe3d90)


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

