### PR TITLE
processToIdle before counting slide previews

### DIFF
--- a/cypress_test/integration_tests/common/impress_helper.js
+++ b/cypress_test/integration_tests/common/impress_helper.js
@@ -55,13 +55,15 @@ function typeTextAndVerify(text, expected, copy) {
 // We use the number of slide previews as indicators.
 // Parameters:
 // slides - number of expected slides
-function assertNumberOfSlidePreviews(slides) {
-	cy.log('>> assertNumberOfSlidePreviews - start');
+function assertSlidePreviewCountAfterIdle(win, slides) {
+	cy.log('>> assertSlidePreviewCountAfterIdle - start');
 
+	helper.processToIdle(win);
+	// +1 to account for #first-drop-site which also has the .preview-frame class
 	cy.cGet('#slide-sorter .preview-frame')
 		.should('have.length', slides + 1);
 
-	cy.log('<< assertNumberOfSlidePreviews - end');
+	cy.log('<< assertSlidePreviewCountAfterIdle - end');
 }
 
 // Trigger mouse click on center of the screen
@@ -240,7 +242,7 @@ function changeSlide(changeNum,direction) {
 module.exports.assertNotInTextEditMode = assertNotInTextEditMode;
 module.exports.assertInTextEditMode = assertInTextEditMode;
 module.exports.typeTextAndVerify = typeTextAndVerify;
-module.exports.assertNumberOfSlidePreviews = assertNumberOfSlidePreviews;
+module.exports.assertSlidePreviewCountAfterIdle = assertSlidePreviewCountAfterIdle;
 module.exports.clickCenterOfSlide = clickCenterOfSlide;
 module.exports.selectTextShapeInTheCenter = selectTextShapeInTheCenter;
 module.exports.triggerNewSVGForShapeInTheCenter = triggerNewSVGForShapeInTheCenter;

--- a/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/slide_operations_spec.js
@@ -18,14 +18,14 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', functio
 	it('Add slides', function() {
 		cy.cGet('#presentation-toolbar #insertpage').click();
 
-		impressHelper.assertNumberOfSlidePreviews(2);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 2);
 	});
 
 	it('Remove slides', function() {
 		// Add slides
 		cy.cGet('#presentation-toolbar #insertpage').click();
 
-		impressHelper.assertNumberOfSlidePreviews(2);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 2);
 
 		// Remove Slides
 		cy.cGet('#presentation-toolbar #deletepage')
@@ -39,7 +39,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', functio
 		cy.cGet('#presentation-toolbar #deletepage')
 			.should('have.attr', 'disabled')
 
-		impressHelper.assertNumberOfSlidePreviews(1);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 1);
 
 	});
 
@@ -74,7 +74,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide operations', functio
 		cy.cGet('#Insert-tab-label').click();
 		desktopHelper.getNbIcon('DuplicatePage', 'Insert').click();
 
-		impressHelper.assertNumberOfSlidePreviews(2);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 2);
 		cy.cGet('#SlideStatus').should('have.text', 'Slide 2 of 2');
 		cy.cGet('[id^=annotation-content-area-]').should('include.text', 'some text0');
 

--- a/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/hamburger_menu_spec.js
@@ -13,6 +13,9 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 
 		// Click on edit button
 		mobileHelper.enableEditingMobile();
+		cy.getFrameWindow().then((win) => {
+			this.win = win;
+		});
 	});
 
 	it('Save', { defaultCommandTimeout: 60000 }, function() {
@@ -212,27 +215,27 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 	});
 
 	it('Slide: New Slide.', function() {
-		impressHelper.assertNumberOfSlidePreviews(1);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 1);
 
 		mobileHelper.selectHamburgerMenuItem(['Slide', 'New Slide']);
 
-		impressHelper.assertNumberOfSlidePreviews(2);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 2);
 	});
 
 	it('Slide: Duplicate Slide.', function() {
-		impressHelper.assertNumberOfSlidePreviews(1);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 1);
 
 		mobileHelper.selectHamburgerMenuItem(['Slide', 'Duplicate Slide']);
 
-		impressHelper.assertNumberOfSlidePreviews(2);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 2);
 	});
 
 	it('Slide: Delete Slide.', function() {
-		impressHelper.assertNumberOfSlidePreviews(1);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 1);
 
 		mobileHelper.selectHamburgerMenuItem(['Slide', 'New Slide']);
 
-		impressHelper.assertNumberOfSlidePreviews(2);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 2);
 
 		mobileHelper.selectHamburgerMenuItem(['Slide', 'Delete Slide']);
 
@@ -240,7 +243,7 @@ describe.skip(['tagmobile'], 'Trigger hamburger menu options.', function() {
 		cy.cGet('#deleteslide-modal-response').click();
 		cy.cGet('#mobile-wizard-content-modal-dialog-deleteslide-modal').should('not.exist');
 
-		impressHelper.assertNumberOfSlidePreviews(1);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 1);
 	});
 
 	it('Full Screen.', function() {

--- a/cypress_test/integration_tests/mobile/impress/insertion_wizard_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/insertion_wizard_spec.js
@@ -10,6 +10,9 @@ describe(['tagmobile', 'tagnextcloud'], 'Impress insertion wizard.', function() 
 		helper.setupAndLoadDocument('impress/insertion_wizard.odp');
 
 		mobileHelper.enableEditingMobile();
+		cy.getFrameWindow().then((win) => {
+			this.win = win;
+		});
 	});
 
 	function selectionShouldBeTextShape(checkShape) {
@@ -370,10 +373,10 @@ describe(['tagmobile', 'tagnextcloud'], 'Impress insertion wizard.', function() 
 	});
 
 	it('Insert new slide with plus button.', function() {
-		impressHelper.assertNumberOfSlidePreviews(1);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 1);
 		cy.cGet('body').contains('.leaflet-control-zoom-in', '+').should('be.visible');
 		cy.cGet('body').contains('.leaflet-control-zoom-in', '+').click();
-		impressHelper.assertNumberOfSlidePreviews(2);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 2);
 		if (Cypress.env('INTEGRATION') !== 'nextcloud') {
 			cy.cGet('#toolbar-mobile-back').click();
 			cy.cGet('.leaflet-control-zoom-in').should('not.exist');

--- a/cypress_test/integration_tests/mobile/impress/slide_operation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/slide_operation_spec.js
@@ -10,24 +10,27 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Slide operations', function
 		helper.setupAndLoadDocument('impress/slide_operations.odp');
 
 		mobileHelper.enableEditingMobile();
+		cy.getFrameWindow().then((win) => {
+			this.win = win;
+		});
 	});
 
 	it('Add slides', function() {
 		cy.cGet('.leaflet-control-zoom-in').click();
 
-		impressHelper.assertNumberOfSlidePreviews(2);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 2);
 	});
 
 	it('Remove Slides', function() {
 		//add slides
 		cy.cGet('.leaflet-control-zoom-in').click();
-		impressHelper.assertNumberOfSlidePreviews(2);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 2);
 		//remove slides
 		mobileHelper.openHamburgerMenu();
 		cy.cGet('.menu-entry-icon.slidemenu').parent().click();
 		cy.cGet('.menu-entry-icon.deletepage').parent().click();
 		cy.cGet('#deleteslide-modal-response').click();
-		impressHelper.assertNumberOfSlidePreviews(1);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 1);
 	});
 
 	it('Duplicate Slide', function() {
@@ -36,7 +39,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Slide operations', function
 		cy.cGet('.menu-entry-icon.slidemenu').parent().click();
 		cy.cGet('.menu-entry-icon.duplicatepage').parent().click();
 
-		impressHelper.assertNumberOfSlidePreviews(2);
+		impressHelper.assertSlidePreviewCountAfterIdle(this.win, 2);
 	});
 
 });


### PR DESCRIPTION
rename assertNumberOfSlidePreviews to assertSlidePreviewCountAfterIdle and always do it there.

cy:command ✔  click
    cy:log ✱  >> assertNumberOfSlidePreviews - start
cy:command ✔  cGet    #slide-sorter .preview-frame
cy:command ✘  assert    expected **[ <div#first-drop-site.preview-frame.preview-frame-landscape>, 1 more... ]** to have a length of **3** but got **2**
cy:command ✔  fail:
              Test failed: integration_tests/desktop/impress/slide_operations_spec.js / Slide operations / Remove slides

              Timed out retrying after 10000ms: Not enough elements found. Found '2', expected '3'.

              /home/collabora/jenkins/workspace/github_online_master_debug_vs_co-25.04_cypress_desktop/cypress_test/integration_tests/common/impress_helper.js:45:10
                43 |     cy.log('>> assertNumberOfSlidePreviews - start');
                44 |     cy.cGet('#slide-sorter .preview-frame')
              > 45 |         .should('have.length', slides + 1);
                   |          ^
                46 |     cy.log('<< assertNumberOfSlidePreviews - end');
                47 | }
                48 | // Trigger mouse click on center of the screen
  cons:log ✱  ==== debug.html receiveMessage: {"MessageId":"Doc_ModifiedStatus","SendTime":1770383478244,"Values":{"Modified":true}}
    cy:log ✱  Finishing test: integration_tests/desktop/impress/slide_operations_spec.js / Slide operations / Remove slides


Change-Id: I35fa01e768a911e29af7cbef615a2241686bc5e4


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

