### PR TITLE
jsdialog: support readonly property for multiline edit widgets

### DIFF
--- a/browser/src/control/jsdialog/Widget.MultilineEdit.js
+++ b/browser/src/control/jsdialog/Widget.MultilineEdit.js
@@ -82,6 +82,10 @@ function _multiLineEditControl(parentContainer, data, builder, callback) {
 		edit.disabled = true;
 	}
 
+	if (controlType === 'textarea' && data.readonly === true) {
+		edit.readOnly = true;
+	}
+
 	function _keyupChangeHandler() {
 		if (callback)
 			callback(this.value);


### PR DESCRIPTION
Handle the "readonly" property from core's DumpAsPropertyTree to set the HTML textarea as readOnly. This makes read-only multiline edits non-editable while still allowing text selection and copying, unlike the cursor=false path which creates a `<p> `element.

Fixes the writable edit boxes in the View Certificate dialog's Details and Certificate Path tabs.


Change-Id: If40bebe459807574631f951de5f358b31eaa3167

It works together with https://gerrit.libreoffice.org/c/core/+/199405
