### PR TITLE
try a bigger hammer to avoid npm install/ci hangs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -852,7 +852,7 @@ clean-vscode: clean-clangd
 	cd $(abs_srcdir) && rm -rf .vscode
 
 browser/node_modules: browser/package.json browser/node_shrinkpack
-	@cd browser && npm ci --offline
+	@cd browser && UV_USE_IO_URING=0 npm ci --offline
 
 eslint: browser/node_modules
 	@$(MAKE) -C browser eslint

--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -937,7 +937,7 @@ $(DIST_FOLDER)/cool.html: $(srcdir)/html/cool.html.m4 \
 		$(srcdir)/html/cool.html.m4 > $@
 
 node_modules: package.json node_shrinkpack
-	@npm ci --offline
+	@UV_USE_IO_URING=0 npm ci --offline
 	@touch node_modules
 
 update-shrinkpack:

--- a/cypress_test/Makefile.am
+++ b/cypress_test/Makefile.am
@@ -265,7 +265,7 @@ NODE_BINS = \
 $(NODE_BINS): $(NPM_INSTALLED);
 
 $(NPM_INSTALLED): package.json eslint_plugin/index.js eslint_plugin/package.json
-	$(V)npm install --no-audit
+	$(V)UV_USE_IO_URING=0 npm install --no-audit
 	$(V)echo node_modules:
 	$(V)ls node_modules
 	$(V)mkdir -p $(dir $(NPM_INSTALLED))
@@ -771,7 +771,7 @@ do-run-cov: @JAILS_PATH@ @CACHE_PATH@ $(NODE_BINS)
 	$(V)echo
 	rm -rf .nyc_output
 	rm -rf coverage
-	npm install @cypress/code-coverage --no-save
+	UV_USE_IO_URING=0 npm install @cypress/code-coverage --no-save
 	$(V)echo "import '@cypress/code-coverage/support';" >> $(SUPPORT_FILE_ABS)
 	$(V)echo "" >> $(SUPPORT_FILE_ABS)
 	cd .. && npx nyc instrument --compact=false browser/src browser/dist/src && cd cypress_test


### PR DESCRIPTION
uname -a
Linux oracle7-b 6.1.0-27-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.115-1 (2024-11-01) x86_64 x86_64 x86_64 GNU/Linux

npm --version
10.2.4

node --version
v20.11.0

- https://github.com/amazonlinux/amazon-linux-2023/issues/856 — npm/pnpm/yarn install all hang due to backported kernel io_uring bug
- https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2105471 — io_uring process deadlock
- https://github.com/nodejs/node/issues/51875 — io_uring caused regression on node 20 and 21
- https://github.com/NixOS/nixpkgs/issues/353709 — yarn install takes indefinitely


Change-Id: Ib0bccbba7100cf80e3e5d6c873b9a5a9f45f6b9d


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

