### PR TITLE
wsd: Fix lint-discovery.py

### DIFF
--- a/wsd/lint-discovery.py
+++ b/wsd/lint-discovery.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright the Collabora Online contributors.
 #
@@ -84,7 +84,7 @@ class FilterTypeHandler(xml.sax.handler.ContentHandler):
         if name == "prop" and self.inExtensions:
             self.inExtensions = False
             self.extensions = "".join(self.content).strip()\
-                                .encode("utf-8").split(self.extensionsSep)
+                                .encode("utf-8").split(bytes(self.extensionsSep, "utf-8"))
             self.extensionsSep = " "
             self.content = []
 
@@ -123,7 +123,7 @@ class FilterFragmentHandler(xml.sax.handler.ContentHandler):
         elif name == "prop" and self.inFlags:
             self.inFlags = False
             encodedFlags = "".join(self.content).strip().encode("utf-8")
-            self.flags = encodedFlags.split(" ")
+            self.flags = encodedFlags.split(b" ")
             self.content = []
         elif name == "prop" and self.inDocumentService:
             self.inDocumentService = False
@@ -210,7 +210,9 @@ extensionsSkipList = {
 
 def main():
     discoveryXml = "discovery.xml"
-    repoGuess = os.path.join(os.environ["HOME"], "git/libreoffice/master")
+    repoGuess = os.environ["LOCOREPATH"]
+    if repoGuess is None:
+        repoGuess = os.path.join(os.environ["HOME"], "git/libreoffice/master")
     filterDir = os.path.join(repoGuess, "filter/source/config/fragments")
     if len(sys.argv) >= 3:
         discoveryXml = sys.argv[1]


### PR DESCRIPTION
Hash bang should look for python3
Some of the string ops require bytes for utf-8
Don't assume the source is in ~/git/libreoffice/master


Change-Id: I732870b547b3f9a9de75863594043db57a0588f0


* Refs: https://github.com/CollaboraOnline/online/pull/14004#pullrequestreview-3650625099
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

