### PR TITLE
Doc Functions: Fix isXOrdinateInFrozenPane and isYOrdinateInFrozenPan…

### DIFF
--- a/browser/src/docstatefunctions.js
+++ b/browser/src/docstatefunctions.js
@@ -93,7 +93,7 @@ app.isXOrdinateInFrozenPane = function (pixelX) {
 	if (app.map._docLayer._splitPanesContext) {
 		const splitPos = app.map._docLayer._splitPanesContext.getSplitPos();
 
-		if (pixelX < splitPos.x) return true;
+		if (pixelX < splitPos.x && pixelX >= 0) return true;
 		else return false;
 	} else return false;
 };
@@ -102,7 +102,7 @@ app.isYOrdinateInFrozenPane = function (pixelY) {
 	if (app.map._docLayer._splitPanesContext) {
 		const splitPos = app.map._docLayer._splitPanesContext.getSplitPos();
 
-		if (pixelY < splitPos.y) return true;
+		if (pixelY < splitPos.y && pixelY >= 0) return true;
 		else return false;
 	} else return false;
 };


### PR DESCRIPTION
…e functions.

They need to check if coordinate is above 0. Or they assume the coordinate is in frozen pane.


Change-Id: I528a3a946066f07cb42d05c203b398ee5ed2d296


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

