### PR TITLE
Notebookbar: Keep checkbox labels on a single line and align with checkboxes

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -355,6 +355,10 @@ label.notebookbar.ui-checkbox-label {
 	padding-left: 0;
 }
 
+.notebookbar #table-style-options #chk_filter_buttons2 {
+	margin-bottom: 23px;
+}
+
 #table-HomeTab .unospan-uptoolbar:not(.disabled) {
 	border-top-left-radius: 12px;
 	border-bottom-left-radius: 12px;

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1756,7 +1756,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 						'vertical': 'true'
 					},
 					{
-						'type': 'container',
+						'type': 'toolbox',
 						'children': [
 							{
 								'id': 'chk_filter_buttons2',
@@ -1765,20 +1765,20 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 								'text': _('Filter Buttons'),
 								'accessibility': { focusBack: true,	combination: 'SF', de: null }
 							},
-							{
-								'id': 'tablestyles_cb2',
-								'type': 'listbox',
-								'selectedCount': '1',
-								'selectedEntries': [
-									'0'
-								],
-								'command': '.uno:DatabaseSettings',
-								'accessibility': { focusBack: true,	combination: 'TS', de: null }
-							}
-						],
-						'vertical': 'true'
+						]
 					},
 				]
+			},
+			{ type: 'separator', id: 'table-style-options-break', orientation: 'vertical' },
+			{
+				'id': 'tablestyles_cb2',
+				'type': 'listbox',
+				'selectedCount': '1',
+				'selectedEntries': [
+					'0'
+				],
+				'command': '.uno:DatabaseSettings',
+				'accessibility': { focusBack: true,	combination: 'TS', de: null }
 			}
 		];
 


### PR DESCRIPTION
Change-Id: I314e816ebd7b0ddbacfed920e5fc1b3689d8b299


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
- Add white-space: nowrap to prevent labels from wrapping to multiple lines
- Set padding to 0 to eliminate excessive spacing between checkboxes and labels caused by inherited mobilewizard styles.


### PREVIEW
<img width="1095" height="123" alt="2026-01-21_13-13" src="https://github.com/user-attachments/assets/1bfa7f78-fa24-465d-b267-ab8e55711163" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

