### PR TITLE
fix(treeview): make search text translatable

### DIFF
--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -1627,7 +1627,7 @@ class TreeViewControl {
 	showSearchBar(parent: HTMLElement) {
 		const searchBox = document.createElement('input');
 		searchBox.id = JSDialog.MakeIdUnique('ui-treeview-search-input'); // Form fields should have either a name or an ID - using this instead of a class
-		searchBox.placeholder = 'Search...';
+		searchBox.placeholder = _('Search...');
 		searchBox.addEventListener('input', () =>
 			this.filterEntries(searchBox.value),
 		);


### PR DESCRIPTION
Previously this Search... placeholder couldn't be translated. I think it should be able to be


Change-Id: I2dd9ca04e723313093e8850c269bad8c6a6a6964


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

