### PR TITLE
Fix stack-use-after-return

### DIFF
--- a/wsd/wopi/WopiProxy.cpp
+++ b/wsd/wopi/WopiProxy.cpp
@@ -123,7 +123,7 @@ void WopiProxy::handleRequest(std::istream & message,
             }
             // Remove from the current poll and transfer.
             disposition.setTransfer(*poll,
-                [this, &poll, docKey = std::move(docKey), url = std::move(url),
+                [this, poll, docKey = std::move(docKey), url = std::move(url),
                  uriPublic, postBody](const std::shared_ptr<Socket>& moveSocket)
                 {
                     LOG_TRC_S('#' << moveSocket->getFD()


### PR DESCRIPTION
> ==1525987==ERROR: AddressSanitizer: stack-use-after-return on address 0x7bb8b914ca40 at pc 0x55af5b1c723a bp 0x7bb8c9884550 sp 0x7bb8c9884548
> READ of size 8 at 0x7bb8b914ca40 thread T6 (websrv_poll)
>     #0 0x55af5b1c7239 in std::__shared_ptr<TerminatingPoll, (__gnu_cxx::_Lock_policy)2>::__shared_ptr(std::__shared_ptr<TerminatingPoll, (__gnu_cxx::_Lock_policy)2> const&) /usr/lib/gcc/x86_64-redhat-linux/15/../../../../include/c++/15/bits/shared_ptr_base.h:1529:7
>     #1 0x55af5b1c7239 in std::shared_ptr<TerminatingPoll>::shared_ptr(std::shared_ptr<TerminatingPoll> const&) /usr/lib/gcc/x86_64-redhat-linux/15/../../../../include/c++/15/bits/shared_ptr.h:203:7
>     #2 0x55af5b1c7239 in WopiProxy::checkFileInfo(std::shared_ptr<TerminatingPoll> const&, Poco::URI const&, std::optional<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>> const&, int) ~/cowasm/online-host/../online/wsd/wopi/WopiProxy.cpp:146:35
>     #3 0x55af5b1c9bf0 in WopiProxy::handleRequest(std::istream&, std::shared_ptr<TerminatingPoll> const&, SocketDisposition&)::$_0::operator()(std::shared_ptr<Socket> const&) const ~/cowasm/online-host/../online/wsd/wopi/WopiProxy.cpp:135:21

(as seen when opening a document via the COWASM wasm.html endpoint)


Change-Id: I363c7738ccb239eefec8727335d323b72dc97860


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

