### PR TITLE
Don't include common/SettingsStorage.cpp in COOLWSD server

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -163,7 +163,6 @@ shared_sources = common/FileUtil.cpp \
                  $(util_platform_cpp) \
                  common/Util-unix.cpp \
                  common/ConfigUtil.cpp \
-                 common/SettingsStorage.cpp \
                  common/Authorization.cpp \
                  common/CommandControl.cpp \
                  common/Simd.cpp \


### PR DESCRIPTION
5ed968a83e57ec3f14e3529736f6a63821905e92 "Expose Settings dialog in coda-qt" had added that new source file to CODA-Q (qt/Makefile.am), but also, and for no clear reasons, to the COOLWSD server.  Building the latter (which I'm doing on the private/sberg/collab-endpoint branch) would now fail to link, because Desktop::getConfigPath etc., which are referenced from common/SettingsStorage.cpp, are only implemented in qt/coda-qt.cpp.


Change-Id: I322431a527354abf5861d74f5b7c084d87132fdf


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

