### PR TITLE
fix create-l10n-all-js.pl for Cpanel::JSON::XS

### DIFF
--- a/browser/util/create-l10n-all-js.pl
+++ b/browser/util/create-l10n-all-js.pl
@@ -21,7 +21,7 @@ BEGIN {
     eval {
         require Cpanel::JSON::XS;
         Cpanel::JSON::XS->import(qw(decode_json encode_json));
-        $json_pretty = Cpanel::JSON::XS->new->utf8->canonical->pretty;
+        $json_pretty = Cpanel::JSON::XS->new->utf8->canonical->pretty->allow_nonref;
         1;
     } or eval {
         require JSON::XS;
@@ -66,8 +66,8 @@ sub insert(@) {
                 my $prev = $seen_in{$k} // '(unknown)';
 
                 # Also, warn only if the value changes (stringify via JSON for a simple deep-ish compare).
-                my $old_json = encode_json($merged{$k});
-                my $new_json = encode_json($obj->{$k});
+                my $old_json = $json_pretty->encode($merged{$k});
+                my $new_json = $json_pretty->encode($obj->{$k});
 
                 if ($old_json ne $new_json) {
                     my $old_s = _short($old_json, 140);


### PR DESCRIPTION
without this patch I get the following error on building Desktop Linux if Cpanel::JSON::XS is installed
```
perl ./util/create-l10n-all-js.pl >dist/l10n-all.js
hash- or arrayref expected (not a simple scalar, use allow_nonref to allow this)
at ./util/create-l10n-all-js.pl line 69.
```

since (Change-Id: I36c6b38acc0930eb6e005479f7cf7003bbeec3a5), which reinstantiates b578c1578116cf05a91786fc99a8717f8c192865:(Change-Id: Ia26802ac1ebe9fc696d23706f9bab6b84f0efab4)

The encode_json() function in Cpanel::JSON::XS (v4.40 is what I have installed on my machine) rejects simple scalar values (strings) by default, requiring a hashref or arrayref.

Fix by using $json_pretty->encode() with allow_nonref enabled for Cpanel::JSON::XS. This allows encoding scalar values when comparing translation entries for the overwrite warning.

AFAICS, this is only the case for Cpanel::JSON::XS, and not for other json lib options.


Change-Id: I4f6986a2fe5013f29ef124e0a0c92880fe249d2c


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

