### PR TITLE
ServerConnectionService: be ready for initializedui earlier

### DIFF
--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -56,14 +56,25 @@ window.L.Map.WOPI = window.L.Handler.extend({
 	_appLoaded: false,
 	_insertImageMenuSetupDone: false,
 
-	initialize: function(map) {
-		this._map = map;
-
-		// init message handlers should be available as soon as possible
+	postLoadEnable: function() {
 		this._map.on('docloaded', this._postLoaded, this);
-		app.events.on('updatepermission', this._postLoaded.bind(this));
+		app.events.on('updatepermission', this._postLoadedBound);
 		this._map.on('viewinfo', this._postLoaded, this);
 		this._map.on('initializedui', this._postLoaded, this);
+	},
+
+	postLoadDisable: function() {
+		this._map.off('docloaded', this._postLoaded, this);
+		app.events.off('updatepermission', this._postLoadedBound);
+		this._map.off('viewinfo', this._postLoaded, this);
+		this._map.off('initializedui', this._postLoaded, this);
+	},
+
+	initialize: function(map) {
+		this._map = map;
+		this._postLoadedBound = this._postLoaded.bind(this);
+		// init messages handlers should be available as soon as possible
+		this.postLoadEnable();
 	},
 
 	addHooks: function() {
@@ -106,9 +117,7 @@ window.L.Map.WOPI = window.L.Handler.extend({
 	removeHooks: function() {
 		this._map.off('postMessage', this._postMessage, this);
 
-		// init messages
-		this._map.off('docloaded', this._postLoaded, this);
-		this._map.off('viewinfo', this._postLoaded, this);
+		this.postLoadDisable();
 
 		this._map.off('wopiprops', this._setWopiProps, this);
 		window.L.DomEvent.off(window, 'message', this._postMessageListener, this);


### PR DESCRIPTION
- when we finish initializeSpecializdUI in UIManager we send a signal "initializedui"
- that is received by Map.WOPI and marked as done
- Map.WOPI has vector of conditions which - when all are fullfiled - trigger later ui initialization
- it seems that we didn't get all conditions done in some cases
- the symptoms are that style previews are missing
- this is a blind fix, be sure we listen for all the signals early


I noticed we have a lot of:
`PostMessage: _postLoaded - viewinfo global.js:1:15661`
on user join/close session, which shoudn't appear after all is done