### PR TITLE
color picker: use standard color names for non-theme palette entries

### DIFF
--- a/browser/src/control/jsdialog/Widget.ColorPicker.ts
+++ b/browser/src/control/jsdialog/Widget.ColorPicker.ts
@@ -141,12 +141,16 @@ function createColor(
 
 	// Set color tooltips
 	var colorTooltip;
-	const found = themeColors.find(
-		(item: ThemeColor) => item.Value.toLowerCase() === colorItem.toLowerCase(),
-	);
-	if (found) colorTooltip = found.Name;
-	else if (window.app.colorNames) colorTooltip = findColorName(colorItem);
-	else colorTooltip = _('Unknown color');
+	if (themeData) {
+		const found = themeColors.find(
+			(item: ThemeColor) =>
+				item.Value.toLowerCase() === colorItem.toLowerCase(),
+		);
+		if (found) colorTooltip = found.Name;
+	}
+	if (!colorTooltip && window.app.colorNames)
+		colorTooltip = findColorName(colorItem);
+	if (!colorTooltip) colorTooltip = _('Unknown color');
 
 	if (window.enableAccessibility) {
 		color.setAttribute('aria-label', colorTooltip);


### PR DESCRIPTION
Theme color names were always looked up first by hex value, so when a StandardColors entry like "Dark Red 2" shared the same hex as theme "Accent 6", the tooltip showed "Accent 6" instead.

Only use theme color names when the entry actually has theme data.


Change-Id: Ibbf0ac8c522f267a7fe9a7a8732d519b66c3543c
