### PR TITLE
use weak_from_this() to detect if session ended before clipboard resp…

### DIFF
--- a/common/Unit.hpp
+++ b/common/Unit.hpp
@@ -54,6 +54,8 @@ namespace Poco
 class Session;
 class StorageBase;
 
+namespace http { class Session; }
+
 typedef UnitBase *(CreateUnitHooksFunction)();
 typedef UnitBase**(CreateUnitHooksFunctionMulti)();
 extern "C" {
@@ -556,6 +558,17 @@ public:
     {
         return false;
     }
+
+    /// Called before a clipboard download URL is used.
+    /// Override to replace the URL, e.g. with a non-routable address to test timeouts.
+    virtual void filterClipboardDownloadURL(std::string& /*url*/) {}
+
+    /// Called after an async clipboard download request is set up.
+    /// Override to adjust the session, e.g. to set a shorter timeout.
+    virtual void onClipboardDownloadRequest(std::shared_ptr<http::Session>& /*httpSession*/) {}
+
+    /// Called when the clipboard download callback detects its session has already been destroyed.
+    virtual void onClipboardDownloadSessionGone() {}
 
     /// Called before uri is set as a preinstall settings asset
     virtual void filterRegisterPresetAsset(std::string& /*uri*/) {}

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -106,6 +106,7 @@ all_la_unit_tests = \
 	unit-timeout_none.la \
 	unit-serversock_accept1.la \
 	unit-streamsock_ctor1.la \
+	unit-clipboard-close.la \
 	unit-kit-child-session.la
 #	unit-admin.la
 #	unit-tilecache.la # Empty test.
@@ -241,6 +242,8 @@ unit_typing_la_SOURCES = UnitTyping.cpp
 unit_typing_la_LIBADD = $(CPPUNIT_LIBS)
 unit_copy_paste_la_SOURCES = UnitCopyPaste.cpp
 unit_copy_paste_la_LIBADD = $(CPPUNIT_LIBS)
+unit_clipboard_close_la_SOURCES = UnitClipboardClose.cpp
+unit_clipboard_close_la_LIBADD = $(CPPUNIT_LIBS)
 unit_copy_paste_writer_la_SOURCES = UnitCopyPasteWriter.cpp
 unit_copy_paste_writer_la_LIBADD = $(CPPUNIT_LIBS)
 unit_convert_la_SOURCES = UnitConvert.cpp

--- a/test/UnitClipboardClose.cpp
+++ b/test/UnitClipboardClose.cpp
@@ -1,0 +1,187 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+// Test that a clipboard download timeout arriving after the document
+// is closed doesn't crash. See: use weak_from_this() to detect if
+// session ended before clipboard response.
+
+#include <config.h>
+
+#include <HttpRequest.hpp>
+#include <Unit.hpp>
+#include <UnitHTTP.hpp>
+#include <WebSocketSession.hpp>
+#include <helpers.hpp>
+#include <lokassert.hpp>
+#include <test.hpp>
+#include <wsd/COOLWSD.hpp>
+#include <wsd/ClientSession.hpp>
+
+#include <Poco/Net/HTMLForm.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <Poco/Net/StringPartSource.h>
+
+using namespace std::literals;
+using namespace Poco::Net;
+
+// Inside the WSD process
+class UnitClipboardClose : public UnitWSD
+{
+    STATE_ENUM(Phase, RunTest, WaitDocClose, Done) _phase;
+
+    std::string _clipURI;
+    bool _sessionGoneCalled = false;
+
+public:
+    UnitClipboardClose()
+        : UnitWSD("UnitClipboardClose")
+        , _phase(Phase::RunTest)
+    {
+        setTimeout(std::chrono::seconds(30));
+    }
+
+    /// Replace the clipboard download URL with a non-routable address
+    /// so the HTTP request will hang rather than completing immediately.
+    void filterClipboardDownloadURL(std::string& url) override
+    {
+        TST_LOG("Replacing clipboard download URL [" << url
+                << "] with non-routable address");
+        url = "http://10.255.255.1/cool/clipboard";
+    }
+
+    /// Set a short timeout so the callback fires quickly during
+    /// the DocBroker's flush phase rather than waiting 30s.
+    void onClipboardDownloadRequest(std::shared_ptr<http::Session>& httpSession) override
+    {
+        TST_LOG("Setting short timeout on clipboard download session");
+        httpSession->setTimeout(std::chrono::seconds(2));
+    }
+
+    void onClipboardDownloadSessionGone() override
+    {
+        TST_LOG("Callback detected session was already destroyed");
+        _sessionGoneCalled = true;
+    }
+
+    std::string getSessionClipboardURI(size_t session)
+    {
+        std::vector<std::shared_ptr<DocumentBroker>> brokers =
+            COOLWSD::getBrokersTestOnly();
+        assert(!brokers.empty());
+        auto sessions = brokers[0]->getSessionsTestOnlyUnsafe();
+        assert(sessions.size() > session);
+        return sessions[session]->getClipboardURI(false);
+    }
+
+    bool setClipboard(const std::string& clipURIstr, const std::string& rawData,
+                      HTTPResponse::HTTPStatus expected)
+    {
+        TST_LOG("setClipboard: connect to " << clipURIstr);
+        Poco::URI clipURI(clipURIstr);
+
+        std::unique_ptr<HTTPClientSession> session(helpers::createSession(clipURI));
+        HTTPRequest request(HTTPRequest::HTTP_POST, clipURI.getPathAndQuery());
+        HTMLForm form;
+        form.setEncoding(HTMLForm::ENCODING_MULTIPART);
+        form.set("format", "txt");
+        form.addPart("data", new StringPartSource(rawData, "application/octet-stream", "clipboard"));
+        form.prepareSubmit(request);
+        form.write(session->sendRequest(request));
+
+        HTTPResponse response;
+        try
+        {
+            session->receiveResponse(response);
+        }
+        catch (NoMessageException&)
+        {
+            TST_LOG("Error: No response from setting clipboard.");
+            exitTest(TestResult::Failed);
+            return false;
+        }
+
+        if (response.getStatus() != expected)
+        {
+            TST_LOG("Error: response for clipboard " << response.getStatus()
+                    << " != expected " << expected);
+            exitTest(TestResult::Failed);
+            return false;
+        }
+
+        return true;
+    }
+
+    void onDocBrokerDestroy(const std::string& docKey) override
+    {
+        TST_LOG("DocBroker destroyed for [" << docKey << ']');
+        LOK_ASSERT_STATE(_phase, Phase::WaitDocClose);
+        LOK_ASSERT_MESSAGE("Clipboard callback should have detected destroyed session",
+                           _sessionGoneCalled);
+        TRANSITION_STATE(_phase, Phase::Done);
+    }
+
+    void invokeWSDTest() override
+    {
+        switch (_phase)
+        {
+            case Phase::RunTest:
+            {
+                std::string documentPath, documentURL;
+                helpers::getDocumentPathAndURL("hello.odt", documentPath,
+                                               documentURL, testname);
+
+                std::shared_ptr<http::WebSocketSession> socket =
+                    helpers::loadDocAndGetSession(
+                        socketPoll(), Poco::URI(helpers::getTestServerURI()),
+                        documentURL, testname);
+
+                _clipURI = getSessionClipboardURI(0);
+
+                // Post a JSON clipboard payload. The JSON triggers the
+                // async HTTP download path in handleClipboardRequest.
+                // The URL must contain /cool/clipboard in its path.
+                // filterClipboardDownloadURL replaces it with a
+                // non-routable address and onClipboardDownloadRequest
+                // sets a short timeout so the callback fires quickly.
+                const std::string jsonPayload =
+                    "{\"url\": \"http://localhost/cool/clipboard\","
+                    " \"commandName\": \".uno:Paste\"}";
+
+                TST_LOG("Posting JSON clipboard to trigger async download");
+                LOK_ASSERT(setClipboard(_clipURI, jsonPayload,
+                                        HTTPResponse::HTTP_OK));
+
+                TRANSITION_STATE(_phase, Phase::WaitDocClose);
+
+                // Close the document while the async clipboard HTTP
+                // request is still pending. This destroys the
+                // ClientSession. The 2s timeout will fire during the
+                // DocBroker's flush phase, invoking the finished
+                // callback after the session is already gone.
+                TST_LOG("Closing document while clipboard request pending");
+                socket->asyncShutdown();
+                LOK_ASSERT_MESSAGE(
+                    "Expected successful disconnection of the WebSocket",
+                    socket->waitForDisconnection(5s));
+                break;
+            }
+            case Phase::WaitDocClose:
+                break;
+            case Phase::Done:
+                passTest("Clipboard timeout after doc close didn't crash");
+                break;
+        }
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitClipboardClose(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -403,6 +403,8 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
                         if (!selfLifecycle)
                         {
                             LOG_ERR_S("Session that requested: " << clipFile << " has already ended.");
+                            if (UnitWSD::isUnitTesting())
+                                UnitWSD::get().onClipboardDownloadSessionGone();
                             return;
                         }
 
@@ -437,6 +439,9 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
                         }
                     };
 
+                    if (UnitWSD::isUnitTesting())
+                        UnitWSD::get().filterClipboardDownloadURL(url);
+
                     const std::string pathAndQuery = Poco::URI(url).getPathAndQuery();
                     if (pathAndQuery.find("/cool/clipboard") != std::string::npos)
                     {
@@ -454,6 +459,10 @@ void ClientSession::handleClipboardRequest(DocumentBroker::ClipboardRequest     
                             httpSession->setConnectFailHandler(std::move(connectFailCallback));
                             http::Request httpRequest(Poco::URI(url).getPathAndQuery());
                             httpSession->asyncRequest(httpRequest, docBroker->getPoll());
+
+                            if (UnitWSD::isUnitTesting())
+                                UnitWSD::get().onClipboardDownloadRequest(httpSession);
+
                             const std::shared_ptr<http::Response> httpResponse = httpSession->response();
                             httpResponse->saveBodyToFile(jailClipFile);
                         }


### PR DESCRIPTION
…onse

A) A clipboard copy from a document on another coolwsd server B) A paste of that clipboard to a document on this coolwsd server C) This coolwsd attempts to contact the other coolwsd server D) That attempt timeouts, for whatever reason, (routing, test vs production networks?) E) Meanwhile the document on this coolwsd server was closed by the user, ending the session F) The timeout arrives and that failure notice is delivered to the deleted session and we crash

can be reproduced manually by bodging:
- http::Session::create(url);
+ http::Session::create("http://10.255.255.1"); and the above steps


Change-Id: I0afc5cbc04f30ac2e3428b7a872533aa19b9999f


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

