### PR TITLE
wsd: test: remove global test instance shortcuts

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -357,11 +357,6 @@ private:
 
     std::string getReason() const;
 
-    static UnitBase* get(UnitType type);
-
-    /// setup global instance for get() method
-    static void rememberInstance(UnitType type, UnitBase* instance);
-
     static void* DlHandle; ///< The handle to the unit-test .so.
     static char *UnitLibPath;
     static UnitBase** GlobalArray; ///< All the tests.


### PR DESCRIPTION
We don't really need the shortcuts and it's
simpler without them.

Change-Id: I42fc47f070d9b495f57455dc5004770b16024e24
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
