### PR TITLE
enable a11y test of EditStyle dialogs

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -360,8 +360,8 @@ window.L.Map.include({
 
 		if ((command.startsWith('.uno:Sidebar') && !command.startsWith('.uno:SidebarShow')) ||
 			command.startsWith('.uno:CustomAnimation') || command.startsWith('.uno:ModifyPage') ||
-			command.startsWith('.uno:MasterSlidesPanel') || command.startsWith('.uno:SidebarDeck') || 
-			command.startsWith('.uno:EditStyle')) {
+			command.startsWith('.uno:MasterSlidesPanel') || command.startsWith('.uno:SidebarDeck') ||
+			(command.startsWith('.uno:EditStyle') && command.indexOf('Family:short=') == -1)) {
 
 			// sidebar control is present only in desktop/tablet case
 			if (this.sidebar) {

--- a/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
@@ -7,6 +7,8 @@ var desktopHelper = require('../../common/desktop_helper');
 const allWriterDialogs = [
     '.uno:ChapterNumberingDialog',
     '.uno:EditRegion',
+    '.uno:EditStyle?Param:string=Example&Family:short=1',
+    '.uno:EditStyle?Param:string=Heading&Family:short=2',
     '.uno:FieldDialog',
     '.uno:FontDialog',
     '.uno:FootnoteDialog',


### PR DESCRIPTION
Change-Id: I71205c9276608b0890db722e56ef814268cf7051


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

