### PR TITLE
make mobile/impress/apply_font_text_spec.js more reliable

### DIFF
--- a/cypress_test/integration_tests/common/impress_helper.js
+++ b/cypress_test/integration_tests/common/impress_helper.js
@@ -126,9 +126,18 @@ function removeShapeSelection() {
 			var XPos = items[0].getBoundingClientRect().left + 10;
 			var YPos = items[0].getBoundingClientRect().top + 10;
 			cy.cGet('body').click(XPos, YPos);
-			cy.cGet('body').type('{esc}');
-			cy.cGet('body').type('{esc}');
 		});
+
+	// The click triggers MouseControl.onClick which calls focus(false),
+	// blurring the textarea on mobile. Re-focus depends on INCOMING
+	// invalidatecursor from core. processToIdle ensures that message
+	// has been received before we send the Esc keys.
+	cy.getFrameWindow().then(function(win) {
+		helper.processToIdle(win);
+	});
+
+	cy.cGet('body').type('{esc}');
+	cy.cGet('body').type('{esc}');
 
 	cy.cGet('#document-container')
 		.should(function(overlay) {


### PR DESCRIPTION
integration_tests/mobile/calc/annotation_spec.js
      cy:command ✔  cGet    #toolbar-up #comment_wizard
      cy:command ✔  assert    expected **<div#comment_wizard.unotoolbutton.jsdialog.ui-content.unospan.comment_wizard.no-label>** not to have class **disabled**
      cy:command ✔  cGet    #toolbar-up #comment_wizard button
      cy:command ✔  click
      cy:command ✔  cGet    #toolbar-up #comment_wizard
      cy:command ✔  assert    expected **<div#comment_wizard.unotoolbutton.jsdialog.ui-content.unospan.comment_wizard.no-label.selected>** to have class **selected**
          cy:log ✱  << openCommentWizard - end
      cy:command ✔  cGet    #mobile-wizard-content
      cy:command ✔  assert    expected **<div#mobile-wizard-content.portrait>** to exist in the DOM
      cy:command ✔  cGet    #annotation-content-area-1
      cy:command ✘  assert    expected **#annotation-content-area-1** to have text **some text**, but the text was **''**

      Timed out retrying after 10000ms: Expected to find element: `#annotation-content-area-1`, but never found it.

      /home/caolan/LibreOffice/collabora-online/cypress_test/integration_tests/mobile/calc/annotation_spec.js:19:47
        17 |         mobileHelper.openCommentWizard();
        18 |         cy.cGet('#mobile-wizard-content').should('exist');
      > 19 |         cy.cGet('#annotation-content-area-1').should('have.text', 'some text');
             |                                               ^
        20 |         cy.cGet('#comment-container-1').should('exist');
        21 |     });
        22 |     it('Modifying comm ...


Change-Id: Ib26c0d2d2aaf94a34f041ae82eb99edec9cddeca


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

