### PR TITLE
chore(helm): use entire image repository URL for best practices

### DIFF
--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -4,7 +4,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: collabora/code
+  repository: docker.io/collabora/code
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

It is best practices to specify the entire URL fo the image repository even if `docker.io` is emplied. 

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

