### PR TITLE
Use the copy of _sessions to iterate over instead of the original.

### DIFF
--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -5304,7 +5304,7 @@ bool DocumentBroker::forwardToClient(const std::shared_ptr<Message>& payload)
             // Broadcast to all.
             // Events could cause the removal of sessions.
             std::map<std::string, std::shared_ptr<ClientSession>> sessions(_sessions);
-            for (const auto& it : _sessions)
+            for (const auto& it : sessions)
             {
                 if (!it.second->inWaitDisconnected())
                     it.second->handleKitToClientMessage(payload);


### PR DESCRIPTION
Avoiding a somewhat theoretical race in some cases, introduced in:

commit 9e791fb0d4d4c701c50b8b50091b5665b832c3f1
Author: Michael Meeks <michael.meeks@collabora.com>
Date:   Thu Jul 4 10:50:33 2019 +0100

    clipboard: persist selections for a while after a view closes.

Change-Id: I343fe5cb927bc0af4f82fc41ff6ca943c1919ade


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

