### PR TITLE
ci: Allow to manually trigger nightly docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: Build nightly docker image
 on:
   schedule:
     - cron: "30 0 * * *"
+  workflow_dispatch:
 
 jobs:
   docker:


### PR DESCRIPTION
This allows to dispatch a workflow execution on demand