### PR TITLE
wsd: always expose serverId in capabilities

### DIFF
--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -2788,12 +2788,12 @@ std::string getCapabilitiesJson(bool convertToAvailable)
     // Set the product name
     capabilities->set("productName", ConfigUtil::getString("product_name", APP_NAME));
 
+    // Set the Server ID
+    capabilities->set("serverId", Util::getProcessIdentifier());
+
     CONFIG_STATIC const bool sig = ConfigUtil::getBool("security.server_signature", false);
     if (sig)
     {
-        // Set the Server ID
-        capabilities->set("serverId", Util::getProcessIdentifier());
-
         // Set the product version
         capabilities->set("productVersion", Util::getCoolVersion());
 


### PR DESCRIPTION
Partially revert bf48b414, which made serverId conditional and broke compatibility with cool-controller.
ServerId is already unconditionally included in public URLs via `ClientSession::createPublicURI()`

Change-Id: Ifadfe1d99c1da3be785e8392e315455540a972f0

* Target version: main
