### PR TITLE
perf: optimize ruler update on scroll

### DIFF
--- a/browser/src/control/HRuler.ts
+++ b/browser/src/control/HRuler.ts
@@ -810,13 +810,7 @@ class HRuler extends Ruler {
 		}
 	}
 
-	_fixOffset() {
-		app.layoutingService.appendLayoutingTask(() => {
-			this._fixOffsetImpl();
-		});
-	}
-
-	_fixOffsetImpl() {
+	protected _fixOffsetImpl(): void {
 		if (!app.activeDocument || app.activeDocument.fileSize.x === 0) return;
 
 		const rulerOffset =

--- a/browser/src/control/Ruler.ts
+++ b/browser/src/control/Ruler.ts
@@ -154,6 +154,14 @@ abstract class Ruler {
 
 		if (showRuler) map.uiManager.showRuler();
 	}
+
+	public _fixOffset() {
+		app.layoutingService.appendLayoutingTask(() => {
+			this._fixOffsetImpl();
+		});
+	}
+
+	protected abstract _fixOffsetImpl(): void;
 }
 
 app.definitions.ruler = Ruler;

--- a/browser/src/control/VRuler.ts
+++ b/browser/src/control/VRuler.ts
@@ -402,13 +402,7 @@ class VRuler extends Ruler {
 		}
 	}
 
-	_fixOffset() {
-		app.layoutingService.appendLayoutingTask(() => {
-			this._fixOffsetImpl();
-		});
-	}
-
-	_fixOffsetImpl() {
+	protected _fixOffsetImpl(): void {
 		// in case of disabled ruler at docload or event like 'moveend' calculation of offset can be ignored
 		if (
 			!app.activeDocument ||


### PR DESCRIPTION
* Resolves: https://github.com/CollaboraOnline/online/issues/14283

Before:
<img width="853" height="795" alt="Screenshot From 2026-01-31 20-47-22" src="https://github.com/user-attachments/assets/ae2725d0-b183-4e99-8886-bed660fbdc55" />


After:
<img width="1216" height="785" alt="Screenshot From 2026-01-31 21-04-32" src="https://github.com/user-attachments/assets/45694004-0850-4a45-bd1b-816f40537f0b" />

(few smaller tasks - style recalculation happens at the end after all possible updates were made)

-----------------------------------------------

    perf: update ruler in layouting task #14283
    
    Fixes #14283
    
    - when we scroll, _moveEnd is called in panBy
    - it was doing synchronous call to check getBoundClientRect which
      causes style recalculation in the browser
    - make it a separate layouting task - ruler can be updated in idle,
      we don't expect it to be updated on every small scroll step