### PR TITLE
css: remove dead w2ui CSS rules

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -181,12 +181,6 @@ textarea.cool-annotation-textarea {
 	height: 100%;
 	overflow-y: scroll;
 }
-#toolbar-up.w2ui-toolbar {
-	padding-top: 0px;
-	padding-bottom: 0px;
-	background: transparent;
-	align-self: end;
-}
 .formulabar.unotoolbutton {
 	justify-self: center;
 }
@@ -263,44 +257,8 @@ textarea.cool-annotation-textarea {
 	filter: drop-shadow(0px 0px 4px var(--color-primary-darker));
 	border-color: transparent;
 }
-#toolbar-down table.w2ui-button .w2ui-tb-image {
-	margin: 5px 9px !important;
-}
-#toolbar-down table.w2ui-button .textcolor {
-	margin-bottom: 0px !important;
-}
-#toolbar-down table.w2ui-button .backcolor {
-	margin-bottom: 0px !important;
-}
-#toolbar-down table.w2ui-button .selected-color-classic {
-	height: 5px;
-	width: 26px;
-	margin: auto;
-	position: relative;
-	top: -6px;
-	border: 1px solid var(--color-border-dark);
-	border-radius: 7px;
-	outline: 1px solid var(--color-background-lighter);
-}
-.w2ui-toolbar .w2ui-break {
-	background-image: none;
-	background-color: #dae6f3;
-}
-#formulabar .w2ui-break {
-	visibility: hidden;
-}
 #setgamma input.spinfield, #linewidth input.spinfield, #nolines input.spinfield {
 	width: 140px !important;
-}
-#toolbar-down table.w2ui-button:not(.checked) td.w2ui-tb-down > div {
-	border-top: none !important;
-	margin-top: 0 !important;
-	border-bottom: 5px solid #8D99A7 !important;
-}
-#toolbar-down table.w2ui-button.checked td.w2ui-tb-down > div {
-	border-bottom: none;
-	border-top: 5px solid #8D99A7;
-	margin-bottom: 5px !important;
 }
 #toolbar-search #search * {
 	width: 100% !important;

--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -497,11 +497,6 @@ p.mobile-wizard.ui-combobox-text.selected {
 	border-bottom: solid 1px var(--color-primary-dark);
 }
 
-[id|='tb_colorselector'] .w2ui-tb-caption > div {
-	height: 32px !important;
-	width: 32px !important;
-}
-
 [name|='colorselector'] {
 	width: 80px;
 }
@@ -1039,10 +1034,6 @@ label[disabled] {
 #toolbar-search {
 	background-color: var(--color-main-background);
 }
-.w2ui-toolbar table {
-	height: var(--header-height);
-}
-
 #criteria.ui-tab, #inputhelp.ui-tab {
 	width: 30% !important;
 }

--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -188,47 +188,10 @@
 	border-top: 1px solid var(--color-border);
 }
 
-.w2ui-icon-check:before {
-	color: var(--color-primary);
-}
-
-.w2ui-toolbar table.w2ui-button .w2ui-tb-down > div {
-	border-top: 5px solid var(--color-main-text);
-}
 #toolbar-down .ToolbarStatusInactive {
 	color: var(--color-text-lighter);
 	box-shadow: inset 0px 0px 0px 10px var(--color-background-dark), 0px 0px 0px 2px var(--color-background-dark), 4px 0px 0px 1px var(--color-background-lighter), -4px 0px 0px 1px #fff, 0px 0px 0px 5px var(--color-background-lighter);
 }
-.w2ui-overlay {
-	-webkit-box-shadow: 0 0 3px var(--color-border);
-	box-shadow: 0 0 3px var(--color-box-shadow);
-	border-radius: var(--border-radius);
-	background-color: var(--color-background-lighter);
-}
-.w2ui-overlay.bottom-arrow:before {
-	border-top: 6px solid var(--color-border-dark);
-}
-.w2ui-overlay .menu {
-	overflow: hidden auto;
-	border-radius: var(--border-radius);
-	position: static !important;
-}
-.w2ui-overlay > div {
-	border: 1px solid var(--color-border-dark);
-	border-radius: var(--border-radius);
-}
-.w2ui-overlay table.w2ui-drop-menu {
-	color: var(--color-main-text);
-	background-color: var(--color-main-background);
-}
-.w2ui-overlay table.w2ui-drop-menu tr:hover {
-	color: var(--color-text-darker);
-	background-color: var(--color-background-darker);
-}
-.w2ui-overlay.bottom-arrow:after {
-	border-top-color: var(--color-background-lighter);
-}
-
 #presentation-toolbar {
 	bottom: 0;
 	background-color: var(--color-background-lighter);
@@ -247,12 +210,6 @@
 	display: flex !important;
 	flex: 1;
 	justify-content: space-between;
-}
-
-.w2ui-toolbar .w2ui-break {
-	height: 18px;
-	background-image: none;
-	background-color: var(--color-border-lighter);
 }
 
 /* scroll wrapper */
@@ -418,17 +375,9 @@
 	width: 95%;
 }
 
-.w2ui-button {
-	margin: 0 !important;
-}
-
 .w2ui-tb-image {
 	width: 24px !important;
 	height: 24px !important;
-}
-
-.w2ui-break {
-	margin: 0 4px !important;
 }
 
 .leaflet-bar a {
@@ -506,8 +455,7 @@ button.leaflet-control-search-next
 	border-radius: var(--border-radius);
 	border: 1px solid var(--color-border-dark);
 }
-.sidebar.jsdialog.ui-listbox:hover,
-.w2ui-toolbar table.w2ui-button.checked:hover {
+.sidebar.jsdialog.ui-listbox:hover {
 	background-color: var(--color-background-lighter);
 	color: var(--color-text-darker);
 }
@@ -604,22 +552,6 @@ button.leaflet-control-search-next
 	width: fit-content;
 }
 
-.w2ui-toolbar table.w2ui-button {
-	background-color: transparent;
-	border: 1px solid transparent;
-	color: var(--color-main-text);
-}
-.w2ui-toolbar table.w2ui-button:hover {
-	background-color: var(--color-border-darker);
-}
-.w2ui-toolbar table.w2ui-button.over {
-	border: 1px solid var(--color-border-darker) !important;
-}
-.w2ui-toolbar table.w2ui-button.checked {
-	background-color: var(--color-background-dark);
-	border: 1px solid var(--color-border-dark);
-	color: var(--color-text-dark);
-}
 
 .w2ui-icon.basicshapes_rectangle { background: url('images/lc_rect.svg') no-repeat center; }
 .w2ui-icon.basicshapes_round-rectangle { background: url('images/lc_rect_rounded.svg') no-repeat center; }
@@ -1828,17 +1760,6 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	#userListHeader {
 		display: none;
 	}
-}
-
-.w2ui-color {
-	background-color: transparent;
-}
-
-.w2ui-toolbar table.w2ui-button .w2ui-tb-caption,
-.w2ui-toolbar table.w2ui-button.checked .w2ui-tb-caption,
-.w2ui-reset table tr th, .w2ui-reset table tr td {
-	font-size: var(--default-font-size);
-	color: var(--color-main-text);
 }
 
 .slidelayout-button {


### PR DESCRIPTION
Remove CSS rules that reference w2ui classes (w2ui-toolbar, w2ui-button, w2ui-break, w2ui-overlay, w2ui-drop-menu, w2ui-tb-down, w2ui-tb-caption, w2ui-icon-check, w2ui-color, w2ui-reset) which are never set in any JS/TS/HTML code. These are leftovers from the old w2ui toolbar library that was removed long ago.


Change-Id: I7f27564329df81670b2433ae0f50e7f6ad4965fa
