### PR TITLE
SettingIframe: Introduce e-signature configuration in admin iframe

### DIFF
--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -42,6 +42,7 @@ interface ConfigData {
 	browsersetting: ConfigItem[] | null;
 	viewsetting: ConfigItem[] | null;
 	xcu: ConfigItem[] | null;
+	serverprivateinfo: ConfigItem[] | null;
 }
 
 interface ViewSettings {
@@ -49,6 +50,11 @@ interface ViewSettings {
 	signatureCert: string;
 	signatureKey: string;
 	signatureCa: string;
+}
+
+interface ServerPrivateSettings {
+	ESignatureClientId: string;
+	ESignatureSecret: string;
 }
 
 interface SectionConfig {
@@ -149,12 +155,17 @@ class SettingIframe {
 	private wordbook;
 	private xcuEditor;
 	private _viewSetting;
+	private _serverPrivateSetting: ServerPrivateSettings;
 	private xcuInitializationAttempted = false;
 	private _viewSettingLabels = {
 		zoteroAPIKey: 'Zotero',
 		signatureCert: _('Signature Certificate'),
 		signatureKey: _('Signature Key'),
 		signatureCa: _('Signature CA'),
+	};
+	private _serverPrivateSettingLabels = {
+		ESignatureClientId: _('Client ID for the electronic signature API '),
+		ESignatureSecret: _('Secret for the electronic signature API '),
 	};
 	private readonly settingLabels: Record<string, string> = {
 		accessibilityState: _('In-document Screen Reader'),
@@ -251,6 +262,8 @@ class SettingIframe {
 			this.settingConfigBasePath() + '/browsersetting/',
 		viewSettingsUpload: () => this.settingConfigBasePath() + '/viewsetting/',
 		XcuUpload: () => this.settingConfigBasePath() + '/xcu/',
+		serverPrivateSettingsUpload: () =>
+			this.settingConfigBasePath() + '/serverprivateinfo/',
 	};
 	private browserSettingOptions: Record<string, any> = {};
 
@@ -279,6 +292,14 @@ class SettingIframe {
 	): Promise<void> {
 		const file = new File([content], filename, { type: 'text/plain' });
 		await this.uploadFile(this.PATH.viewSettingsUpload(), file);
+	}
+
+	async uploadServerPrivateSettingFile(
+		filename: string,
+		content: string,
+	): Promise<void> {
+		const file = new File([content], filename, { type: 'application/json' });
+		await this.uploadFile(this.PATH.serverPrivateSettingsUpload(), file);
 	}
 
 	private initWindowVariables(): void {
@@ -1470,6 +1491,72 @@ class SettingIframe {
 		);
 	}
 
+	private generateServerPrivateSettingUI(data: ServerPrivateSettings): void {
+		this._serverPrivateSetting = data;
+		const settingsContainer = this._allConfigSection;
+		if (!settingsContainer || !this.isAdmin()) return;
+
+		let serverPrivateContainer = document.getElementById(
+			'serverprivate-section',
+		);
+		if (serverPrivateContainer) {
+			serverPrivateContainer.remove();
+		}
+
+		serverPrivateContainer = document.createElement('div');
+		serverPrivateContainer.id = 'serverprivate-section';
+		serverPrivateContainer.classList.add('section');
+
+		serverPrivateContainer.appendChild(
+			this.createHeading(_('Electronic Signature')),
+		);
+
+		const divContainer = document.createElement('div');
+		divContainer.id = 'serverprivate-editor';
+		serverPrivateContainer.appendChild(divContainer);
+
+		const fieldset = document.createElement('fieldset');
+		fieldset.classList.add('view-settings-fieldset');
+		divContainer.appendChild(fieldset);
+
+		const allKeys: (keyof ServerPrivateSettings)[] = [
+			'ESignatureClientId',
+			'ESignatureSecret',
+		];
+
+		for (const key of allKeys) {
+			const label = this._serverPrivateSettingLabels[key];
+			if (!label) continue;
+
+			const text = data[key] as string;
+			fieldset.appendChild(
+				this.createInputField(key as string, label, text, data, false, false),
+			);
+		}
+
+		serverPrivateContainer.appendChild(
+			this.createServerPrivateSettingActions(),
+		);
+		settingsContainer.appendChild(serverPrivateContainer);
+	}
+
+	private createServerPrivateSettingActions(): HTMLDivElement {
+		return this.createSettingsActions(
+			'serverprivatesettings',
+			'Electronic Signature',
+			'serverprivateinfo.json',
+			() => this.getDefaultServerPrivateSettings(),
+			() => {
+				return this._serverPrivateSetting;
+			},
+			(settings) =>
+				this.uploadServerPrivateSettingFile(
+					'serverprivateinfo.json',
+					JSON.stringify(settings),
+				),
+		);
+	}
+
 	private async populateSharedConfigUI(data: ConfigData): Promise<void> {
 		const browserSettingButton = document.getElementById(
 			'uploadBrowserSettingsButton',
@@ -1492,6 +1579,25 @@ class SettingIframe {
 				xcuSettingButton.style.display = 'none';
 			} else {
 				xcuSettingButton.style.removeProperty('display');
+			}
+		}
+
+		if (data.kind === 'shared' && this.isAdmin()) {
+			if (data.serverprivateinfo && data.serverprivateinfo.length > 0) {
+				const fileId = data.serverprivateinfo[0].uri;
+				const fetchContent = await this.fetchSettingFile(fileId);
+				if (fetchContent) {
+					const loadedSettings = JSON.parse(fetchContent);
+					const mergedSettings: ServerPrivateSettings = {
+						ESignatureClientId: loadedSettings?.ESignatureClientId || '',
+						ESignatureSecret: loadedSettings?.ESignatureSecret || '',
+					};
+					this.generateServerPrivateSettingUI(mergedSettings);
+				}
+			} else {
+				this.generateServerPrivateSettingUI(
+					this.getDefaultServerPrivateSettings(),
+				);
 			}
 		}
 
@@ -1797,6 +1903,13 @@ class SettingIframe {
 			signatureCert: '',
 			signatureKey: '',
 			signatureCa: '',
+		};
+	}
+
+	private getDefaultServerPrivateSettings(): ServerPrivateSettings {
+		return {
+			ESignatureClientId: '',
+			ESignatureSecret: '',
 		};
 	}
 

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1536,14 +1536,15 @@ void ClientSession::uploadBrowserSettingsToWopiHost()
     httpSession->asyncRequest(httpRequest, COOLWSD::getWebServerPoll());
 }
 
-void ClientSession::uploadViewSettingsToWopiHost()
+void ClientSession::uploadSettingsToWopiHost(const std::string& filePath,
+                                              const std::string& jsonBody,
+                                              const std::string& settingName)
 {
     try
     {
         const Authorization& auth = getAuthorization();
         Poco::URI uriObject = DocumentBroker::getPresetUploadBaseUrl(_uriPublic);
 
-        const std::string filePath = "/settings/userconfig/viewsetting/viewsetting.json";
         uriObject.addQueryParameter("fileId", filePath);
         auth.authorizeURI(uriObject);
 
@@ -1553,12 +1554,10 @@ void ClientSession::uploadViewSettingsToWopiHost()
         httpRequest.setVerb(http::Request::VERB_POST);
         auto httpSession = StorageConnectionManager::getHttpSession(uriObject);
 
-        std::ostringstream jsonStream;
-        _viewSettingsJSON->stringify(jsonStream, 2);
-        httpRequest.setBody(jsonStream.str(), "application/json; charset=utf-8");
+        httpRequest.setBody(jsonBody, "application/json; charset=utf-8");
 
         http::Session::FinishedCallback finishedCallback =
-            [this, uriAnonym](const std::shared_ptr<http::Session>& wopiSession)
+            [this, uriAnonym, settingName](const std::shared_ptr<http::Session>& wopiSession)
         {
             wopiSession->asyncShutdown();
 
@@ -1566,22 +1565,42 @@ void ClientSession::uploadViewSettingsToWopiHost()
             const http::StatusLine statusLine = httpResponse->statusLine();
             if (statusLine.statusCode() != http::StatusCode::OK)
             {
-                LOG_ERR("Failed to upload updated viewsetting to wopiHost["
+                LOG_ERR("Failed to upload updated " << settingName << " to wopiHost["
                         << uriAnonym << "] with status[" << statusLine.reasonPhrase() << ']');
                 return;
             }
-            LOG_TRC("Successfully uploaded viewsetting to wopiHost");
+            LOG_TRC("Successfully uploaded " << settingName << " to wopiHost");
         };
 
-        LOG_DBG("Uploading viewsetting json [" << jsonStream.str() << "] to wopiHost[" << uriAnonym
-                                               << ']');
+        LOG_DBG("Uploading " << settingName << " json [" << jsonBody << ']');
         httpSession->setFinishedHandler(std::move(finishedCallback));
         httpSession->asyncRequest(httpRequest, COOLWSD::getWebServerPoll());
     }
     catch (const std::exception& e)
     {
-        LOG_ERR("Failed to upload viewsetting to WOPI host: " << e.what());
+        LOG_ERR("Failed to upload " << settingName << " to WOPI host: " << e.what());
     }
+}
+
+void ClientSession::uploadViewSettingsToWopiHost()
+{
+    std::ostringstream jsonStream;
+    _viewSettingsJSON->stringify(jsonStream, 2);
+    uploadSettingsToWopiHost("/settings/userconfig/viewsetting/viewsetting.json", jsonStream.str(),
+                             "viewsetting");
+}
+
+void ClientSession::uploadServerPrivateInfoToWopiHost()
+{
+    const std::string& serverPrivateInfo = getServerPrivateInfo();
+    if (serverPrivateInfo.empty())
+    {
+        LOG_TRC("No serverPrivateInfo to upload to WOPI host");
+        return;
+    }
+
+    uploadSettingsToWopiHost("/settings/systemconfig/serverprivateinfo/serverprivateinfo.json",
+                             serverPrivateInfo, "serverprivateinfo");
 }
 
 void ClientSession::updateBrowserSettingsJSON(const std::string& json)

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -315,6 +315,8 @@ public:
 
     void uploadViewSettingsToWopiHost();
 
+    void uploadServerPrivateInfoToWopiHost();
+
     /// Override parsedDocOption values we get from browser setting json
     /// Because when client sends `load url` it doesn't have information about browser setting json
     void overrideDocOption();
@@ -328,6 +330,10 @@ private:
     {
         return std::static_pointer_cast<ClientSession>(shared_from_this());
     }
+
+    /// Helper function to upload settings to WOPI host
+    void uploadSettingsToWopiHost(const std::string& filePath, const std::string& jsonBody,
+                                   const std::string& settingName);
 
     /// SocketHandler: disconnection event.
     void onDisconnect() override;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1359,6 +1359,80 @@ bool DocumentBroker::doDownloadDocument(const Authorization& auth,
 }
 
 #if !MOBILEAPP
+
+static void updateServerPrivateField(const Poco::JSON::Object::Ptr& adminConfig,
+                                      Poco::JSON::Object::Ptr& serverInfo,
+                                      const std::string& fieldName,
+                                      bool& needUpdate)
+{
+    std::string adminValue, existingValue;
+    if (JsonUtil::findJSONValue(adminConfig, fieldName, adminValue))
+    {
+        JsonUtil::findJSONValue(serverInfo, fieldName, existingValue);
+        if (adminValue.empty() && !existingValue.empty())
+        {
+            needUpdate = true;
+        }
+        else if (!adminValue.empty())
+        {
+            serverInfo->set(fieldName, adminValue);
+            LOG_DBG("Overriding " << fieldName << " from admin settings file");
+        }
+    }
+}
+
+static void applyAdminServerPrivateInfo(const std::shared_ptr<ClientSession>& session,
+                                        const std::string& adminConfigPath)
+{
+    std::ifstream ifs(adminConfigPath);
+    if (!ifs.good())
+        return;
+
+    Poco::JSON::Object::Ptr adminConfig;
+    try
+    {
+        Poco::JSON::Parser parser;
+        auto result = parser.parse(ifs);
+        adminConfig = result.extract<Poco::JSON::Object::Ptr>();
+    }
+    catch (const std::exception& exc)
+    {
+        LOG_ERR("Failed to parse admin server private info: " << exc.what());
+        return;
+    }
+
+    const std::string currentInfo = session->getServerPrivateInfo();
+    Poco::JSON::Object::Ptr serverInfo;
+
+    if (currentInfo.empty() || !JsonUtil::parseJSON(currentInfo, serverInfo))
+    {
+        const std::string adminConfigJson = JsonUtil::jsonToString(adminConfig);
+        session->setServerPrivateInfo(adminConfigJson);
+        return;
+    }
+
+    bool serverPrivateInfoNeedUpdate = false;
+
+    updateServerPrivateField(adminConfig, serverInfo, "ESignatureClientId", serverPrivateInfoNeedUpdate);
+    updateServerPrivateField(adminConfig, serverInfo, "ESignatureSecret", serverPrivateInfoNeedUpdate);
+
+    const std::string updatedInfo = JsonUtil::jsonToString(serverInfo);
+    session->setServerPrivateInfo(updatedInfo);
+
+    if (serverPrivateInfoNeedUpdate)
+    {
+        const std::optional<bool> isAdmin = session->getIsAdminUser();
+        if (isAdmin.has_value() && isAdmin.value())
+        {
+            session->uploadServerPrivateInfoToWopiHost();
+        }
+        else
+        {
+            LOG_WRN("Skipping serverPrivateInfo upload - user is not admin");
+        }
+    }
+}
+
 std::string
 DocumentBroker::updateSessionWithWopiInfo(const std::shared_ptr<ClientSession>& session,
                                           WopiStorage* wopiStorage,
@@ -1646,6 +1720,8 @@ void PresetsInstallTask::addGroup(const Poco::JSON::Object::Ptr& settings, const
             filePath = Poco::Path(destDir.toString(), "browsersetting.json").toString();
         else if (groupName == "viewsetting")
             filePath = Poco::Path(destDir.toString(), "viewsetting.json").toString();
+        else if (groupName == "serverprivateinfo")
+            filePath = Poco::Path(destDir.toString(), "serverprivateinfo.json").toString();
         else
         {
             // Check for a file_name='something' and use that if it exists and
@@ -1700,6 +1776,7 @@ void PresetsInstallTask::install(const Poco::JSON::Object::Ptr& settings,
         else
         {
             addGroup(settings, "browsersetting", presets);
+            addGroup(settings, "serverprivateinfo", presets);
             addGroup(settings, "autotext", presets);
             addGroup(settings, "wordbook", presets);
             addGroup(settings, "viewsetting", presets);
@@ -1854,6 +1931,20 @@ void DocumentBroker::asyncInstallPresets(const std::shared_ptr<ClientSession>& s
                 const std::string settings = extractViewSettings(viewSettings, session, _isViewSettingsUpdated);
                 session->sendTextFrame("viewsetting: " + settings);
             }
+
+            if (!_configId.empty())
+            {
+                const std::string sharedPresets = Poco::Path(COOLWSD::ChildRoot, JailUtil::CHILDROOT_TMP_SHARED_PRESETS_PATH).toString();
+                const std::string configIdPresets = Poco::Path(sharedPresets, Uri::encode(_configId)).toString();
+                const std::string serverPrivateInfoPath = configIdPresets + "/serverprivateinfo/serverprivateinfo.json";
+                LOG_DBG("Checking for serverprivateinfo at: " << serverPrivateInfoPath);
+
+                if (FileUtil::Stat(serverPrivateInfoPath).exists())
+                {
+                    applyAdminServerPrivateInfo(session, serverPrivateInfoPath);
+                }
+            }
+
             forwardToChild(session, "addconfig");
         }
         else
@@ -5136,6 +5227,24 @@ bool DocumentBroker::forwardUrpToChild(const std::string& message)
 }
 
 std::string
+DocumentBroker::applyServerPrivateInfo(const std::string& message,
+                                       const std::shared_ptr<ClientSession>& session) const
+{
+    const std::string& serverPrivateInfo = session->getServerPrivateInfo();
+    if (serverPrivateInfo.empty())
+    {
+        LOG_TRC("No serverPrivateInfo to add to load message for session[" << session->getId() << "]");
+        return message;
+    }
+
+    std::string encodedServerPrivateInfo;
+    Poco::URI::encode(serverPrivateInfo, "", encodedServerPrivateInfo);
+
+    LOG_TRC("Adding serverPrivateInfo to load message for session[" << session->getId() << "]");
+    return message + " serverprivateinfo=" + encodedServerPrivateInfo;
+}
+
+std::string
 DocumentBroker::applySignViewSettings(const std::string& message,
                                       const std::shared_ptr<ClientSession>& session) const
 {
@@ -5215,6 +5324,13 @@ std::string DocumentBroker::applyViewSetting(const std::string& message, const s
     return applyBrowserAccessibility(msgWithSignSettings, viewId);
 }
 
+std::string DocumentBroker::applyAllSettings(const std::string& message, const std::string& viewId,
+                                             const std::shared_ptr<ClientSession>& session)
+{
+    std::string msgWithServerInfo = applyServerPrivateInfo(message, session);
+    return applyViewSetting(msgWithServerInfo, viewId, session);
+}
+
 bool DocumentBroker::forwardToChild(const std::shared_ptr<ClientSession>& session,
                                     const std::string& message, bool binary)
 {
@@ -5280,13 +5396,13 @@ bool DocumentBroker::forwardToChild(const std::shared_ptr<ClientSession>& sessio
                     if (!selfLifecycle)
                         return;
 
-                    _childProcess->sendFrame(applyViewSetting(msg, viewId, session), binary);
+                    _childProcess->sendFrame(applyAllSettings(msg, viewId, session), binary);
                 };
                 _asyncInstallTask->appendCallback(sendLoad);
                 return true;
             }
 #endif
-            return _childProcess->sendFrame(applyViewSetting(msg, viewId, session), binary);
+            return _childProcess->sendFrame(applyAllSettings(msg, viewId, session), binary);
         }
     }
 

--- a/wsd/DocumentBroker.hpp
+++ b/wsd/DocumentBroker.hpp
@@ -1730,12 +1730,20 @@ private:
     std::string applyBrowserAccessibility(const std::string& message,
                                        const std::string& viewId);
 
+    /// Apply server private info specially esign values
+    std::string applyServerPrivateInfo(const std::string& message,
+                                       const std::shared_ptr<ClientSession>& session) const;
+
     /// Apply signature view settings to the message
     std::string applySignViewSettings(const std::string& message,
                                       const std::shared_ptr<ClientSession>& session) const;
 
     /// Apply all view settings (signature and accessibility) to the message
     std::string applyViewSetting(const std::string& message, const std::string& viewId,
+                                 const std::shared_ptr<ClientSession>& session);
+
+    /// Apply all settings serverPrivateInfo(sharedconfig) and view settings(userconfig) to the message
+    std::string applyAllSettings(const std::string& message, const std::string& viewId,
                                  const std::shared_ptr<ClientSession>& session);
 
     /// What type are we: affects priority.


### PR DESCRIPTION
Change-Id: I37e923cd982c063b1f634ba07f61954979852bcb

* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

SettingIframe: Introduce e-signature configuration in admin iframe
- Introduce a new serverprivateinfo.json settings file containing ESignatureClientId and ESignatureSecret, with inputs available only in the admin settings iframe.

- Handle migration cases: if users have already configured e-signature values via the old WOPI's URL, those values are migrated to serverprivateinfo.json and propagated to the WOPI host, ensuring backward compatibility and persistence of existing configurations.

