### PR TITLE
browser: a11y: add accessible role to PushButton

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1349,6 +1349,10 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			window.L.control.attachTooltipEventListener(pushbutton, builder.map);
 		}
 
+		if (data.aria && data.aria.role) {
+			pushbutton.setAttribute('role', data.aria.role);
+		}
+
 		builder.map.hideRestrictedItems(data, wrapper, pushbutton);
 		builder.map.disableLockedItem(data, wrapper, pushbutton);
 		if (data.hidden)


### PR DESCRIPTION
Certain buttons serve as a tablist role for switching panes
(e.g., in the Find and Replace dialog), which is necessary
for accessibility.

Change-Id: Iab6953763281abd81e6dd07c437054496471b4be
Signed-off-by: Henry Castro <hcastro@collabora.com>
