### PR TITLE
Tabbed view: Fix small savemodified icon

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -167,7 +167,7 @@ html:not([data-theme='dark']) .unoSave.savemodified .unobutton img {
 	background: url('images/lc_savemodified.svg') no-repeat center;
 }
 
-html:not([data-theme='dark']) .savemodified.unotoolbutton .unobutton img {
+html:not([data-theme='dark']) .savemodified.unotoolbutton:not(.notebookbar) .unobutton img {
 	background: url('images/compact_savemodified.svg') no-repeat center;
 }
 
@@ -175,7 +175,7 @@ html[data-theme='dark'] .unoSave.savemodified .unobutton img {
 	background: url('images/dark/lc_savemodified.svg') no-repeat center;
 }
 
-html[data-theme='dark'] .savemodified.unotoolbutton .unobutton img {
+html[data-theme='dark'] .savemodified.unotoolbutton:not(.notebookbar) .unobutton img {
 	background: url('images/dark/compact_savemodified.svg') no-repeat center;
 }
 


### PR DESCRIPTION
Make sure that we only target the compact view when setting the
compact savemodified icon.

Regression started on:
- 824c3c02478e96300adc358b27720a208a125654
- from https://github.com/CollaboraOnline/online/pull/14242

Ideally we would refactor where we set these icons,
historically we have some in notebookbar.css and some in the
menubar.css. But that is out of the scope of this commit.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I0573b6f4ea750c0f7300ebee6711c80a679c8507
