### PR TITLE
Backport-13944

### DIFF
--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -431,7 +431,7 @@ class SlideShowPresenter {
 		if (this._slideCompositor) this._slideCompositor.deleteResources();
 		this._slideRenderer.deleteResources();
 
-		window.removeEventListener('keydown', this._onKeyDownHandler);
+		window.removeEventListener('keydown', this._onKeyDownHandler, true);
 
 		window.L.DomUtil.remove(this._slideShowCanvas);
 		this._slideShowCanvas = null;
@@ -1169,6 +1169,8 @@ class SlideShowPresenter {
 		this._enablePresenterConsole(true);
 		this._startingPresentation = true;
 		app.socket.sendMessage('getpresentationinfo');
+		// Attach the keydown event listener for present in window
+		window.addEventListener('keydown', this._onKeyDownHandler, true);
 	}
 
 	/// called as a response on getpresentationinfo


### PR DESCRIPTION
Backport: https://github.com/CollaboraOnline/online/issues/13944

- Before this patch keybindings were not working on start slide show presentation
- we do added event listener with capture phase so the `keydown` will not get override by  other key binding
- start window needs to have the the top priority for arrow key listeners

This fixes an issue in Firefox where arrow keys would not reliably trigger slide changes when presenting in window mode.


Change-Id: I604c1df0ace918d4bda4877390e92837b9b058d9


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

