### PR TITLE
enhancement: make document movements smooth when making space for comments

### DIFF
--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -417,6 +417,9 @@ window.L.Map = window.L.Evented.extend({
 		if (!offset.x && !offset.y)
 			return this;
 
+		if (this._docLayer && this._docLayer._docType === 'text' && offset.x != 0)
+			offset.x += (app.activeDocument.activeLayout).getDocumentScrollOffset();
+
 		//If we pan too far then chrome gets issues with tiles
 		// and makes them disappear or appear in the wrong place (slightly offset) #2602
 		if (!this.getSize().contains(offset)) {


### PR DESCRIPTION
Previously `documentZoomOrResizeCallback` was added in `ViewLayoutWriter` and was used as a callback to zoom and resize events where we scrolled off the document to the left to make some space for the comments on the right. Before this, there was canvas code which would recenter the document on zoom/resize.

When the user resized the window, these two approaches clashed with each other and the document would be centered & then moved left & then centered & then moved left... It would dance in the center as the user changed the window size.

It was also hard to coordinate between events like if the user zooms in/out, ideally we would want to calculate the document scroll offset after the zoom calculations are done, but with the old scroll mechanism that wasn't possible since everything was done via "layouting tasks".

Now we add the `documentScrollOffset` to the code which recentered the document. So all the calculations happen in one place at once and we don't move the document around to make it flicker.


Change-Id: Ic0753cec4685c92e10dfacd95a05ba7f7c3b5b32


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

