### PR TITLE
PDF Viewer: make context menu available in Edit mode

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -247,7 +247,7 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 			var isMasterView = this._map['stateChangeHandler'].getItemValue('.uno:SlideMasterPage');
 			var pcw = document.getElementById('presentation-controls-wrapper');
 			var $trigger = $(pcw);
-			if (isMasterView === 'true' || app.isReadOnly()) {
+			if (isMasterView === 'true' || (app.isReadOnly() && !app.file.editComment)) {
 				$trigger.contextMenu(false);
 				return;
 			}
@@ -296,7 +296,7 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 		window.L.DomEvent.on(img, 'contextmenu', function(e) {
 			var isMasterView = this._map['stateChangeHandler'].getItemValue('.uno:SlideMasterPage');
 			var $trigger = $('#' + img.id);
-			if (isMasterView === 'true' || app.isReadOnly()) {
+			if (isMasterView === 'true' || (app.isReadOnly() && !app.file.editComment)) {
 				$trigger.contextMenu(false);
 				return;
 			}


### PR DESCRIPTION
- on the PDF viewer, right-click on the page previews should open a context menu - in Edit mode.
- in Read-only mode, there should be no context menu on the page previews.


Change-Id: I8f1196394756b9d20941bcff0b00dbc508242f94


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

