### PR TITLE
CompareChanges view: Update view data inside a layouting task.

### DIFF
--- a/browser/src/app/ViewLayoutCompareChanges.ts
+++ b/browser/src/app/ViewLayoutCompareChanges.ts
@@ -24,7 +24,8 @@ class ViewLayoutCompareChanges extends ViewLayoutNewBase {
 		super();
 
 		this.adjustViewZoomLevel();
-		this.updateViewData();
+
+		app.layoutingService.appendLayoutingTask(() => this.updateViewData());
 	}
 
 	public adjustViewZoomLevel() {


### PR DESCRIPTION
It sets CSS properties. Without this, cursor is misplaced at start.


Change-Id: Ia889bc033fb3e763b46ece72d6c10ef0b60ed466


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

