### PR TITLE
cypress: fix Insert/delete chart test in writer/top_toolbar_spec

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -341,6 +341,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 
 		// exit active object mode
 		helper.typeIntoDocument('{esc}');
+		helper.typeIntoDocument('{esc}');
 
 		//delete
 		helper.typeIntoDocument('{del}');


### PR DESCRIPTION
apparently {esc} needs to be pressed twice to exit active object mode


Change-Id: I36867b9941e98fab94d936e52f1c874fc845d611


* Target version: main

### Summary

see: https://github.com/CollaboraOnline/online/pull/14428#issuecomment-3895144472
