### PR TITLE
restore .jsdialog-overlay click

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
@@ -71,6 +71,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test jumping on large cell
 		cy.cGet('#View-tab-label').click();
 		desktopHelper.getNbIconArrow('FreezePanes').click();
 		desktopHelper.getNbIcon('FreezePanes').last().click();
+		cy.cGet('.jsdialog-overlay').click(); // close popup
 
 		// Scroll down.
 		helper.typeIntoInputField(helper.addressInputSelector, 'Z110');


### PR DESCRIPTION
 `<input class="ui-combobox-content addressInput jsdialog" id="pos_window-input-address" role="combobox" autocomplete="off" aria-autocomplete="list" aria-expanded="false" aria-label="D7">`

 is being covered by another element:

 `<button class="ui-content unobutton selected" id="layout-freeze-panes264-button" aria-label="Freeze Rows and Columns" aria-pressed="true">...</button>`


Change-Id: Iff06f1c6e01de14c9f5c9c4f51db2cea92ec1690


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

