### PR TITLE
a11y: add support for aria role attribute

### DIFF
--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -442,6 +442,7 @@ interface CheckboxWidgetJSON extends WidgetJSON {
 interface AriaLabelAttributes {
 	label?: string;
 	description?: string;
+	role?: string;
 }
 
 interface SeparatorWidgetJSON extends WidgetJSON {

--- a/browser/src/control/jsdialog/Widget.Containers.ts
+++ b/browser/src/control/jsdialog/Widget.Containers.ts
@@ -161,6 +161,10 @@ JSDialog.toolbox = function (
 		}
 	}
 
+	if (data.aria?.role) {
+		toolbox.setAttribute('role', data.aria.role);
+	}
+	
 	const enabledCallback = function (enable: boolean) {
 		for (const j in data.children) {
 			const childId = data.children[j].id;


### PR DESCRIPTION
Add a "role" property to HTML to allow accessibility roles (e.g., "group") from JSON received from core.

This was discovered while improving accessibility for Sidebar -> Paragraph -> Indent, where groups require role="group".


Change-Id: I08fd14ebfc9866c375e75222ceb74445a304b2fc


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

