### PR TITLE
Calc comments: Leave right side of the cell for comment section event…

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -581,7 +581,7 @@ export class Comment extends CanvasSectionObject {
 				this.size[0] = 5;
 		}
 		else if (this.sectionProperties.data.cellRange && app.map._docLayer._docType === 'spreadsheet') {
-			this.size = this.calcCellSize();
+			this.size = this.calcOptimumSizeForCalc();
 			var cellPos = app.map._docLayer._cellRangeToTwipRect(this.sectionProperties.data.cellRange).toRectangle();
 			let startX = cellPos[0];
 			if (this.isCalcRTL()) { // Mirroring is done in setPosition
@@ -589,7 +589,7 @@ export class Comment extends CanvasSectionObject {
 				startX += sizeX;  // but adjust for width of the cell.
 			}
 			this.setShowSection(true);
-			var position: Array<number> = [Math.round(cellPos[0] * app.twipsToPixels), Math.round(cellPos[1] * app.twipsToPixels)];
+			var position: Array<number> = [Math.round((cellPos[0] + cellPos[2]) * app.twipsToPixels - this.size[0]), Math.round(cellPos[1] * app.twipsToPixels)];
 
 			this.setPosition(position[0], position[1]);
 		}
@@ -1441,7 +1441,7 @@ export class Comment extends CanvasSectionObject {
 			else if (app.map._docLayer._docType === 'spreadsheet' &&
 				 parseInt(this.sectionProperties.data.tab) === app.map._docLayer._selectedPart) {
 
-				var cellSize = this.calcCellSize();
+				var cellSize = this.calcOptimumSizeForCalc();
 				if (cellSize[0] !== 0 && cellSize[1] !== 0) { // don't draw notes in hidden cells
 					// `zoom` represents the current zoom level of the map, retrieved from `this.map.getZoom()`.
 					// `baseSize` is a constant that defines the base size of the square at the initial zoom level.
@@ -1498,12 +1498,20 @@ export class Comment extends CanvasSectionObject {
 		}
 	}
 
-	public calcCellSize (): number[] {
+	private calcCellSize(): number[] {
 		var cellPos = app.map._docLayer._cellRangeToTwipRect(this.sectionProperties.data.cellRange).toRectangle();
 		return [Math.round((cellPos[2]) * app.twipsToPixels), Math.round((cellPos[3]) * app.twipsToPixels)];
 	}
 
-	public onMouseEnter (): void {
+	private calcOptimumSizeForCalc(): number[] {
+		const size = this.calcCellSize();
+
+		if (size[0] > 40 ) size[0] = 40;
+
+		return size;
+	}
+
+	public onMouseEnter(): void {
 		if (this.calcContinueWithMouseEvent()) {
 			// When mouse is above this section, comment's HTML element will be shown.
 			// If mouse pointer goes to HTML element, onMouseLeave event shouldn't be fired.
@@ -1527,11 +1535,11 @@ export class Comment extends CanvasSectionObject {
 		}
 	}
 
-	public onMouseLeave (point: cool.SimplePoint): void {
+	public onMouseLeave(point: cool.SimplePoint): void {
 		if (this.calcContinueWithMouseEvent()) {
 			if (parseInt(this.sectionProperties.data.tab) === app.map._docLayer._selectedPart) {
 				// Revert the changes we did on "onMouseEnter" event.
-				this.size = this.calcCellSize();
+				this.size = this.calcOptimumSizeForCalc();
 				if (point) {
 					this.hide();
 				}

--- a/cypress_test/integration_tests/desktop/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/annotation_spec.js
@@ -28,7 +28,7 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 		cy.cGet('#test-div-OwnCellCursor').then((items) => {
 			const cursor = items[0];
 			const clientRectangle = cursor.getBoundingClientRect();
-			const x = Math.round(clientRectangle.left + clientRectangle.width * 0.5);
+			const x = Math.round(clientRectangle.left + clientRectangle.width * 0.7);
 			const y = Math.round(clientRectangle.top + clientRectangle.height * 0.5);
 			const width = clientRectangle.width;
 			const height = clientRectangle.height;


### PR DESCRIPTION
… handling.

Issue:
* When there is a comment on a cell, user can not start a dragging event for selection. They can click on the cell but cannot start a multiple cell selection.

Reason:
* OnClick event of the comment section sends the click to the core side. So user can still click on the cell.
* Other events like onMouseButtonDown should also notify the MouseControl section or the core side.
  * That is not an optimal solution.
  * There are 2 possible good solutions:
	* Reserve some space in the cell for comment section. User can use that space for interacting with comment and use the rest for the cell interactions.
	* Play with "isHit" function in order to determine when a comment should handle the event and when not.

Fix:
* This commit implements the first solution.


Change-Id: I28d31c03b94d13457cad9ba8d6347d75b53f1691


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

