### PR TITLE
cypress: more stable writer/scrolling_spec.js

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/scrolling_spec.js
@@ -11,13 +11,15 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Scroll through document', 
 
 	it('Check if we jump the view on new page insertion', function() {
 		desktopHelper.assertScrollbarPosition('vertical', 0, 10);
+		desktopHelper.assertVisiblePage(1, 1, 4);
+
 		helper.typeIntoDocument('{ctrl+enter}');
 		helper.typeIntoDocument('{ctrl+enter}');
 
 		cy.wait(500);
 		desktopHelper.assertVisiblePage(2, 3, 6);
 
-		desktopHelper.assertScrollbarPosition('vertical', 120, 150);
+		desktopHelper.assertScrollbarPosition('vertical', 120, 250);
 	});
 
 	it('Scrolling to bottom/top', function() {


### PR DESCRIPTION
- wait for initial page number state
- all which is not watching first page will be ok, don't limit to low to not fail
