### PR TITLE
cool#13988 redline render mode: add a HTTP parameter to activate this mode on load

### DIFF
--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -549,6 +549,17 @@ class UIManager extends window.L.Control {
 				this.map.quickFindPanel = JSDialog.QuickFindPanel(this.map);
 				this.map.addControl(this.map.quickFindPanel);
 			}
+
+			if (this.getStartCompareChanges()) {
+				// Don't switch to the comparechanges view yet, first wait for the
+				// document to be loaded to avoid accessing not yet initialized
+				// state.
+				const enterCompareChanges = () => {
+					app.dispatcher.dispatch('comparechanges');
+					this.map.off('docloaded', enterCompareChanges);
+				};
+				this.map.on('docloaded', enterCompareChanges);
+			}
 		}
 
 		if (this.map.isPresentationOrDrawing() && (isDesktop || window.mode.isTablet())) {
@@ -2350,5 +2361,10 @@ class UIManager extends window.L.Control {
 	getBooleanDocTypePref(name: string, defaultValue: boolean = false): boolean {
 		const docType = this.map.getDocType();
 		return window.prefs.getBoolean(`${docType}.${name}`, defaultValue);
+	}
+
+	getStartCompareChanges(): boolean {
+		const compareChangesOption = window.coolParams.get('comparechanges');
+		return compareChangesOption === 'true' || compareChangesOption === '1';
 	}
 }

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3149,6 +3149,12 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 		if (this.isCalc() || this.isDraw())
 			return;
 
+		if (this._map.uiManager.getStartCompareChanges()) {
+			// comparechanges view, don't zoom in, to have space for two pages side by
+			// side.
+			return;
+		}
+
 		if (this.isImpress() && !maxZoom)
 			maxZoom = 10;
 


### PR DESCRIPTION
An integrator may want to load a text document which already has
redlines as the result if comparing two documents. In this case asking
the user to click on Review -> View Changes to enter the side-by-side
diff mode is not great.

When that button is pressed, we enter doc compare mode by dispatching
the comparechanges event.

Fix the problem by adding a new 'comparechanges' HTTP GET parameter,
similar to how 'startPresentation' can auto-start Impress files already.

Note that UIManager.initializeSpecializedUI() would run before
CanvasTileLayer._fitWidthZoom(), resulting in a view that has 2 pages
side by side, but the zoom would set to fit the width of one page. Fix
this by not zooming in when we're in doc compare mode, similar to how we
return early already in Calc and Draw.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I18ef73063b43524f424c4c32a1c4b3007d12e7af
