### PR TITLE
Add kit version and hash to capabilities

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -782,6 +782,8 @@ std::string COOLWSD::FileServerRoot;
 std::string COOLWSD::ServiceRoot;
 std::string COOLWSD::TmpFontDir;
 std::string COOLWSD::LOKitVersion;
+std::string COOLWSD::LOKitVersionNumber;
+std::string COOLWSD::LOKitVersionHash;
 std::string COOLWSD::ConfigFile = COOLWSD_CONFIGDIR "/coolwsd.xml";
 std::string COOLWSD::ConfigDir = COOLWSD_CONFIGDIR "/conf.d";
 bool COOLWSD::EnableTraceEventLogging = false;
@@ -3056,7 +3058,15 @@ private:
                 else if (param.first == "configid")
                     configId = param.second;
                 else if (param.first == "version")
+                {
                     COOLWSD::LOKitVersion = param.second;
+                    Poco::JSON::Object::Ptr object;
+                    if (JsonUtil::parseJSON(COOLWSD::LOKitVersion, object))
+                    {
+                        COOLWSD::LOKitVersionNumber = JsonUtil::getJSONValue<std::string>(object, "ProductVersion") + JsonUtil::getJSONValue<std::string>(object, "ProductExtension");
+                        COOLWSD::LOKitVersionHash = JsonUtil::getJSONValue<std::string>(object, "BuildId").substr(0, 8);
+                    }
+                }
                 else if (param.first.size() > 6 &&
                          param.first.compare(0, 5, "adms_") == 0)
                     admsProps[param.first.substr(5)] = param.second;

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -84,6 +84,8 @@ public:
     static std::string ServiceRoot; ///< There are installations that need prefixing every page with some path.
     static std::string TmpFontDir;
     static std::string LOKitVersion;
+    static std::string LOKitVersionNumber;
+    static std::string LOKitVersionHash;
     static bool EnableTraceEventLogging;
     static bool EnableAccessibility;
     static bool EnableMountNamespaces;

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -2778,6 +2778,12 @@ std::string getCapabilitiesJson(bool convertToAvailable)
     // Set the product version hash
     capabilities->set("productVersionHash", Util::getCoolVersionHash());
 
+    // Set the kit version
+    capabilities->set("productKitVersion", COOLWSD::LOKitVersionNumber);
+
+    // Set the kit version hash
+    capabilities->set("productKitVersionHash", COOLWSD::LOKitVersionHash);
+
     // Set that this is a proxy.php-enabled instance
     capabilities->set("hasProxyPrefix", COOLWSD::IsProxyPrefixEnabled);
 


### PR DESCRIPTION
So they can be queried externally.
Eg. mso-test is interested in this information.


Change-Id: Ia918ca0a8f821cca0b1bcd7ee7e38dda7560ff58

* Target version: main

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

