### PR TITLE
use test-div-shapeHandlesSection to detect selection removeed

### DIFF
--- a/cypress_test/integration_tests/common/impress_helper.js
+++ b/cypress_test/integration_tests/common/impress_helper.js
@@ -133,7 +133,7 @@ function removeShapeSelection() {
 			expect(overlay.children('svg').length).to.equal(0);
 		});
 
-	cy.cGet('.leaflet-drag-transform-marker').should('not.exist');
+	cy.cGet('#test-div-shapeHandlesSection').should('not.exist');
 
 	cy.log('<< removeShapeSelection - end');
 }


### PR DESCRIPTION
.leaflet-drag-transform-marker is removed by the click via brower-side events, while #test-div-shapeHandlesSection is removed on receipt of the core's 'graphicselection: EMPTY' so that's a better choice to indicate the the shape selection has truly been removed.

cy: command ✔  assert     expected **.leaflet-drag-transform-marker** not to exist in the DOM
    cy:log ✱  << removeShapeSelection - end
cy: command ✔  cGet       #document-container
cy: command ✔  assert     expected **<div#document-container.notebookbar-active.slide-normal-mode.landscape.parts-preview-document>** to have a length of **1**
cy: command ✔  cGet       body
cy: command ✔  click      625.5, 348, {ctrlkey: true}
cy: command ✔  wrap       null
cy: command ✔  assert     .uno:ReportWhenIdle result with idleID 11: expected **{ Object (proxy, thisValue, ...) }** to be an object
cy: command ✔  cGet       [id^="info-modal-label2"]
cy: command ✘  assert     expected **[id^="info-modal-label2"]** to have text **http://www.something.com/**, but the text was **''**
cy: command ✔  fail:
              Timed out retrying after 10000ms: Expected to find element: `[id^="info-modal-label2"]`, but never found it. Queried from:
                            > cy.get(#coolframe, [object Object]).its(0.contentDocument, [object Object])
              /home/collabora/jenkins/workspace/github_online_master_debug_vs_co-25.04_cypress_desktop/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js:120:46
                118 |         impressHelper.clickCenterOfSlide({ ctrlKey: true });
                119 |         helper.processToIdle(this.win);
              > 120 |         cy.cGet('[id^="info-modal-label2"]').should('have.text', 'http://www.something.com/');
                    |                                              ^
                121 |         cy.cGet( ...
    cy:log ✱  Finishing test: integration_tests/desktop/impress/top_toolbar_spec.js / Top toolbar tests. / Click shape hyperlink.
cy: command ✔  getFrameWindow     #coolframe

Change-Id: I9ff51648ab84a16ce0b868a9e206876645542b3f


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

