### PR TITLE
wsd/WopiStorage: prevent saving empty string as LastModifiedTime

### DIFF
--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -966,8 +966,12 @@ WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
             {
                 const std::string lastModifiedTime =
                     JsonUtil::getJSONValue<std::string>(object, "LastModifiedTime");
-                LOG_TRC(wopiLog << " returns LastModifiedTime [" << lastModifiedTime << "].");
-                setLastModifiedTime(lastModifiedTime);
+                if (lastModifiedTime.empty()) {
+                    LOG_WRN(wopiLog << " Missing LastModifiedTime from PutFile answer.");
+                } else {
+                    LOG_TRC(wopiLog << " returns LastModifiedTime [" << lastModifiedTime << "].");
+                    setLastModifiedTime(lastModifiedTime);
+                }
 
                 if (details.isSaveAs || details.isRename)
                 {


### PR DESCRIPTION
If the LastModifiedTime field is missing from the put_file upload, we would set the lastModifiedTime to an invalid "".

And output a warning if LastModifiedTime is not set as expected.

Any Subsequent CheckFileInfo call would compare this to the known LastModifiedTime and deduce a conflict.


Change-Id: Ib2d789f1bedd1621744f989065924e78169c0fd9


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

So that the log can help us detect wopi issues.

The warning might be excessive, LastModifiedTime could be considered optional.

But this causes timestamp comparison failure creating conflicts. 

To help upholding https://sdk.collaboraonline.com/docs/advanced_integration.html#detecting-external-document-change

Like in https://gitlab.com/pleio/platform/-/merge_requests/769/diffs

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

