### PR TITLE
fix: mention doesn't work when inserted at the start of the comment

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -1741,14 +1741,41 @@ export class Comment extends CanvasSectionObject {
 
 	public autoCompleteMention(username: string, profileLink: string, replacement: string): void {
 		const selection = window.getSelection();
-		if (!selection.rangeCount) return;
+		if (!selection)
+			return;
 
-		const range = selection.getRangeAt(0);
+		const editorElement = this.getActiveEditorElement();
+		let range: Range | null = null;
+		if (selection.rangeCount) {
+			const candidateRange = selection.getRangeAt(0);
+			if (
+				!editorElement ||
+				editorElement.contains(candidateRange.startContainer)
+			)
+				range = candidateRange;
+		}
+		const container = range ? range.startContainer : null;
+		let textNode: Text | null = null;
+		let cursorPosition = range ? range.endOffset : 0;
 
-		const cursorPosition = range.endOffset;
-		const container = range.startContainer;
+		if (container && container.nodeType === Node.TEXT_NODE) {
+			textNode = container as Text;
+		} else if (!range) {
+			if (!editorElement) return;
+			const walker = document.createTreeWalker(
+				editorElement,
+				NodeFilter.SHOW_TEXT,
+				null,
+			);
+			textNode = walker.nextNode() as Text | null;
+			if (!textNode) {
+				textNode = document.createTextNode('');
+				editorElement.appendChild(textNode);
+			}
+			cursorPosition = textNode.textContent?.length ?? 0;
+		}
 
-		const containerText = container.textContent || '';
+		const containerText = textNode?.textContent || container?.textContent || editorElement?.textContent || '';
 		const mentionStart = containerText.lastIndexOf(replacement, cursorPosition);
 
 		if (mentionStart !== -1) {
@@ -1761,8 +1788,12 @@ export class Comment extends CanvasSectionObject {
 			hyperlink.href = profileLink;
 			hyperlink.textContent = `@${username}`;
 
-			container.textContent = beforeMention;
-			container.parentNode?.insertBefore(hyperlink, container.nextSibling);
+			if (!textNode || !textNode.parentNode) {
+				return;
+			}
+
+			textNode.textContent = beforeMention;
+			textNode.parentNode?.insertBefore(hyperlink, textNode.nextSibling);
 
 			const afterTextNode = document.createTextNode(afterMention);
 			const extraSpaceNode = document.createTextNode('\u00A0');
@@ -1776,6 +1807,33 @@ export class Comment extends CanvasSectionObject {
 			selection.removeAllRanges();
 			selection.addRange(newRange);
 		}
+	}
+
+	private getActiveEditorElement(): HTMLElement | null {
+		if ((<any>window).mode.isMobile()) {
+			const commentSection = app.sectionContainer.getSectionWithName(
+				app.CSections.CommentList.name,
+			);
+			const isMobileCommentActive = commentSection?.isMobileCommentActive();
+			if (!isMobileCommentActive) return null;
+			const mobileCommentModalId = commentSection?.getMobileCommentModalId();
+			return document.getElementById(mobileCommentModalId);
+		}
+		if (
+			this.sectionProperties.nodeModify &&
+			this.sectionProperties.nodeModify.style.display !== 'none'
+		)
+			return this.sectionProperties.nodeModifyText;
+		if (
+			this.sectionProperties.nodeReply &&
+			this.sectionProperties.nodeReply.style.display !== 'none'
+		)
+			return this.sectionProperties.nodeReplyText;
+		return (
+			this.sectionProperties.nodeModifyText ||
+			this.sectionProperties.nodeReplyText ||
+			null
+		);
 	}
 }
 


### PR DESCRIPTION
In Webkit, sometimes due to some sort of race condition the range is
null for selection or range points to treeview popup element.

Only set range variable when range.startContainer contains the editor element.
If range is null, we get the active editor and find the TEXT_NODE manually.

Steps to reproduce in WebKit browser:
1. Open writer document
2. Insert comment
3. Start typing mention and insert mention
4. Notice mention is not inserted and cursor moves to start position

I tested with epiphany. It is not always reproducible, on about 10 tries
I was able to reproduce it once or twice.

Change-Id: I83965c56c3f8420a673be254dcbf12f4c90c5503

* Target version: main

