### PR TITLE
Don't manually declare LokHookFunction2

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -22,7 +22,7 @@
 
 #include <test/testlog.hpp>
 
-#include <LibreOfficeKit/LibreOfficeKit.h>
+#include <LibreOfficeKit/LibreOfficeKitInit.h>
 
 class UnitBase;
 class UnitWSD;
@@ -60,7 +60,6 @@ extern "C" {
     UnitBase *unit_create_wsd(void);
     UnitBase** unit_create_wsd_multi(void);
     UnitBase *unit_create_kit(void);
-    typedef LibreOfficeKit *(LokHookFunction2)( const char *install_path, const char *user_profile_url );
 }
 /// Derive your WSD unit test / hooks from me.
 class UnitBase


### PR DESCRIPTION
...following up on 2d039955ac6e487a1894e0f3b7db2542001b07b4 "fix build to work with either '_LibreOfficeKit' or 'LibreOfficeKitStruct'"


Change-Id: I663ac1b2cecc44120c875167a84480f9071d9cff


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

