### PR TITLE
allow document properties password option to be available in testing

### DIFF
--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -474,8 +474,10 @@ bool FileServerRequestHandler::isAdminLoggedIn(const HTTPRequest& request, http:
             fileInfo->set("Size", localFile->size);
             fileInfo->set("Version", "1.0");
             fileInfo->set("OwnerId", "test");
-            // usually in debug mode with debug.html the user that opening the document is same therefore set the static userId
-            fileInfo->set("UserId", "0");
+            // usually in debug mode with debug.html the user that opening the document is same therefore set a static userId
+            // if this is not the same as the OwnerId then the user is not considered the owner and cannot change the password
+            // via document, properties
+            fileInfo->set("UserId", "test");
             fileInfo->set("UserFriendlyName", userNameString);
 
             //allow &configid to override etag to force another subforkit


### PR DESCRIPTION
Change-Id: I7f45f1089b3ea23e1ed3ccaac9ec5df053a0394f


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

