### PR TITLE
cool#14299 redline render mode: change notebookbar button type to bigcustomtoolitem

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2319,7 +2319,7 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 					{
 						'id': 'compare-tracked-change',
 						'type': 'bigcustomtoolitem',
-						'text': _('Compare Changes'),
+						'text': _('View Changes'),
 						'command': 'comparechanges',
 						'accessibility': { focusBack: true, combination: 'CC' }
 					},
@@ -2411,7 +2411,7 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 					{
 						'id': 'review-compare:CompareDocumentsMenu',
 						'type': 'menubutton',
-						'text': _('Document Comparison'),
+						'text': _('Compare Documents'),
 						'command': '.uno:CompareDocuments',
 						'accessibility': { focusBack: true, combination: 'CD', de: null }
 					},


### PR DESCRIPTION
So that it doesn't leave the lower half of the vertical space empty,
next to the (redline) Show button.

Original suggestion was a bigtoolitem, but this has to dispatch a custom
JS action, so go with a bigcustomtoolitem instead.

Also change the label to Compare View, so it's more clear this is about
changing the view to a side-by-side diff, it's not about creating new
redlines by comparing two documents.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Iedb2c66c554f917c4248038618ef4f8505f2c90f
