### PR TITLE
Remove dead Poco < 1.8.0 compat code from UnitHTTP.hpp

### DIFF
--- a/test/UnitHTTP.hpp
+++ b/test/UnitHTTP.hpp
@@ -18,7 +18,6 @@
 #include <Poco/Net/HTTPServerRequest.h>
 #include <Poco/Net/HTTPServerResponse.h>
 #include <Poco/Net/SocketAddress.h>
-#include <Poco/Version.h>
 
 #include "Common.hpp"
 
@@ -78,18 +77,10 @@ public:
     {
         return _dummyStream;
     }
-#if POCO_VERSION < 0x01080000
-    virtual bool expectContinue() const override
-    {
-        return false;
-    }
-#endif
-#if POCO_VERSION >= 0x01080000
     virtual bool secure() const override
     {
         return true;
     }
-#endif
     virtual const Poco::Net::SocketAddress& clientAddress() const override
     {
         return _clientAddress;


### PR DESCRIPTION
We require Poco >= 1.12.0, so the #if POCO_VERSION < 0x01080000 guard for expectContinue() is dead code. Remove it and the now-unconditional secure() override, along with the unused Poco/Version.h include.


Change-Id: I49739aa86a2cba38de75d3f2a80741e2ac9963fd

