### PR TITLE
Check ENABLE_DEBUG with #if, not #ifdef

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -149,7 +149,7 @@ public:
     /// Do we have a unit test library hooking things & loaded
     static bool isUnitTesting()
     {
-#ifdef ENABLE_DEBUG
+#if ENABLE_DEBUG
         return DlHandle;
 #else
         return false; // In non-debug builds unit-tests cannot be run. See test/run_unit.sh.


### PR DESCRIPTION
ENABLE_DEBUG is always defined in config.h, as 0 or 1. We use #if in all other places.


Change-Id: I1e1da848626de373fecd7f31fbf77b79a0e1907c


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

