### PR TITLE
admin: rename Document to AdminDocument

### DIFF
--- a/wsd/AdminModel.hpp
+++ b/wsd/AdminModel.hpp
@@ -152,11 +152,11 @@ public:
 };
 
 /// A document in Admin controller.
-class Document final
+class AdminDocument final
 {
 public:
-    Document(const std::string& docKey, pid_t pid,
-             const std::string& filename, const Poco::URI& wopiSrc)
+    AdminDocument(const std::string& docKey, pid_t pid, const std::string& filename,
+                  const Poco::URI& wopiSrc)
         : _wopiSrc(wopiSrc.toString())
         , _hostName(wopiSrc.getHost())
         , _docKey(docKey)
@@ -440,7 +440,7 @@ public:
     void sendShutdownReceivedMsg();
 
 private:
-    void doRemove(std::map<std::string, Document>::iterator &docIt);
+    void doRemove(std::map<std::string, AdminDocument>::iterator &docIt);
 
     std::string getMemStats() const;
 
@@ -462,7 +462,7 @@ private:
     DocProcSettings _defDocProcSettings;
 
     std::map<int, Subscriber> _subscribers;
-    std::map<std::string, Document> _documents;
+    std::map<std::string, AdminDocument> _documents;
 
     /// The serialized histories of all expired documents.
     std::vector<std::string> _expiredDocumentsHistories;


### PR DESCRIPTION
Fixes this -flto warning:

	./kit/Kit.hpp:200:7: error: type 'struct Document' violates the C++ One Definition Rule [-Werror=odr]
	  200 | class Document final : public std::enable_shared_from_this<Document>, private TilePrioritizer
	      |       ^
	wsd/AdminModel.hpp:155:7: note: a type with different bases is defined in another translation unit
	  155 | class Document final
	      |       ^

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ifa1b13679fe93e5fa4cd1c0d98882b0bd026674c
