### PR TITLE
Don't use an identifier starting with an underscore and an uppercase …

### DIFF
--- a/common/RecentFiles.hpp
+++ b/common/RecentFiles.hpp
@@ -47,7 +47,7 @@ private:
     bool _initialised;
 
     std::string _fileName;
-    std::vector<Entry> _MRU;
+    std::vector<Entry> _mostRecentlyUsed;
     int _maxFiles;
 };
 


### PR DESCRIPTION
…letter

Such are reserved for the C++ implementation.

It's typical. A day after me complaining about the bad habit of using initial underscores in https://gerrit.libreoffice.org/c/core/+/196572 , I notice that I did it myself just a week or so earlier here, in the freshly written RecentFiles class.

Here in online the convention to use an initial underscore for private class members comes from Poco. Ideally we should get rid of all of it. But that will take time. Until then at least we shouldn't use identifiers starting with an undersore and an uppercase letter. Such are definitely reserved. (Identifiers starting with a single underscore and a lowercase letter are apparently OK, but as it is easy to forget exactly what is reserved, IMNSHO it is best to avoid them, too.)


Change-Id: I645eef09b5b44d8301b98b0d537d1061875b950f


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

