### PR TITLE
CODA-Q: Cleanup DBus name registration when exiting.

### DIFF
--- a/qt/DBusService.cpp
+++ b/qt/DBusService.cpp
@@ -65,6 +65,17 @@ DBusService::DBusService(QObject* parent)
 {
 }
 
+DBusService::~DBusService()
+{
+    QDBusConnection sessionBus = QDBusConnection::sessionBus();
+
+    // Unregister the object first
+    sessionBus.unregisterObject(OBJECT_PATH);
+
+    // Then unregister the service name
+    sessionBus.unregisterService(SERVICE_NAME);
+}
+
 void DBusService::openFiles(const QStringList& files)
 {
     coda::openFiles(files);

--- a/qt/DBusService.hpp
+++ b/qt/DBusService.hpp
@@ -28,6 +28,7 @@ class DBusService : public QObject
 
 public:
     explicit DBusService(QObject* parent = nullptr);
+    ~DBusService();
 
     static bool tryForwardToExistingInstance(const QStringList& files, const QString& templateType);
     static bool registerService(DBusService* service);


### PR DESCRIPTION
Added a desctructor to DBusService that unregisters the object and service during shutdown.
This should fix any issues users may be having with the flatpak leaving the name in use after exit causing the application to not launch afterwards.

I think this is an improvement, but I'm not 100% sure how to test what I built. flatpak list shows a test branch version, but I'm not sure if that's what I just built locally with my changes or something else. Anyway, wanted to get more eyes on it in case this is all we need. Will continue to figure out if what I'm testing is what I built.

Change-Id: I6af3a852433d28ccc6fe3b4ebb3b9a0f6a39a579


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

