### PR TITLE
autofilter: try to show same row range after filter application

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -802,8 +802,17 @@ window.L.CalcTileLayer = window.L.CanvasTileLayer.extend({
 
 		this._replayPrintTwipsMsgs(differentSheet);
 
-		this.sheetGeometry.setViewArea(this._pixelsToTwips(this._map._getTopLeftPoint()),
-			this._pixelsToTwips(this._map.getSize()));
+		if (this.sheetGeometry.autoFilterChanged) {
+			this.sheetGeometry.autoFilterChanged = false;
+			let firstVisibleRow = this.sheetGeometry.getFirstNewVisibleRow();
+			app.activeDocument.activeLayout.scrollTo(
+				this._map._getTopLeftPoint().x,
+				this.sheetGeometry.getRowsGeometry().getElementData(firstVisibleRow).startpos);
+		} else {
+			this.sheetGeometry.setViewArea(
+				this._pixelsToTwips(this._map._getTopLeftPoint()),
+				this._pixelsToTwips(this._map.getSize()));
+		}
 
 		this._addRemoveGroupSections();
 
@@ -930,6 +939,10 @@ window.L.CalcTileLayer = window.L.CanvasTileLayer.extend({
 		}
 		else if (e.commandName === 'AutoFilterInfo') {
 			app.calc.autoFilterCell = { 'row': e.state.row, 'column': e.state.column };
+		}
+		else if (e.commandName === 'AutoFilterChange')
+		{
+			this.sheetGeometry.autoFilterChanged = true;
 		}
 		else if (e.commandName === 'PivotTableFilterInfo') {
 			app.calc.pivotTableFilterCell = { 'row': e.state.row, 'column': e.state.column };


### PR DESCRIPTION
problem:
when autofilter is applied sheet reset to view the first row(i.e row 0) very inconvenient with big sheets to go and find the row you were looking at

now after this patch
when autofilter is applied we try to show row which is in current view and will also be visible after applying the filter. In case if no row will be visible after filter from current view we show the next visible row

example 1:
our current view is showing row 550 to 580
after autofilter row 570 is first visible row in this range so the view will reset to row 570 as first row in the view

example 1:
our current view is showing row 550 to 580
after autofilter no row is visible in this range
row 603 is first visible row afte this range
so the view will reset to row 603 as first row in the view


Change-Id: I02a7315e7a42ef1f0a6f5dc4ab4be05b8aa6f5a8


* Target version: main

requires https://gerrit.libreoffice.org/c/core/+/197302 for this patch to work

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

