### PR TITLE
FileServer: ensure to set LOGO_URL macro value

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -1803,6 +1803,7 @@ FileServerRequestHandler::ResourceAccessDetails FileServerRequestHandler::prepro
         }
         Poco::replaceInPlace(preprocess, std::string("%PRODUCT_BRANDING_NAME%"), std::string());
         Poco::replaceInPlace(preprocess, std::string("%PRODUCT_BRANDING_URL%"), std::string());
+        Poco::replaceInPlace(preprocess, std::string("%LOGO_URL%"), std::string());
     #else // configurable
         std::string enableWelcomeMessage = stringifyBoolFromConfig(config, "welcome.enable", false);
         std::string autoShowWelcome = stringifyBoolFromConfig(config, "welcome.enable", false);


### PR DESCRIPTION
in ENABLE_WELCOME_MESSAGE case

Amends c7743b32f52988fb8c93592161a405769281751a


Change-Id: Ica0c5883d83022d831b5fe219f74eb8fe3ea679e


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

Fixes #14095

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

