### PR TITLE
CanvasSectionContainer::flushLayoutingTasks bypassed calling drain ca…

### DIFF
--- a/browser/src/app/LayoutingService.ts
+++ b/browser/src/app/LayoutingService.ts
@@ -60,6 +60,13 @@ class LayoutingService {
 		this._requestedFrame = null;
 	}
 
+	// Called by CanvasSectionContainer after it synchronously flushes tasks
+	public triggerDrainCallbacks(): void {
+		if (!this.hasTasksPending()) {
+			this._runDrainCallbacks();
+		}
+	}
+
 	// internal implementation below
 
 	private _setupTimer() {

--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -597,6 +597,9 @@ class CanvasSectionContainer {
 			layoutingService.cancelFrame();
 
 		while (layoutingService.runTheTopTask());
+
+		// Trigger drain callbacks since we bypassed the normal async flow
+		layoutingService.triggerDrainCallbacks();
 	}
 
 	private isCanvasSizeValidAfterDisplayChange(): boolean {


### PR DESCRIPTION
…llback

so a11y sidebar test doesn't get notification


Change-Id: I4dc8e0c2c5b80d04e898e37c75cc282d57cebc89


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

