### PR TITLE
fix(accessibility): add aria role to canvas

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -457,6 +457,8 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 
 		this._canvas = window.L.DomUtil.createWithId('canvas', 'document-canvas', this._canvasContainer);
 		this._canvas.style.visibility = 'hidden';
+		this._canvas.role = 'img';
+		this._canvas.ariaLabel = _('Online Editor');
 
 		app.sectionContainer = new CanvasSectionContainer(this._canvas, this.isCalc() /* disableDrawing? */);
 		app.activeDocument = new DocumentBase();


### PR DESCRIPTION
The motivation for this is that the canvas, by default, is not focusable with iOS' VoiceOver. By adding certain roles, we can make it so it can be focused, allowing reading out the document text.

The role I settled on was img, here's why:
- main: sounds like it might fit well, but isn't selectable with voiceover
- window: abstract role that shouldn't be used in websites. Subrole of 'dialog' but that doesn't fit here
- document: sounds like it should fit, but described on MDN as 'for focusable content within complex composite widgets or applications for which assistive technologies can switch reading content back to a reading mode'. Unfortunately, the content in the canvas isn't really readable like that
- textbox: we allow submitting freeform text, but not in a way that browsers are likely to understand if we set our role to this
- img: for components that are used to deliver information in a visual manner. It's fine, I guess... that's what the canvas is nominally for, even if it has the grander purpose of faking being an inputtable element

Since as reading the document happens by snatching away control from the canvas again, we can't make this be labelled with the document content. To provide some kind of description to people who focus this, I've used the page title ("Online Editor") but translateable...


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

