### PR TITLE
fix coolforkit build-id: use __attribute__((used)) instead of [[maybe…

### DIFF
--- a/kit/forkit-main.cpp
+++ b/kit/forkit-main.cpp
@@ -18,7 +18,7 @@ std::string MasterLocation;
 
 // Embed variant string to ensure different build-id for coolforkit-caps vs coolforkit-ns
 #ifdef COOL_FORKIT_VARIANT
-[[maybe_unused]] static const char* const ForkitVariant = COOL_FORKIT_VARIANT;
+__attribute__((used)) static const char* const ForkitVariant = COOL_FORKIT_VARIANT;
 #endif
 
 int main (int argc, char **argv)


### PR DESCRIPTION
…_unused]]

The [[maybe_unused]] attribute only suppresses compiler warnings but doesn't prevent the variable from being optimized away. Use __attribute__((used)) to force the compiler to emit the symbol, ensuring the variant string is actually embedded in the binary.


Change-Id: I2bc26a1f400f2f7b1faf8d03579ed852fef5803c
