### PR TITLE
hint to look for an earlier fatal error on 'Unstopped threads'

### DIFF
--- a/common/Log.cpp
+++ b/common/Log.cpp
@@ -782,7 +782,8 @@ namespace Log
 #endif // !NDEBUG
 
             assert(ThreadLocalBufferCount <= 1 &&
-                   "Unstopped threads may have unflushed buffered log entries");
+                   "Unstopped threads may have unflushed buffered log entries. "
+                   "This is common if there has been an earlier fatal error. Check previous log entries");
         }
 
         // continue logging shutdown on mobile


### PR DESCRIPTION
Change-Id: I7af732f61b2d3c3bc8856696201304eaaf4154fa


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

