### PR TITLE
Fix bg of ui-combobox-entry for selected and normal states

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1327,14 +1327,12 @@ input[type='number']:hover::-webkit-outer-spin-button {
 }
 
 .ui-combobox-entry:hover {
-	background-color: var(--color-background-dark);
+	background-color: var(--color-background-hover);
 }
 
 .ui-combobox-entry.selected:not(:hover) span,
 .margin-item.selected {
-	border: 1px solid var(--color-primary);
-	background-color: var(--color-primary);
-	color: var(--color-primary-text);
+	background-color: var(--color-background-darker);
 }
 
 .ui-combobox-entry span {


### PR DESCRIPTION
Widget was inheriting the primary color so, odd colors could be passed by the integrator and this was affecting all comboboxes. Examples:

- Home tab > Font size
- View/Edit mode combobox

Before:

<img width="105" height="112" alt="image" src="https://github.com/user-attachments/assets/6a821644-1262-4ebc-afeb-90297ea09dcb" />
