### PR TITLE
color picker button: update tooltip when color changes

### DIFF
--- a/browser/src/control/jsdialog/Widget.ColorPickerButton.js
+++ b/browser/src/control/jsdialog/Widget.ColorPickerButton.js
@@ -217,6 +217,22 @@ JSDialog.colorPickerButton = function (parentContainer, data, builder) {
 				} else {
 					valueNode.style.borderColor = 'var(--color-border)';
 				}
+
+				// Update the button tooltip with the current color name
+				if (menubutton.container && data.text) {
+					var colorName = '';
+					var hexColor = selectedColor;
+					if (hexColor && hexColor[0] === '#') hexColor = hexColor.substr(1);
+					if (hexColor && hexColor !== 'transparent' && window.app.colorNames) {
+						var entry = window.app.colorNames.find(function (c) {
+							return c.hexCode.toLowerCase() === hexColor.toLowerCase();
+						});
+						if (entry) colorName = entry.name;
+					}
+					var tooltip = data.text;
+					if (colorName) tooltip += ' (' + colorName + ')';
+					menubutton.container.setAttribute('data-cooltip', tooltip);
+				}
 			};
 
 			builder.map.on(


### PR DESCRIPTION
The color picker button tooltip (e.g. "Font Color (Dark Red 2)") was set once from the server JSON and never updated when the color changed. Now the updateFunction also looks up the current color name from the standard palette and updates the tooltip accordingly.


Change-Id: I18e249ab66d51935dccc42f350512339d41540fe

