### PR TITLE
Compact mode: Position Undo and Redo buttons after Save

### DIFF
--- a/browser/src/control/Control.TopToolbar.js
+++ b/browser/src/control/Control.TopToolbar.js
@@ -102,9 +102,11 @@ class TopToolbar extends JSDialog.Toolbar {
 	getToolItems() {
 		var saveGroup = [
 			{type: 'customtoolitem',  id: 'closemobile', desktop: false, mobile: false, tablet: true, visible: false},
-			{type: 'customtoolitem',  id: 'save', command: 'save', text: _UNO('.uno:Save'), lockUno: '.uno:Save', icon: 'compact_save.svg'},
-			{type: 'customtoolitem',  id: 'print', command: 'print', text: _UNO('.uno:Print'), mobile: false, tablet: false, lockUno: '.uno:Print', icon: 'compact_print.svg'},
-			{type: 'menubutton',  id: 'printoptions',  command: 'printoptions', noLabel: true, text: _UNO('.uno:Print', 'text'), mobile: false, tablet: false, lockUno: '.uno:Print', icon: 'compact_print.svg',
+			{type: 'customtoolitem',  id: 'save', command: 'save', text: _UNO('.uno:Save'), lockUno: '.uno:Save'},
+		];
+		var printGroup = [
+			{type: 'customtoolitem',  id: 'print', command: 'print', text: _UNO('.uno:Print'), mobile: false, tablet: false, lockUno: '.uno:Print'},
+			{type: 'menubutton',  id: 'printoptions',  command: 'printoptions', noLabel: true, text: _UNO('.uno:Print', 'text'), mobile: false, tablet: false, lockUno: '.uno:Print',
 				menu: [
 					{id: 'print-active-sheet', action: 'print-active-sheet', text: _('Active Sheet')},
 					{id: 'print-all-sheets', action: 'print-all-sheets', text: _('All Sheets')},
@@ -205,6 +207,8 @@ class TopToolbar extends JSDialog.Toolbar {
 				{type: 'separator', orientation: 'vertical', id: 'savebreak', mobile: false},
 				{type: 'overflowgroup', id: 'undo-toptoolbar', children: undoGroup},
 				{type: 'separator', orientation: 'vertical', id: 'redobreak', mobile: false, tablet: false,},
+				{type: 'overflowgroup', id: 'save-toptoolbar', children: printGroup},
+				{type: 'separator', orientation: 'vertical', id: 'printbreak', mobile: false},
 				{type: 'overflowgroup', id: 'font-toptoolbar', children: fontGroup},
 				{type: 'separator', orientation: 'vertical', id: 'breakfontsizes', invisible: true, mobile: false, tablet: false},
 				{type: 'overflowgroup', id: 'format-toptoolbar', children: formatGroup},

--- a/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
@@ -57,6 +57,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply font color on text shape.', function() {
+		desktopHelper.getCompactIconArrow('FontColor').click();
 		desktopHelper.getCompactIconArrow('Color').click();
 		desktopHelper.selectColorFromPalette('FFFF00');
 
@@ -66,6 +67,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Apply highlight color on text shape.', function() {
+		desktopHelper.getCompactIconArrow('FontColor').click();
 		desktopHelper.getCompactIconArrow('CharBackColor').click();
 		desktopHelper.selectColorFromPalette('FFBF00');
 


### PR DESCRIPTION
Keep the Save button untouched as it is a critical action sought by
the user when looking at the far left top corner BUT re-position Undo
and Redo button so they appear immediately after the save button and
before print actions. The print button is less important than the undo
redo group.

This in turn, makes it more familiar to the users.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iaaf232be4d34002696c0e29813928c71cbfc74b0
