### PR TITLE
Fix build: test/ missing CommandControl.cpp

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -189,6 +189,7 @@ common_sources = \
 	../net/Socket.cpp \
 	../net/NetUtil.cpp \
 	../wsd/Auth.cpp \
+	../common/CommandControl.cpp \
 	../wsd/HostUtil.cpp
 
 globals_sources = ../common/Globals.cpp


### PR DESCRIPTION
happens in my clang build after 0ac620bc50bfce11cb25a598eb829905ff966a03

online/test/../wsd/HostUtil.cpp:147:(.text+0x1929): undefined reference to `CommandControl::LockManager::unlockLinkMap[abi:cxx11]'
