### PR TITLE
Calc: move Comment button closer to left in Insert tab

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1890,6 +1890,14 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 			},
 			{ type: 'separator', id: 'insert-deletecalctable-break', orientation: 'vertical' },
 			{
+				'id': 'insert-insert-annotation',
+				'type': 'bigtoolitem',
+				'text': _UNO('.uno:InsertAnnotation'),
+				'command': '.uno:InsertAnnotation',
+				'accessibility': { focusBack: true,	combination: 'IA', de: null }
+			},
+			{ type: 'separator', id: 'insert-annotation-break', orientation: 'vertical' },
+			{
 				'type': 'overflowgroup',
 				'id': 'insert-illustrations',
 				'name':_('Illustrations'),
@@ -2128,38 +2136,12 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 			},
 			{ type: 'separator', id: 'insert-editheaderandfooter-break', orientation: 'vertical' },
 			{
-				'id': 'Insert-Charmap-Annotation',
-				'type': 'container',
-				'children': [
-					{
-						'id': 'LineA153',
-						'type': 'toolbox',
-						'children': [
-							{
-								'id': 'CharmapControl',
-								'class': 'unoCharmapControl',
-								'type': 'customtoolitem',
-								'text': _UNO('.uno:CharmapControl'),
-								'command': 'charmapcontrol',
-								'accessibility': { focusBack: true,	combination: 'ZS', de: null }
-							}
-						]
-					},
-					{
-						'id': 'LineB163',
-						'type': 'toolbox',
-						'children': [
-							{
-								'id': 'insert-insert-annotation',
-								'type': 'toolitem',
-								'text': _UNO('.uno:InsertAnnotation', 'text'),
-								'command': '.uno:InsertAnnotation',
-								'accessibility': { focusBack: true,	combination: 'IA', de: null }
-							}
-						]
-					}
-				],
-				'vertical': 'true'
+				'id': 'CharmapControl',
+				'class': 'unoCharmapControl',
+				'type': 'customtoolitem',
+				'text': _UNO('.uno:CharmapControl'),
+				'command': 'charmapcontrol',
+				'accessibility': { focusBack: true,	combination: 'ZS', de: null }
 			}
 		];
 


### PR DESCRIPTION
Change-Id: I027a6fa8756d8f55c97333dae78f388e7cd33679

<img width="2749" height="240" alt="Screenshot 2026-01-02 182447" src="https://github.com/user-attachments/assets/628099c2-e2f1-4cb9-b95d-6ddd86570078" />


move the comment button to the left side of chart .

issue :[ link](https://github.com/CollaboraOnline/online/issues/13688)

