### PR TITLE
'replace' can trigger a rebuild of the dialog while cypress tries to …

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/replace_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/replace_dialog_spec.js
@@ -6,6 +6,9 @@ var findHelper = require('../../common/find_helper');
 describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Replace Dialog Tests', function() {
     beforeEach(function() {
         helper.setupAndLoadDocument('writer/find_replace.odt');
+        cy.getFrameWindow().then(function(win) {
+            this.win = win;
+        });
     });
 
     it('Ctrl H should open search dialog with replace tab active', function() {
@@ -89,8 +92,14 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Replace Dialog Tests', fun
         // Type replacement and press Enter
         cy.cGet('#replaceterm-input-dialog').type('replaced').realPress('Enter');
 
-        // Close the dialog
-        cy.cGet('.ui-dialog-titlebar-close').click();
+        // The replace triggers a jsdialog update and when the browser-side
+        // processes the update the dialog gets rebuilt, and
+        // .ui-dialog-titlebar-close temporarily disappears, so wait for the
+        // replace operation round-trip and dialog rebuild to complete before
+        // closing the dialog.
+        helper.processToIdle(this.win);
+
+        findHelper.closeFindDialog();
 
         // Select all text to verify replacement happened
         helper.selectAllText();


### PR DESCRIPTION
…close it

The replace triggers a jsdialog update and when the browser-side processes the update the dialog gets rebuilt, and
.ui-dialog-titlebar-close temporarily disappears, so wait for the replace operation round-trip and dialog rebuild to complete before closing the dialog.


Change-Id: Ib0998cff1dae1bcd16fec45a812faadb86f9dd19


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

