### PR TITLE
browser: ensure placeholder is same size as image

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2824,7 +2824,7 @@ kbd,
 	max-height: 19vh;
 }
 
-#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry img,
+#ColorPage.jsdialog :is(#iconview_colors, #iconview_recent_colors).ui-iconview .ui-iconview-entry :is(img, span),
 :is(#colorwindow_iv_colors, #colorwindow_iv_recentcolors) .ui-iconview-entry img {
 	padding: 1px;
 }

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -389,6 +389,8 @@ interface IconViewEntry {
 	separator: boolean; // is separator
 	selected: boolean; // is currently selected
 	image: string; // base64 encoded image
+	width: number; // width in pixels; used for on demand rendering
+	height: number; // height in pixels; used for on demand rendering
 	text: string; // label of an entry
 	tooltip: string; // tooltip of an entry
 	ondemand: boolean; // if true then we ignore image property and request it on demand (when shown)

--- a/browser/src/control/jsdialog/Widget.IconView.ts
+++ b/browser/src/control/jsdialog/Widget.IconView.ts
@@ -105,6 +105,14 @@ function _iconViewEntry(
 			builder.options.cssClass,
 			entryContainer,
 		);
+		// Ensure the placeholder is the same size as the image to avoid the dialog changing size
+		if (entry.width !== undefined && entry.height !== undefined) {
+			placeholder.style.width = entry.width + 'px';
+			placeholder.style.height = entry.height + 'px';
+			placeholder.style.overflow = 'hidden';
+			placeholder.style.display = 'block';
+		}
+
 		placeholder.innerText = entry.text ? entry.text : '';
 		if (entry.tooltip) placeholder.title = entry.tooltip;
 		else if (entry.text) placeholder.title = entry.text;


### PR DESCRIPTION
Cause placeholder text to be the same size as the image to be loaded. Requires https://gerrit.libreoffice.org/c/core/+/196571.

Partially fixes issue described in https://github.com/CollaboraOnline/online/issues/13775.