### PR TITLE
calc: do not auto scroll on UI interation

### DIFF
--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -164,7 +164,7 @@ export class ScrollSection extends CanvasSectionObject {
 
 		if (e.pos.y > e.map._size.y - 50) {
 			vy = 50;
-		} else if (e.pos.y < 50 && e.map._getTopLeftPoint().y > 50) {
+		} else if (e.pos.y >= 0 && e.pos.y < 50 && e.map._getTopLeftPoint().y > 50) {
 			vy = -50;
 		}
 
@@ -172,7 +172,7 @@ export class ScrollSection extends CanvasSectionObject {
 		const mapLeft: number = this.isRTL() ? e.map._size.x - e.map._getTopLeftPoint().x : e.map._getTopLeftPoint().x;
 		if (mousePosX > e.map._size.x - 50) {
 			vx = 50;
-		} else if (mousePosX < 50 && mapLeft > 50) {
+		} else if (e.pos.x >= 0 && mousePosX < 50 && mapLeft > 50) {
 			vx = -50;
 		}
 


### PR DESCRIPTION
This patch is for fixing issues which appeared after commit 1b1cfd8d40f69d285f52acc2039a8ceaeeeaa9d5
"MouseControl: Initiate auto scroll when dragging
the mouse pointer to outside of the view."
for "Put canvas in front of the map element."
https://github.com/CollaboraOnline/online/pull/13261

We have only 2 options in onHandleAutoScroll:
- 0,0 cancels the scrolling
- anything different starts auto scrolling

The issue was that after using context menu if we clicked on formulabar which is above canvas - we got auto scrolling event. e received negative numbers - so we started to auto scroll with no complementary event to stop it.
