### PR TITLE
add "filename" argument for "Download_As" postmessage

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1549,7 +1549,7 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 
 		this._map.hideBusy();
 		if (this._map['wopi'].DownloadAsPostMessage) {
-			this._map.fire('postMessage', {msgId: 'Download_As', args: {Type: command.id, URL: url}});
+			this._map.fire('postMessage', {msgId: 'Download_As', args: {Type: command.id, URL: url, filename: command.filename}});
 		}
 		else if (command.id === 'print') {
 			if (this._map.options.print === false || window.L.Browser.cypressTest) {

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1417,7 +1417,8 @@ bool ChildSession::downloadAs(const StringVector& tokens)
     const std::string tmpDir = FileUtil::createRandomDir(jailDoc);
     const std::string urlToSend = tmpDir + '/' + filenameParam.getFileName();
     const std::string url = jailDoc + urlToSend;
-    const std::string urlAnonym = jailDoc + tmpDir + '/' + Poco::Path(nameAnonym).getFileName();
+    const std::string filename = Poco::Path(nameAnonym).getFileName();
+    const std::string urlAnonym = jailDoc + tmpDir + '/' + filename;
 
     LOG_DBG("Calling LOK's saveAs with URL: ["
             << urlAnonym << "], Format: [" << (format.empty() ? "(nullptr)" : format.c_str())
@@ -1441,8 +1442,8 @@ bool ChildSession::downloadAs(const StringVector& tokens)
     _docManager->sendFrame(docBrokerMessage.c_str(), docBrokerMessage.length());
 
     // Send download id to the client
-    sendTextFrame("downloadas: downloadid=" + tmpDir +
-                  " port=" + std::to_string(ClientPortNumber) + " id=" + id);
+    sendTextFrame("downloadas: downloadid=" + tmpDir + " port=" + std::to_string(ClientPortNumber) +
+                  " id=" + id + " filename=" + filename);
 #endif
     return true;
 }

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -560,7 +560,7 @@ contextmenu: <json description of the context menu>
             ]
         }
 
-downloadas: jail=<jail directory> dir=<a tmp dir> name=<name> port=<port>
+downloadas: jail=<jail directory> dir=<a tmp dir> name=<name> port=<port> filename=<filename>
 
     The client should then request http://server:port/jail/dir/name in order to download
     the document


### PR DESCRIPTION
We do pass filename as part of "Content-Disposion" response header but according to integrators it would require a custom downloader. This will help on integrator's android app to create file with correct extension

Change-Id: I703538c3b2ac1ac2c360616f1668351baac21735