### PR TITLE
fix typeError js issue

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -752,9 +752,9 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			container.id = data.id;
 
 			var expanded = data.expanded === true || (data.children[0] && data.children[0].checked === true);
+			var expander = window.L.DomUtil.create('button', 'ui-expander ' + builder.options.cssClass, container);
 			if (data.children[0].text && data.children[0].text !== '') {
 				var prefix = data.children[0].id ? data.children[0].id : data.id;
-				var expander = window.L.DomUtil.create('button', 'ui-expander ' + builder.options.cssClass, container);
 				expander.tabIndex = '0';
 				expander.setAttribute('aria-controls', prefix + '-children');
 				var label = window.L.DomUtil.create('span', 'ui-expander-label ' + builder.options.cssClass, expander);


### PR DESCRIPTION
problem:
clicking on side navigator caused js error when file is readonly

error was due to vatiable not being initialised and used

Change-Id: I588b78e7177e7f4eaa359defa72351b65c575b0b


* Target version: main



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

