### PR TITLE
Remove Compare overflowgroup and reorder menu entries

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2403,19 +2403,11 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 			},
 			{ type: 'separator', id: 'review-accepttrackedchanges-break', orientation: 'vertical' },
 			hideChangeTrackingControls ? {} : {
-				'type': 'overflowgroup',
-				'id': 'review-compare',
-				'name':_('Compare'),
-				'accessibility': { focusBack: false, combination: 'RC', de: null },
-				'children' : [
-					{
-						'id': 'review-compare:CompareDocumentsMenu',
-						'type': 'menubutton',
-						'text': _('Compare Documents'),
-						'command': '.uno:CompareDocuments',
-						'accessibility': { focusBack: true, combination: 'CD', de: null }
-					},
-				]
+				'id': 'review-compare:CompareDocumentsMenu',
+				'type': 'menubutton',
+				'text': _UNO('.uno:CompareDocuments', 'text'),
+				'command': '.uno:CompareDocuments',
+				'accessibility': { focusBack: true, combination: 'RO', de: null }
 			},
 			hideChangeTrackingControls ? {} : { type: 'separator', id: 'review-compare-break', orientation: 'vertical' },
 			{

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -221,7 +221,7 @@ window.L.Map.WOPI = window.L.Handler.extend({
 			/* Separate, because needs explicit integration support */
 			menuEntriesMultimedia.push({action: 'remotemultimedia', text: _UNO('.uno:InsertAVMedia', '', true)});
 
-			menuEntriesCompare.push({action: 'remotecomparedocuments', text: _('Compare Document...')});
+			menuEntriesCompare.unshift({action: 'remotecomparedocuments', text: _('Compare Document...')});
 		}
 
 		this._insertImageMenuSetupDone = true;


### PR DESCRIPTION
Change-Id: I9ac61b7d15a815667c2e74e3b5532e55aa67b025


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
- Remove unnecessary overflowgroup from 'review-compare' button
- Move 'Compare Document...' to first position in the entries

### PREVIEW
<img width="234" height="165" alt="2026-02-04_05-13" src="https://github.com/user-attachments/assets/b575f676-0549-419b-b10a-d612fe264ace" />


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

