### PR TITLE
use pointer events on the dropdown arrow instead of onclick -> showPicker()

### DIFF
--- a/browser/src/control/jsdialog/Widget.Listbox.ts
+++ b/browser/src/control/jsdialog/Widget.Listbox.ts
@@ -78,9 +78,7 @@ JSDialog.listbox = function (
 		container,
 	);
 	listboxArrow.id = 'listbox-arrow-' + data.id;
-	listboxArrow.onclick = function () {
-		listbox.showPicker();
-	};
+	listboxArrow.style.pointerEvents = 'none';
 
 	if (data.enabled === false) {
 		container.disabled = true;


### PR DESCRIPTION
pointer events are better supported compared to showPicker which might have a different implementation based on the browser.


Change-Id: I404112719c5c7163d73b3c14d0376b86c75b0cc6



### TODO

- [ ] add a test for it once https://github.com/CollaboraOnline/online/pull/13849 is merged.
