### PR TITLE
Remove the slurp event delay based on missing tiles

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -1946,22 +1946,6 @@ class TileManager {
 		}
 	}
 
-	// Returns a guess of how many tiles are yet to arrive
-	public static predictTilesToSlurp() {
-		if (!this.checkPointers()) return 0;
-
-		var size = app.map.getSize();
-
-		if (size.x === 0 || size.y === 0) return 0;
-
-		var zoom = Math.round(app.map.getZoom());
-		var pixelBounds = app.map.getPixelBoundsCore(app.map.getCenter(), zoom);
-
-		var queue = this.getMissingTiles(pixelBounds, zoom);
-
-		return queue.length;
-	}
-
 	public static pruneTiles() {
 		this.updateAllTileDistances();
 		this.garbageCollect();


### PR DESCRIPTION
We don't do partial tile redraws and we only paint once per frame, so it no longer makes sense to delay slurp event emission based on the number of tiles we're waiting on.

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required