### PR TITLE
WOPI discovery: offer a view action for every edit action

### DIFF
--- a/discovery.xml
+++ b/discovery.xml
@@ -6,16 +6,21 @@
         <app name="writer" favIconUrl="images/x-office-document.svg">
             <action name="view" default="true" ext="sxw"/>
             <action name="edit" default="true" ext="odt"/>
+            <action name="view" default="true" ext="odt"/>
             <action name="edit" default="true" ext="fodt"/>
+            <action name="view" default="true" ext="fodt"/>
             <!-- Text template documents -->
             <action name="view" default="true" ext="stw"/>
             <action name="view" default="true" ext="ott"/>
             <!-- MS Word -->
             <action name="edit" default="true" ext="doc"/>
+            <action name="view" default="true" ext="doc"/>
             <action name="view" default="true" ext="dot"/>
             <!-- OOXML wordprocessing -->
             <action name="edit" default="true" ext="docx"/>
+            <action name="view" default="true" ext="docx"/>
             <action name="edit" default="true" ext="docm"/>
+            <action name="view" default="true" ext="docm"/>
             <action name="view" default="true" ext="dotx"/>
             <action name="view" default="true" ext="dotm"/>
             <!-- Others -->
@@ -27,7 +32,9 @@
             <action name="view" default="true" ext="lrf"/>
             <action name="view" default="true" ext="mw"/>
             <action name="edit" default="true" ext="rtf"/>
+            <action name="view" default="true" ext="rtf"/>
             <action name="edit" default="true" ext="txt"/>
+            <action name="view" default="true" ext="txt"/>
             <action name="view" default="true" ext="fb2"/>
             <action name="view" default="true" ext="cwk"/>
             <action name="view" default="true" ext="pages"/>
@@ -39,37 +46,51 @@
             <!-- Text master documents -->
             <action name="view" default="true" ext="sxg"/>
             <action name="edit" default="true" ext="odm"/>
+            <action name="view" default="true" ext="odm"/>
             <!-- Writer master document templates -->
             <action name="view" default="true" ext="otm"/>
         </app>
 
         <app name="writer-web">
             <action name="edit" default="true" ext="oth"/>
+            <action name="view" default="true" ext="oth"/>
         </app>
 
         <!-- Calc documents -->
         <app name="calc" favIconUrl="images/x-office-spreadsheet.svg">
             <action name="view" default="true" ext="sxc"/>
             <action name="edit" default="true" ext="ods"/>
+            <action name="view" default="true" ext="ods"/>
             <action name="edit" default="true" ext="fods"/>
+            <action name="view" default="true" ext="fods"/>
             <!-- Spreadsheet template documents -->
             <action name="view" default="true" ext="stc"/>
             <action name="view" default="true" ext="ots"/>
             <!-- MS Excel -->
             <action name="edit" default="true" ext="xls"/>
+            <action name="view" default="true" ext="xls"/>
             <action name="edit" default="true" ext="xla"/>
+            <action name="view" default="true" ext="xla"/>
             <!-- OOXML spreadsheet -->
             <action name="view" default="true" ext="xltx"/>
             <action name="view" default="true" ext="xltm"/>
             <action name="edit" default="true" ext="xlsx"/>
+            <action name="view" default="true" ext="xlsx"/>
             <action name="edit" default="true" ext="xlsb"/>
+            <action name="view" default="true" ext="xlsb"/>
             <action name="edit" default="true" ext="xlsm"/>
+            <action name="view" default="true" ext="xlsm"/>
             <!-- Others -->
             <action name="edit" default="true" ext="dif"/>
+            <action name="view" default="true" ext="dif"/>
             <action name="edit" default="true" ext="slk"/>
+            <action name="view" default="true" ext="slk"/>
             <action name="edit" default="true" ext="csv"/>
+            <action name="view" default="true" ext="csv"/>
             <action name="edit" default="true" ext="tsv"/>
+            <action name="view" default="true" ext="tsv"/>
             <action name="edit" default="true" ext="dbf"/>
+            <action name="view" default="true" ext="dbf"/>
             <action name="view" default="true" ext="wk1"/>
             <action name="view" default="true" ext="wks"/>
             <action name="view" default="true" ext="xlr"/>
@@ -86,19 +107,25 @@
         <app name="impress" favIconUrl="images/x-office-presentation.svg">
             <action name="view" default="true" ext="sxi"/>
             <action name="edit" default="true" ext="odp"/>
+            <action name="view" default="true" ext="odp"/>
             <action name="edit" default="true" ext="fodp"/>
+            <action name="view" default="true" ext="fodp"/>
             <!-- Presentation template documents -->
             <action name="view" default="true" ext="sti"/>
             <action name="view" default="true" ext="otp"/>
             <!-- MS PowerPoint -->
             <action name="edit" default="true" ext="ppt"/>
+            <action name="view" default="true" ext="ppt"/>
             <action name="view" default="true" ext="pot"/>
             <!-- OOXML presentation -->
             <action name="edit" default="true" ext="pptx"/>
+            <action name="view" default="true" ext="pptx"/>
             <action name="edit" default="true" ext="pptm"/>
+            <action name="view" default="true" ext="pptm"/>
             <action name="view" default="true" ext="potx"/>
             <action name="view" default="true" ext="potm"/>
             <action name="edit" default="true" ext="ppsx"/>
+            <action name="view" default="true" ext="ppsx"/>
             <!-- Others -->
             <action name="view" default="true" ext="cgm"/>
             <action name="view" default="true" ext="key"/>
@@ -108,7 +135,9 @@
         <app name="draw">
             <action name="view" default="true" ext="sxd"/>
             <action name="edit" default="true" ext="odg"/>
+            <action name="view" default="true" ext="odg"/>
             <action name="edit" default="true" ext="fodg"/>
+            <action name="view" default="true" ext="fodg"/>
             <!-- Drawing template documents -->
             <action name="view" default="true" ext="std"/>
             <action name="view" default="true" ext="otg"/>
@@ -150,9 +179,11 @@
         </app>
         <app name="application/vnd.ms-powerpoint">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.ms-excel">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- Writer documents -->
@@ -161,9 +192,11 @@
         </app>
         <app name="application/vnd.oasis.opendocument.text">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.oasis.opendocument.text-flat-xml">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- Calc documents -->
@@ -172,9 +205,11 @@
         </app>
         <app name="application/vnd.oasis.opendocument.spreadsheet">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.oasis.opendocument.spreadsheet-flat-xml">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- Impress documents -->
@@ -183,25 +218,31 @@
         </app>
         <app name="application/vnd.oasis.opendocument.presentation">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.oasis.opendocument.presentation-flat-xml">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- Draw documents -->
         <app name="application/vnd.sun.xml.draw">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.oasis.opendocument.graphics">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.oasis.opendocument.graphics-flat-xml">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- Chart documents -->
         <app name="application/vnd.oasis.opendocument.chart">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- Text master documents -->
@@ -210,6 +251,7 @@
         </app>
         <app name="application/vnd.oasis.opendocument.text-master">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- Math documents -->
@@ -262,27 +304,33 @@
         <!-- MS Word -->
         <app name="application/msword">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/msword">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- MS Excel -->
         <app name="application/vnd.ms-excel">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- MS PowerPoint -->
         <app name="application/vnd.ms-powerpoint">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- OOXML wordprocessing -->
         <app name="application/vnd.openxmlformats-officedocument.wordprocessingml.document">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.ms-word.document.macroEnabled.12">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.openxmlformats-officedocument.wordprocessingml.template">
             <action name="view" default="true" ext=""/>
@@ -300,20 +348,25 @@
         </app>
         <app name="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.ms-excel.sheet.binary.macroEnabled.12">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.ms-excel.sheet.macroEnabled.12">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
 
         <!-- OOXML presentation -->
         <app name="application/vnd.openxmlformats-officedocument.presentationml.presentation">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.ms-powerpoint.presentation.macroEnabled.12">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.openxmlformats-officedocument.presentationml.template">
             <action name="view" default="true" ext=""/>
@@ -346,12 +399,15 @@
         </app>
         <app name="text/spreadsheet">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="text/csv">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/x-dbase">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/vnd.lotus-1-2-3">
             <action name="view" default="true" ext=""/>
@@ -397,15 +453,18 @@
         </app>
         <app name="application/vnd.oasis.opendocument.text-web">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/x-pagemaker">
             <action name="view" default="true" ext=""/>
         </app>
         <app name="text/rtf">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="text/plain">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/x-fictionbook+xml">
             <action name="view" default="true" ext=""/>
@@ -421,6 +480,7 @@
         </app>
         <app name="application/vnd.openxmlformats-officedocument.presentationml.slideshow">
             <action name="edit" default="true" ext=""/>
+            <action name="view" default="true" ext=""/>
         </app>
         <app name="application/x-iwork-keynote-sffkey">
             <action name="view" default="true" ext=""/>


### PR DESCRIPTION
Part of #13894


Change-Id: I89efcf1ef43520e99efa032b951dd37a427cc134


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

There are considerations about compatibility. 

Currently the URL for view and edit are the same, and the edit action is first in the DOM so that mitigate taking the first entry. (not checking the action)

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

