### PR TITLE
browser: a11y: remove aria-pressed attribute

### DIFF
--- a/browser/src/control/jsdialog/Widget.MenuButton.js
+++ b/browser/src/control/jsdialog/Widget.MenuButton.js
@@ -72,6 +72,10 @@ function _menubuttonControl (parentContainer, data, builder) {
 		var options = {hasDropdownArrow: menuEntries.length > 1};
 		var control = builder._unoToolButton(parentContainer, data, builder, options);
 
+		if (!window.L.DomUtil.hasClass(control.container, 'selected')) {
+			control.button.removeAttribute('aria-pressed');
+		}
+
 		var isSplitButton = !!data.applyCallback;
 		// can be function or string with command identifier
 		const applyCallback =


### PR DESCRIPTION
After initialization, remove the aria-pressed attribute from
the menu button, as it is a different instance with specific
characteristics.

Change-Id: I00aabc8120c51bc1ea0804fb74660f25c54457a5
Signed-off-by: Henry Castro <hcastro@collabora.com>
