### PR TITLE
fix coolforkit-caps and coolforkit-ns having identical build-ids

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -262,11 +262,17 @@ coolforkit_caps_SOURCES = $(coolforkit_sources) \
 
 coolforkit_caps_LDADD = ${coolforkit_ldadd}
 
+# Define variant to ensure different binary content and thus different build-id
+coolforkit_caps_CPPFLAGS = $(AM_CPPFLAGS) -DCOOL_FORKIT_VARIANT=\"caps\"
+
 coolforkit_ns_SOURCES = $(coolforkit_sources) \
                         $(shared_sources) \
                         kit/forkit-main.cpp
 
 coolforkit_ns_LDADD = ${coolforkit_ldadd}
+
+# Define variant to ensure different binary content and thus different build-id
+coolforkit_ns_CPPFLAGS = $(AM_CPPFLAGS) -DCOOL_FORKIT_VARIANT=\"ns\"
 
 if ENABLE_DEBUG
 coolwsd_inproc_SOURCES = $(coolwsd_sources) \

--- a/kit/forkit-main.cpp
+++ b/kit/forkit-main.cpp
@@ -16,6 +16,11 @@
 int ClientPortNumber = DEFAULT_CLIENT_PORT_NUMBER;
 std::string MasterLocation;
 
+// Embed variant string to ensure different build-id for coolforkit-caps vs coolforkit-ns
+#ifdef COOL_FORKIT_VARIANT
+[[maybe_unused]] static const char* const ForkitVariant = COOL_FORKIT_VARIANT;
+#endif
+
 int main (int argc, char **argv)
 {
     return forkit_main(argc, argv);


### PR DESCRIPTION
Add different CPPFLAGS to each target to embed a variant string, ensuring the binaries have different content and thus different SHA1-based build-ids. This fixes RPM package conflicts.


Change-Id: I7b0cb6680c908709a3b209a2fde79ec62d69284a

