### PR TITLE
improve desktop/calc/find_dialog_spec.js stability

### DIFF
--- a/cypress_test/integration_tests/common/find_helper.js
+++ b/cypress_test/integration_tests/common/find_helper.js
@@ -37,9 +37,8 @@ function typeIntoSearchField(text) {
     cy.cGet('input#searchterm-input-dialog').type('{selectall}{backspace}' + text);
     cy.cGet('input#searchterm-input-dialog').should('have.prop', 'value', text);
 
-    cy.cGet('#search').should('not.be.disabled');
-    cy.cGet('#searchall').should('not.be.disabled'); //doesnt seem to exist in impress
-    cy.cGet('#backsearch').should('not.be.disabled');
+    cy.cGet('#search-button').should('not.have.attr', 'disabled');
+    cy.cGet('#backsearch-button').should('not.have.attr', 'disabled');
 
     cy.log('<< typeIntoSearchField - end');
 }
@@ -48,8 +47,8 @@ function typeIntoSearchField(text) {
 function findNext() {
     cy.log('>> findNext - start');
 
-    cy.cGet('#search').should('not.have.attr', 'disabled');
-    cy.cGet('#search').click();
+    cy.cGet('#search-button').should('not.have.attr', 'disabled');
+    cy.cGet('#search-button').click();
 
     cy.log('<< findNext - end');
 }
@@ -58,8 +57,8 @@ function findNext() {
 function findPrev() {
     cy.log('>> findPrev - start');
 
-    cy.cGet('#backsearch').should('not.have.attr', 'disabled');
-    cy.cGet('#backsearch').click();
+    cy.cGet('#backsearch-button').should('not.have.attr', 'disabled');
+    cy.cGet('#backsearch-button').click();
 
     cy.log('<< findPrev - end');
 }


### PR DESCRIPTION
Wait for the actual button element to be enabled, not just the wrapper div. Plausible that SynchronizeDisabledState defers the button's disabled attribute removal via a layouting task.

remove searchall[-button] test, doesn't exist in impress and isn't used here anyway.


Change-Id: I9951232f43cc342691a755e74e5d28e9ea5705f4


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

