### PR TITLE
app:linux handle `basename` token for newdoc

### DIFF
--- a/qt/DBusService.cpp
+++ b/qt/DBusService.cpp
@@ -52,7 +52,7 @@ namespace coda
 
     void openNewDocument(const QString& templateType)
     {
-        WebView* webViewInstance = WebView::createNewDocument(Application::getProfile(), templateType.toStdString());
+        WebView* webViewInstance = WebView::createNewDocument(Application::getProfile(), templateType.toStdString(), {}, {});
         if (!webViewInstance)
         {
             LOG_ERR("Failed to create new document");

--- a/qt/WebView.cpp
+++ b/qt/WebView.cpp
@@ -151,7 +151,8 @@ Poco::Path getTemplatePath(const std::string& templateType, const std::string& t
     return resolvedPath;
 }
 
-std::pair<QString, QString> getDocumentNameInfo(const std::string& templateType)
+std::pair<QString, QString> getDocumentNameInfo(const std::string& templateType,
+                                                const std::string& baseName)
 {
     QString docNamePrefix;
     QString extension;
@@ -182,6 +183,10 @@ std::pair<QString, QString> getDocumentNameInfo(const std::string& templateType)
         docNamePrefix = QObject::tr("Text Document");
         extension = "odt";
     }
+
+    // if we received an explicit basename in the `newdoc` message use that.
+    if (!baseName.empty())
+        docNamePrefix = QString::fromStdString(baseName);
 
     return {docNamePrefix, extension};
 }
@@ -633,7 +638,7 @@ void WebView::load(const Poco::URI& fileURL, bool newFile, bool isStarterMode)
     _mainWindow->show();
 }
 
-WebView* WebView::createNewDocument(QWebEngineProfile* profile, const std::string& templateType, const std::string& templatePath)
+WebView* WebView::createNewDocument(QWebEngineProfile* profile, const std::string& templateType, const std::string& templatePath, const std::string& basename)
 {
     // Get template file path
     Poco::Path templatePathObj = getTemplatePath(templateType, templatePath);
@@ -642,7 +647,7 @@ WebView* WebView::createNewDocument(QWebEngineProfile* profile, const std::strin
     QString documentsDir = getDocumentsDirectory();
 
     // Get document name prefix and extension based on template type
-    auto [docNamePrefix, extension] = getDocumentNameInfo(templateType);
+    auto [docNamePrefix, extension] = getDocumentNameInfo(templateType, basename);
 
     // Find the next available document name
     QString newFilePath = findNextAvailableDocumentName(documentsDir, docNamePrefix, extension);

--- a/qt/WebView.hpp
+++ b/qt/WebView.hpp
@@ -65,7 +65,10 @@ public:
     QMainWindow* mainWindow() { return _mainWindow; }
 
     void load(const Poco::URI& fileURL = Poco::URI(), bool newFile = false, bool isStarterMode = false);
-    static WebView* createNewDocument(QWebEngineProfile* profile, const std::string& templateType, const std::string& templatePath = "");
+
+    // templatePath and basename can be empty strings and are optional.
+    static WebView* createNewDocument(QWebEngineProfile* profile, const std::string& templateType,
+                                      const std::string& templatePath, const std::string& baseName);
 
     static WebView* findOpenDocument(const Poco::URI& documentURI);
     static WebView* findStarterScreen();


### PR DESCRIPTION
<!-- Message of single commit: -->

fix(app:linux): handle the `basename` token in newdoc command

properly handle the previously ignored `basename` token in the newdoc command
introduced for CODA-W at patch 1f0d81dff2adffe99ddeac3b68cce89a643ec77b (with
Change-Id: Ib0e4a697b27540fda44a4ea888de524ea2f9d808)

Signed-off-by: Sarper Akdemir <sarper.akdemir@collabora.com>
Change-Id: I30a64f3161c4a96411b12e4e39db544b9dfc0b77