### PR TITLE
Replace Poco::RegularExpression with std::regex

### DIFF
--- a/common/RegexUtil.cpp
+++ b/common/RegexUtil.cpp
@@ -19,8 +19,6 @@
 
 #include "RegexUtil.hpp"
 
-#include <Poco/RegularExpression.h>
-
 #include <regex>
 
 namespace RegexUtil
@@ -38,12 +36,10 @@ bool matchRegex(const std::set<std::string>& set, const std::string& subject)
         try
         {
             // Not performance critical to warrant caching.
-            Poco::RegularExpression re(value, Poco::RegularExpression::RE_CASELESS);
-            Poco::RegularExpression::Match reMatch;
+            std::regex re(value, std::regex_constants::icase);
 
             // Must be a full match.
-            if (re.match(subject, reMatch) && reMatch.offset == 0 &&
-                reMatch.length == subject.size())
+            if (std::regex_match(subject, re))
             {
                 return true;
             }
@@ -70,12 +66,10 @@ std::string getValue(const std::map<std::string, std::string>& map, const std::s
         try
         {
             // Not performance critical to warrant caching.
-            Poco::RegularExpression re(value.first, Poco::RegularExpression::RE_CASELESS);
-            Poco::RegularExpression::Match reMatch;
+            std::regex re(value.first, std::regex_constants::icase);
 
             // Must be a full match.
-            if (re.match(subject, reMatch) && reMatch.offset == 0 &&
-                reMatch.length == subject.size())
+            if (std::regex_match(subject, re))
             {
                 return value.second;
             }
@@ -103,12 +97,10 @@ std::string getValue(const std::set<std::string>& set, const std::string& subjec
         try
         {
             // Not performance critical to warrant caching.
-            Poco::RegularExpression re(value, Poco::RegularExpression::RE_CASELESS);
-            Poco::RegularExpression::Match reMatch;
+            std::regex re(value, std::regex_constants::icase);
 
             // Must be a full match.
-            if (re.match(subject, reMatch) && reMatch.offset == 0 &&
-                reMatch.length == subject.size())
+            if (std::regex_match(subject, re))
             {
                 return value;
             }

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -32,7 +32,7 @@
 
 #include <Poco/File.h>
 #include <Poco/Path.h>
-#include <Poco/RegularExpression.h>
+#include <regex>
 
 #define LOK_USE_UNSTABLE_API
 #include <LibreOfficeKit/LibreOfficeKitEnums.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1581,22 +1581,6 @@ AS_IF([test "$ENABLE_IOSAPP" != "true" -a "$ENABLE_ANDROIDAPP" != "true" -a "$ho
                 [AC_MSG_ERROR([header Poco/SAX/SAXParser.h not found, perhaps you want to use --with-poco-includes])])
        fi
 
-       # If poco is built with --unbundled, it uses the system pcre library
-       AC_MSG_CHECKING([if we need to link with -lpcre])
-       AC_LINK_IFELSE([AC_LANG_SOURCE([
-       #include <Poco/RegularExpression.h>
-       int main(int argc, char **argv)
-       {
-           (void)argc;
-           Poco::RegularExpression e("abc.[def]");
-           Poco::RegularExpression::Match m;
-           return e.match(argv[[1]], m);
-       }
-       ])],
-                      [AC_MSG_RESULT([no])],
-                      [AC_MSG_RESULT([yes])
-                       LIBS="$LIBS -lpcre"])
-
        ])
 
 AS_IF([test `uname -s` = "Linux" -o `uname -s` = "FreeBSD" -o `uname -s` = "Darwin"],

--- a/test/UnitBadDocLoad.cpp
+++ b/test/UnitBadDocLoad.cpp
@@ -21,7 +21,6 @@
 #include <helpers.hpp>
 
 #include <Poco/Exception.h>
-#include <Poco/RegularExpression.h>
 #include <Poco/URI.h>
 #include <test/lokassert.hpp>
 

--- a/test/UnitCursor.cpp
+++ b/test/UnitCursor.cpp
@@ -21,7 +21,6 @@
 #include <test/lokassert.hpp>
 
 #include <Poco/Exception.h>
-#include <Poco/RegularExpression.h>
 #include <Poco/URI.h>
 
 #include <memory>

--- a/test/UnitInsertDelete.cpp
+++ b/test/UnitInsertDelete.cpp
@@ -16,7 +16,6 @@
 #include <config.h>
 
 #include <Poco/Exception.h>
-#include <Poco/RegularExpression.h>
 #include <Poco/URI.h>
 #include <test/lokassert.hpp>
 

--- a/test/UnitWOPIFileUrl.cpp
+++ b/test/UnitWOPIFileUrl.cpp
@@ -17,6 +17,8 @@
 
 #include <lokassert.hpp>
 
+#include <regex>
+
 #include <Poco/Net/HTTPRequest.h>
 
 #include <WopiTestServer.hpp>
@@ -85,14 +87,14 @@ public:
                                                << " request: " << uriReq.toString());
 
         constexpr auto DefaultUrlFilename = "empty.odt";
-        static const Poco::RegularExpression regContent("/wopi/files/[0-9]/contents");
+        static const std::regex regContent("/wopi/files/[0-9]/contents");
 
         if (request.getMethod() == "GET")
         {
-            static const Poco::RegularExpression regInfo("/wopi/files/[0-9]");
+            static const std::regex regInfo("/wopi/files/[0-9]");
 
             // CheckFileInfo
-            if (regInfo.match(uriReq.getPath()))
+            if (std::regex_match(uriReq.getPath(), regInfo))
             {
                 TST_LOG("FakeWOPIHost: Handling WOPI::CheckFileInfo: " << uriReq.getPath());
 
@@ -132,7 +134,7 @@ public:
                 return true;
             }
 
-            if (regContent.match(uriReq.getPath()))
+            if (std::regex_match(uriReq.getPath(), regContent))
             {
                 if (_fileUrlState == FileUrlState::Valid)
                 {
@@ -157,7 +159,7 @@ public:
             LOK_ASSERT_STATE(_phase, Phase::WaitPutFile);
 
             LOK_ASSERT_MESSAGE("Always the default URI must be used for PutFile",
-                               regContent.match(uriReq.getPath()));
+                               std::regex_match(uriReq.getPath(), regContent));
 
             std::streamsize size = request.getContentLength();
             LOK_ASSERT(size > 0);

--- a/test/UnitWOPIHttpRedirect.cpp
+++ b/test/UnitWOPIHttpRedirect.cpp
@@ -24,6 +24,7 @@
 
 #include <Poco/Net/HTTPRequest.h>
 
+#include <regex>
 #include <string>
 
 class UnitWopiHttpRedirect : public WopiTestServer
@@ -44,17 +45,17 @@ public:
                                    const std::shared_ptr<StreamSocket>& socket) override
     {
         Poco::URI uriReq(request.getURI());
-        Poco::RegularExpression regInfo("/wopi/files/1");
+        static const std::regex regInfo("/wopi/files/1");
         std::string redirectUri = "/wopi/files/0";
-        Poco::RegularExpression regRedirected(redirectUri);
-        Poco::RegularExpression regContents("/wopi/files/0/contents");
+        static const std::regex regRedirected("/wopi/files/0");
+        static const std::regex regContents("/wopi/files/0/contents");
         std::string redirectUri2 = "/wopi/files/2/contents";
-        Poco::RegularExpression regContentsRedirected(redirectUri2);
+        static const std::regex regContentsRedirected("/wopi/files/2/contents");
 
         TST_LOG("FakeWOPIHost: Request URI [" << uriReq.toString() << "]:\n");
 
         // CheckFileInfo - returns redirect response
-        if (request.getMethod() == "GET" && regInfo.match(uriReq.getPath()))
+        if (request.getMethod() == "GET" && std::regex_match(uriReq.getPath(), regInfo))
         {
             TST_LOG("FakeWOPIHost: Handling CheckFileInfo (1/2)");
 
@@ -70,7 +71,7 @@ public:
             return true;
         }
         // CheckFileInfo - for redirected URI
-        else if (request.getMethod() == "GET" && regRedirected.match(uriReq.getPath()) && !regContents.match(uriReq.getPath()))
+        else if (request.getMethod() == "GET" && std::regex_match(uriReq.getPath(), regRedirected) && !std::regex_match(uriReq.getPath(), regContents))
         {
             TST_LOG("FakeWOPIHost: Handling CheckFileInfo: (2/2)");
 
@@ -97,7 +98,7 @@ public:
             return true;
         }
         // GetFile - first try
-        else if (request.getMethod() == "GET" && regContents.match(uriReq.getPath()))
+        else if (request.getMethod() == "GET" && std::regex_match(uriReq.getPath(), regContents))
         {
             TST_LOG("FakeWOPIHost: Handling GetFile: " << uriReq.getPath());
 
@@ -113,7 +114,7 @@ public:
             return true;
         }
         // GetFile - redirected
-        else if (request.getMethod() == "GET" && regContentsRedirected.match(uriReq.getPath()))
+        else if (request.getMethod() == "GET" && std::regex_match(uriReq.getPath(), regContentsRedirected))
         {
             TST_LOG("FakeWOPIHost: Handling GetFile: " << uriReq.getPath());
 
@@ -179,13 +180,13 @@ public:
                                    const std::shared_ptr<StreamSocket>& socket) override
     {
         Poco::URI uriReq(request.getURI());
-        Poco::RegularExpression regInfo("/wopi/files/[0-9]+");
+        static const std::regex regInfo("/wopi/files/[0-9]+");
         static unsigned redirectionCount = 0;
 
         TST_LOG("FakeWOPIHost: Request URI [" << uriReq.toString() << "]:\n");
 
         // CheckFileInfo - always returns redirect response
-        if (request.getMethod() == "GET" && regInfo.match(uriReq.getPath()))
+        if (request.getMethod() == "GET" && std::regex_match(uriReq.getPath(), regInfo))
         {
             TST_LOG("FakeWOPIHost: Handling CheckFileInfo");
 

--- a/test/httpwstest.cpp
+++ b/test/httpwstest.cpp
@@ -22,7 +22,6 @@
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/Net/InvalidCertificateHandler.h>
 #include <Poco/Net/SSLManager.h>
-#include <Poco/RegularExpression.h>
 #include <Poco/URI.h>
 
 #include <cppunit/extensions/HelperMacros.h>

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -35,7 +35,7 @@
 
 #include <Poco/DirectoryIterator.h>
 #include <Poco/FileStream.h>
-#include <Poco/RegularExpression.h>
+#include <regex>
 #include <Poco/StreamCopier.h>
 #include <Poco/Util/LayeredConfiguration.h>
 
@@ -50,8 +50,7 @@
 
 bool filterTests(CPPUNIT_NS::TestRunner& runner, CPPUNIT_NS::Test* testRegistry, const std::string& testName)
 {
-    Poco::RegularExpression re(testName, Poco::RegularExpression::RE_CASELESS);
-    Poco::RegularExpression::Match reMatch;
+    std::regex re(testName, std::regex_constants::icase);
 
     bool haveTests = false;
     for (int i = 0; i < testRegistry->getChildTestCount(); ++i)
@@ -62,7 +61,7 @@ bool filterTests(CPPUNIT_NS::TestRunner& runner, CPPUNIT_NS::Test* testRegistry,
             CPPUNIT_NS::Test* testCase = testSuite->getChildTestAt(j);
             try
             {
-                if (re.match(testCase->getName(), reMatch))
+                if (std::regex_search(testCase->getName(), re))
                 {
                     runner.addTest(testCase);
                     haveTests = true;

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -62,7 +62,6 @@
 #include <Poco/Net/NameValueCollection.h>
 #include <Poco/Net/NetException.h>
 #include <Poco/Net/PartHandler.h>
-#include <Poco/RegularExpression.h>
 #include <Poco/Runnable.h>
 #include <Poco/SHA1Engine.h>
 #include <Poco/StreamCopier.h>
@@ -75,6 +74,7 @@
 #include <iomanip>
 #include <sstream>
 #include <string>
+#include <regex>
 #include <vector>
 
 #include <dirent.h>
@@ -858,12 +858,12 @@ std::string FileServerRequestHandler::getRequestPathname(const HTTPRequest& requ
 
     std::string path(requestUri.getPath());
 
-    Poco::RegularExpression gitHashRe("/([0-9a-f]+)/");
-    std::string gitHash;
-    if (gitHashRe.extract(path, gitHash))
+    static const std::regex gitHashRe("/([0-9a-f]+)/");
+    std::smatch gitHashMatch;
+    if (std::regex_search(path, gitHashMatch, gitHashRe))
     {
         // Convert version back to a real file name.
-        Poco::replaceInPlace(path, std::string("/browser" + gitHash), std::string("/browser/dist/"));
+        Poco::replaceInPlace(path, std::string("/browser" + gitHashMatch[0].str()), std::string("/browser/dist/"));
     }
 
 #if !MOBILEAPP

--- a/wsd/HostUtil.cpp
+++ b/wsd/HostUtil.cpp
@@ -27,6 +27,7 @@
 #include <common/RegexUtil.hpp>
 
 #include <map>
+#include <regex>
 #include <set>
 #include <string>
 
@@ -89,22 +90,15 @@ std::string HostUtil::parseAlias(const std::string& aliasPattern)
 
     // check if it is plain uri, then convert to a strict regex for this uri if needed
     // Must be a full match.
-    Poco::RegularExpression re(
-        "^(https?://)?(?<hostname>([a-z0-9\\-]+)(\\.[a-z0-9\\-]+)+)(:[0-9]{1,5})?(/[a-z0-9\\-&?_]*)*$",
-        Poco::RegularExpression::RE_CASELESS);
+    // Group 2 captures the hostname.
+    std::regex re(
+        "^(https?://)?(([a-z0-9\\-]+)(\\.[a-z0-9\\-]+)+)(:[0-9]{1,5})?(/[a-z0-9\\-&?_]*)*$",
+        std::regex_constants::icase);
 
-    std::vector<Poco::RegularExpression::Match> matches;
-    if (re.match(aliasPattern, 0, matches) && matches.size() > 1)
+    std::smatch matches;
+    if (std::regex_match(aliasPattern, matches, re) && matches.size() > 2)
     {
-        std::string hostname;
-        for (const auto& match : matches)
-        {
-            if (match.name == "hostname")
-            {
-                hostname = aliasPattern.substr(match.offset, match.length);
-                break;
-            }
-        }
+        std::string hostname = matches[2].str();
 
         if (hostname.empty())
         {


### PR DESCRIPTION
This removes the dependency on Poco's regex (and transitively PCRE) in favor of the C++ standard library's std::regex.


Change-Id: Ia2a17f049cabdab9137742f47e4360cca89a1d72

