### PR TITLE
Tiles Compare-Changes view: Check both modes before filtering tiles out.

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -1293,7 +1293,7 @@ class TileManager {
 		return boundList.map((x: any) => this.pxBoundsToTileRange(x));
 	}
 
-	private static updateTileDistance(tile: Tile, zoom: number) {
+	private static getModeArray() {
 		let modes = [app.map._docLayer._selectedMode];
 		if (
 			app.activeDocument &&
@@ -1302,6 +1302,11 @@ class TileManager {
 			// 2 modes are active at the same time in compare changes view mode.
 			modes = [TileMode.LeftSide, TileMode.RightSide];
 		}
+		return modes;
+	}
+
+	private static updateTileDistance(tile: Tile, zoom: number) {
+		const modes = this.getModeArray();
 		if (
 			tile.coords.z !== zoom ||
 			tile.coords.part !== app.map._docLayer._selectedPart ||
@@ -1421,10 +1426,12 @@ class TileManager {
 		const part: number = app.map._docLayer._selectedPart;
 		const mode: number = app.map._docLayer._selectedMode;
 
+		const modes = this.getModeArray();
+
 		for (let i = coordsQueue.length - 1; i > 0; i--) {
 			if (
 				coordsQueue[i].part !== part ||
-				coordsQueue[i].mode !== mode ||
+				!modes.includes(coordsQueue[i].mode) ||
 				!this.tileNeedsFetch(coordsQueue[i].key())
 			) {
 				coordsQueue.splice(i, 1);


### PR DESCRIPTION
Issue: Sometimes there are missing tiles on the screen. This change seems to improve the situation. Also, logically correct.


Change-Id: I51672f58feb9fbbd91c63d1426c6ee421c889019


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

