### PR TITLE
common, kit: fix build

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -58,7 +58,7 @@ extern "C" {
     UnitBase *unit_create_wsd(void);
     UnitBase** unit_create_wsd_multi(void);
     UnitBase *unit_create_kit(void);
-    typedef struct _LibreOfficeKit LibreOfficeKit;
+    typedef struct LibreOfficeKitStruct LibreOfficeKit;
     typedef LibreOfficeKit *(LokHookFunction2)( const char *install_path, const char *user_profile_url );
 }
 /// Derive your WSD unit test / hooks from me.

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -150,7 +150,7 @@ int getCurrentThreadCount()
 
 #endif
 
-_LibreOfficeKit* loKitPtr = nullptr;
+LibreOfficeKitStruct* loKitPtr = nullptr;
 
 static bool EnableWebsocketURP = false;
 #if !MOBILEAPP

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -547,7 +547,7 @@ std::shared_ptr<lok::Document> getLOKDocumentForAndroidOnly();
 std::shared_ptr<DocumentBroker> getDocumentBrokerForAndroidOnly();
 #endif
 
-extern _LibreOfficeKit* loKitPtr;
+extern LibreOfficeKitStruct* loKitPtr;
 
 /// Check if URP is enabled
 bool isURPEnabled();


### PR DESCRIPTION
After core.git commit bac44a65b0f2d8dfd65a899599e13542c73e1173 (Don't
use illegal identifiers in LibreOfficeKit, 2026-01-07), which renamed
'_LibreOfficeKit' to 'LibreOfficeKitStruct'.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ie794da638ee23f0d0dcdf30730a044586a62ea07
