### PR TITLE
cypress: make calc/cell_edit_spec.js more stable

### DIFF
--- a/browser/src/app/ServerConnectionService.ts
+++ b/browser/src/app/ServerConnectionService.ts
@@ -103,6 +103,7 @@ class ServerConnectionService {
 
 		// initialize notebookbar in core
 		app.map.uiManager.initializeLateComponents();
+		JSDialog.RefreshScrollables();
 	}
 
 	public onNotebookbarInCoreInit() {

--- a/browser/src/control/jsdialog/Util.ScrollableBar.ts
+++ b/browser/src/control/jsdialog/Util.ScrollableBar.ts
@@ -130,7 +130,9 @@ function setupPriorityStatusHandler(scrollable: Element, toolItems: any[]) {
 			item.classList.remove('status-hidden');
 		});
 
-		const availableWidth = window.innerWidth;
+		const availableWidth = scrollable.parentElement
+			? scrollable.parentElement.clientWidth
+			: window.innerWidth;
 		let contentWidth = rootContainer.scrollWidth;
 
 		if (contentWidth > availableWidth) {

--- a/cypress_test/integration_tests/desktop/draw/sign_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/sign_spec.js
@@ -8,6 +8,8 @@ describe(['tagdesktop'], 'Signature operations.', function() {
 		// Given a document that can be signed:
 		helper.setupAndLoadDocument('draw/sign.pdf', /*isMultiUser=*/false, /*copyCertificates=*/true);
 
+		cy.wait(1000); // wait for resize after the first tile is received
+
 		// When visually signing that document:
 		cy.cGet('#menu-insert').click();
 		// Insert signature line/shape:


### PR DESCRIPTION
it mostly fails at the beforeEach step due to #zoomin button not being visible, so refresh scrollables on receiving first tile.

Change-Id: I6d683ac0458283b2cd22ada032cb890eeeb5386c


* Target version: main

### Summary

![image](https://cpci.cbg.collabora.co.uk:8080/job/github_online_master_debug_vs_co-25.04_cypress_desktop/7075/artifact/failed_test/Test_rendering_of_a_cell_on_edit_--_Redraw_after_undo_--_before_each_hook_(failed)_(attempt_2).png)


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

