### PR TITLE
plausible fix attempt for follow_me_slideshow_spec.js cypress failure

### DIFF
--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -199,6 +199,10 @@ class SlideShowNavigator {
 
 	switchSlide(nOffset: number, bSkipTransition: boolean) {
 		NAVDBG.print('SlideShowNavigator.switchSlide: nOffset: ' + nOffset);
+		if (this.currentSlide === undefined) {
+			NAVDBG.print('SlideShowNavigator.switchSlide: currentSlide undefined');
+			return;
+		}
 		this.displaySlide(this.currentSlide + nOffset, bSkipTransition);
 	}
 


### PR DESCRIPTION
It's plausible that this.currentSlide is undefined here from the timeout of browser/src/slideshow/engine/SlideShowHandler.ts

cypress failure in ci seen of:

              Test failed: integration_tests/multiuser/impress/follow_me_slideshow_spec.js / Follow me slide show / Exit

              The following error originated from your application code, not from Cypress.

                > Maximum call stack size exceeded

              When Cypress detects uncaught errors originating from your application it will automatically fail the current test.

              This behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.

              https://on.cypress.io/uncaught-exception-from-application

cy: command ✘  uncaught exception	RangeError: Maximum call stack size exceeded cy: command ✔  error:	Maximum call stack size exceeded
              RangeError: Maximum call stack size exceeded
                  at SlideShowNavigator.displaySlide (http://localhost:9900/browser/6383bd4834/src/slideshow/engine/SlideShowNavigator.js:211:74)
                  at SlideShowNavigator.displaySlide (http://localhost:9900/browser/6383bd4834/src/slideshow/engine/SlideShowNavigator.js:255:18)
                  at SlideShowNavigator.displaySlide (http://localhost:9900/browser/6383bd4834/src/slideshow/engine/SlideShowNavigator.js:255:18)

Change-Id: I4e3aaa80241ff3060cb39ee0ce6699f573ee0aad


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

