### PR TITLE
browser: a11y: change color picker to 24×24 size

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1927,8 +1927,8 @@ button.menubutton.sidebar > span {
 .ui-color-picker-entry {
 	border: 1px solid transparent;
 	cursor: pointer;
-	width: 16px;
-	height: 16px;
+	width: 24px;
+	height: 24px;
 	appearance: none;
 	webkit-appearance: none;
 	margin: 0;
@@ -2994,7 +2994,7 @@ kbd,
 
 /* Listbox UI grid */
 .jsdialog.ui-grid[role='listbox']:not(:has(> .ui-iconview)) {
-	max-height: min(470px, 45vh);
+	max-height: 99vh;
 }
 
 .jsdialog.ui-grid[role='listbox'] {


### PR DESCRIPTION
Change-Id: Ide38a0260739b5a52b389dde4be83a0099ea5752
Signed-off-by: Henry Castro <hcastro@collabora.com>
