### PR TITLE
wsd: test mount namespace in grandchild fork before entering in parent process

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1220,6 +1220,57 @@ void COOLWSD::requestTerminateSpareKits()
     }
 }
 
+// Due to the possibility of enterMountingNS failing at an intermediate stage
+// after entering a usernamespace, but unable to enter a useful mounting namespace
+// do a test mount in another separate child whose failure don't affect the parent
+bool COOLWSD::testMountingNSInFork()
+{
+    Log::preFork();
+
+    pid_t pid = fork();
+    if (!pid)
+    {
+        // Child
+        Log::postFork();
+
+        // setupChildRoot does a test bind mount + umount to see if that fully works
+        // so we have a mount namespace here just for the purposes of that test
+        LOG_DBG("Test moving into user namespace as uid 0 in level 2 child");
+
+        int ret = JailUtil::enterMountingNS(geteuid(), getegid());
+
+        LOG_DBG("Level 2 child enterMountingNS result is: " << ret);
+
+        _exit(ret);
+    }
+
+    // Parent
+
+    if (pid == -1)
+    {
+        LOG_SYS("testMountingNSInFork fork failed");
+        return false;
+    }
+
+    int wstatus;
+    const int rc = waitpid(pid, &wstatus, 0);
+    if (rc == -1)
+    {
+        LOG_SYS("testMountingNSInFork waitpid failed");
+        return false;
+    }
+
+    if (!WIFEXITED(wstatus))
+    {
+        LOG_SYS("testMountingNSInFork abnormal termination");
+        return false;
+    }
+
+    int status = WEXITSTATUS(wstatus);
+    LOG_DBG("testMountingNSInFork status: " << std::hex << status << std::dec);
+    return status == 1;
+}
+
 void COOLWSD::setupChildRoot(const bool UseMountNamespaces)
 {
     JailUtil::disableBindMounting(); // Default to assume failure
@@ -1242,8 +1293,14 @@ void COOLWSD::setupChildRoot(const bool UseMountNamespaces)
         {
             // setupChildRoot does a test bind mount + umount to see if that fully works
             // so we have a mount namespace here just for the purposes of that test
+
+            // First see if it works in (another) throw away child so a successful
+            // NEWUSER, but a failed NEWNS, or an unusable one, doesn't affect this
+            // process. So on failure we can skip the enterMountingNS at this level.
+            const bool childMountWorked = COOLWSD::testMountingNSInFork();
+
             LOG_DBG("Move into user namespace as uid 0");
-            if (JailUtil::enterMountingNS(geteuid(), getegid()))
+            if (childMountWorked && JailUtil::enterMountingNS(geteuid(), getegid()))
                 JailUtil::enableMountNamespaces();
             else
                 LOG_ERR("creating usernamespace for mount user failed.");

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -286,6 +286,7 @@ protected:
 private:
 #if !MOBILEAPP
     void processFetchUpdate(const std::shared_ptr<SocketPoll>& poll);
+    static bool testMountingNSInFork();
     static void setupChildRoot(bool UseMountNamespaces);
     void initializeEnvOptions();
 #endif // !MOBILEAPP


### PR DESCRIPTION
I tested the patch with by building the docker image and running it inside ubuntu-vm with following settings:

```yaml
services:
  collabora:
    image: rash419/fix-bind-mount
    container_name: collabora

    ports:
      - "9980:9980"

    environment:
      extra_params: "--o:ssl.enable=false --o:logging.level=trace"
      aliasgroup1: "http://nextcloud.test"

    extra_hosts:
      - "nextcloud.test:192.168.1.33"

    cap_drop:
      - ALL

    cap_add:
      - SYS_CHROOT
      - SYS_ADMIN
      - FOWNER
      - CHOWN

    security_opt:
      - apparmor=unconfined
```

* Resolves: #14087
* Target version: main
