### PR TITLE
Fix key binding issues in "Present in Window" 

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -1169,6 +1169,8 @@ class SlideShowPresenter {
 		this._enablePresenterConsole(true);
 		this._startingPresentation = true;
 		app.socket.sendMessage('getpresentationinfo');
+		// Attach the keydown event listener for present in window
+		window.addEventListener('keydown', this._onKeyDownHandler);
 	}
 
 	/// called as a response on getpresentationinfo


### PR DESCRIPTION
- Ensure the canvas element gains focus when the "Present in Window" feature is initialized.
- Added fallback to attach `keydown` event listener to capture arrow key events reliably.


Change-Id: Iec46ecaa3033b68c083138fa3e7b38be6d1d6477


* Resolves: # <!-- related github issue -->
* Target version: master 

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

