### PR TITLE
present-to all: mark mark as not following on button press

### DIFF
--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -522,6 +522,7 @@ class SlideShowNavigator {
 		if (handler) {
 			aEvent.preventDefault();
 			aEvent.stopPropagation();
+			if (this.presenter.isFollower()) this.presenter.setFollowing(false);
 			handler();
 		}
 	}


### PR DESCRIPTION
when user navigates slide with keyboard
during slideshow mark them as not following if
they are follower

problem:
when follower navigated the slides with keyboard
they were not marked as unfollowed so that's why
"follow presenter" button would not work

Change-Id: I9ac443ab21244a4f42fd36cc71c7c41568bfd3de


* Target version: main



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

