### PR TITLE
browser: allow GotoPage command in read-only mode

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -383,7 +383,7 @@ window.L.Map.include({
 			'.uno:ShowResolvedAnnotations',
 			'.uno:ToolbarMode?Mode:string=notebookbar_online.ui', '.uno:ToolbarMode?Mode:string=Default',
 			'.uno:ExportToEPUB', '.uno:ExportToPDF', '.uno:ExportDirectToPDF', '.uno:MoveKeepInsertMode', '.uno:ShowRuler',
-			'.uno:Navigator'];
+			'.uno:Navigator', '.uno:GotoPage'];
 		if (app.isCommentEditingAllowed()) {
 			allowedCommands.push('.uno:InsertAnnotation','.uno:DeleteCommentThread', '.uno:DeleteAnnotation', '.uno:DeleteNote',
 				'.uno:DeleteComment', '.uno:ReplyComment', '.uno:ReplyToAnnotation', '.uno:PromoteComment', '.uno:ResolveComment',


### PR DESCRIPTION
Change-Id: If64ab136e24166eed22251ca620b09cb78ce1b2d

* Target version: main

### Summary

Clicking the page selector ('Page x of y') in the status bar sends .uno:GotoPage, which was not in the read-only allowed commands list.
Add it to allow a specific page navigation in read-only mode.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

