### PR TITLE
make sure document-canvas is visible and not obscured by busypopup

### DIFF
--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -373,8 +373,9 @@ function waitForInterferingUser() {
 function documentChecks(skipInitializedCheck = false) {
 	cy.log('>> documentChecks - start');
 
-	cy.cGet('#document-canvas', {timeout : Cypress.config('defaultCommandTimeout') * 2.0});
+	var canvasCheck = cy.cGet('#document-canvas', {timeout : Cypress.config('defaultCommandTimeout') * 2.0});
 	if (!skipInitializedCheck) {
+		canvasCheck.should('be.visible');
 		cy.cGet('#map', {timeout : Cypress.config('defaultCommandTimeout') * 2.0})
 			.should('have.class', 'initialized');
 	}
@@ -423,6 +424,11 @@ function documentChecks(skipInitializedCheck = false) {
 			cy.cGet('#pos_window-input-address.addressInput').should('exist');
 			//cy.cGet('#pos_window-input-address.addressInput').should('not.be.empty');
 		});
+	}
+
+	// Ensure the busypopup overlay is gone so it doesn't swallow clicks.
+	if (!skipInitializedCheck) {
+		cy.cGet('#busypopup-overlay').should('not.exist');
 	}
 
 	if (Cypress.env('INTERFERENCE_TEST') === true) {


### PR DESCRIPTION
Change-Id: I6310365bbcba43e15036b5c8166fd2f322989480


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

