### PR TITLE
filter kit-side origined download messages the same as client-side

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1840,30 +1840,9 @@ bool ClientSession::filterMessage(const std::string& message) const
     if (tokens.equals(0, "downloadas"))
     {
         std::string id;
-        if (tokens.size() >= 3 && getTokenString(tokens[2], "id", id))
-        {
-            if (id == "print" && _wopiFileInfo && _wopiFileInfo->getDisablePrint())
-            {
-                allowed = false;
-                LOG_WRN("WOPI host has disabled print for this session");
-            }
-            else if (id == "export" && _wopiFileInfo && _wopiFileInfo->getDisableExport())
-            {
-                allowed = false;
-                LOG_WRN("WOPI host has disabled export for this session");
-            }
-            else if (id == "slideshow" && _wopiFileInfo &&
-                     (_wopiFileInfo->getDisableExport() || !_wopiFileInfo->getWatermarkText().empty()))
-            {
-                allowed = false;
-                LOG_WRN("WOPI host has disabled slideshow for this session");
-            }
-        }
-        else
-        {
-            allowed = false;
-            LOG_WRN("No value of id in downloadas message");
-        }
+        if (tokens.size() >= 3)
+            getTokenString(tokens[2], "id", id);
+        allowed = filterDownloadAs(id);
     }
     else if (tokens.equals(0, "gettextselection"))
     {
@@ -1876,6 +1855,37 @@ bool ClientSession::filterMessage(const std::string& message) const
         }
     }
 
+    return allowed;
+}
+
+bool ClientSession::filterDownloadAs(const std::string& id) const
+{
+    bool allowed = true;
+
+    if (!id.empty())
+    {
+        if (id == "print" && _wopiFileInfo && _wopiFileInfo->getDisablePrint())
+        {
+            allowed = false;
+            LOG_WRN("WOPI host has disabled print for this session");
+        }
+        else if (id == "export" && _wopiFileInfo && _wopiFileInfo->getDisableExport())
+        {
+            allowed = false;
+            LOG_WRN("WOPI host has disabled export for this session");
+        }
+        else if (id == "slideshow" && _wopiFileInfo &&
+                 (_wopiFileInfo->getDisableExport() || !_wopiFileInfo->getWatermarkText().empty()))
+        {
+            allowed = false;
+            LOG_WRN("WOPI host has disabled slideshow for this session");
+        }
+    }
+    else
+    {
+        allowed = false;
+        LOG_WRN("No value of id in downloadas message");
+    }
     return allowed;
 }
 
@@ -2103,7 +2113,18 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
         COOLWSD::dumpOutgoingTrace(docBroker->getJailId(), getId(), firstLine);
 
     const auto& tokens = payload->tokens();
-    if (tokens.equals(0, "unocommandresult:"))
+    if (tokens.equals(0, "downloadas:"))
+    {
+        std::string id;
+        if (tokens.size() >= 4)
+            getTokenString(tokens[3], "id", id);
+        if (!filterDownloadAs(id))
+        {
+            LOG_WRN("Ignoring kit to client message of: " << firstLine);
+            return false;
+        }
+    }
+    else if (tokens.equals(0, "unocommandresult:"))
     {
         LOG_INF("Command: " << firstLine);
         const std::string stringJSON = payload->jsonString();

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -342,6 +342,9 @@ private:
     /// Eg. in readonly mode only few messages should be allowed
     bool filterMessage(const std::string& msg) const;
 
+    /// Returns true if the download message of type 'id' should be allowed or not
+    bool filterDownloadAs(const std::string& id) const;
+
     void dumpState(std::ostream& os) override;
 
     /// Handle invalidation message coming from a kit and transfer it to a tile request.


### PR DESCRIPTION
Change-Id: I15958ce526964ebe1fb34a89f7b5ceb1fbfc4fa0


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

