### PR TITLE
zoom: add required method to base view

### DIFF
--- a/browser/src/app/ViewLayout.ts
+++ b/browser/src/app/ViewLayout.ts
@@ -36,6 +36,8 @@ class ScrollProperties {
 	moveBy: number[] | null = null; // Pending move event (pX, pY).
 }
 
+// FIXME: should be abstract to split Writer and other layouts
+// so we can have abstract methods and be warned about missing bits
 class ViewLayoutBase {
 	public readonly type: string = 'ViewLayoutBase';
 
@@ -188,6 +190,13 @@ class ViewLayoutBase {
 
 	protected getDocumentAnchorSection(): CanvasSectionObject {
 		return app.sectionContainer.getDocumentAnchorSection();
+	}
+
+	/// used in Views which can show pages (Writer) to determine left alignment
+	// FIXME: confusing name, should be abstract
+	public getDocumentScrollOffset(): number {
+		app.console.error('not implemented');
+		return 0;
 	}
 
 	private calculateHorizontalScrollLength(

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -417,7 +417,8 @@ window.L.Map = window.L.Evented.extend({
 		if (!offset.x && !offset.y)
 			return this;
 
-		if (this._docLayer && this._docLayer._docType === 'text' && offset.x != 0)
+		if (this._docLayer && this._docLayer._docType === 'text' && offset.x != 0 &&
+			app.activeDocument.activeLayout.type === 'ViewLayoutWriter')
 			offset.x += (app.activeDocument.activeLayout).getDocumentScrollOffset();
 
 		//If we pan too far then chrome gets issues with tiles


### PR DESCRIPTION
We got error when changing page size in mutli-page view: global.js:598 Exception TypeError: app.activeDocument.activeLayout.getDocumentScrollOffset is not a function

Missing method comes from:
commit db0011166aa49caa1196e0087a68e94f5f635dba
enhancement: make document movements smooth when making space for comments

This mistake is caused by the class hierarchy:
We have ViewLayoutWriter which inherits from a base class, but ViewLayoutMultiPage or Compare are also for Writer...

For now let's use the new comment-positioning code only in the layout which was adjusted for them in mentioned commit.

