### PR TITLE
(app:linux) better locate Qt execs and lib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1595,20 +1595,49 @@ AS_IF([test "$ENABLE_WINDOWSAPP" != "true"],
 
 dnl config for qtapp frontend for cool
 AS_IF([test "$ENABLE_QTAPP" = true],
-      [PKG_CHECK_MODULES([QT6],[Qt6Core Qt6Widgets Qt6Gui Qt6WebEngineCore Qt6WebChannel Qt6WebEngineWidgets Qt6DBus],,)
-       dnl Qt6 moc executable is found at /usr/lib64/qt6/libexec/moc with
-       dnl qt-base-devel on fedora... TODO: check what is the story with other
-       dnl distros is it ever really in the PATH?
-       AC_PATH_PROG([MOC], [moc], [no], [$PATH$PATH_SEPARATOR/usr/lib64/qt6/libexec$PATH_SEPARATOR/usr/lib/qt6$PATH_SEPARATOR/usr/libexec/qt6$PATH_SEPARATOR/usr/lib/qt6/libexec])
-       if test "x$MOC" = "xno"; then
-             AC_MSG_ERROR([moc not found. Please install Qt development tools.])
+      [
+       PKG_CHECK_MODULES([QT6],
+             [Qt6Core Qt6Widgets Qt6Gui Qt6WebEngineCore Qt6WebChannel Qt6WebEngineWidgets Qt6DBus Qt6PrintSupport],,
+             [AC_MSG_ERROR([Qt6 not found. Set QT6_CFLAGS and QT6_LIBS if your distro lacks .pc files.])])
+
+       dnl Locate qtpaths6 for Qt6 tool discovery
+       AC_PATH_PROG([QTPATHS6], [qtpaths6], [no],
+             [$PATH$PATH_SEPARATOR/usr/lib/qt6/bin])
+       if test "x$QTPATHS6" = "xno"; then
+             AC_MSG_ERROR([qtpaths6 not found. Install Qt6 development tools.])
+       fi
+       QT_LIBEXEC_DIR=$($QTPATHS6 --qt-query QT_INSTALL_LIBEXECS 2>/dev/null)
+       QT_BIN_DIR=$($QTPATHS6 --qt-query QT_INSTALL_BINS 2>/dev/null)
+
+       AC_MSG_CHECKING([for moc])
+       if test -n "$QT_LIBEXEC_DIR" -a -x "$QT_LIBEXEC_DIR/moc"; then
+             MOC="$QT_LIBEXEC_DIR/moc"
+             AC_MSG_RESULT([$MOC])
+       else
+             AC_MSG_RESULT([no])
+             AC_MSG_ERROR([moc not found in $QT_LIBEXEC_DIR])
        fi
        AC_SUBST(MOC)
-       AC_PATH_PROGS(LRELEASE, [lrelease6 lrelease-qt6 lrelease], [:], [$PATH$PATH_SEPARATOR/usr/lib/qt6/bin])
-       AC_PATH_PROGS(LUPDATE,  [lupdate6  lupdate-qt6  lupdate],  [:], [$PATH$PATH_SEPARATOR/usr/lib/qt6/bin])
-       if test "x$LRELEASE" = "x:"; then
-             AC_MSG_ERROR([lrelease or lrelease6 not found – please install Qt Linguist tools])
+
+       AC_MSG_CHECKING([for lrelease])
+       if test -n "$QT_BIN_DIR" -a -x "$QT_BIN_DIR/lrelease"; then
+             LRELEASE="$QT_BIN_DIR/lrelease"
+             AC_MSG_RESULT([$LRELEASE])
+       else
+             AC_MSG_RESULT([no])
+             AC_MSG_ERROR([lrelease not found in $QT_BIN_DIR])
        fi
+       AC_SUBST(LRELEASE)
+
+       AC_MSG_CHECKING([for lupdate])
+       if test -n "$QT_BIN_DIR" -a -x "$QT_BIN_DIR/lupdate"; then
+             LUPDATE="$QT_BIN_DIR/lupdate"
+             AC_MSG_RESULT([$LUPDATE])
+       else
+             AC_MSG_RESULT([no])
+             AC_MSG_WARN([lupdate not found in $QT_BIN_DIR])
+       fi
+       AC_SUBST(LUPDATE)
 ])
 
 AM_CONDITIONAL([ENABLE_DEBUG], [test "$ENABLE_DEBUG" = "true"])


### PR DESCRIPTION
On Ubuntu (24.04) and probably some other distros, it was a huge hassle to build app:linux. Since Qt6 comes without any pkg-config files user had to self declare bunch of paths.

Steer away from pkg-config, and use qtpaths6 to locate anything Qt6 related.

Still expect qtpaths6 in the $PATH as the start point.

Tested on Ubuntu 24.04 and Fedora 43, seems to work without problems.

Should also improve build experience in ArchLinux as some have reported the `moc` in the $PATH being the one from qt5 instead of qt6. Now we have a single source of truth, `qtpaths6`.

**Did not test if it works for the flatpak.**

---

<!-- Message of single commit: -->

app:linux use qtpaths6 for locating Qt execs and libs

Qt6 comes without pkg-config for some distros, causing quite a hairy process for
locating the libraries down the line.

Apparently CMake is the preferred build tooling in general for Qt6 apps.
Meanwhile we can use qtpaths6 for locating the bits and with higher accuracy.

Take paths queried via qtpaths6 as the only ground source of truth and do not
cast a wide net. Several arch users had trouble with a stray qt5 `moc` binary
being available in their $PATH.

Signed-off-by: Sarper Akdemir <sarper.akdemir@collabora.com>
Change-Id: I712f4763670614413a2be8f24c83315945c28504