### PR TITLE
Compact view: Set again save and print compact icons

### DIFF
--- a/browser/src/control/Control.TopToolbar.js
+++ b/browser/src/control/Control.TopToolbar.js
@@ -102,11 +102,11 @@ class TopToolbar extends JSDialog.Toolbar {
 	getToolItems() {
 		var saveGroup = [
 			{type: 'customtoolitem',  id: 'closemobile', desktop: false, mobile: false, tablet: true, visible: false},
-			{type: 'customtoolitem',  id: 'save', command: 'save', text: _UNO('.uno:Save'), lockUno: '.uno:Save'},
+			{type: 'customtoolitem',  id: 'save', command: 'save', text: _UNO('.uno:Save'), lockUno: '.uno:Save', icon: 'compact_save.svg'},
 		];
 		var printGroup = [
-			{type: 'customtoolitem',  id: 'print', command: 'print', text: _UNO('.uno:Print'), mobile: false, tablet: false, lockUno: '.uno:Print'},
-			{type: 'menubutton',  id: 'printoptions',  command: 'printoptions', noLabel: true, text: _UNO('.uno:Print', 'text'), mobile: false, tablet: false, lockUno: '.uno:Print',
+			{type: 'customtoolitem',  id: 'print', command: 'print', text: _UNO('.uno:Print'), mobile: false, tablet: false, lockUno: '.uno:Print', icon: 'compact_print.svg'},
+			{type: 'menubutton',  id: 'printoptions',  command: 'printoptions', noLabel: true, text: _UNO('.uno:Print', 'text'), mobile: false, tablet: false, lockUno: '.uno:Print', icon: 'compact_print.svg',
 				menu: [
 					{id: 'print-active-sheet', action: 'print-active-sheet', text: _('Active Sheet')},
 					{id: 'print-all-sheets', action: 'print-all-sheets', text: _('All Sheets')},


### PR DESCRIPTION
It seems someone rebased my PR:
https://github.com/CollaboraOnline/online/pull/14141
and solved the conflicts my removing the icon: compact_save.svg and
icon: compact_print.svg that was added previously in
https://github.com/CollaboraOnline/online/pull/14277

Add those changes back.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Iba629bc3acd96f9fd16a6d3d8bef8bc08f758f8e
