### PR TITLE
calc: Add themes widget and “Add Theme” button to Notebookbar

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -2879,12 +2879,25 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 			},
 			{ type: 'separator', id: 'format-sparkline-break', orientation: 'vertical' },
 			{
-				'id': 'format-theme-dialog',
+				'id': 'themes-group',
+				'type': 'overflowgroup',
+				'name': _('Themes'),
+				'nofold': true,
+				'icon': 'lc_themesthames.svg',
+				'children': [
+					{
+						'id': 'iconview_theme_colors', // has to match core id
+						'type': 'iconview'
+					}
+				]
+			},
+			{
+				'id': 'add-theme-dialog',
 				'type': 'bigtoolitem',
-				'text': _UNO('.uno:ThemeDialog'),
-				'command': '.uno:ThemeDialog',
-				'accessibility': { focusBack: false, combination: 'J', de: null }
-			}
+				'text': _UNO('.uno:AddTheme'),
+				'command': '.uno:AddTheme',
+				'accessibility': { focusBack: false, combination: 'AT', de: null }
+			},
 		];
 
 		return this.getTabPage('Format', content);


### PR DESCRIPTION
Change-Id: I3233c35a915808b4ed707ba64cab93f17f8df14a


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
- Switch from the theme dialog to an icon view themes widget in the Notebookbar.
- Added new "Add theme" bigtoolitem button


### PREVIEW
<img width="596" height="115" alt="2026-02-04_02-52" src="https://github.com/user-attachments/assets/b0c6288c-18a8-4d5f-9777-96656479f468" />


### CORE CHANGES
Widget: https://gerrit.libreoffice.org/c/core/+/198631
Add Theme: https://gerrit.libreoffice.org/c/core/+/198611

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

