### PR TITLE
Linux Desktop fix run-from-build disappearing on make clean

### DIFF
--- a/qt/Makefile.am
+++ b/qt/Makefile.am
@@ -136,6 +136,6 @@ translations_DATA = $(QM_FILES)
 
 # Distribute sources and clean up generated files
 EXTRA_DIST += $(TS_FILES) run-from-build.in
-CLEANFILES += $(QM_FILES) run-from-build
+CLEANFILES += $(QM_FILES)
 
 ### --- Qt translations integration end ---


### PR DESCRIPTION
`make clean` deleting run-from-build is not ideal for successive `make clean` &&
`make` loops. `make` does not create `qt/run-from-build`.

Do not know if this would mess something up with out of tree builds, but
hopefully not(?)

`make distclean` should be used for cleaning `run-from-build` generated by `configure`

<!-- Message of single commit: -->

---

fix run-from-build disappearing on make clean

run-from-build being deleted on make clean, prevents qt/coda-qt from executing
as expected.

run-from-build is generated on ./configure, so if you did
./configure ... --enable-qtapp ..
make
make clean
make

it would not be generated on second make, leaving the in-tree built qt/coda-qt
executable faulty.

do not delete run-from-build on `make clean`. `make distclean` should still
delete it.

Signed-off-by: Sarper Akdemir <sarper.akdemir@collabora.com>
Change-Id: I3a3db73fdf5219ba75636c957e4b7af118b846af