### PR TITLE
make desktop/writer/file_properties_spec.js more reliable

### DIFF
--- a/cypress_test/integration_tests/common/writer_helper.js
+++ b/cypress_test/integration_tests/common/writer_helper.js
@@ -22,7 +22,7 @@ function selectAllTextOfDoc() {
 	cy.log('<< selectAllTextOfDoc - end');
 }
 
-function openFileProperties() {
+function openFileProperties(win) {
 	cy.log('>> openFileProperties - start');
 
 	cy.cGet('.jsdialog-window').should('not.exist');
@@ -33,6 +33,8 @@ function openFileProperties() {
 
 		cy.cGet('#File-container .unoSetDocumentProperties').click();
 	});
+
+	helper.processToIdle(win);
 
 	cy.cGet('.jsdialog-window').should('exist');
 

--- a/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/file_properties_spec.js
@@ -17,9 +17,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 	});
 
 	it('Add File Description.', function() {
-		cy.wait(1000);
-
-		writerHelper.openFileProperties();
+		writerHelper.openFileProperties(this.win);
 
 		cy.cGet('#tabcontrol-2').click();
 
@@ -29,9 +27,10 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 
 		cy.cGet('#ok.ui-pushbutton-wrapper').click();
 
-		writerHelper.openFileProperties();
+		writerHelper.openFileProperties(this.win);
 
 		cy.cGet('#tabcontrol-2').click();
+
 		cy.cGet('#title-input.ui-edit').should('have.value', 'New Title');
 		cy.cGet('#comments.ui-textarea').should('have.value', 'New');
 
@@ -39,7 +38,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 	});
 
 	it('Add Custom Property.', function() {
-		writerHelper.openFileProperties();
+		writerHelper.openFileProperties(this.win);
+
 		cy.cGet('#tabcontrol-3').click();
 
 		// Add property
@@ -50,8 +50,10 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 		cy.cGet('#ok.ui-pushbutton-wrapper button').click();
 
 		// Check property saved
-		writerHelper.openFileProperties();
+		writerHelper.openFileProperties(this.win);
+
 		cy.cGet('#tabcontrol-3').click();
+
 		cy.cGet('#valueedit-input').should('have.value', '123 Address');
 		cy.cGet('#namebox-input-dialog').should('have.value', 'Mailstop');
 
@@ -59,7 +61,8 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 	});
 
 	it('Add Custom Duration Property.', function() {
-		writerHelper.openFileProperties();
+		writerHelper.openFileProperties(this.win);
+
 		cy.cGet('#tabcontrol-3').click();
 
 		// Add property
@@ -78,15 +81,18 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 		cy.cGet('#ok.ui-pushbutton-wrapper button').click();
 
 		// Check property saved
-		writerHelper.openFileProperties();
+		writerHelper.openFileProperties(this.win);
+
 		cy.cGet('#tabcontrol-3').click();
+
 		cy.cGet('#duration-input').should('have.value', '- Y: 1 M: 0 D: 2 H: 0 M: 0 S: 3');
 		cy.cGet('#namebox-input-dialog').should('have.value', 'Received from');
 		cy.cGet('#cancel.ui-pushbutton-wrapper button').click();
 	});
 
 	it('Add Custom Yes/No Property.', function() {
-		writerHelper.openFileProperties();
+		writerHelper.openFileProperties(this.win);
+
 		cy.cGet('#tabcontrol-3').click();
 
 		// Add property
@@ -97,8 +103,10 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'File Property Tests', func
 		cy.cGet('#ok.ui-pushbutton-wrapper button').click();
 
 		// Check property saved
-		writerHelper.openFileProperties();
+		writerHelper.openFileProperties(this.win);
+
 		cy.cGet('#tabcontrol-3').click();
+
 		cy.cGet('#yes-input').should('be.checked');
 		cy.cGet('#namebox-input-dialog').should('have.value', 'Telephone number');
 		cy.cGet('#cancel.ui-pushbutton-wrapper button').click();


### PR DESCRIPTION
cy: command ✔  wait       1000
    cy:log ✱  >> openFileProperties - start
cy: command ✔  cGet       .jsdialog-window
cy: command ✔  assert     expected **.jsdialog-window** not to exist in the DOM
cy: command ✔  cGet       #File-tab-label
cy: command ✔  cGet       #File-container .unoSetDocumentProperties
cy: command ✔  click
cy: command ✔  cGet       .jsdialog-window
cy: command ✔  assert     expected **<div#4.jsdialog-window.fadein>** to exist in the DOM
    cy:log ✱  << openFileProperties - end
cy: command ✔  cGet       #tabcontrol-2
cy: command ✔  click
cy: command ✔  cGet       #title-input.ui-edit
cy: command ✘  assert     expected **<input#title-input.ui-edit.jsdialog>** to be **visible**
cy: command ✔  fail:
              Timed out retrying after 10000ms: expected '<input#title-input.ui-edit.jsdialog>' to be 'visible'
              This element `<input#title-input.ui-edit.jsdialog>` is not visible because its parent `<div#title.ui-edit-container.jsdialog.ui-grid-cell>` has CSS property: `visibility: hidden`
              /home/collabora/jenkins/workspace/github_online_master_debug_vs_co-25.04_cypress_desktop/cypress_test/integration_tests/desktop/writer/file_properties_spec.js:19:41
                17 |         writerHelper.openFileProperties();
                18 |         cy.cGet('#tabcontrol-2').click();
              > 19 |         cy.cGet('#title-input.ui-edit').should('be.visible');
                   |                                         ^
                20 |          ...
    cy:log ✱  Finishing test: integration_tests/desktop/writer/file_properties_spec.js / File Property Tests / Add File Description.
cy: command ✔  getFrameWindow     #coolframe

Change-Id: I7a0d3fb6174da4bfe1e9f1995a20ca296c06c03f


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

