### PR TITLE
Increase MaxFileSizeToCacheInBytes when serving (debug-enabled) Wasm …

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -132,6 +132,9 @@
 /* Define to 1 if this is the WASM app build. */
 #undef WASMAPP
 
+/* Define to 1 if the "fallback to Wasm" capability is enabled: */
+#define ENABLE_WASM_SUPPORT 0
+
 /* Makes config variables conditionally static, only in non-debug builds, to allow for overriding them in unit-tests. */
 #undef CONFIG_STATIC_TYPE
 

--- a/configure.ac
+++ b/configure.ac
@@ -984,8 +984,10 @@ AM_CONDITIONAL([ENABLE_WASM_FALLBACK], [test -n "$with_wasm_fallback"])
 WASM_BUILDDIR="$with_wasm_fallback"
 AC_SUBST(WASM_BUILDDIR)
 AS_IF([test -n "$with_wasm_fallback"],
-      [WASM_SUPPORT_ENABLE=true],
-      [WASM_SUPPORT_ENABLE=false])
+      [WASM_SUPPORT_ENABLE=true
+       AC_DEFINE([ENABLE_WASM_SUPPORT],1,[Define to 1 if the "fallback to Wasm" capability is enabled])],
+      [WASM_SUPPORT_ENABLE=false
+       AC_DEFINE([ENABLE_WASM_SUPPORT],0,[Define to 1 if the "fallback to Wasm" capability is enabled])])
 AC_SUBST(WASM_SUPPORT_ENABLE)
 
 AM_CONDITIONAL([ENABLE_WASM_ADDITIONAL_FILES], [test -n "$with_wasm_additional_files"])

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -82,8 +82,13 @@ using Poco::Net::NameValueCollection;
 using Poco::Util::Application;
 
 // We have files that are at least 2.5 MB already.
-// WASM files are in the order of 30 MB, however,
-constexpr auto MaxFileSizeToCacheInBytes = 50 * 1024 * 1024;
+// WASM files are in the order of 30 MB (250 MB in debug builds), however,
+constexpr auto MaxFileSizeToCacheInBytes = 1024 * 1024 *
+#if ENABLE_WASM_SUPPORT && ENABLE_DEBUG
+    500;
+#else
+    50;
+#endif
 constexpr std::string_view MetaViewPort = "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1, minimum-scale=1, interactive-widget=resizes-content\">";
 
 namespace


### PR DESCRIPTION
…files

...to avoid failures like

> wsd-1501834-1501834 2026-01-09 09:32:54.413450 +0100 [ coolwsd ] ERR  Failed to read file [/home/sberg/cowasm/online-host//browser/dist/wasm/online.wasm] or is too large to cache and serve| online/wsd/FileServer.cpp:1321

when trying to serve a 250MB browser/dist/wasm/online.wasm


Change-Id: I747502bc8a8235bb1ca108571375b123179187e8


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

