### PR TITLE
Ensure comments have been loaded from the server before opening wizard

### DIFF
--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -30,6 +30,11 @@ function enableEditingMobile() {
 			.should('be.visible');
 	});
 
+	// Wait until core has processed outstanding input and has returned to idle.
+	cy.getFrameWindow().then((win) => {
+		helper.processToIdle(win);
+	});
+
 	cy.log('<< enableEditingMobile - end');
 }
 


### PR DESCRIPTION
(speculative)

cy:command ✔  cGet    #toolbar-up #comment_wizard
cy:command ✔  assert    expected **<div#comment_wizard.unotoolbutton.jsdialog.ui-content.unospan.comment_wizard.no-label>** not to have class **disabled**
cy:command ✔  cGet    #toolbar-up #comment_wizard button
cy:command ✔  click
cy:command ✔  cGet    #toolbar-up #comment_wizard
cy:command ✔  assert    expected **<div#comment_wizard.unotoolbutton.jsdialog.ui-content.unospan.comment_wizard.no-label.selected>** to have class **selected**
    cy:log ✱  << openCommentWizard - end
cy:command ✔  cGet    #mobile-wizard-content
cy:command ✔  assert    expected **<div#mobile-wizard-content.portrait>** to exist in the DOM
cy:command ✔  cGet    #annotation-content-area-1
cy:command ✘  assert    expected **#annotation-content-area-1** to have text **some text**, but the text was **''**
  cons:log ✱  ==== debug.html receiveMessage: {"MessageId":"Doc_ModifiedStatus","SendTime":1770585959666,"Values":{"Modified":false}}
cy:command ✔  fail:
              Test failed: integration_tests/mobile/calc/annotation_spec.js / Annotation Tests / Saving comment.

              Timed out retrying after 10000ms: Expected to find element: `#annotation-content-area-1`, but never found it. Queried from:

                            > cy.get(#coolframe, [object Object]).its(0.contentDocument, [object Object])

              /home/caolan/LibreOffice/collabora-online/cypress_test/integration_tests/mobile/calc/annotation_spec.js:19:47
                17 |         mobileHelper.openCommentWizard();
                18 |         cy.cGet('#mobile-wizard-content').should('exist');
              > 19 |         cy.cGet('#annotation-content-area-1').should('have.text', 'some text');
                   |                                               ^
                20 |         cy.cGet('#comment-container-1').should('exist');
                21 |     });
                22 |     it('Modifying comm ...
    cy:log ✱  Finishing test: integration_tests/mobile/calc/annotation_spec.js / Annotation Tests / Saving comment.


Change-Id: Ib008ef292275ec78bcf91fcc0af12b91203388ec


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

