### PR TITLE
cypress: fix interactive run under wayland

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1982,6 +1982,9 @@ fi
 AC_SUBST([ENABLE_WASM_ZETAJS_EXAMPLE])
 AM_CONDITIONAL([ENABLE_WASM_ZETAJS_EXAMPLE], [test "$ENABLE_WASM_ZETAJS_EXAMPLE" = true])
 
+AC_SUBST([WAYLAND_DISPLAY])
+AM_CONDITIONAL([WAYLAND_RUNNING], [test ! -z "$WAYLAND_DISPLAY"])
+
 AC_CONFIG_FILES([Makefile
                  cypress_test/Makefile
                  gtk/Makefile

--- a/cypress_test/Makefile.am
+++ b/cypress_test/Makefile.am
@@ -75,9 +75,13 @@ KILL_COMMAND=$(if $(coolwsd),true,pkill -F $(PID_FILE) || pkill --signal SIGKILL
 LOAD_PID_FILE=$(abs_builddir)/workdir/load.pids
 PARALLEL_BUILD = $(findstring -j,$(MAKEFLAGS))
 DISPLAY_NUMBER = 100
+if WAYLAND_RUNNING
+export DISPLAY=$(shell echo $$DISPLAY)
+else
 HEADLESS_BUILD := $(findstring Command failed,$(shell xhost > /dev/null 2>&1 || echo "Command failed, so we are in a headless environment."))
 export HEADLESS_DISPLAY=$(shell who | grep `whoami` | grep -v ": " | xargs | cut -d " " -f2)
 export DISPLAY=$(if $(HEADLESS_BUILD),:$(DISPLAY_NUMBER),$(shell echo $$DISPLAY))
+endif
 
 COMMA :=,
 EMPTY :=


### PR DESCRIPTION
Issue: In an wayland only distro like Fedora 43 cypress test interactive mode run fails with the below message:
```
[104864:0211/211544.505450:ERROR:ui/ozone/platform/x11/ozone_platform_x11.cc:250] Missing X server or $DISPLAY
[104864:0211/211544.505466:ERROR:ui/aura/env.cc:257] The platform failed to initialize.  Exiting.
```
In wayland there is no xhost, so it forces non interactive run with arbitrarily set DISPLAY var (now set to :100 for some reason). Special case setting of DISPLAY for wayland case based on WAYLAND_DISPLAY shell variable.


Change-Id: I69d9bc711e1f4317727c0f633db514cb73c3e1fc


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

