### PR TITLE
Highlight correct mode in view/edit dropdown menu

### DIFF
--- a/browser/src/control/PermissionMode.ts
+++ b/browser/src/control/PermissionMode.ts
@@ -103,8 +103,18 @@ class PermissionViewMode extends JSDialogComponent {
 			image: false, // Suppress image generation
 			visible: visible, // JSDialogBuilder checks visible: false
 			menu: [
-				{ id: 'view', text: _('Viewing Mode'), type: 'action' },
-				{ id: 'edit', text: _('Editing Mode'), type: 'action' },
+				{
+					id: 'view',
+					text: _('Viewing Mode'),
+					type: 'action',
+					selected: !this.map.isEditMode(),
+				},
+				{
+					id: 'edit',
+					text: _('Editing Mode'),
+					type: 'action',
+					selected: this.map.isEditMode(),
+				},
 			],
 		};
 	}

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -201,7 +201,8 @@ interface MenuDefinition extends WidgetJSON {
 	img?: string; // icon name
 	icon?: string; // icon name FIXME: duplicated property, used in exportMenuButton
 	checked?: boolean; // state of check mark
-	items?: Array<any>; // submenu
+	items?: Array<any>;
+	selected?: boolean; // selected state for entry
 }
 
 interface HtmlContentJson extends WidgetJSON {


### PR DESCRIPTION
Change-Id: I9c9faeafda95688160ab303b7e18e69775056f08


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
- Remove the visual selection highlight applied to the first entry when the View Mode dropdown is opened by clearing outline and background styling.

### PREVIEW
<img width="276" height="127" alt="2026-01-27_01-38" src="https://github.com/user-attachments/assets/839afae7-6823-414a-992c-a85970c75af8" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

