### PR TITLE
Consider the custom logo for loading spinner

### DIFF
--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -699,6 +699,11 @@ div.leaflet-cursor-container:hover > .leaflet-cursor-header {
 	}
 }
 
+@keyframes MoveUpDown {
+	0%, 100% {bottom: -38px;}
+	50% {bottom: -48px;}
+}
+
 .leaflet-text-selection-container {
 	position: absolute;
 	text-align: center;
@@ -823,7 +828,17 @@ input.clipboard {
 	margin: 0 0 4px;
 	text-align: center;
 }
-
+.leaflet-progress-spinner::before {
+	content: '';
+	position: relative;
+	animation: MoveUpDown 1s linear infinite;
+	z-index: 1;
+	display: block;
+	width: 100%;
+	height: 78px;
+	margin: 0 0 4px;
+	background: var(--spinner-logo) no-repeat 44px center/78px;
+}
 .leaflet-progress-spinner-canvas {
 	position: static !important;
 }

--- a/browser/src/layer/marker/ProgressOverlay.js
+++ b/browser/src/layer/marker/ProgressOverlay.js
@@ -32,6 +32,13 @@ L.ProgressOverlay = window.L.Layer.extend({
 		} else {
 			productName = (typeof brandProductName !== 'undefined') ? brandProductName : 'Collabora Online Development Edition (unbranded)';
 		}
+		if (window.logoURL) {
+			this._spinner.style.setProperty(
+				'--spinner-logo',
+				`url("${window.logoURL}")`
+			);
+			this._spinnerCanvas.style.opacity = '0';
+		}
 		this._brandLabel = window.L.DomUtil.create('div', 'leaflet-progress-label brand-label', this._container);
 		this._brandLabel.innerHTML = productName;
 


### PR DESCRIPTION
- logoURL parameter enables users to override the default logo with their own branding.
- As an enhancement, the same `logoURL` should be applied to the loading spinner.
- If a custom `logoURL` is provided, the loading spinner should use it instead of the default logo.
- If no `logoURL` is set, the spinner should fall back to the default logo.

This patch will have the missing improvement of using that logoURL (custom logo) in spinner


[Screencast from 2026-01-28 16-53-56.webm](https://github.com/user-attachments/assets/26d55c19-e4a0-4198-8450-530ce2fc8755)



Change-Id: Ic53485eb78f612010b9932ed37fa4cc775a0c32a


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

