### PR TITLE
cypress: remove EditStyle and TableDialog from buggy list

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
@@ -72,14 +72,7 @@ const buggyDialogs = [
     '.uno:HyperlinkDialog',
     '.uno:InsertFrame',
     '.uno:OutlineBullet',
-
-    // Below dialogs have tabindex=0 with empty alt tag
-    '.uno:EditStyle?Param:string=Example&Family:short=1',
-    '.uno:EditStyle?Param:string=Heading&Family:short=2',
-    '.uno:FontDialog',
     '.uno:PageDialog',
-    '.uno:ParagraphDialog',
-    '.uno:TableDialog',
 ];
 
 describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: false }, function () {


### PR DESCRIPTION
These dialogs had focusable images with empty alt attributes,

fixed by core commits:
https://gerrit.libreoffice.org/c/core/+/198547
https://gerrit.libreoffice.org/c/core/+/198548


Change-Id: I82fd36623079f91331bdf682acf43a4866393fec


* Resolves: # <!-- related github issue -->
* Target version: main
