### PR TITLE
Close contextual popups before opening JSDialog dialogs

### DIFF
--- a/browser/src/control/jsdialog/Util.MessageRouter.ts
+++ b/browser/src/control/jsdialog/Util.MessageRouter.ts
@@ -104,6 +104,7 @@ class JSDialogMessageRouter {
 				);
 			}
 		} else if (msgData.jsontype === 'dialog') {
+			app.socket._map.fire('closepopups');
 			app.socket._map.fire('jsdialog', { data: msgData, callback: callbackFn });
 		} else if (msgData.jsontype === 'sidebar') {
 			app.socket._map.fire('sidebar', { data: msgData });


### PR DESCRIPTION
* Resolves: #14418
* Target version: main

### Summary
Fix popup stacking issue where the contextual menu overlaps with the Styles dialog and other JSDialogs.
This is done by firing the `closepopups` event before opening JSDialog dialogs, ensuring any active contextual popups are closed.

### TODO
- [x] Close contextual menu popups before opening JSDialog dialogs
- [x] Prevent overlapping popups (context menu + styles dialog)

### Checklist
- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required
