### PR TITLE
Use forward declaration for LOKit headers in some headers

### DIFF
--- a/android/lib/src/main/cpp/androidapp.cpp
+++ b/android/lib/src/main/cpp/androidapp.cpp
@@ -21,6 +21,9 @@
 #include <SetupKitEnvironment.hpp>
 #include <common/Util.hpp>
 
+#define LIBO_INTERNAL_ONLY
+#include <LibreOfficeKit/LibreOfficeKit.hxx>
+
 #include <osl/detail/android-bootstrap.h>
 
 const int SHOW_JS_MAXLEN = 70;

--- a/common/MobileApp.hpp
+++ b/common/MobileApp.hpp
@@ -13,9 +13,6 @@
 
 #if MOBILEAPP
 
-#define LIBO_INTERNAL_ONLY
-#include <LibreOfficeKit/LibreOfficeKit.hxx>
-
 #include <Storage.hpp>
 
 #ifdef IOS
@@ -38,6 +35,11 @@
 // the core SfxViewShell::GetDocId() returns, but there might be situations where multi-threading
 // and opening of several documents in sequence very quickly might cause discrepancies, so it is
 // better to use a different counter to be sure. Patches to use just one counter welcome.
+
+namespace lok
+{
+class Document;
+}
 
 class DocumentData
 {

--- a/ios/Mobile/DocumentViewController.mm
+++ b/ios/Mobile/DocumentViewController.mm
@@ -31,6 +31,9 @@
 #import "Clipboard.hpp"
 #import "CoolURLSchemeHandler.h"
 
+#define LIBO_INTERNAL_ONLY
+#import <LibreOfficeKit/LibreOfficeKit.hxx>
+
 #import "DocumentViewController.h"
 
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -25,6 +25,7 @@
 #include <common/Util.hpp>
 
 #define LOK_USE_UNSTABLE_API
+#include <LibreOfficeKit/LibreOfficeKit.hxx>
 #include <LibreOfficeKit/LibreOfficeKitEnums.h>
 
 #include <Poco/StreamCopier.h>

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -16,11 +16,14 @@
 #include <kit/StateRecorder.hpp>
 #include <kit/Watermark.hpp>
 
-#define LOK_USE_UNSTABLE_API
-#include <LibreOfficeKit/LibreOfficeKit.hxx>
-
 #include <chrono>
 #include <queue>
+
+namespace lok
+{
+class Document;
+class Office;
+}
 
 class Document;
 class ChildSession;

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -35,6 +35,9 @@
 #include <kit/SetupKitEnvironment.hpp>
 #include <net/ServerSocket.hpp>
 
+#define LOK_USE_UNSTABLE_API
+#include <LibreOfficeKit/LibreOfficeKit.hxx>
+
 #include <Poco/Path.h>
 #include <Poco/URI.h>
 

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -26,8 +26,7 @@
 
 #include <Socket.hpp>
 
-#define LOK_USE_UNSTABLE_API
-#include <LibreOfficeKit/LibreOfficeKit.hxx>
+#include <LibreOfficeKit/LibreOfficeKitTypes.h>
 
 #if MOBILEAPP
 
@@ -41,6 +40,14 @@
 #ifdef IOS
 void runKitLoopInAThread();
 #endif
+
+namespace lok
+{
+class Document;
+class Office;
+}
+struct LibreOfficeKitStruct;
+using LibreOfficeKit = LibreOfficeKitStruct;
 
 void lokit_main(
 #if !MOBILEAPP


### PR DESCRIPTION
To reduce build times if LibreOfficeKit.h/hxx change, eg. if someone jumps between core commits during bisecting.

This will later also require forward declaring
LibreOfficeKit in LibreOfficeKitInit.h in core.

Change-Id: If6b7e13b301e8cf9215b346ab52382b3cd0aeeda

* Target version: main

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

