### PR TITLE
impress: fixed incorrect slide pasting position

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -257,6 +257,8 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 				nPos = that._findClickedPart(frame) - 1;
 			else if (this.isPaddingClick(frame, e, 'bottom'))
 				nPos = that._findClickedPart(frame);
+			else if (this.isPaddingClick(frame, e, 'right') || this.isPaddingClick(frame, e, 'left'))
+				nPos = that._findClickedPart(frame);
 
 			$trigger.contextMenu(true);
 			if (!that._isSelected(e))
@@ -269,11 +271,10 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 						name: app.IconUtil.createMenuItemLink(_('Paste Slide'), 'Paste'),
 						isHtmlName: true,
 						callback: function(key, options) {
-							var part = that._findClickedPart(options.$trigger[0].parentNode);
-							if (part !== null) {
+								if (!nPos)
+									nPos = that._findClickedPart(options.$trigger[0]);
 								that._setPart(that.copiedSlide);
-								that._map.duplicatePage(parseInt(part));
-							}
+								that._map.duplicatePage(nPos);
 						},
 						visible: function() {
 							return that.copiedSlide;


### PR DESCRIPTION
problem:
when context menu was invoked by clicking on the empty spaces in the slidesorter, and slides were pasted using option in the context menu, slides were always pasted at the end and not where it was clicked


Change-Id: I2aba5d37ffca1eb86b02d76563887eae71ace2e6


* Target version: main



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

