### PR TITLE
browser: use action messages instead of update

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2364,7 +2364,14 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 				}
 			}
 			break;
-
+		case 'setImage':
+			console.log(control);
+			if (typeof control.onSetImage === 'function') {
+				control.onSetImage(data.image);
+			}
+			
+			break;
+		
 		case 'rendered_entry':
 		case 'rendered_combobox_entry':
 		{

--- a/browser/src/control/jsdialog/Widget.DrawingArea.js
+++ b/browser/src/control/jsdialog/Widget.DrawingArea.js
@@ -47,6 +47,10 @@ function _drawingAreaControl (parentContainer, data, builder) {
 	image.draggable = false;
 	image.ondragstart = function() { return false; };
 
+	container.onSetImage = (dataurl) => {
+		image.src = dataurl;
+	}
+
 	if (data.enabled && data.canFocus) {
 		image.tabIndex = 0;
 	}


### PR DESCRIPTION
Attempt at using actions to set drawing image; currently a lot slower, see core change.

Allow the use of setImage actions from core for updating drawingAreas. Currently is a lot laggier than the update method.

Requires https://gerrit.libreoffice.org/c/core/+/197459.


Change-Id: Ic8ca9f75ed74f492991f17b955c004c66a6a6964