### PR TITLE
Fix(cypress): remove InsertSymbol dialog from buggy list

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
@@ -74,7 +74,6 @@ const buggyDialogs = [
     '.uno:OutlineBullet',
 
     // Below dialogs have tabindex=0 with empty alt tag
-    '.uno:InsertSymbol',
     '.uno:EditStyle?Param:string=Example&Family:short=1',
     '.uno:EditStyle?Param:string=Heading&Family:short=2',
     '.uno:FontDialog',


### PR DESCRIPTION
Change-Id: If41dd19a081c4a098323bed28ff99f71191fc74d


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

