### PR TITLE
configure.ac: fix typos in CHK_FILE_VAR suffix arguments

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1146,7 +1146,7 @@ if test "x$with_coverage" != "x"; then
 
     AC_DEFUN([AC_PROG_LCOV], [AC_CHECK_PROG(LCOV,lcov,yes)])
     AC_PROG_LCOV
-    if test x"${LCOV}" == x"yes" ; then
+    if test x"${LCOV}" = x"yes" ; then
         AC_MSG_RESULT([yes ($with_coverage)])
         CODE_COVERAGE=1
         CXXFLAGS="$CXXFLAGS --coverage"


### PR DESCRIPTION
Fix incorrect suffixes in Android multi-ABI sanity checks:
- _X64 -> _X86 (4 occurrences)
- _X86_X64 -> _X86_64 (1 occurrence)

These typos caused the sanity checks for x86 builds to silently not run, since the variables POCOINCLUDE_X64, POCOLIB_X64, etc. were never defined.


Change-Id: Iea99e787cbf183f2d6dbea4bd5a1a591dcb21a7a

