### PR TITLE
Enable automated test of CODA

### DIFF
--- a/windows/coda/CODA/CODA.vcxproj.user
+++ b/windows/coda/CODA/CODA.vcxproj.user
@@ -4,4 +4,10 @@
     <LocalDebuggerDebuggerType>NativeOnly</LocalDebuggerDebuggerType>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <LocalDebuggerCommandArguments>
+    </LocalDebuggerCommandArguments>
+    <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerEnvironment>CODA_ENABLE_WEBDRIVER=1</LocalDebuggerEnvironment>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Use the --remote-debugging-port=9222 option for the WebView2 when the CODA_ENABLE_WEBDRIVER environment variable exists.

Will need to use a separate port for each WebView2 created. Later.

This is just a very small commit; obviously the actual testing will be much more, in another program that uses Selenium and the Edge WebDriver and connects to that debugging port.


Change-Id: I095e9c2ee4340232b9dd3f071f95f9973d159c90


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

