### PR TITLE
cypress: make writer/replace_dialog_spec.js more stable

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/replace_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/replace_dialog_spec.js
@@ -52,17 +52,20 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Replace Dialog Tests', fun
         cy.cGet('#FindReplaceDialog').should('be.visible');
 
         // Go to first instance - Not Bold text
-        cy.cGet('#searchterm-input-dialog').type('test{enter}');
+        cy.cGet('#searchterm-input-dialog').type('test');
+        cy.realPress('Enter');
         helper.textSelectionShouldExist();
         cy.cGet('#copy-paste-container p b').should('not.exist');
 
         // Search forward again to get to second instance - Bold text
-        cy.cGet('#searchterm-input-dialog').type('{enter}');
+        cy.cGet('#searchterm-input-dialog').focus();
+        cy.realPress('Enter');
         helper.copy();
         cy.cGet('#copy-paste-container p b').should('exist'); 
 
         // Now search backward with Shift+Enter - Not Bold text
-        cy.cGet('#searchterm-input-dialog').type('{shift}{enter}');
+        cy.cGet('#searchterm-input-dialog').focus();
+        cy.realPress('Enter', {shiftKey: true});
         helper.copy();
         cy.cGet('#copy-paste-container p b').should('not.exist');
     });


### PR DESCRIPTION
by using realPress to simulate Enter and Shift+Enter events


Change-Id: I011def3efe24ac9832dd373549e6aa93b697f5cc

* Target version: main

### Summary

When it fails:
<img width="1918" height="898" alt="screenshot_13012026_115042" src="https://github.com/user-attachments/assets/402852a4-9fee-4b21-b7fc-6bbb85a32e1c" />

Here the bold "test" should have been highlighted. In the dialog, the search field is focused as it should be, so focus is not an issue.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

