### PR TITLE
cypress: stabilize stylebar tests

### DIFF
--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -388,7 +388,7 @@ function documentChecks(skipInitializedCheck = false) {
 	if (Cypress.env('INTEGRATION') !== 'nextcloud') {
 		doIfOnDesktop(function() {
 			if (Cypress.env('pdf-view') !== true)
-				cy.cGet('#sidebar-panel').should('be.visible').should('not.be.empty');
+				cy.cGet('#sidebar-panel', { timeout: 20000 }).should('be.visible').should('not.be.empty');
 
 			// Check that the document does not take the whole window width.
 			cy.window()

--- a/cypress_test/integration_tests/desktop/writer/stylebar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/stylebar_spec.js
@@ -8,28 +8,30 @@ describe(['tagdesktop'], 'Test style sidebar', function() {
 		cy.viewport(1920,1080);
 		helper.setupAndLoadDocument('writer/stylebar.odt');
 
+		// wait for notebookbar load
+		cy.cGet('#stylesview .ui-iconview-entry img').should('exist');
+
 		cy.cGet('#Format-tab-label').click();
 		cy.cGet('#toolbar-up [id^="format-style-dialog"] button:visible').click();
 		cy.cGet('#StyleListDeck').should('exist').should('be.visible');
 
+		renderEntry('Complimentary Close');
+
 		cy.viewport(1000,660);
 
-		// wait for entries
-
-		cy.cGet('#treeview .ui-treeview-cell-text').contains('Complimentary Close')
-			.should('exist');
-
-		cy.wait(2000); // stabilize
-
-		// show and trigger render
-		cy.cGet('#treeview .ui-treeview-cell-text').contains('Complimentary Close')
-			.should('exist').scrollIntoView();
-
-		cy.wait(2000); // stabilize
+		getEntry('Complimentary Close'); // check render exists
 	});
 
+	/// finds rendered entry or text one and scrolls into view to trigger observer action
+	function renderEntry(text) {
+		cy.cGet('#treeview .ui-treeview-cell-text [textContent="' + text + '"], #treeview img.ui-treeview-custom-render[alt="' + text + '"]',
+			{ timeout: 20000 }).should('exist').scrollIntoView();
+	}
+
+	/// finds rendered entry
 	function getEntry(text) {
-		return cy.cGet('#treeview img.ui-treeview-custom-render[alt="' + text + '"]').should('exist');
+		return cy.cGet('#treeview img.ui-treeview-custom-render[alt="' + text + '"]', { timeout: 20000 })
+			.should('exist');
 	}
 
 	it('Style sidebar updates rendered preview on added style', function() {


### PR DESCRIPTION
- we failed often not having an entry
- try to better handle rendering trigger
- we can find text or already image - then scroll into view
- that way we will not fail when image was already done
- do not use cy.wait, increase timeout

