### PR TITLE
WOPI: set the net-zone name properly for https

### DIFF
--- a/discovery.xml
+++ b/discovery.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <wopi-discovery>
-    <net-zone name="external-http">
+    <net-zone name="external-%SRV_PROTO%">
 
         <!-- Writer documents -->
         <app name="writer" favIconUrl="images/x-office-document.svg">


### PR DESCRIPTION
%SRV_PROTO% will be replaced by http or https as needed in the discovery file.

Part of #13894


Change-Id: I2e6a7e3a05850cc856bbcbc081414d8ad89e4cff


* Partially resolves: #13894
* Target version: main

### Summary

Some consideration: any WOPI Host that was looking for the net-zone by name despite it being incorrect might need to be fixed.

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

