### PR TITLE
ui: add overflow:hidden to hover buttons to prevent clipping

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -81,6 +81,7 @@
 	color: var(--color-text-darker);
 	border-radius: var(--border-radius);
 	background-color: var(--color-background-tabs-group);
+	overflow: hidden;
 }
 
 /* toolbuttons selected */


### PR DESCRIPTION
This prevents child elements color to spill out of its parent's border.

Change-Id: Idce0c85be2f4e6e1213b623e946f67196e5be576


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

Before:
<img width="133" height="90" alt="image" src="https://github.com/user-attachments/assets/258c6121-32ce-45ef-9ad9-cb9b83bdab6a" />

After:
<img width="133" height="90" alt="image" src="https://github.com/user-attachments/assets/34453950-d3a2-4dfb-ade2-b044c1a798f6" />

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

