### PR TITLE
browser: a11y: prevent file input from receiving focus on programmatic click

### DIFF
--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -163,10 +163,10 @@ m4_ifelse(MOBILEAPP,[true],
         <progress id="mobile-progress-bar" class="progress-bar" value="0" max="99"></progress>
       </div>
 
-      <input id="insertgraphic" aria-labelledby="menu-insertgraphic" type="file" accept="image/*">
-      <input id="insertmultimedia" aria-labelledby="menu-insertmultimedia" type="file" accept="audio/*, video/*">
-      <input id="selectbackground" aria-labelledby="menu-selectbackground" type="file" accept="image/*">
-      <input id="comparedocuments" aria-labelledby="menu-comparedocuments" type="file" accept="application/*">
+      <input id="insertgraphic" aria-labelledby="menu-insertgraphic" type="file" accept="image/*" tabindex="-1">
+      <input id="insertmultimedia" aria-labelledby="menu-insertmultimedia" type="file" accept="audio/*, video/*" tabindex="-1">
+      <input id="selectbackground" aria-labelledby="menu-selectbackground" type="file" accept="image/*" tabindex="-1">
+      <input id="comparedocuments" aria-labelledby="menu-comparedocuments" type="file" accept="application/*" tabindex="-1">
     </dialog>
 
     <div id="main-document-content">


### PR DESCRIPTION
The screen reader should not announce a hidden input
if it receives focus and the Enter key is pressed.

Change-Id: I5b9ae3c66dd6069a5603d54d92a01244aee34da8
Signed-off-by: Henry Castro <hcastro@collabora.com>
