### PR TITLE
Define ENABLE_DEBUG based on --enable-debug as 0 or 1 for CODA-W, too

### DIFF
--- a/common/Log-windows.cpp
+++ b/common/Log-windows.cpp
@@ -103,6 +103,8 @@ void setLevel(const std::string& logLevel)
     }
 }
 
+void setDisabledAreas(const std::string &areaStr) { }
+
 Level getLevel() { return level; }
 
 const std::string& getLevelName() { return levelName; }

--- a/configure.ac
+++ b/configure.ac
@@ -495,6 +495,7 @@ if test "$enable_debug" = "yes"; then
    AC_DEFINE([ENABLE_DEBUG],1,[Whether to compile in some extra debugging support code and disable some security pieces])
    AC_DEFINE([CONFIG_STATIC_TYPE],,[Static config values are disabled in debug builds to allow for overriding in tests])
    ENABLE_DEBUG=true
+   ENABLE_DEBUG_0_OR_1=1
    ENABLE_DEBUG_PROTOCOL=true
    COOLWSD_LOGLEVEL="trace"
    COOLWSD_LOG_TO_FILE="true"
@@ -534,11 +535,13 @@ if test "$enable_debug" = "yes"; then
       AC_MSG_RESULT([no (to enable --enable-logging-test-asserts)])
     fi
 else
+    ENABLE_DEBUG_0_OR_1=0
     AC_MSG_RESULT([no (Release build)])
     AC_DEFINE([ENABLE_DEBUG],0,[Whether to compile in some extra debugging support code and disable some security pieces])
     AC_DEFINE([CONFIG_STATIC_TYPE],static,[Static config values are enabled in release builds for performance])
 fi
 AC_SUBST(ENABLE_DEBUG)
+AC_SUBST(ENABLE_DEBUG_0_OR_1)
 AC_SUBST(ENABLE_BUNDLE)
 AC_SUBST(COOLWSD_LOGLEVEL)
 AC_DEFINE_UNQUOTED([COOLWSD_LOGLEVEL],["$COOLWSD_LOGLEVEL"],[Default coolwsd loglevel.])

--- a/windows/coda/config.h.in
+++ b/windows/coda/config.h.in
@@ -47,7 +47,7 @@
 
 /* Whether to compile in some extra debugging support code and disable some
    security pieces */
-#undef ENABLE_DEBUG
+#define ENABLE_DEBUG @ENABLE_DEBUG_0_OR_1@
 
 /* Whether to compile and enable feature locking */
 #undef ENABLE_FEATURE_LOCK
@@ -143,7 +143,7 @@
 #undef MACOS
 
 /* Makes config variables conditionally static, only in non-debug builds, to allow for overriding them in unit-tests. */
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG
 #define CONFIG_STATIC
 #else
 #define CONFIG_STATIC static


### PR DESCRIPTION
Previously we used to not define it at all.

As a consequence, have to add a dummy setDisabledAreas().

We still use a separate windows/coda/config.h for CODA-W but should probably start using just the one in the top level, like for CODA-M. But one step at a time.


Change-Id: I4c6aeee2cf303a1a3f073120fed77272dd802471


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

