### PR TITLE
fix: add aria-haspopup role for improved accessibility in dialog components

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1732,6 +1732,8 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		const isSplitButton = !!data.applyCallback;
 		const isDropdownButton = !!data.dropdown;
 
+		const hasPopupRole = data.aria && data.aria.role === 'popup';
+
 		/**
 		 * Determines if the dropdown arrow should be interactive (focusable button) vs decorative (div).
 		 * This affects ARIA attribute placement and arrowbackground element type creation.
@@ -1811,7 +1813,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 				button.accessKey = data.accessKey;
 
 			// if dropdown arrow does not exist or is not interactive then only button can have aria-haspopup
-			if (hasPopUp && !isArrowInteractive)
+			if (hasPopUp && !isArrowInteractive || hasPopupRole)
 				button.setAttribute('aria-haspopup', true);
 
 			if (data.w2icon) {
@@ -1877,13 +1879,15 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			const selectFn = () => {
 				window.L.DomUtil.addClass(button, 'selected');
 				window.L.DomUtil.addClass(div, 'selected');
-				button.setAttribute('aria-pressed', true);
+				if(!button.hasAttribute('aria-haspopup'))
+					button.setAttribute('aria-pressed', true);
 			};
 
 			const unSelectFn = () => {
 				window.L.DomUtil.removeClass(button, 'selected');
 				window.L.DomUtil.removeClass(div, 'selected');
-				button.setAttribute('aria-pressed', false);
+				if(!button.hasAttribute('aria-haspopup'))
+					button.setAttribute('aria-pressed', false);
 			};
 
 			if (data.command) {

--- a/browser/src/control/jsdialog/Widget.SidebarContainers.ts
+++ b/browser/src/control/jsdialog/Widget.SidebarContainers.ts
@@ -76,7 +76,7 @@ JSDialog.panel = function (
 			{
 				type: 'toolitem',
 				command: expanderData.command,
-				aria: { label: moreOptionsText },
+				aria: { label: moreOptionsText, role: 'popup' },
 				icon: app.LOUtil.getIconNameOfCommand('morebutton'),
 				tooltip: moreOptionsText,
 			} as any as WidgetJSON, // FIXME: use toolitem JSON type


### PR DESCRIPTION
Change-Id: I8780b01f8156668bea5218d1b7cd2527c2231d93

Changes:
1. enable 'popup' role for more options button
2. do not add 'aria-pressed', if element already have 'aria-haspopup' role

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

