### PR TITLE
Notebookbar: Center Table Style Options and correct overflow group label alignment

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -451,6 +451,7 @@ algned to the bottom */
 	margin-bottom: 14px !important;
 }
 
+#table-style-options .notebookbar.ui-overflow-group-inner,
 .unotoolbutton.notebookbar.ui-content.has-label > *:not(.arrowbackground) {
 	height: var(--notebookbar-element-height) !important;
 	align-content: center;


### PR DESCRIPTION
Change-Id: I52678f36a000736418b08ea673b68898d62b8fb7


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
- Adjust the inner overflow group container of the Table Style Options section to use --notebookbar-element-height for consistent vertical sizing.

- This ensures the table style options are properly centered within the group and aligns the group label consistently with other Notebookbar sections by anchoring it to the expected bottom alignment baseline.


### PREVIEW
#### BEFORE
<img width="999" height="120" alt="2026-02-12_01-59" src="https://github.com/user-attachments/assets/5d07989c-9137-4f42-9b6e-883d698c55e7" />


#### AFTER
<img width="1093" height="130" alt="2026-02-12_02-00" src="https://github.com/user-attachments/assets/a6edc17d-cf18-4d96-9acc-984dce9cc18c" />



- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

