### PR TITLE
Improve instructions how to attach gdb

### DIFF
--- a/common/SigUtil-server.cpp
+++ b/common/SigUtil-server.cpp
@@ -550,8 +550,8 @@ void resetTerminationFlags()
         // Prepare this in advance just in case.
         std::ostringstream stream;
         stream << "\nERROR: Fatal signal! Attach debugger with:\n"
-               << "sudo gdb --pid=" << getpid() << "\n or \n"
-               << "sudo gdb --q --n --ex 'thread apply all backtrace full' --batch --pid="
+               << "gdb -iex 'set sysroot /' --pid=" << getpid() << "\n or \n"
+               << "gdb -iex 'set sysroot /' --q --n --ex 'thread apply all backtrace full' --batch --pid="
                << getpid() << '\n';
         std::string streamStr = stream.str();
         assert(sizeof(FatalGdbString) > streamStr.size() + 1);


### PR DESCRIPTION
Without `set sysroot /`, gdb would fail to find any object files for me, assuming their pathnames had some `target:` prefix.  And with `set sysroot /`, it works fine without `sudo` for me (cf.
<https://collaboraonline.github.io/post/debug-code/#gdb-debugging-for-cpp-files>).


Change-Id: Idfca11ded3ee616fb1c76381936d27e9349d9d92


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

