### PR TITLE
CODA-Q: set property desktopFilename for the application

### DIFF
--- a/qt/coda-qt.cpp
+++ b/qt/coda-qt.cpp
@@ -1359,6 +1359,7 @@ int main(int argc, char** argv)
     // default application name
     QApplication::setApplicationName(APP_NAME);
     QApplication::setWindowIcon(QIcon::fromTheme("com.collaboraoffice.Office.startcenter"));
+    QApplication::instance()->setProperty("desktopFileName", "com.collaboraoffice.Office");
 
     QCommandLineParser argParser;
     argParser.setApplicationDescription("Collabora Office - Desktop Office Suite");


### PR DESCRIPTION
So that in Wayland, when launching the executable from the commandline it can have its icon set.


Change-Id: I246892f5a4c57e0f3c75ea45e42d047075136b2c


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

