### PR TITLE
browser: use tooltip as alt text if text undefined

### DIFF
--- a/browser/src/control/jsdialog/Widget.IconView.ts
+++ b/browser/src/control/jsdialog/Widget.IconView.ts
@@ -310,7 +310,7 @@ JSDialog.iconView = function (
 			entry.row,
 			placeholder,
 			entryContainer,
-			entry.text,
+			entry.text ? entry.text : entry.tooltip,
 		);
 	};
 


### PR DESCRIPTION
When using on demand rendering, if there is a cached combobox entry the alt text of the image was set to 'entry.text'; for some objects (e.g. Layout->Page Setup -> Borders -> Line Arrangement) there is no text, so the alt text is set to 'undefined'.

These objects can have a 'entry.tooltip', so if there is no text then we use the tooltip instead. The tooltip for the placeholder (before the object is loaded) defaults to the tooltip anyway.

The issue could be reproduced by going to 'Layout->Page Setup -> Borders -> Line Arrangement', noting the titles are 'No Borders', etc., then closing and reopening the dialog and going immediately to the Borders Tab. If the image was cached, the hover text will be 'undefined'.


Change-Id: Idfe85bbd321c66ff6b3e669eaba71a286a6a6964


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

