### PR TITLE
feat(shortcuts): allow C-g for bold in French

### DIFF
--- a/browser/src/map/handler/Map.KeyboardShortcuts.ts
+++ b/browser/src/map/handler/Map.KeyboardShortcuts.ts
@@ -377,4 +377,9 @@ keyboardShortcuts.definitions.set('de', new Array<ShortcutDescriptor>(
     new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL | Mod.SHIFT, key: '`', preventDefault: false, platform: Platform.MAC }), // Cycle through windows
 ));
 
+// French shortcuts.
+keyboardShortcuts.definitions.set('fr', new Array<ShortcutDescriptor>(
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 'g', unoAction: '.uno:Bold' }),
+));
+
 window.KeyboardShortcuts = keyboardShortcuts;


### PR DESCRIPTION
Some software uses C-g (for Gras) rather than C-b for bolding text in French.

We did allow this until 24.04.5.1, but that was removed - we believe it may be due to the "Go to page" feature (which is also bound to C-g). To support standard French workflows, it's better to allow C-g to be bold, even at the cost of the "Go to page" shortcut...


Change-Id: Ie8ba46c2fa67874291917f8ce2d271466a6a6964


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

