### PR TITLE
cypress, cursor header section: improve testability

### DIFF
--- a/browser/src/canvas/sections/CursorHeaderSection.ts
+++ b/browser/src/canvas/sections/CursorHeaderSection.ts
@@ -16,7 +16,7 @@ class CursorHeaderSection extends HTMLObjectSection {
     static duration = 3000;
 
     constructor(viewId: number, username: string, documentPosition: cool.SimplePoint, color: string) {
-        super(CursorHeaderSection.namePrefix + viewId, null, null, documentPosition);
+        super(CursorHeaderSection.namePrefix + viewId, null, null, documentPosition, 'cursor-header-section');
 
         this.sectionProperties.deletionTimeout = null;
         this.sectionProperties.viewId = viewId;

--- a/cypress_test/integration_tests/multiuser/writer/cursor_spec.js
+++ b/cypress_test/integration_tests/multiuser/writer/cursor_spec.js
@@ -21,8 +21,8 @@ describe(['tagmultiuser'], 'Check cursor and view behavior', function() {
 		cy.cSetActiveFrame('#iframe2');
 		// Wait for the cursor header to appear (shown when cursor moves), then
 		// wait for it to auto-hide.
-		cy.cGet('#canvas-container .html-object-section').should('contain.text', 'LocalUser');
-		cy.cGet('#canvas-container .html-object-section').should('not.contain.text', 'LocalUser');
+		cy.cGet('#canvas-container .cursor-header-section').should('exist');
+		cy.cGet('#canvas-container .cursor-header-section').should('not.exist');
 
 		// When moving the mouse over the view cursor in the second view:
 		cy.getFrameWindow().then((win) => {
@@ -61,11 +61,9 @@ describe(['tagmultiuser'], 'Check cursor and view behavior', function() {
 
 		// Then make sure that the cursor header appears on mouse enter:
 		// Without the accompanying fix in place, this test would have failed with:
-		// Timed out retrying after 10000ms: expected '[
-		// <div.html-object-section.text-selection-handle-start>, 3 more... ]' to contain
-		// text 'LocalUser', but the text was ''
-		cy.cGet('#canvas-container .html-object-section')
-			.should('contain.text', 'LocalUser');
+		// Timed out retrying after 10000ms: Expected to find element: `#canvas-container
+		// .cursor-header-section`, but never found it.
+		cy.cGet('#canvas-container .cursor-header-section').should('exist');
 	});
 
 	it('Do not center the view if cursor is already visible', function() {


### PR DESCRIPTION
This is similar to what CursorHandler does, and then we can assert that
a cursor header section exists or not, not just guess based on the text
content.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I93eed9b773411eee9e67ee5f2922046be724bfb9
