### PR TITLE
cypress(a11y): validate alt attribute for images with tabindex=0

### DIFF
--- a/browser/src/app/A11yValidator.ts
+++ b/browser/src/app/A11yValidator.ts
@@ -95,6 +95,12 @@ class A11yValidator {
 			if (altValue === '' && parent) {
 				const isDecorativeImg = img.classList.contains('ui-decorative-image'); // exclude ui-decorative-image decorative images - they can have empty alt
 
+				if (isFocusable) {
+					throw new A11yValidatorException(
+						`In '${this.getDialogTitle(element)}' at '${this.getElementPath(img)}': focusable image in widget of type '${type}' has empty alt attribute (screen readers need alt text for focusable images)`,
+					);
+				}
+
 				if (!parentHasLabel && !isDecorativeImg) {
 					throw new A11yValidatorException(
 						`In '${this.getDialogTitle(element)}' at '${this.getElementPath(img)}': image in widget of type '${type}' has empty alt attribute but parent element lacks label`,

--- a/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
@@ -63,6 +63,15 @@ const buggyDialogs = [
     '.uno:HyperlinkDialog',
     '.uno:InsertFrame',
     '.uno:OutlineBullet',
+
+    // Below dialogs have tabindex=0 with empty alt tag
+    '.uno:InsertSymbol',
+    '.uno:EditStyle?Param:string=Example&Family:short=1',
+    '.uno:EditStyle?Param:string=Heading&Family:short=2',
+    '.uno:FontDialog',
+    '.uno:PageDialog',
+    '.uno:ParagraphDialog',
+    '.uno:TableDialog',
 ];
 
 describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: false }, function () {


### PR DESCRIPTION
Follow-up to e31e38e020b849fa2051615cdd4d62862490d3e7 (a11y: preserve alt text for focusable DrawingArea images).

Add validation to ensure images with tabindex=0 have a non-empty alt attribute. This prevents regressions where focusable images could be rendered without proper accessible names.


Change-Id: Ie15c9453c297a4bb6ecb9efd67843152c62ee02f


* Resolves: # <!-- related github issue -->
* Target version: main

Mentioned in PR : #14129

Case:

1. Insert → Symbol → Favorite Characters
<img width="3620" height="1532" alt="image" src="https://github.com/user-attachments/assets/f5403c83-5c9b-413e-af84-4a7f4514f84e" />

2. Sidebar → Character “More” button → Border → User-defined
<img width="2718" height="1340" alt="image" src="https://github.com/user-attachments/assets/f99a21d2-3e5c-462b-83ca-45d85e897306" />

The patch would be:
```diff
diff --git a/browser/src/app/A11yValidator.ts b/browser/src/app/A11yValidator.ts
index decf0e188a..771606f938 100644
--- a/browser/src/app/A11yValidator.ts
+++ b/browser/src/app/A11yValidator.ts
@@ -95,6 +95,12 @@ class A11yValidator {
 			if (altValue === '' && parent) {
 				const isDecorativeImg = img.classList.contains('ui-decorative-image'); // exclude ui-decorative-image decorative images - they can have empty alt
 
+				if (isFocusable) {
+					throw new A11yValidatorException(
+						`In '${this.getDialogTitle(element)}' at '${this.getElementPath(img)}': focusable image in widget of type '${type}' has empty alt attribute (screen readers need alt text for focusable images)`,
+					);
+				}
+				
 				if (!parentHasLabel && !isDecorativeImg) {
 					throw new A11yValidatorException(
 						`In '${this.getDialogTitle(element)}' at '${this.getElementPath(img)}': image in widget of type '${type}' has empty alt attribute but parent element lacks label`,

```