### PR TITLE
SBOM: add macaron, the single header base64 decode/encoder

### DIFF
--- a/cool-sbom-template.spdx.json
+++ b/cool-sbom-template.spdx.json
@@ -232,6 +232,14 @@
       "filesAnalyzed": false,
       "downloadLocation": "NONE",
       "licenseConcluded": "OFL-1.1"
+    },
+    {
+      "SPDXID": "SPDXRef-macaron",
+      "name": "Macaron - single header base64 decoder/encoder",
+      "versionInfo": "NONE",
+      "filesAnalyzed": false,
+      "downloadLocation": "https://gist.github.com/tomykaira/f0fd86b6c73063283afe550bc5d77594",
+      "licenseConcluded": "MIT"
     }
   ],
   "relationships": [


### PR DESCRIPTION
Change-Id: I201c84009cc54234378e8e9b49403d77c8337519
