### PR TITLE
Impress: avoid null deref in selection rectangle mouse move

### DIFF
--- a/browser/src/canvas/sections/ImpressSelectionRectangle.ts
+++ b/browser/src/canvas/sections/ImpressSelectionRectangle.ts
@@ -42,7 +42,8 @@ class SelectionRectangle extends CanvasSectionObject {
 
 		if (
 			this.containerObject.isDraggingSomething() &&
-			this.containerObject.targetSection === this.name
+			this.containerObject.targetSection === this.name &&
+			this.sectionProperties.positionOnMouseDown
 		) {
 			this.sectionProperties.selectionSize = [
 				point.pX - this.sectionProperties.positionOnMouseDown.pX,


### PR DESCRIPTION
Guard against a null positionOnMouseDown when updating selectionSize in onMouseMove to prevent runtime TypeError.


Change-Id: Id7d9e9db644ece5744add5ee26c81c2fbb778188

* Target version: main

### Summary

fixes the error:
```
Uncaught TypeError: Cannot read properties of null (reading 'pX')
    at SelectionRectangle.onMouseMove (ImpressSelectionRectangle.ts:48:59)
    at CanvasSectionContainer.propagateOnMouseMove (CanvasSectionContainer.ts:813:28)
    at CanvasSectionContainer.onMouseMove (CanvasSectionContainer.ts:1173:11)
```

