### PR TITLE
Writer: Shorten label to “Compare Document...” in Compare menu

### DIFF
--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -221,7 +221,7 @@ window.L.Map.WOPI = window.L.Handler.extend({
 			/* Separate, because needs explicit integration support */
 			menuEntriesMultimedia.push({action: 'remotemultimedia', text: _UNO('.uno:InsertAVMedia', '', true)});
 
-			menuEntriesCompare.push({action: 'remotecomparedocuments', text: _UNO('.uno:CompareDocuments', '', true)});
+			menuEntriesCompare.push({action: 'remotecomparedocuments', text: _('Compare Document...')});
 		}
 
 		this._insertImageMenuSetupDone = true;


### PR DESCRIPTION
Change-Id: Iabd0ecce1e943d9848a8d10505b72f28ac410de3


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
- Replaces the “Compare Non-Track Changed Document” label with “Compare Document...” to improve readability and align with existing action-based menu naming conventions for example "insert image"


### PREVIEW
<img width="276" height="179" alt="2026-01-29_01-55" src="https://github.com/user-attachments/assets/c90ceb01-9ee2-4db7-8bce-97197afa57a3" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

