### PR TITLE
Load l10n-all.js in debug mode for apps

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -16,10 +16,11 @@ if !ENABLE_MOBILEAPP
 L10N_JSON = $(patsubst $(srcdir)/po/help-%.po,$(DIST_FOLDER)/l10n/help-%.json,$(L10N_PO))
 L10N_JSON += $(patsubst $(srcdir)/po/ui-%.po,$(DIST_FOLDER)/l10n/ui-%.json,$(L10N_PO))
 else
-L10N_IOS_ALL_JS = $(DIST_FOLDER)/l10n-all.js
-L10N_JSON = $(L10N_IOS_ALL_JS)
+L10N_ALL_JS = $(DIST_FOLDER)/l10n-all.js
+L10N_JSON = $(L10N_ALL_JS)
+L10N_ALL_JS_ENTRY = l10n-all.js
 
-$(L10N_IOS_ALL_JS) : $(wildcard $(srcdir)/po/ui-*.po) $(wildcard $(srcdir)/po/help-*.po) $(shell find $(srcdir)/l10n -name '*.*') $(srcdir)/util/create-l10n-all-js.pl
+$(L10N_ALL_JS) : $(wildcard $(srcdir)/po/ui-*.po) $(wildcard $(srcdir)/po/help-*.po) $(shell find $(srcdir)/l10n -name '*.*') $(srcdir)/util/create-l10n-all-js.pl
 	for F in $(wildcard $(srcdir)/po/ui-*.po); do \
 		$(srcdir)/util/po2json.py $$F -o $$F.json; \
 	done
@@ -755,7 +756,7 @@ endef
 define bundle_all
 	$(if $(IS_SEPARATE),\
 		@touch $@,\
-		$(QUIET_M4) m4 -PE -DL10N_IOS_ALL_JS=$(L10N_IOS_ALL_JS) \
+		$(QUIET_M4) m4 -PE -DL10N_ALL_JS=$(L10N_ALL_JS) \
 			-DNODE_MODULES_JS=$(subst $(SPACE),$(COMMA),$(NODE_MODULES_JS)) \
 			-DCOOL_LIBS_JS=$(subst $(SPACE),$(COMMA),$(COOL_LIBS_JS_SRC)) \
 			-DCOOL_JS=$(INTERMEDIATE_DIR)/cool-src.js \
@@ -959,7 +960,7 @@ $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist: $(COOL_JS_DST)
 	$(QUIET_CMP) if cmp -s $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist.tmp $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist; then rm $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist.tmp; else mv $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist.tmp $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist; fi
 
 $(INTERMEDIATE_DIR)/COOL_JS.m4: $(INTERMEDIATE_DIR)/COOL_JS.m4.jslist
-	$(foreach file,$(NODE_MODULES_JS) $(COOL_LIBS_JS) $(patsubst %.ts,%.js,$(COOL_JS_WEBORDER)), $(shell echo -n $(file), >> $(INTERMEDIATE_DIR)/COOL_JS.m4.tmp))
+	$(foreach file,$(L10N_ALL_JS_ENTRY) $(NODE_MODULES_JS) $(COOL_LIBS_JS) $(patsubst %.ts,%.js,$(COOL_JS_WEBORDER)), $(shell echo -n $(file), >> $(INTERMEDIATE_DIR)/COOL_JS.m4.tmp))
 	@truncate $(if $(filter Darwin FreeBSD,$(shell uname -s)),-s -1,--size=-1) $(INTERMEDIATE_DIR)/COOL_JS.m4.tmp
 	@mv $(INTERMEDIATE_DIR)/COOL_JS.m4.tmp $(INTERMEDIATE_DIR)/COOL_JS.m4
 

--- a/browser/bundle.js.m4
+++ b/browser/bundle.js.m4
@@ -5,8 +5,8 @@ m4_define([m4_foreachq],[m4_ifelse([$2],[],[],[m4_pushdef([$1])_$0([$1],[$3],[],
 m4_define([_m4_foreachq],[m4_ifelse([$#],[3],[],[m4_define([$1],[$4])$2[]$0([$1],[$2],m4_shift(m4_shift(m4_shift($@))))])])m4_dnl
 m4_define([m4_trim],[m4_patsubst([$1],[^. ?\(.*\) .$])])m4_dnl
 m4_dnl
-m4_dnl files for IOS
-m4_ifelse(m4_trim(L10N_IOS_ALL_JS),[],[],[m4_syscmd([cat ]L10N_IOS_ALL_JS)])
+m4_dnl l10n for apps
+m4_ifelse(m4_trim(L10N_ALL_JS),[],[],[m4_syscmd([cat ]L10N_ALL_JS)])
 
 m4_dnl node_modules
 m4_foreachq([fileNode],[NODE_MODULES_JS],[


### PR DESCRIPTION
In debug mode (--enable-debug), JS files are loaded individually instead of being bundled. The l10n-all.js file was only included in bundle.js but not loaded separately, causing missing translations in debug builds for apps like qtapp.

Add L10N_ALL_JS_ENTRY to include l10n-all.js in the COOL_JS.m4 list for app builds, ensuring it loads first in debug mode.

Also rename L10N_IOS_ALL_JS to L10N_ALL_JS since it applies to all apps, not just iOS.


Change-Id: I5d131ffdc9496633f60bfa93c0c12f9cfc431a7b

