### PR TITLE
filter kit-side origined download messages the same as client-side

### DIFF
--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -309,6 +309,9 @@ private:
     /// Eg. in readonly mode only few messages should be allowed
     bool filterMessage(const std::string& msg) const;
 
+    /// Returns true if the download message of type 'id' should be allowed or not
+    bool filterDownloadAs(const std::string& id) const;
+
     void dumpState(std::ostream& os) override;
 
     /// Handle invalidation message coming from a kit and transfer it to a tile request.


### PR DESCRIPTION
Change-Id: I15958ce526964ebe1fb34a89f7b5ceb1fbfc4fa0


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

