### PR TITLE
browser: add type to the new deferredDrawCallback

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -196,7 +196,7 @@ class CanvasSectionContainer {
 	private drawRequest: number = null;
 	private drawingPaused: number = 0;
 	private drawingEnabled: boolean = true;
-	private deferredDrawCallback: any = null;
+	private deferredDrawCallback: () => void = null;
 	private sectionsDirty: boolean = false;
 	private framesRendered: number = 0; // Total frame count for debugging
 
@@ -391,7 +391,7 @@ class CanvasSectionContainer {
 
 	// Drawing requests will call this callback instead of queueing a redraw. Set the
 	// callback to null to resume the standard drawing chain.
-	public deferDrawing (callback: any) {
+	public deferDrawing (callback: () => void) {
 		this.deferredDrawCallback = callback;
 	}
 


### PR DESCRIPTION
Added in commit 823c22f27c79d6cfb5ffb6d8b79d8c5b45205c4e (Reclaim all
tile bitmaps when document loses focus, 2025-12-20), this is currently
set to a non-null value at a single place, where it points to a function
that takes no arguments and has no return value. Make this explicit to
get rid of the 'any'.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I8e347cf4f4de1b9ae59059926deb876d70b06424
