### PR TITLE
make desktop/impress/apply_paragraph_props_text_spec more reliable

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/apply_paragraph_props_text_spec.js
@@ -12,11 +12,15 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties
 
 		cy.cGet('.close-navigation-button').click();
 		cy.cGet('#navigator-sidebar').should('not.exist');
+		cy.getFrameWindow().then((win) => {
+			this.win = win;
+		});
 	});
 
-	function selectText() {
+	function selectText(win) {
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 		impressHelper.selectTextOfShape();
+		helper.processToIdle(win);
 	}
 
 	it.skip('Apply horizontal alignment on selected text.', function() {
@@ -58,8 +62,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties
 	});
 
 	it('Apply default bulleting on selected text.', function() {
-		selectText();
-		cy.wait(500);
+		selectText(this.win);
 
 		// We have no bulleting by default
 		cy.cGet('#document-container g.Page .BulletChars')
@@ -70,27 +73,26 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Apply paragraph properties
 		// Apply bulleting
 		desktopHelper.getCompactIcon('DefaultBullet').click();
 
-		selectText();
+		selectText(this.win);
 		cy.cGet('#document-container g.Page .BulletChars')
 			.should('exist');
 	});
 
 	it('Apply default numbering on selected text.', function() {
-		selectText();
-		cy.wait(500);
+		selectText(this.win);
 
-		// We have no bulleting by default
-		cy.cGet('#document-container g.Page .SVGTextShape tspan')
-			.should('not.have.attr', 'ooo:numbering-type');
+		// We have no numbering by default
+		cy.cGet('#document-container g.Page .SVGTextShape tspan[ooo\\:numbering-type]')
+			.should('not.exist');
 
 		desktopHelper.getCompactIconArrow('DefaultNumbering').click();
 
 		// Apply numbering
 		desktopHelper.getCompactIcon('DefaultNumbering').click();
 
-		selectText();
-		cy.cGet('#document-container g.Page .SVGTextShape tspan')
-			.should('have.attr', 'ooo:numbering-type', 'number-style');
+		selectText(this.win);
+		cy.cGet('#document-container g.Page .SVGTextShape tspan[ooo\\:numbering-type="number-style"]')
+			.should('exist');
 	});
 
 	// FIXME: fails on 6600 might be related to recent core margin updates


### PR DESCRIPTION
Change-Id: I028c68435b60347a1f1cf65eb34d1c7cfc4d7406


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

