### PR TITLE
uimanager: Properly return the item was found

### DIFF
--- a/browser/src/control/Control.NotebookbarBase.ts
+++ b/browser/src/control/Control.NotebookbarBase.ts
@@ -116,8 +116,8 @@ class NotebookbarBase extends JSDialogComponent {
 		this.impl?.reloadShortcutsBar();
 	}
 
-	public showNotebookbarCommand(commandId: string, show: boolean) {
-		this.impl?.showNotebookbarCommand(commandId, show);
+	public showNotebookbarCommand(commandId: string, show: boolean): boolean {
+		return this.impl?.showNotebookbarCommand(commandId, show);
 	}
 
 	// tabs

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1129,13 +1129,21 @@ class UIManager extends window.L.Control {
 
 		var found = false;
 		if (this.getCurrentMode() === 'classic') {
-			found ||= this.showCommandInClassicToolbar(command, show);
-			found ||= this.showCommandInMenubar(command, show);
+			if (this.showCommandInClassicToolbar(command, show)) {
+				found = true;
+			}
+			if (this.showCommandInMenubar(command, show)) {
+				found = true;
+			}
 		}
 
 		if (this.notebookbar) {
-			if (this.getCurrentMode() === 'notebookbar') this.notebookbar.reloadShortcutsBar();
-			found ||= this.notebookbar.showNotebookbarCommand(command, show);
+			if (this.getCurrentMode() === 'notebookbar') {
+				this.notebookbar.reloadShortcutsBar();
+			}
+			if (this.notebookbar.showNotebookbarCommand(command, show)) {
+				found = true;
+			}
 		}
 
 		if (!found)


### PR DESCRIPTION
We were getting an error that the command wasn't found when it was: showNotebookbarCommand() should return a boolean like the impl

Also:
When converting to typescript. 'found |= something()' was converted to 'found ||= something()' because TypeScript complained which in turn transpile to 'found || (found = something())' which make something not being called if found is already true. This would made this.showCommandInMenubar() i not being called.


Change-Id: I03016f86df847b310609282706c2610d7a72d4d3


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

