### PR TITLE
browser: a11y: add custom-label and custom-label-for properties

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2598,6 +2598,15 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			var isContainer = this.isContainerType(childData.type);
 			if (hasManyChildren && isContainer) {
 				var table = window.L.DomUtil.createWithId('div', childData.id, containerToInsert);
+
+				if (childData.cargo && childData.cargo['custom-label']) {
+					var label = window.L.DomUtil.create('label', '', table);
+					label.textContent = childData.cargo['custom-label'];
+					label.htmlFor = childData.cargo['custom-label-for'] + '-input';
+					table.id = '';
+					table = window.L.DomUtil.createWithId('div', childData.id, table);
+				}
+
 				$(table).addClass(this.options.cssClass);
 
 				if (!isVertical) {


### PR DESCRIPTION
Slightly adjust the container to add a label without
affecting the current layout.

Change-Id: I2f38c9b21167a517f0dbd1a3cab8be0d7639890e
Signed-off-by: Henry Castro <hcastro@collabora.com>
