### PR TITLE
cool#14299 redline render mode: change notebookbar button type to bigcustomtoolitem

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2318,11 +2318,9 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 					},
 					{
 						'id': 'compare-tracked-change',
-						'class': '',
-						'type': 'customtoolitem',
+						'type': 'bigcustomtoolitem',
 						'text': _('Compare Changes'),
 						'command': 'comparechanges',
-						'inlineLabel': true,
 						'accessibility': { focusBack: true, combination: 'CC' }
 					},
 					{
@@ -2413,9 +2411,9 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 					{
 						'id': 'review-compare:CompareDocumentsMenu',
 						'type': 'menubutton',
-						'text': _UNO('.uno:CompareDocuments', 'text'),
+						'text': _('Compare Documents'),
 						'command': '.uno:CompareDocuments',
-						'accessibility': { focusBack: true, combination: 'RO', de: null }
+						'accessibility': { focusBack: true, combination: 'CD', de: null }
 					},
 				]
 			},


### PR DESCRIPTION
So that it doesn't leave the lower half of the vertical space empty,
next to the (redline) Show button.

Original suggestion was a bigtoolitem, but this has to dispatch a custom
JS action, so go with a bigcustomtoolitem instead.

Also change the label of the Compare button to Compare Documents, so
it's more clear Compare Changes is about changing the view to a
side-by-side diff, and Compare Documents is about creating new redlines
by comparing two documents.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Iedb2c66c554f917c4248038618ef4f8505f2c90f
