### PR TITLE
html/framed.doc: add json validity check to the message textarea

### DIFF
--- a/browser/html/framed.doc.html
+++ b/browser/html/framed.doc.html
@@ -274,10 +274,15 @@
 
       // Wrap the message execution to catch exceptions
       function executeMessage() {
+          let paramArea = document.getElementById('execute-param');
+          if (!paramArea.checkValidity()) {
+              paramArea.reportValidity();
+              return;
+          }
           try {
               Execute(
                   document.getElementById('execute-message').value,
-                  JSON.parse(document.getElementById('execute-param').value)
+                  JSON.parse(paramArea.value)
               );
           } catch(e) {
               console.error("Execute message error:", e);
@@ -501,6 +506,21 @@
           file_path = file_path.substr(0, index + 1) + filename;
           startCool(frameUrl, file_path);
       }
+
+      document.addEventListener("DOMContentLoaded", function(event) {
+          let paramArea = document.getElementById('execute-param');
+          paramArea.checkValidity = () => {
+            let valid = true;
+            try {
+              JSON.parse(paramArea.value);
+              paramArea.setCustomValidity('');
+            } catch(e) {
+              paramArea.setCustomValidity("Not valid json : \n" + e);
+              valid = false;
+            }
+            return valid;
+          };
+      });
 
     </script>
 


### PR DESCRIPTION
Change-Id: Ibf745a98aec960702f9b9c2bef5de993895b3610


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

Add a json validity check, so the user is warned when his input is wrong.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

