### PR TITLE
show select element's options when the arrow is clicked

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1436,7 +1436,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 
 		var listboxArrow = window.L.DomUtil.create('span', builder.options.cssClass + ' ui-listbox-arrow', container);
 		listboxArrow.id = 'listbox-arrow-' + data.id;
-
+		listboxArrow.onclick = function() { listbox.showPicker(); };
 
 		if (data.enabled === false) {
 			container.disabled = true;


### PR DESCRIPTION
Change-Id: I2ad8a921f6df4531b2864803ea8ef7d6d518df95


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

