### PR TITLE
fix: documentbackground doesn't follow UIDefault when no preference is set

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1633,10 +1633,15 @@ void ClientSession::overrideDocOption()
 
     // follow darkTheme preference if darkBackgroundForTheme is not set
     if (darkBackgroundObj.isNull())
-        setDarkBackground(darkTheme);
+    {
+        if (!darkTheme.empty())
+            setDarkBackground(darkTheme);
+    }
     else
+    {
         JsonUtil::findJSONValue(darkBackgroundObj, darkTheme == "true" ? "dark" : "light",
                                 darkBackgroundForTheme);
+    }
 
     if (!darkTheme.empty())
     {


### PR DESCRIPTION

Problem:
We were setting the darkBackground to `darkTheme` value when `darkBackgroundForTheme` is null. We were missing check to make sure `darkTheme` is not empty.
Adding this check fixed the problem

Change-Id: I2afef5083fffabf8c8cae84b5e528daeb40f0851
* Target version: main