### PR TITLE
Impress: Overview: hide "Copy" option from slide sorter context menu

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -318,7 +318,7 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 							that._map._clip._execCopyCutPaste('copy', '.uno:CopySlide');
 						},
 						visible: function() {
-							return true;
+							return !(app.impress.hasOverviewPage && that._map._docLayer._selectedPart === 0);
 						}
 					},
 					paste: {

--- a/browser/src/docstate.ts
+++ b/browser/src/docstate.ts
@@ -57,6 +57,7 @@
 	},
 	impress: {
 		partList: null, // Info for parts.
+		hasOverviewPage: false, //Whether the file has an overview page
 		notesMode: false, // Opposite of "NormalMultiPaneGUI".
 		twipsCorrection: 0.567, // There is a constant ratio between tiletwips and impress page twips. For now, this seems safe to use.
 	},

--- a/browser/src/map/handler/Map.StateChanges.js
+++ b/browser/src/map/handler/Map.StateChanges.js
@@ -133,6 +133,10 @@ window.L.Map.StateChangeHandler = window.L.Handler.extend({
 			}
 		}
 
+		if (commandName == '.uno:HasOverviewPage') {
+			app.impress.hasOverviewPage = e.state === "true";
+		}
+
 		$('#document-container').removeClass('slide-master-mode');
 		$('#document-container').addClass('slide-normal-mode');
 		if (slideMasterPageItem) {


### PR DESCRIPTION
* Resolves: #13994 
* Target version: main

### Summary

The corresponding core patches are:
- https://gerrit.libreoffice.org/c/core/+/197195
- https://gerrit.libreoffice.org/c/core/+/197196

<img width="424" height="318" alt="screenshot_13012026_193052" src="https://github.com/user-attachments/assets/d9a6cbbb-f53a-44ce-b5c2-9c8fe2803778" />

NOTE: This fails when you refresh the page - the context menu shows "Copy" for Overview slide.
I will fix it in an upcoming PR.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

