### PR TITLE
annotation: fix comment overlapping commented word

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -1998,7 +1998,7 @@ export class CommentSection extends CanvasSectionObject {
 			var isRTL = document.documentElement.dir === 'rtl';
 
 			if (selectedComment) {
-				const commentWidth = this.sectionProperties.showSelectedBigger ? this.sectionProperties.commentWidthBigger: this.sectionProperties.commentWidth;
+				const commentWidth = (this.sectionProperties.showSelectedBigger ? this.sectionProperties.commentWidthBigger: this.sectionProperties.commentWidth) / app.dpiScale;
 				const documentCanvasWidth = parseInt((document.getElementById('document-canvas') as any).style.width);
 				let posX = (this.sectionProperties.showSelectedBigger ?
 								Math.round((documentCanvasWidth - commentWidth)/2) :


### PR DESCRIPTION
problem:
in tablet and devices when dpi scale was not one,
selecting comments used to overlap the commented word (when document is zoomed in and comment area is out of view)

also in tablet full view comment was getting out of view this fixes it


Change-Id: Icf4896cf9a11baffd32882f6a6c06116e0670eb5


* Target version: main



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

