### PR TITLE
cool#14299 browser: update unocommands.js

### DIFF
--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -121,6 +121,7 @@ var unoCommandsArray = {
 	'CommonAlignRight':{global:{menu:_('Right'),},},
 	'CommonAlignTop':{global:{menu:_('Top'),},},
 	'CommonAlignVerticalCenter':{global:{menu:_('Center'),},},
+	'CompareDocuments':{global:{context:_('Compare Non-Track Changed Document'),menu:_('Compare'),},},
 	'CompressGraphic':{global:{menu:_('Co~mpress...'),},presentation:{menu:_('Co~mpress...'),},},
 	'CondDateFormatDialog':{spreadsheet:{menu:_('Date...'),},},
 	'ConditionalFormatManagerDialog':{spreadsheet:{menu:_('Manage...'),},},


### PR DESCRIPTION
Otherwise the build fails with:

	ERROR: The following commands are not covered in unocommands.js, run scripts/unocommands.py --update:
	.uno:CompareDocuments
	make[4]: *** [Makefile:1608: /home/vmiklos/git/collaboraonline/online-clang/browser/debug/cool-src.js] Error 1

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I831fbffb45146a7618b07c8eb47f6feb72f40927
