### PR TITLE
feat: add Util.KeyCodes module for key code handling and refactor icon view entry key event processing

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -477,6 +477,7 @@ COOL_JS_LST =\
 	src/control/jsdialog/Util.Dropdown.ts \
 	src/control/jsdialog/Util.GenerateTableIcon.ts \
 	src/control/jsdialog/Util.Events.ts \
+	src/control/jsdialog/Util.KeyCodes.ts \
 	src/control/jsdialog/Util.KeyboardTabNavigation.ts \
 	src/control/jsdialog/Util.KeyboardGridNavigation.ts \
 	src/control/jsdialog/Util.KeyboardListNavigation.ts \

--- a/browser/src/control/jsdialog/Util.KeyCodes.ts
+++ b/browser/src/control/jsdialog/Util.KeyCodes.ts
@@ -1,0 +1,41 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * JSDialog.KeyCodes - key code related functions
+ */
+
+/* global _UNO app */
+
+JSDialog.getUNOKeyCodeWithModifiers = function (
+	e: KeyboardEvent,
+	map: any,
+): number {
+	let keyCode = e.keyCode;
+
+	const shift =
+		keyCode === map.keyboard.keyCodes.SHIFT ? app.UNOModifier.SHIFT : 0;
+	const ctrl =
+		keyCode === map.keyboard.keyCodes.CTRL || e.metaKey
+			? app.UNOModifier.CTRL
+			: 0;
+	const alt = keyCode === map.keyboard.keyCodes.ALT ? app.UNOModifier.ALT : 0;
+
+	const modifier = shift | ctrl | alt;
+
+	if (modifier) {
+		keyCode = e.key.toUpperCase().charCodeAt(0);
+		keyCode = map.keyboard._toUNOKeyCode(keyCode);
+		keyCode |= modifier;
+	}
+
+	return keyCode;
+};

--- a/browser/src/control/jsdialog/Widget.IconView.ts
+++ b/browser/src/control/jsdialog/Widget.IconView.ts
@@ -199,35 +199,6 @@ function _iconViewEntry(
 		}
 		builder._preventDocumentLosingFocusOnClick(entryContainer);
 
-		const getUNOKeyCodeWithModifiers = function (
-			e: KeyboardEvent,
-			builder: any,
-			app: any,
-		): number {
-			let keyCode = e.keyCode;
-
-			const shift =
-				keyCode === builder.map.keyboard.keyCodes.SHIFT
-					? app.UNOModifier.SHIFT
-					: 0;
-			const ctrl =
-				keyCode === builder.map.keyboard.keyCodes.CTRL || e.metaKey
-					? app.UNOModifier.CTRL
-					: 0;
-			const alt =
-				keyCode === builder.map.keyboard.keyCodes.ALT ? app.UNOModifier.ALT : 0;
-
-			const modifier = shift | ctrl | alt;
-
-			if (modifier) {
-				keyCode = e.key.toUpperCase().charCodeAt(0);
-				keyCode = builder.map.keyboard._toUNOKeyCode(keyCode);
-				keyCode |= modifier;
-			}
-
-			return keyCode;
-		};
-
 		const isInNotebookbar = builder.options.cssClass === 'notebookbar';
 		entryContainer.addEventListener('keydown', function (e: KeyboardEvent) {
 			if (e.key === ' ' || e.code === 'Space')
@@ -253,7 +224,7 @@ function _iconViewEntry(
 				parentContainer.builderCallback(
 					'iconview',
 					'keypress',
-					getUNOKeyCodeWithModifiers(e, builder, app),
+					JSDialog.getUNOKeyCodeWithModifiers(e, builder.map),
 					builder,
 				);
 			}
@@ -263,7 +234,7 @@ function _iconViewEntry(
 			parentContainer.builderCallback(
 				'iconview',
 				'keyrelease',
-				getUNOKeyCodeWithModifiers(e, builder, app),
+				JSDialog.getUNOKeyCodeWithModifiers(e, builder.map),
 				builder,
 			);
 		});


### PR DESCRIPTION
As per review comment in https://github.com/CollaboraOnline/online/pull/13638#discussion_r2663706607
"this is very useful in many contexts, can should move to separate:
control/jsdialog.Util.KeyCodes.ts ... I will add an easy hack later (we should also move all the enums there to be free from external dependencies like map / builder."
This PR addresses this. 