### PR TITLE
Override automake's default ARFLAGS to silence 'u' modifier warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,11 @@ LT_INIT([shared, disable-static, dlopen])
 
 AM_INIT_AUTOMAKE([1.10 foreign subdir-objects tar-pax -Wno-portability])
 
+# Drop the 'u' from automake's default 'cru' to silence the warning:
+# "ar: `u' modifier ignored since `D' is the default (see `U')"
+# Don't use 'crD' as the 'D' flag is GNU-specific and unsupported on macOS/FreeBSD.
+AC_SUBST([ARFLAGS], [cr])
+
 AC_CONFIG_MACRO_DIR([m4])
 
 # We don't want to require pkg-config and PKG_CHECK_MODULES on macOS


### PR DESCRIPTION
Automake 1.16 hardcodes ARFLAGS=cru, but modern GNU ar defaults to deterministic mode (D), making the 'u' modifier meaningless and producing a warning. Use AC_SUBST to override with 'cr', which is portable across Linux, macOS, and FreeBSD.


Change-Id: Ie756786d607f1b9dda371ddf1d27074ef0e3ecc9

