### PR TITLE
classic menu: set iconClass for document-logo

### DIFF
--- a/browser/src/app/LOUtil.ts
+++ b/browser/src/app/LOUtil.ts
@@ -891,6 +891,26 @@ class LOUtil {
 		}
 		return '';
 	}
+
+	public static getDocumentLogoClass(docType: string) {
+		let iconClass: string;
+		let iconTooltip: string;
+		if (docType === 'text') {
+			iconClass = 'writer-icon-img';
+			iconTooltip = 'Writer';
+		} else if (docType === 'spreadsheet') {
+			iconClass = 'calc-icon-img';
+			iconTooltip = 'Calc';
+		} else if (docType === 'presentation') {
+			iconClass = 'impress-icon-img';
+			iconTooltip = 'Impress';
+		} else if (docType === 'drawing') {
+			iconClass = 'draw-icon-img';
+			iconTooltip = 'Draw';
+		}
+
+		return [iconClass, iconTooltip];
+	}
 }
 
 app.LOUtil = LOUtil;

--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -2447,12 +2447,17 @@ class Menubar extends window.L.Control {
 
 			if (window.logoURL) {
 				aItem.style.backgroundImage = "url(" + window.logoURL + ")";
+			} else {
+				const docType = this._map.getDocType();
+				const [iconClass, iconTooltip] = app.LOUtil.getDocumentLogoClass(docType);
+				aItem.classList.add(iconClass);
+				aItem.setAttribute('data-cooltip', iconTooltip);
 			}
 
 			if (this._menubarCont != null)
 				this._menubarCont.insertBefore(liItem, this._menubarCont.firstChild);
 
-			var $docLogo = $(aItem);
+			const $docLogo = $(aItem);
 			$docLogo.bind('click', {self: this}, this._createDocument);
 			$docLogo.bind('click', this._createDocument.bind(this));
 		}

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -85,24 +85,12 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 			const docLogoHeader = window.L.DomUtil.create('div', '');
 			docLogoHeader.id = 'document-header';
 
-			let iconClass = 'document-logo';
+			let iconClass = '';
 			let iconTooltip;
 			if (!window.logoURL) {
-				if (docType === 'text') {
-					iconClass += ' writer-icon-img';
-					iconTooltip = 'Writer';
-				} else if (docType === 'spreadsheet') {
-					iconClass += ' calc-icon-img';
-					iconTooltip = 'Calc';
-				} else if (docType === 'presentation') {
-					iconClass += ' impress-icon-img';
-					iconTooltip = 'Impress';
-				} else if (docType === 'drawing') {
-					iconClass += ' draw-icon-img';
-					iconTooltip = 'Draw';
-				}
+				[iconClass, iconTooltip] = app.LOUtil.getDocumentLogoClass(docType);
 			}
-			const docLogo = window.L.DomUtil.create('a', iconClass, docLogoHeader);
+			const docLogo = window.L.DomUtil.create('a', 'document-logo ' + iconClass, docLogoHeader);
 
 			docLogo.setAttribute('id', 'document-logo');
 			docLogo.setAttribute('type', 'action');


### PR DESCRIPTION
Change-Id: Ie05e50caa443d1c6f0e549a25fe965ad8380159a

This has been broken for a while.

There is a styling issue, due to the sm-simple / lo-menu :hover.
I won't fix this here.

* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

In classic menu, add document icon.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

