### PR TITLE
wsd: allow parallel 'make run' to work nicely.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -637,6 +637,7 @@ clean-local:
 if ENABLE_DEBUG
 # can write to /tmp/coolwsd.log
   OUTPUT_TO_FILE=true
+  FIND_FREE_PORT_PARAM=--find-free-port
 else
 # can't write to /var/log/coolwsd.log
   OUTPUT_TO_FILE=false
@@ -658,6 +659,7 @@ setup-wsd: all @JAILS_PATH@ @CACHE_PATH@ presets-dir
 	@echo
 
 COMMON_PARAMS = \
+	$(FIND_FREE_PORT_PARAM) \
 	$(if $(TEST_APPARMOR),--disable-cool-user-checking) \
 	--o:sys_template_path="@SYSTEMPLATE_PATH@" \
 	--o:child_root_path="@JAILS_PATH@" \

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -789,6 +789,9 @@ std::string COOLWSD::UserInterface = "default";
 bool COOLWSD::AnonymizeUserData = false;
 bool COOLWSD::CheckCoolUser = true;
 bool COOLWSD::CleanupOnly = false; ///< If we should cleanup and exit.
+#if ENABLE_DEBUG
+bool COOLWSD::FindFreePort = false; ///< If we should find a free port to listen on.
+#endif
 bool COOLWSD::IsProxyPrefixEnabled = false;
 unsigned COOLWSD::MaxConnections;
 unsigned COOLWSD::MaxDocuments;
@@ -2349,6 +2352,12 @@ void COOLWSD::defineOptions(Poco::Util::OptionSet& optionSet)
                         .repeatable(false)
                         .argument("port_number"));
 
+#if ENABLE_DEBUG
+    optionSet.addOption(Option("find-free-port", "", "Find a free port to listen on, starting from the default.")
+                        .required(false)
+                        .repeatable(false));
+#endif
+
     optionSet.addOption(Option("disable-ssl", "", "Disable SSL security layer.")
                         .required(false)
                         .repeatable(false));
@@ -2438,6 +2447,10 @@ void COOLWSD::handleOption(const std::string& optionName,
         CleanupOnly = true; // Flag for later as we need the config.
     else if (optionName == "port")
         ClientPortNumber = std::stoi(value);
+#if ENABLE_DEBUG
+    else if (optionName == "find-free-port")
+        FindFreePort = true;
+#endif
     else if (optionName == "disable-ssl")
         _overrideSettings["ssl.enable"] = "false";
     else if (optionName == "disable-cool-user-checking")
@@ -3529,7 +3542,11 @@ std::shared_ptr<ServerSocket> COOLWSDServer::findServerPort()
 #ifdef BUILDING_TESTS
            true
 #else
-           UnitWSD::isUnitTesting()
+           (UnitWSD::isUnitTesting()
+#if ENABLE_DEBUG
+            || COOLWSD::FindFreePort
+#endif
+           )
 #endif
         )
     {

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -101,6 +101,9 @@ public:
     static bool AnonymizeUserData;
     static bool CheckCoolUser;
     static bool CleanupOnly;
+#if ENABLE_DEBUG
+    static bool FindFreePort;
+#endif
     static bool IsProxyPrefixEnabled;
     static std::atomic<unsigned> NumConnections;
     static std::unique_ptr<TraceFileWriter> TraceDumper;


### PR DESCRIPTION
Add a debug-only --find-free-port option that enables the existing port retry loop, allowing coolwsd to find a free port when the default (9980) is already in use. This allows 'make run' to work in parallel with a running server instance.

Pass --find-free-port via COMMON_PARAMS in debug builds for all make run targets.


Change-Id: I1d74d8dac456f1eda16a4aac9ad340673560fbdb


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

