### PR TITLE
wsd: guarantee that the AsyncDNS thread is created only once

### DIFF
--- a/net/NetUtil.cpp
+++ b/net/NetUtil.cpp
@@ -413,7 +413,8 @@ static std::unique_ptr<AsyncDNS> AsyncDNSThread;
 //static
 void AsyncDNS::startAsyncDNS()
 {
-    AsyncDNSThread = std::make_unique<AsyncDNS>();
+    static std::once_flag once;
+    std::call_once(once, [&]() { AsyncDNSThread = std::make_unique<AsyncDNS>(); });
 }
 
 //static


### PR DESCRIPTION
At least in unit-tests, the AsyncDNS thread can
dead-lock when it's created twice. The following
is the stacktrace, which shows the problem:

    Thread 3 (Thread 0x7f60bc7356c0 (LWP 4140615) "asyncdns"):
    #0  __syscall_cancel_arch () at ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S:56
    #1  0x00007f60bd099668 in __internal_syscall_cancel (a1=<optimized out>, a2=<optimized out>, a3=<optimized out>, a4=<optimized out>, a5=a5@entry=0, a6=a6@entry=4294967295, nr=202) at ./nptl/
    cancellation.c:49
    #2  0x00007f60bd099c9c in __futex_abstimed_wait_common64 (private=0, futex_word=0x56483d721cb8, expected=<optimized out>, op=<optimized out>, abstime=0x0, cancel=true) at ./nptl/futex-intern
    al.c:57
    #3  __futex_abstimed_wait_common (futex_word=futex_word@entry=0x56483d721cb8, expected=<optimized out>, clockid=clockid@entry=0, abstime=abstime@entry=0x0, private=private@entry=0, cancel=ca
    ncel@entry=true) at ./nptl/futex-internal.c:87
    #4  0x00007f60bd099cfb in __GI___futex_abstimed_wait_cancelable64 (futex_word=futex_word@entry=0x56483d721cb8, expected=<optimized out>, clockid=clockid@entry=0, abstime=abstime@entry=0x0, p
    rivate=private@entry=0) at ./nptl/futex-internal.c:139
    #5  0x00007f60bd09c158 in __pthread_cond_wait_common (cond=0x56483d721c98, mutex=0x56483d721c70, clockid=0, abstime=0x0) at ./nptl/pthread_cond_wait.c:426
    #6  ___pthread_cond_wait (cond=0x56483d721c98, mutex=0x56483d721c70) at ./nptl/pthread_cond_wait.c:458
    #7  0x000056483c9a4baa in net::AsyncDNS::resolveDNS (this=0x56483d721c50) at ../net/NetUtil.cpp:381
    #8  0x000056483c9b4c7f in std::__invoke_impl<void, void (net::AsyncDNS::*)(), net::AsyncDNS*> (__f=@0x56483d71f090: (void (net::AsyncDNS::*)(net::AsyncDNS * const)) 0x56483c9a4aec <net::Asyn
    cDNS::resolveDNS()>, __t=@0x56483d71f088: 0x56483d721c50) at /usr/include/c++/12/bits/invoke.h:74
    #9  0x000056483c9b4bd2 in std::__invoke<void (net::AsyncDNS::*)(), net::AsyncDNS*> (__fn=@0x56483d71f090: (void (net::AsyncDNS::*)(net::AsyncDNS * const)) 0x56483c9a4aec <net::AsyncDNS::reso
    lveDNS()>) at /usr/include/c++/12/bits/invoke.h:96
    #10 0x000056483c9b4b13 in std::thread::_Invoker<std::tuple<void (net::AsyncDNS::*)(), net::AsyncDNS*> >::_M_invoke<0ul, 1ul> (this=0x56483d71f088) at /usr/include/c++/12/bits/std_thread.h:25
    2
    #11 0x000056483c9b4a86 in std::thread::_Invoker<std::tuple<void (net::AsyncDNS::*)(), net::AsyncDNS*> >::operator() (this=0x56483d71f088) at /usr/include/c++/12/bits/std_thread.h:259
    #12 0x000056483c9b49d6 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (net::AsyncDNS::*)(), net::AsyncDNS*> > >::_M_run (this=0x56483d71f080) at /usr/include/c++/12/bits/s
    td_thread.h:210
    #13 0x00007f60bd2e1224 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
    #14 0x00007f60bd09cb7b in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:448
    #15 0x00007f60bd11a7b8 in __GI___clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78

    Thread 2 (Thread 0x7f60bbf346c0 (LWP 4140614) "asyncdns"):
    #0  __syscall_cancel_arch () at ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S:56
    #1  0x00007f60bd099668 in __internal_syscall_cancel (a1=<optimized out>, a2=<optimized out>, a3=<optimized out>, a4=<optimized out>, a5=a5@entry=0, a6=a6@entry=4294967295, nr=202) at ./nptl/
    cancellation.c:49
    #2  0x00007f60bd099c9c in __futex_abstimed_wait_common64 (private=0, futex_word=0x56483d722248, expected=<optimized out>, op=<optimized out>, abstime=0x0, cancel=true) at ./nptl/futex-intern
    al.c:57
    #3  __futex_abstimed_wait_common (futex_word=futex_word@entry=0x56483d722248, expected=<optimized out>, clockid=clockid@entry=0, abstime=abstime@entry=0x0, private=private@entry=0, cancel=ca
    ncel@entry=true) at ./nptl/futex-internal.c:87
    #4  0x00007f60bd099cfb in __GI___futex_abstimed_wait_cancelable64 (futex_word=futex_word@entry=0x56483d722248, expected=<optimized out>, clockid=clockid@entry=0, abstime=abstime@entry=0x0, p
    rivate=private@entry=0) at ./nptl/futex-internal.c:139
    #5  0x00007f60bd09c158 in __pthread_cond_wait_common (cond=0x56483d722228, mutex=0x56483d722200, clockid=0, abstime=0x0) at ./nptl/pthread_cond_wait.c:426
    #6  ___pthread_cond_wait (cond=0x56483d722228, mutex=0x56483d722200) at ./nptl/pthread_cond_wait.c:458
    #7  0x000056483c9a4baa in net::AsyncDNS::resolveDNS (this=0x56483d7221e0) at ../net/NetUtil.cpp:381
    #8  0x000056483c9b4c7f in std::__invoke_impl<void, void (net::AsyncDNS::*)(), net::AsyncDNS*> (__f=@0x56483d71f730: (void (net::AsyncDNS::*)(net::AsyncDNS * const)) 0x56483c9a4aec <net::AsyncDNS::resolveDNS()>, __t=@0x56483d71f728: 0x56483d7221e0) at /usr/include/c++/12/bits/invoke.h:74
    #9  0x000056483c9b4bd2 in std::__invoke<void (net::AsyncDNS::*)(), net::AsyncDNS*> (__fn=@0x56483d71f730: (void (net::AsyncDNS::*)(net::AsyncDNS * const)) 0x56483c9a4aec <net::AsyncDNS::resolveDNS()>) at /usr/include/c++/12/bits/invoke.h:96
    #10 0x000056483c9b4b13 in std::thread::_Invoker<std::tuple<void (net::AsyncDNS::*)(), net::AsyncDNS*> >::_M_invoke<0ul, 1ul> (this=0x56483d71f728) at /usr/include/c++/12/bits/std_thread.h:252
    #11 0x000056483c9b4a86 in std::thread::_Invoker<std::tuple<void (net::AsyncDNS::*)(), net::AsyncDNS*> >::operator() (this=0x56483d71f728) at /usr/include/c++/12/bits/std_thread.h:259
    #12 0x000056483c9b49d6 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (net::AsyncDNS::*)(), net::AsyncDNS*> > >::_M_run (this=0x56483d71f720) at /usr/include/c++/12/bits/std_thread.h:210
    #13 0x00007f60bd2e1224 in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6
    #14 0x00007f60bd09cb7b in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:448
    #15 0x00007f60bd11a7b8 in __GI___clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78

    Thread 1 (Thread 0x7f60bd8947c0 (LWP 4140612) "unithttplib"):
    #0  __syscall_cancel_arch () at ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S:56
    #1  0x00007f60bd099668 in __internal_syscall_cancel (a1=<optimized out>, a2=<optimized out>, a3=<optimized out>, a4=<optimized out>, a5=a5@entry=0, a6=a6@entry=4294967295, nr=202) at ./nptl/cancellation.c:49
    #2  0x00007f60bd099c9c in __futex_abstimed_wait_common64 (private=128, futex_word=0x7f60bbf34990, expected=<optimized out>, op=<optimized out>, abstime=0x0, cancel=true) at ./nptl/futex-internal.c:57
    #3  __futex_abstimed_wait_common (futex_word=futex_word@entry=0x7f60bbf34990, expected=<optimized out>, clockid=clockid@entry=0, abstime=abstime@entry=0x0, private=private@entry=128, cancel=
    cancel@entry=true) at ./nptl/futex-internal.c:87
    #4  0x00007f60bd099cfb in __GI___futex_abstimed_wait_cancelable64 (futex_word=futex_word@entry=0x7f60bbf34990, expected=<optimized out>, clockid=clockid@entry=0, abstime=abstime@entry=0x0, p
    rivate=private@entry=128) at ./nptl/futex-internal.c:139
    #5  0x00007f60bd09e774 in __pthread_clockjoin_ex (threadid=140053446870720, thread_return=0x0, clockid=0, abstime=0x0, block=<optimized out>) at ./nptl/pthread_join_common.c:108
    #6  0x00007f60bd2e129b in std::thread::join() () from /lib/x86_64-linux-gnu/libstdc++.so.6
    #7  0x000056483c9a45e9 in net::AsyncDNS::joinThread (this=0x56483d7221e0) at ../net/NetUtil.cpp:336
    #8  0x000056483c9a4a96 in net::AsyncDNS::~AsyncDNS (this=0x56483d7221e0, __in_chrg=<optimized out>) at ../net/NetUtil.cpp:371
    #9  0x000056483c9aeea0 in std::default_delete<net::AsyncDNS>::operator() (this=0x56483caab9a8 <net::AsyncDNSThread>, __ptr=0x56483d7221e0) at /usr/include/c++/12/bits/unique_ptr.h:95
    #10 0x000056483c9aef14 in std::__uniq_ptr_impl<net::AsyncDNS, std::default_delete<net::AsyncDNS> >::reset (this=0x56483caab9a8 <net::AsyncDNSThread>, __p=0x56483d721c50) at /usr/include/c++/12/bits/unique_ptr.h:203
    #11 0x000056483c9ad196 in std::__uniq_ptr_impl<net::AsyncDNS, std::default_delete<net::AsyncDNS> >::operator= (this=0x56483caab9a8 <net::AsyncDNSThread>, __u=...) at /usr/include/c++/12/bits/unique_ptr.h:183
    #12 0x000056483c9abb85 in std::__uniq_ptr_data<net::AsyncDNS, std::default_delete<net::AsyncDNS>, true, true>::operator= (this=0x56483caab9a8 <net::AsyncDNSThread>) at /usr/include/c++/12/bits/unique_ptr.h:235
    #13 0x000056483c9abbb3 in std::unique_ptr<net::AsyncDNS, std::default_delete<net::AsyncDNS> >::operator= (this=0x56483caab9a8 <net::AsyncDNSThread>) at /usr/include/c++/12/bits/unique_ptr.h:406
    #14 0x000056483c9a4f17 in net::AsyncDNS::startAsyncDNS () at ../net/NetUtil.cpp:416
    #15 0x000056483ca14e02 in HttpRequestTests::HttpRequestTests (this=0x56483d720160) at HttpRequestTests.cpp:107
    #16 0x000056483ca238e4 in CppUnit::ConcretTestFixtureFactory<HttpRequestTests>::makeFixture (this=0x7ffea0a61ac0) at /usr/include/cppunit/extensions/TestFixtureFactory.h:41
    #17 0x000056483ca172d2 in CppUnit::TestSuiteBuilderContext<HttpRequestTests>::makeFixture (this=0x7ffea0a619d0) at /usr/include/cppunit/extensions/TestSuiteBuilderContext.h:138
    #18 0x000056483ca13c86 in HttpRequestTests::addTestsToSuite (baseContext=...) at HttpRequestTests.cpp:60
    #19 0x000056483ca14c86 in HttpRequestTests::suite () at HttpRequestTests.cpp:76
    #20 0x000056483ca238b1 in CppUnit::TestSuiteFactory<HttpRequestTests>::makeTest (this=0x56483caabcb8 <autoRegisterRegistry__827+8>) at /usr/include/cppunit/extensions/TestSuiteFactory.h:20
    #21 0x00007f60bdc4ae7f in CppUnit::TestFactoryRegistry::addTestToSuite(CppUnit::TestSuite*) () from /lib/x86_64-linux-gnu/libcppunit-1.15.so.1
    #22 0x00007f60bdc4b216 in CppUnit::TestFactoryRegistry::makeTest() () from /lib/x86_64-linux-gnu/libcppunit-1.15.so.1
    #23 0x000056483c9bded7 in runClientTests (cmd=0x7ffea0a640a2 "/home/ash/prj/lo/online/test/../test/unithttplib", standalone=true, verbose=true) at test.cpp:225
    #24 0x000056483c9bdbdd in main (argc=2, argv=0x7ffea0a62c38) at test.cpp:147

Change-Id: I1ab7672cbf22a9f65bc3c9e0385c95bd33fdd2cb
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
