### PR TITLE
Overview: do not show Reorder pages snackbar in read only mode

### DIFF
--- a/browser/src/map/handler/Map.StateChanges.js
+++ b/browser/src/map/handler/Map.StateChanges.js
@@ -125,9 +125,12 @@ window.L.Map.StateChangeHandler = window.L.Handler.extend({
 		}
 
 		if (commandName == '.uno:ReshufflePagePopup') {
-			app.map.uiManager.showSnackbar('Reorder pages?', 'Yes', function () {
-				app.map.sendUnoCommand('.uno:ReshufflePages');
-			});
+			if (!app.map.isReadOnlyMode())
+			{
+				app.map.uiManager.showSnackbar('Reorder pages?', 'Yes', function () {
+					app.map.sendUnoCommand('.uno:ReshufflePages');
+				});
+			}
 		}
 
 		$('#document-container').removeClass('slide-master-mode');


### PR DESCRIPTION
Change-Id: I5e0512bf9906b960791cc71b787634c66b7bda6b


* Resolves: #14014 
* Target version: main


https://github.com/user-attachments/assets/694fe477-56e4-4e41-9cce-573228b01919



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

