### PR TITLE
annotation: use correct width property for position calculation

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -1998,7 +1998,7 @@ export class CommentSection extends CanvasSectionObject {
 
 			if (selectedComment) {
 				const commentWidth = this.sectionProperties.showSelectedBigger ? this.sectionProperties.commentWidthBigger: this.sectionProperties.commentWidth;
-				const documentCanvasWidth = (document.getElementById('document-canvas') as any).width;
+				const documentCanvasWidth = parseInt((document.getElementById('document-canvas') as any).style.width);
 				let posX = (this.sectionProperties.showSelectedBigger ?
 								Math.round((documentCanvasWidth - commentWidth)/2) :
 								Math.round(actualPosition[0] / app.dpiScale) - this.sectionProperties.deflectionOfSelectedComment * (isRTL ? -1 : 1));


### PR DESCRIPTION
problem:
referring #document-canvas as object here
in Dekstop object.width and object.style.width are same but in tablet both are different and in these calculations later one is correct


Change-Id: I959e8d1e0f7e89ea82b1eba9cdf5ddb675f8c869


* Target version: main



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

