### PR TITLE
Notebookbar: open Table Design tab when inserting table in Calc

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -50,6 +50,7 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 			this.model.fullUpdate(this.getFullJSON(this.HOME_TAB_ID));
 
 		this.map.on('notebookbar', this.onNotebookbar, this);
+		this.map.on('commandstatechanged', this.onCommandStateChanged, this);
 	},
 
 	// on show
@@ -530,6 +531,23 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 			const tabId = defaultTab.attr('id');
 			this.updateButtonVisibilityForContext(requestedContext, tabId);
 			return;
+		}
+	},
+
+	onCommandStateChanged: function(event) {
+		if (event.commandName === 'TableAutoFillInfo' && this.map.getDocType() === 'spreadsheet') {
+			var isTable = false;
+			if (event.state && event.state.rectangle && event.state.rectangle !== 'EMPTY') {
+				isTable = true;
+			}
+
+			if (isTable) {
+				if (this._lastContext !== 'Table') {
+					app.events.fire('contextchange', { appId: 'com.sun.star.sheet.SpreadsheetDocument', context: 'Table' });
+				}
+			} else if (this._lastContext === 'Table') {
+				app.events.fire('contextchange', { appId: 'com.sun.star.sheet.SpreadsheetDocument', context: 'default' });
+			}
 		}
 	},
 


### PR DESCRIPTION
Change-Id: Id847e9d479ad265d7d0269e6f44a3378afbeea35


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
- Listen for TableAutoFillInfo state changes to detect when a table becomes active in spreadsheets.
- Switch the Notebookbar context to Table when a table is active, revealing the Table Design contextual tab.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

