### PR TITLE
fix(sidebar): remove nested buttons in expander

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -138,7 +138,7 @@ button.jsdialog img {
 
 :not(.main-nav) .button-secondary,
 :not(.main-nav) .button-secondary:not(.arrowbackground),
-:not(.main-nav) > div:not(.toolbox) > button:not(.ui-tab):not(.ui-expander):not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.col):not(.arrowbackground):not(.ui-combobox-button):not(.ui-linkbutton) {
+:not(.main-nav) > div:not(.toolbox) > button:not(.ui-tab):not(.ui-expander-btn):not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.col):not(.arrowbackground):not(.ui-combobox-button):not(.ui-linkbutton) {
 	box-sizing: border-box;
 	height: 32px;
 	line-height: normal;

--- a/browser/css/device-desktop.css
+++ b/browser/css/device-desktop.css
@@ -14,7 +14,7 @@
    Rules not intended for touch devices */
 .ui-toggle button:hover,
 .button-secondary:hover,
-button:not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.notebookbar.ui-tab):not(.ui-expander):not(.arrowbackground):not(.ui-combobox-button):hover {
+button:not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.notebookbar.ui-tab):not(.ui-expander-btn):not(.arrowbackground):not(.ui-combobox-button):hover {
 	cursor: pointer;
 	color: var(--color-text-darker) !important;
 	background-color: var(--color-background-lighter) !important;

--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -65,6 +65,14 @@ img.sidebar.ui-image {
 	align-items: center;
 }
 
+.sidebar.ui-expander-btn {
+	background: transparent;
+	border: none;
+	padding-inline-end: 2px;
+	display: flex;
+	align-items: center;
+}
+
 .sidebar.ui-expander-label {
 	color: var(--color-main-text);
 	font-size: var(--header-font-size);
@@ -88,7 +96,7 @@ img.sidebar.ui-image {
 	width: 10px;
 	height: 10px;
 	padding: 0;
-	margin: 0;
+	margin: 4px;
 }
 
 .ui-expander-icon-right.jsdialog.sidebar .ui-overflow-group-more.unotoolbutton,

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -752,23 +752,26 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			container.id = data.id;
 
 			var expanded = data.expanded === true || (data.children[0] && data.children[0].checked === true);
-			var expander = window.L.DomUtil.create('button', 'ui-expander ' + builder.options.cssClass, container);
+			var expander = window.L.DomUtil.create('div', 'ui-expander ' + builder.options.cssClass, container);
 			if (data.children[0].text && data.children[0].text !== '') {
 				var prefix = data.children[0].id ? data.children[0].id : data.id;
-				expander.tabIndex = '0';
-				expander.setAttribute('aria-controls', prefix + '-children');
-				var label = window.L.DomUtil.create('span', 'ui-expander-label ' + builder.options.cssClass, expander);
+
+				var expanderBtn = window.L.DomUtil.create('button', 'ui-expander-btn ' + builder.options.cssClass, expander);
+				expanderBtn.tabIndex = '0';
+				expanderBtn.setAttribute('aria-controls', prefix + '-children');
+
+				var label = window.L.DomUtil.create('span', 'ui-expander-label ' + builder.options.cssClass, expanderBtn);
 				label.innerText = builder._cleanText(data.children[0].text);
 				label.id = prefix + '-label';
 				if (data.children[0].visible === false)
 					window.L.DomUtil.addClass(label, 'hidden');
-				builder.postProcess(expander, data.children[0]);
+				builder.postProcess(expanderBtn, data.children[0]);
 
 				var state = data.children.length > 1 && expanded;
 				if (state) {
 					window.L.DomUtil.addClass(label, 'expanded');
 				}
-				expander.setAttribute('aria-expanded', state);
+				expanderBtn.setAttribute('aria-expanded', state);
 
 				var toggleFunction = function () {
 					if (customCallback)
@@ -780,12 +783,12 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 					$(expander).siblings().toggleClass('expanded');
 
 					// Toggle aria-expanded attribute
-					const currentState = expander.getAttribute('aria-expanded') === 'true';
-					expander.setAttribute('aria-expanded', (!currentState).toString());
+					const currentState = expanderBtn.getAttribute('aria-expanded') === 'true';
+					expanderBtn.setAttribute('aria-expanded', (!currentState).toString());
 				};
 
-				$(expander).click(toggleFunction);
-				$(expander).keypress(function (event) {
+				$(expanderBtn).click(toggleFunction);
+				$(expanderBtn).keypress(function (event) {
 					if (event.which === 13) {
 						toggleFunction();
 						event.preventDefault();
@@ -799,12 +802,12 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			if (expanded) {
 				if (data.children.length > 1) {
 					label.classList.add('expanded');
-					expander.setAttribute('aria-expanded', 'true');
+					expanderBtn.setAttribute('aria-expanded', 'true');
 				}
 				expanderChildren.classList.add('expanded');
 			}
 			else {
-				expander.setAttribute('aria-expanded', 'false');
+				expanderBtn.setAttribute('aria-expanded', 'false');
 			}
 
 			var children = [];


### PR DESCRIPTION

* Resolves: # <!-- related github issue -->
* Target version: main

fix(sidebar): remove nested buttons in expander

Nested button elements are invalid HTML and cause accessibility issues. Refactored the expander structure by replacing the outer button with a new div container and introducing an inner toggle button.

This ensures the button is no longer nested and is now a sibling element, improving semantic correctness and accessibility.

Before:
```html
<button class="ui-expander">
    <span class="ui-expander-label">...</span>
    <button class="unobutton">More options</button> <!-- nested! -->
</button>
```
After:
```html
<div class="ui-expander">
    <button class="ui-expander-btn">
        <span class="ui-expander-label">...</span>
    </button>
    <button class="unobutton">More options</button> <!-- sibling -->
</div>
```

Change-Id: Iedb2ffef1bf280c1563f3fa4c3570666b83a1b81
