### PR TITLE
Replace std::stoi()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -493,6 +493,7 @@ shared_headers = \
                  common/Log.hpp \
                  common/Message.hpp \
                  common/MobileApp.hpp \
+                 common/NumUtil.hpp \
                  common/Png.hpp \
                  common/Protocol.hpp \
                  common/Rectangle.hpp \

--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -20,6 +20,7 @@
 
 #include <common/FileUtil.hpp>
 #include <common/Log.hpp>
+#include <common/NumUtil.hpp>
 #include <common/Util.hpp>
 
 #include <SigUtil.hpp>
@@ -389,7 +390,7 @@ void cleanupJails(const std::string& root)
             {
                 bool skip = false;
                 const std::string_view pidStr = std::string_view(jail).substr(0, pidSepPos);
-                const auto [pid, success] = Util::i32FromString(pidStr);
+                const auto [pid, success] = NumUtil::i32FromString(pidStr);
                 if (success && pid > 1)
                 {
                     LOG_TRC("Checking pid for jail " << pid << " " << root);

--- a/common/NumUtil.hpp
+++ b/common/NumUtil.hpp
@@ -24,61 +24,6 @@
 namespace NumUtil
 {
 
-/**
-* Similar to std::atoi() but does not require p to be null-terminated.
-*
-* Returns std::numeric_limits<int>::min/max() if the result would overflow.
-*/
-inline int safe_atoi(const char* p, int len)
-{
-    long ret{};
-    if (!p || !len)
-    {
-        return ret;
-    }
-
-    int multiplier = 1;
-    int offset = 0;
-    while (isspace(p[offset]))
-    {
-        ++offset;
-        if (offset >= len)
-        {
-            return ret;
-        }
-    }
-
-    switch (p[offset])
-    {
-        case '-':
-            multiplier = -1;
-            ++offset;
-            break;
-        case '+':
-            ++offset;
-            break;
-    }
-    if (offset >= len)
-    {
-        return ret;
-    }
-
-    while (isdigit(p[offset]))
-    {
-        std::int64_t next = ret * 10 + (p[offset] - '0');
-        if (next >= std::numeric_limits<int>::max())
-            return multiplier * std::numeric_limits<int>::max();
-        ret = next;
-        ++offset;
-        if (offset >= len)
-        {
-            return multiplier * ret;
-        }
-    }
-
-    return multiplier * ret;
-}
-
 /// Convert from a string into an integer, like strto* family,
 /// supporting std::string_view arguments.
 /// The number must be base-10 and can start with
@@ -333,6 +278,17 @@ inline std::uint64_t strtouint64(const std::string_view str)
 inline std::uint64_t praseStrToUint64(const std::string_view str, std::size_t& offset)
 {
     return parseStrTo<std::uint64_t>(str, offset);
+}
+
+/**
+* Similar to std::atoi() but does not require p to be null-terminated.
+*
+* Returns std::numeric_limits<int>::min/max() if the result would overflow.
+*/
+inline int safe_atoi(const char* p, int len)
+{
+    std::size_t offset = 0;
+    return parseStrTo<std::int32_t>(std::string_view(p, len), offset);
 }
 
 } // namespace NumUtil

--- a/common/NumUtil.hpp
+++ b/common/NumUtil.hpp
@@ -13,6 +13,7 @@
 
 #include <cctype>
 #include <cstdint>
+#include <cstdlib>
 #include <limits>
 
 /// Utilities for numeric conversions.
@@ -73,6 +74,47 @@ inline int safe_atoi(const char* p, int len)
     }
 
     return multiplier * ret;
+}
+
+/// Convert a string to 32-bit signed int.
+/// Returns the parsed value and a boolean indicating success or failure.
+/// const auto [number, success] = NumUtil::i32FromString(portString);
+inline std::pair<std::int32_t, bool> i32FromString(const std::string_view input)
+{
+    const char* str = input.data();
+    char* endptr = nullptr;
+    errno = 0;
+    const auto value = std::strtol(str, &endptr, 10);
+    return std::make_pair(value, endptr > str && errno != ERANGE);
+}
+
+/// Convert a string to 32-bit signed int. On failure, returns the default
+/// value, and sets the bool to false (to signify that parsing had failed).
+inline std::pair<std::int32_t, bool> i32FromString(const std::string_view input,
+                                                   const std::int32_t def)
+{
+    const auto pair = i32FromString(input);
+    return pair.second ? pair : std::make_pair(def, false);
+}
+
+/// Convert a string to 64-bit unsigned int.
+/// Returns the parsed value and a boolean indicating success or failure.
+inline std::pair<std::uint64_t, bool> u64FromString(const std::string_view input)
+{
+    const char* str = input.data();
+    char* endptr = nullptr;
+    errno = 0;
+    const auto value = std::strtoul(str, &endptr, 10);
+    return std::make_pair(value, endptr > str && errno != ERANGE);
+}
+
+/// Convert a string to 64-bit unsigned int. On failure, returns the default
+/// value, and sets the bool to false (to signify that parsing had failed).
+inline std::pair<std::uint64_t, bool> u64FromString(const std::string_view input,
+                                                    const std::uint64_t def)
+{
+    const auto pair = u64FromString(input);
+    return pair.second ? pair : std::make_pair(def, false);
 }
 
 } // namespace NumUtil

--- a/common/NumUtil.hpp
+++ b/common/NumUtil.hpp
@@ -1,0 +1,80 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <cctype>
+#include <cstdint>
+#include <limits>
+
+/// Utilities for numeric conversions.
+/// See test/NumUtilWhiteBoxTests.cpp for test cases.
+namespace NumUtil
+{
+
+/**
+* Similar to std::atoi() but does not require p to be null-terminated.
+*
+* Returns std::numeric_limits<int>::min/max() if the result would overflow.
+*/
+inline int safe_atoi(const char* p, int len)
+{
+    long ret{};
+    if (!p || !len)
+    {
+        return ret;
+    }
+
+    int multiplier = 1;
+    int offset = 0;
+    while (isspace(p[offset]))
+    {
+        ++offset;
+        if (offset >= len)
+        {
+            return ret;
+        }
+    }
+
+    switch (p[offset])
+    {
+        case '-':
+            multiplier = -1;
+            ++offset;
+            break;
+        case '+':
+            ++offset;
+            break;
+    }
+    if (offset >= len)
+    {
+        return ret;
+    }
+
+    while (isdigit(p[offset]))
+    {
+        std::int64_t next = ret * 10 + (p[offset] - '0');
+        if (next >= std::numeric_limits<int>::max())
+            return multiplier * std::numeric_limits<int>::max();
+        ret = next;
+        ++offset;
+        if (offset >= len)
+        {
+            return multiplier * ret;
+        }
+    }
+
+    return multiplier * ret;
+}
+
+} // namespace NumUtil
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/common/NumUtil.hpp
+++ b/common/NumUtil.hpp
@@ -12,9 +12,12 @@
 #pragma once
 
 #include <cctype>
+#include <cerrno>
 #include <cstdint>
 #include <cstdlib>
 #include <limits>
+#include <string_view>
+#include <type_traits>
 
 /// Utilities for numeric conversions.
 /// See test/NumUtilWhiteBoxTests.cpp for test cases.
@@ -76,6 +79,148 @@ inline int safe_atoi(const char* p, int len)
     return multiplier * ret;
 }
 
+/// Convert from a string into an integer, like strto* family,
+/// supporting std::string_view arguments.
+/// The number must be base-10 and can start with
+/// either '+' or '-' as well as optional whitespace.
+/// The result is coerced into the return type.
+/// This is typically called while parsing.
+/// @offset is the position at which to start parsing
+/// and will hold the position at which parsing terminated.
+/// As a bonus, this is 2-3x faster than glibc across all lengths.
+template <typename T>
+T parseStrTo(const std::string_view str, std::size_t& orig_offset)
+    requires std::is_integral_v<T>
+{
+    const char* s = str.data();
+    const std::size_t len = str.size();
+    std::size_t offset = orig_offset;
+    if (offset >= len)
+    {
+        return T{};
+    }
+
+    T c = s[offset] - '0';
+    bool neg = false;
+    if (static_cast<std::uint_fast64_t>(c) >= 10)
+    {
+        // Skip whitespace.
+        while (offset < len && (s[offset] == ' ' || s[offset] == '\t'))
+            offset++;
+
+        if (offset >= len)
+            return T{};
+
+        c = s[offset++];
+        neg = (c == '-');
+        if (neg || c == '+')
+        {
+            if (offset >= len)
+                return T{};
+
+            c = s[offset++];
+        }
+
+        c -= '0';
+        if (static_cast<std::uint_fast64_t>(c) >= 10)
+            return T{};
+    }
+    else
+    {
+        ++offset;
+        if (len == 1)
+        {
+            orig_offset = 1;
+            return c;
+        }
+    }
+
+    T res = c;
+
+    // Up to 9 total digits (1 already parsed + 8 remaining). Can't overflow any 32+ bit type.
+    // Use an unrolled switch to avoid per-digit overflow checks and loop overhead.
+    const std::size_t remaining =
+        std::min<std::size_t>(len - offset, std::numeric_limits<T>::digits10 - 1);
+#define CASE(X)                                                                                    \
+    case X:                                                                                        \
+        c = s[offset] - '0';                                                                       \
+        if (static_cast<std::uint_fast64_t>(c) >= 10)                                              \
+            break;                                                                                 \
+        res = 10 * res + c;                                                                        \
+        ++offset;                                                                                  \
+        [[fallthrough]]
+
+    do
+    {
+        switch (remaining)
+        {
+            CASE(8);
+            CASE(7);
+            CASE(6);
+            CASE(5);
+            CASE(4);
+            CASE(3);
+            CASE(2);
+            CASE(1);
+            case 0:
+                if (offset >= len)
+                {
+                    orig_offset = offset;
+                    return static_cast<T>(neg ? -res : res);
+                }
+                break;
+        }
+    } while (false);
+#undef CASE
+
+    if (offset < len)
+    {
+        if constexpr (std::numeric_limits<T>::digits10 > 10)
+        {
+            // Unchecked loop for digits that can't overflow (up to digits10 total).
+            const auto fast_lim =
+                std::min<std::size_t>(len, offset + std::numeric_limits<T>::digits10 - 1);
+            for (; offset < fast_lim;)
+            {
+                c = s[offset] - '0';
+                if (static_cast<std::uint_fast64_t>(c) >= 10)
+                    break;
+
+                ++offset;
+                res = 10 * res + c;
+            }
+        }
+
+        // Overflow-checked loop for remaining digits beyond digits10.
+        constexpr auto cutoff = std::numeric_limits<T>::max() / 10;
+        const auto cutlim =
+            (neg ? -(std::numeric_limits<T>::min() % 10) : std::numeric_limits<T>::max() % 10);
+
+        do
+        {
+            c = s[offset] - '0';
+            if (static_cast<std::uint_fast64_t>(c) >= 10)
+                break;
+
+            ++offset; // Skip the consumed character.
+            if (res > cutoff || (res == cutoff && c > cutlim))
+            {
+                // Overflow.
+                errno = ERANGE;
+                while (offset < len && static_cast<std::uint_fast64_t>(s[offset]) >= 10)
+                    offset++; // Eat all the digits.
+                orig_offset = offset;
+                return neg ? std::numeric_limits<T>::min() : std::numeric_limits<T>::max();
+            }
+
+            res = 10 * res + c;
+        } while (offset < len);
+    }
+
+    orig_offset = offset;
+    return static_cast<T>(neg ? -res : res);
+}
+
 /// Convert a string to 32-bit signed int.
 /// Returns the parsed value and a boolean indicating success or failure.
 /// const auto [number, success] = NumUtil::i32FromString(portString);
@@ -113,6 +258,81 @@ inline std::uint64_t u64FromString(const std::string_view input, const std::uint
 {
     const auto pair = u64FromString(input);
     return pair.second ? pair.first : def;
+}
+
+/// Convert from a string into an integer like strto* family.
+/// The number must be base-10 and can start with
+/// either '+' or '-'.
+/// The result is coerced into the return type.
+/// This is typically called while parsing.
+template <typename T> T strto(const std::string_view str)
+{
+    std::size_t offset = 0;
+    return parseStrTo<T>(str, offset);
+}
+
+/// Convert from a string into a 32-bit int, like std::strtol.
+/// The result is coerced into the return type.
+inline std::int32_t strtoint32(const std::string_view str)
+{
+    std::size_t offset = 0;
+    return parseStrTo<std::int32_t>(str, offset);
+}
+
+/// Convert from a string into a 32-bit int, like std::strtol.
+/// The result is coerced into the return type.
+/// Supports arbitrary starting offset and returns the first unparsed offset.
+inline std::int32_t parseStrToInt32(const std::string_view str, std::size_t& offset)
+{
+    return parseStrTo<std::int32_t>(str, offset);
+}
+
+/// Convert from a string into an unsigned 32-bit int, like std::strtoul.
+/// The result is coerced into the return type.
+inline std::uint32_t strtouint32(const std::string_view str)
+{
+    std::size_t offset = 0;
+    return parseStrTo<std::uint32_t>(str, offset);
+}
+
+/// Convert from a string into an unsigned 32-bit int, like std::strtoul.
+/// The result is coerced into the return type.
+/// Supports arbitrary starting offset and returns the first unparsed offset.
+inline std::uint32_t parseStrToUint32(const std::string_view str, std::size_t& offset)
+{
+    return parseStrTo<std::uint32_t>(str, offset);
+}
+
+/// Convert from a string into a 64-bit int, like std::strtoll.
+/// The result is coerced into the return type.
+inline std::int64_t strtoint64(const std::string_view str)
+{
+    std::size_t offset = 0;
+    return parseStrTo<std::int64_t>(str, offset);
+}
+
+/// Convert from a string into a 64-bit int, like std::strtoll.
+/// The result is coerced into the return type.
+/// Supports arbitrary starting offset and returns the first unparsed offset.
+inline std::int64_t parseStrToInt64(const std::string_view str, std::size_t& offset)
+{
+    return parseStrTo<std::int64_t>(str, offset);
+}
+
+/// Convert from a string into an unsigned 64-bit int, like std::strtoull.
+/// The result is coerced into the return type.
+inline std::uint64_t strtouint64(const std::string_view str)
+{
+    std::size_t offset = 0;
+    return parseStrTo<std::uint64_t>(str, offset);
+}
+
+/// Convert from a string into an unsigned 64-bit int, like std::strtoull.
+/// The result is coerced into the return type.
+/// Supports arbitrary starting offset and returns the first unparsed offset.
+inline std::uint64_t praseStrToUint64(const std::string_view str, std::size_t& offset)
+{
+    return parseStrTo<std::uint64_t>(str, offset);
 }
 
 } // namespace NumUtil

--- a/common/NumUtil.hpp
+++ b/common/NumUtil.hpp
@@ -88,13 +88,12 @@ inline std::pair<std::int32_t, bool> i32FromString(const std::string_view input)
     return std::make_pair(value, endptr > str && errno != ERANGE);
 }
 
-/// Convert a string to 32-bit signed int. On failure, returns the default
-/// value, and sets the bool to false (to signify that parsing had failed).
-inline std::pair<std::int32_t, bool> i32FromString(const std::string_view input,
-                                                   const std::int32_t def)
+/// Convert a string to 64-bit unsigned int. On failure, returns the default value.
+/// Used where there is no interest in knowing whether the input was valid or not.
+inline std::int32_t i32FromString(const std::string_view input, const std::int32_t def)
 {
     const auto pair = i32FromString(input);
-    return pair.second ? pair : std::make_pair(def, false);
+    return pair.second ? pair.first : def;
 }
 
 /// Convert a string to 64-bit unsigned int.
@@ -108,13 +107,12 @@ inline std::pair<std::uint64_t, bool> u64FromString(const std::string_view input
     return std::make_pair(value, endptr > str && errno != ERANGE);
 }
 
-/// Convert a string to 64-bit unsigned int. On failure, returns the default
-/// value, and sets the bool to false (to signify that parsing had failed).
-inline std::pair<std::uint64_t, bool> u64FromString(const std::string_view input,
-                                                    const std::uint64_t def)
+/// Convert a string to 64-bit unsigned int. On failure, returns the default value.
+/// Used where there is no interest in knowing whether the input was valid or not.
+inline std::uint64_t u64FromString(const std::string_view input, const std::uint64_t def)
 {
     const auto pair = u64FromString(input);
-    return pair.second ? pair : std::make_pair(def, false);
+    return pair.second ? pair.first : def;
 }
 
 } // namespace NumUtil

--- a/common/Protocol.cpp
+++ b/common/Protocol.cpp
@@ -62,7 +62,7 @@ namespace COOLProtocol
             token[name.size()] == '=')
         {
             bool success;
-            std::tie(value, success) = Util::i32FromString(token.substr(name.size() + 1));
+            std::tie(value, success) = NumUtil::i32FromString(token.substr(name.size() + 1));
             return success;
         }
 

--- a/common/Protocol.hpp
+++ b/common/Protocol.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <common/NumUtil.hpp>
 #include <common/StringVector.hpp>
 #include <common/Util.hpp>
 
@@ -78,21 +79,21 @@ namespace COOLProtocol
     inline bool stringToInteger(const std::string_view input, int& value)
     {
         bool res;
-        std::tie(value, res) = Util::i32FromString(input);
+        std::tie(value, res) = NumUtil::i32FromString(input);
         return res;
     }
 
     inline bool stringToUInt32(const std::string_view input, uint32_t& value)
     {
         bool res;
-        std::tie(value, res) = Util::i32FromString(input);
+        std::tie(value, res) = NumUtil::i32FromString(input);
         return res;
     }
 
     inline bool stringToUInt64(const std::string_view input, uint64_t& value)
     {
         bool res;
-        std::tie(value, res) = Util::u64FromString(input);
+        std::tie(value, res) = NumUtil::u64FromString(input);
         return res;
     }
 
@@ -140,7 +141,7 @@ namespace COOLProtocol
         if (token.size() > N && token[N - 1] == '=' && token.compare(0, N - 1, name) == 0)
         {
             bool success;
-            std::tie(value, success) = Util::i32FromString(token.substr(N));
+            std::tie(value, success) = NumUtil::i32FromString(token.substr(N));
             return success;
         }
 

--- a/common/StringVector.cpp
+++ b/common/StringVector.cpp
@@ -14,7 +14,7 @@
 
 #include "StringVector.hpp"
 
-#include <common/Util.hpp>
+#include <common/NumUtil.hpp>
 
 bool StringVector::equals(std::size_t index, const StringVector& other, std::size_t otherIndex)
 {
@@ -49,7 +49,7 @@ bool StringVector::getUInt32(std::size_t index, const std::string& key, uint32_t
             _string.compare(token._index, key.size(), key, 0, key.size()) == 0 &&
             _string[token._index + key.size()] == '=')
     {
-        value = Util::safe_atoi(&_string[token._index + offset], token._length - offset);
+        value = NumUtil::safe_atoi(&_string[token._index + offset], token._length - offset);
         return value < std::numeric_limits<uint32_t>::max();
     }
 
@@ -82,7 +82,7 @@ bool StringVector::getNameIntegerPair(std::size_t index, std::string& name, int&
 
     name = _string.substr(token._index, mid - token._index);
     size_t offset = mid + 1;
-    value = Util::safe_atoi(&_string[offset], token._index + token._length - offset);
+    value = NumUtil::safe_atoi(&_string[offset], token._index + token._length - offset);
     return value > std::numeric_limits<int>::min() && value < std::numeric_limits<int>::max();
 }
 

--- a/common/Util-server.cpp
+++ b/common/Util-server.cpp
@@ -435,7 +435,7 @@ std::size_t getStatFromPid(const pid_t pid, int ind)
                     if (index == ind)
                     {
                         fclose(fp);
-                        return NumUtil::u64FromString(&s[pos], 0).first;
+                        return NumUtil::u64FromString(&s[pos], 0);
                     }
                     ++index;
                     pos = s.find(' ', pos + 1);

--- a/common/Util-server.cpp
+++ b/common/Util-server.cpp
@@ -17,6 +17,7 @@
 #include <config.h>
 
 #include <common/Log.hpp>
+#include <common/NumUtil.hpp>
 #include <common/StringVector.hpp>
 #include <common/Util.hpp>
 
@@ -349,7 +350,7 @@ std::size_t getProcessTreePss(pid_t pid)
             std::string child;
             while (children >> child)
             {
-                const auto pair = Util::i32FromString(child);
+                const auto pair = NumUtil::i32FromString(child);
                 if (pair.second)
                 {
                     pss += getProcessTreePss(pair.first);
@@ -434,7 +435,7 @@ std::size_t getStatFromPid(const pid_t pid, int ind)
                     if (index == ind)
                     {
                         fclose(fp);
-                        return Util::u64FromString(&s[pos], 0).first;
+                        return NumUtil::u64FromString(&s[pos], 0).first;
                     }
                     ++index;
                     pos = s.find(' ', pos + 1);

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -753,56 +753,6 @@ namespace Util
         return ApplicationPath;
     }
 
-    int safe_atoi(const char* p, int len)
-    {
-        long ret{};
-        if (!p || !len)
-        {
-            return ret;
-        }
-
-        int multiplier = 1;
-        int offset = 0;
-        while (isspace(p[offset]))
-        {
-            ++offset;
-            if (offset >= len)
-            {
-                return ret;
-            }
-        }
-
-        switch (p[offset])
-        {
-            case '-':
-                multiplier = -1;
-                ++offset;
-                break;
-            case '+':
-                ++offset;
-                break;
-        }
-        if (offset >= len)
-        {
-            return ret;
-        }
-
-        while (isdigit(p[offset]))
-        {
-            std::int64_t next = ret * 10 + (p[offset] - '0');
-            if (next >= std::numeric_limits<int>::max())
-                return multiplier * std::numeric_limits<int>::max();
-            ret = next;
-            ++offset;
-            if (offset >= len)
-            {
-                return multiplier * ret;
-            }
-        }
-
-        return multiplier * ret;
-    }
-
     void forcedExit(int code)
     {
         if (code)

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1221,47 +1221,6 @@ int main(int argc, char**argv)
     // If OS is not mobile, it must be Linux.
     std::string getLinuxVersion();
 
-    /// Convert a string to 32-bit signed int.
-    /// Returns the parsed value and a boolean indicating success or failure.
-    /// const auto [number, success] = Util::i32FromString(portString);
-    inline std::pair<std::int32_t, bool> i32FromString(const std::string_view input)
-    {
-        const char* str = input.data();
-        char* endptr = nullptr;
-        errno = 0;
-        const auto value = std::strtol(str, &endptr, 10);
-        return std::make_pair(value, endptr > str && errno != ERANGE);
-    }
-
-    /// Convert a string to 32-bit signed int. On failure, returns the default
-    /// value, and sets the bool to false (to signify that parsing had failed).
-    inline std::pair<std::int32_t, bool> i32FromString(const std::string_view input,
-                                                       const std::int32_t def)
-    {
-        const auto pair = i32FromString(input);
-        return pair.second ? pair : std::make_pair(def, false);
-    }
-
-    /// Convert a string to 64-bit unsigned int.
-    /// Returns the parsed value and a boolean indicating success or failure.
-    inline std::pair<std::uint64_t, bool> u64FromString(const std::string_view input)
-    {
-        const char* str = input.data();
-        char* endptr = nullptr;
-        errno = 0;
-        const auto value = std::strtoul(str, &endptr, 10);
-        return std::make_pair(value, endptr > str && errno != ERANGE);
-    }
-
-    /// Convert a string to 64-bit unsigned int. On failure, returns the default
-    /// value, and sets the bool to false (to signify that parsing had failed).
-    inline std::pair<std::uint64_t, bool> u64FromString(const std::string_view input,
-                                                        const std::uint64_t def)
-    {
-        const auto pair = u64FromString(input);
-        return pair.second ? pair : std::make_pair(def, false);
-    }
-
     /// Converts and returns the argument to lower-case.
     inline std::string toLower(std::string s)
     {

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1393,13 +1393,6 @@ int main(int argc, char**argv)
 #define ASSERT_CORRECT_THREAD_OWNER(OWNER) Util::assertCorrectThread(OWNER, __FILE__, __LINE__)
 #endif
 
-    /**
-     * Similar to std::atoi() but does not require p to be null-terminated.
-     *
-     * Returns std::numeric_limits<int>::min/max() if the result would overflow.
-     */
-    int safe_atoi(const char* p, int len);
-
     /// Sleep based on count of seconds in env. var
     void sleepFromEnvIfSet(const char *domain, const char *envVar);
 

--- a/ios/Mobile.xcodeproj/project.pbxproj
+++ b/ios/Mobile.xcodeproj/project.pbxproj
@@ -607,6 +607,7 @@
 		BE58E129217F295B00249358 /* Log.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Log.hpp; sourceTree = "<group>"; };
 		BE58E12A217F295B00249358 /* Png.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Png.hpp; sourceTree = "<group>"; };
 		BE58E12B217F295B00249358 /* SigUtil.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = SigUtil.hpp; sourceTree = "<group>"; };
+		BE58E12C217F295B00249359 /* NumUtil.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = NumUtil.hpp; sourceTree = "<group>"; };
 		BE58E12C217F295B00249358 /* Util.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Util.hpp; sourceTree = "<group>"; };
 		BE58E12C217F295B01249358 /* RegexUtil.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = RegexUtil.hpp; sourceTree = "<group>"; };
 		BE58E12C218F295B00249358 /* Uri.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Uri.hpp; sourceTree = "<group>"; };
@@ -2320,6 +2321,7 @@
 				BE5315362CF5C48200A384A4 /* Unit-mobile.cpp */,
 				BE58E12C218F295B00249358 /* Uri.hpp */,
 				BE5EB5BC214FE29900E0826C /* Uri.cpp */,
+				BE58E12C217F295B00249359 /* NumUtil.hpp */,
 				BE58E12C217F295B00249358 /* Util.hpp */,
 				BE5EB5BC213FE29900E0826C /* Util.cpp */,
 				1F957DC12BA82296006C9E78 /* Util-mobile.cpp */,

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -21,6 +21,7 @@
 #include <common/Anonymizer.hpp>
 #include <common/HexUtil.hpp>
 #include <common/Log.hpp>
+#include <common/NumUtil.hpp>
 #include <common/Unit.hpp>
 #include <common/Util.hpp>
 
@@ -2888,7 +2889,7 @@ bool ChildSession::resizeWindow(const StringVector& tokens)
 
 bool ChildSession::sendWindowCommand(const StringVector& tokens)
 {
-    const unsigned winId = (tokens.size() > 1 ? Util::u64FromString(tokens[1], 0).first : 0);
+    const unsigned winId = (tokens.size() > 1 ? NumUtil::u64FromString(tokens[1], 0).first : 0);
 
     getLOKitDocument()->setView(_viewId);
 

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2889,7 +2889,7 @@ bool ChildSession::resizeWindow(const StringVector& tokens)
 
 bool ChildSession::sendWindowCommand(const StringVector& tokens)
 {
-    const unsigned winId = (tokens.size() > 1 ? NumUtil::u64FromString(tokens[1], 0).first : 0);
+    const unsigned winId = (tokens.size() > 1 ? NumUtil::u64FromString(tokens[1], 0) : 0);
 
     getLOKitDocument()->setView(_viewId);
 

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -1013,7 +1013,7 @@ std::shared_ptr<Session> Session::create(std::string host, Protocol protocol, in
 
     if (!portString.empty())
     {
-        const auto [portInt, res] = Util::i32FromString(portString);
+        const auto [portInt, res] = NumUtil::i32FromString(portString);
         assert((port == 0 || port == portInt) && "Two conflicting port numbers given.");
         if (res && portInt > 0)
             port = portInt;

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -20,6 +20,7 @@
 
 #include <common/HexUtil.hpp>
 #include <common/Log.hpp>
+#include <common/NumUtil.hpp>
 #include <common/Util.hpp>
 
 #include <Poco/MemoryStream.h>
@@ -267,7 +268,7 @@ FieldParseState StatusLine::parse(const char* p, int64_t& len)
         LOG_ERR("StatusLine::parse: expected valid integer number");
         return FieldParseState::Invalid;
     }
-    _statusCode = Util::safe_atoi(&p[off], len - off);
+    _statusCode = NumUtil::safe_atoi(&p[off], len - off);
     if (_statusCode < MinValidStatusCode || _statusCode > MaxValidStatusCode)
     {
         LOG_ERR("StatusLine::parse: Invalid StatusCode [" << _statusCode << "]");

--- a/net/HttpRequest.hpp
+++ b/net/HttpRequest.hpp
@@ -18,6 +18,7 @@
 
 #include <common/Common.hpp>
 #include <common/Log.hpp>
+#include <common/NumUtil.hpp>
 #include <common/StateEnum.hpp>
 #include <common/StringVector.hpp>
 #include <common/Util.hpp>
@@ -1403,7 +1404,7 @@ public:
         if (portString.empty())
             return create(std::move(hostname), protocol, getDefaultPort(protocol));
 
-        const auto [port, success] = Util::i32FromString(portString);
+        const auto [port, success] = NumUtil::i32FromString(portString);
         if (success && port > 0)
             return create(std::move(hostname), protocol, port);
 

--- a/test/HttpTestServer.hpp
+++ b/test/HttpTestServer.hpp
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <common/Log.hpp>
+#include <common/NumUtil.hpp>
 #include <common/Util.hpp>
 #include <net/HttpRequest.hpp>
 #include <net/Socket.hpp>
@@ -109,7 +110,7 @@ private:
             if (url.starts_with("/status/"))
             {
                 const auto [statusCode, success] =
-                    Util::i32FromString(std::string_view(url).substr(sizeof("/status")));
+                    NumUtil::i32FromString(std::string_view(url).substr(sizeof("/status")));
                 const auto reason = http::getReasonPhraseForCode(statusCode);
                 LOG_TRC("HandleIncomingMessage: got StatusCode " << statusCode
                                                                  << ", sending back: " << reason);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -159,6 +159,7 @@ test_base_sources = \
 	KitQueueTests.cpp \
 	LoggingWhiteBoxTests.cpp \
 	NetUtilWhiteBoxTests.cpp \
+	NumUtilWhiteBoxTests.cpp \
 	RequestDetailsTests.cpp \
 	StringVectorTests.cpp \
 	TestGlobals.cpp \

--- a/test/NumUtilWhiteBoxTests.cpp
+++ b/test/NumUtilWhiteBoxTests.cpp
@@ -115,7 +115,7 @@ void NumUtilWhiteBoxTests::testSafeAtoi()
 
     // Overflow: safe_atoi clamps to INT_MAX / -INT_MAX.
     LOK_ASSERT_EQUAL(std::numeric_limits<int>::max(), NumUtil::safe_atoi("9999999990", 10));
-    LOK_ASSERT_EQUAL(-std::numeric_limits<int>::max(), NumUtil::safe_atoi("-9999999990", 11));
+    LOK_ASSERT_EQUAL(std::numeric_limits<int>::min(), NumUtil::safe_atoi("-9999999990", 11));
     LOK_ASSERT_EQUAL(std::numeric_limits<int>::max(),
                      NumUtil::safe_atoi("2147483648", 10)); // INT_MAX + 1.
 

--- a/test/NumUtilWhiteBoxTests.cpp
+++ b/test/NumUtilWhiteBoxTests.cpp
@@ -12,26 +12,35 @@
 #include <config.h>
 
 #include <common/NumUtil.hpp>
-#include <common/Util.hpp>
 
 #include <test/lokassert.hpp>
 
 #include <cppunit/TestAssert.h>
 #include <cppunit/extensions/HelperMacros.h>
 
-#include <cstdlib>
-#include <cstring>
+#include <cerrno>
 #include <limits>
 #include <string>
+#include <string_view>
 
 /// Numeric utility unit-tests.
 class NumUtilWhiteBoxTests : public CPPUNIT_NS::TestFixture
 {
     CPPUNIT_TEST_SUITE(NumUtilWhiteBoxTests);
     CPPUNIT_TEST(testSafeAtoi);
+    CPPUNIT_TEST(testStrtoint64MatchesStrtol);
+    CPPUNIT_TEST(testStrtouint64MatchesStrtoul);
+    CPPUNIT_TEST(testStrtoint64MatchesStrtoll);
+    CPPUNIT_TEST(testStrtouint64MatchesStrtoull);
+    CPPUNIT_TEST(testStrtoiWithOffset);
     CPPUNIT_TEST_SUITE_END();
 
     void testSafeAtoi();
+    void testStrtoint64MatchesStrtol();
+    void testStrtouint64MatchesStrtoul();
+    void testStrtoint64MatchesStrtoll();
+    void testStrtouint64MatchesStrtoull();
+    void testStrtoiWithOffset();
 };
 
 void NumUtilWhiteBoxTests::testSafeAtoi()
@@ -132,6 +141,736 @@ void NumUtilWhiteBoxTests::testSafeAtoi()
 
     // Zero length.
     LOK_ASSERT_EQUAL(0, NumUtil::safe_atoi("42", 0));
+}
+
+void NumUtilWhiteBoxTests::testStrtoint64MatchesStrtol()
+{
+    constexpr std::string_view testname = __func__;
+
+    auto compareWithStrtol = [&](const std::string& str)
+    {
+        TST_LOG("Converting [" << str << ']');
+
+        char* endptr = nullptr;
+        errno = 0;
+        const long stdResult = std::strtol(str.c_str(), &endptr, 10);
+        const int stdErrno = errno;
+        const std::size_t stdOffset = endptr - str.c_str();
+        TST_LOG("Std converted [" << str << "] to [" << stdResult << "] with errno [" << stdErrno
+                                  << "] and offset [" << stdOffset << ']');
+
+        errno = 0;
+        std::size_t numUtilOffset = 0;
+        const int64_t numUtilResult = NumUtil::parseStrToInt64(str, numUtilOffset);
+        const int numUtilErrno = errno;
+        TST_LOG("Num converted [" << str << "] to [" << numUtilResult << "] with errno ["
+                                  << numUtilErrno << "] and offset [" << numUtilOffset << ']');
+
+        // Compare results.
+        if (stdErrno == ERANGE)
+        {
+            // Overflow case - both should set ERANGE.
+            LOK_ASSERT_EQUAL_CTX(ERANGE, numUtilErrno, str);
+            // For overflow, NumUtil::strtoi should return INT_MIN or INT_MAX.
+            LOK_ASSERT_CTX(numUtilResult == std::numeric_limits<int>::min() ||
+                               numUtilResult == std::numeric_limits<int>::max(),
+                           str);
+        }
+        else if (endptr == str.c_str())
+        {
+            // No conversion - NumUtil::strtoi returns 0 for empty/invalid input.
+            LOK_ASSERT_EQUAL_CTX(0L, numUtilResult, str);
+        }
+        else
+        {
+            // Valid conversion - results should match (within int range).
+            LOK_ASSERT_EQUAL_CTX(static_cast<int64_t>(stdResult), numUtilResult, str);
+            LOK_ASSERT_EQUAL_CTX(stdErrno, numUtilErrno, str);
+        }
+
+        // Offset should match endptr position.
+        LOK_ASSERT_EQUAL_CTX(stdOffset, numUtilOffset, str);
+    };
+
+    // Test basic positive numbers with strtol.
+    compareWithStrtol("0");
+    compareWithStrtol("1");
+    compareWithStrtol("42");
+    compareWithStrtol("123");
+    compareWithStrtol("999");
+    compareWithStrtol("12345");
+
+    // Test negative numbers with strtol.
+    compareWithStrtol("-1");
+    compareWithStrtol("-42");
+    compareWithStrtol("-123");
+    compareWithStrtol("-999");
+    compareWithStrtol("-12345");
+
+    // Test with leading whitespace.
+    compareWithStrtol("  42");
+    compareWithStrtol("\t123");
+    compareWithStrtol("   -456");
+
+    // Test with leading zeros.
+    compareWithStrtol("0042");
+    compareWithStrtol("00123");
+    compareWithStrtol("-00456");
+
+    // Test with plus sign.
+    compareWithStrtol("+42");
+    compareWithStrtol("+123");
+    compareWithStrtol("+0");
+
+    // Test INT_MAX boundary.
+    compareWithStrtol("2147483647");
+    compareWithStrtol("-2147483648");
+
+    // Test overflow cases (should set errno to ERANGE).
+    compareWithStrtol("2147483648"); // INT_MAX + 1.
+    compareWithStrtol("-2147483649"); // INT_MIN - 1.
+    compareWithStrtol("9999999999999");
+
+    // Test empty and invalid strings.
+    compareWithStrtol("");
+    compareWithStrtol("   ");
+    compareWithStrtol("abc");
+    compareWithStrtol("-");
+    compareWithStrtol("+");
+
+    // Test whitespace + bare sign.
+    compareWithStrtol(" -");
+    compareWithStrtol("\t+");
+
+    // Test sign followed by non-digit.
+    compareWithStrtol("-a");
+    compareWithStrtol("+x");
+
+    // Test double signs.
+    compareWithStrtol("--1");
+    compareWithStrtol("+-1");
+
+    // Test trailing text (verifies offset matches endptr).
+    compareWithStrtol("123abc");
+}
+
+void NumUtilWhiteBoxTests::testStrtouint64MatchesStrtoul()
+{
+    constexpr std::string_view testname = __func__;
+
+    // Helper lambda to compare NumUtil::strtoul with std::strtoul.
+    auto compareWithStrtoul = [&](const std::string& str)
+    {
+        TST_LOG("Converting [" << str << ']');
+
+        char* endptr = nullptr;
+        errno = 0;
+        const unsigned long stdResult = std::strtoul(str.c_str(), &endptr, 10);
+        const int stdErrno = errno;
+        const std::size_t stdOffset = endptr - str.c_str();
+        TST_LOG("Std converted [" << str << "] to [" << stdResult << "] with errno [" << stdErrno
+                                  << "] and offset [" << stdOffset << ']');
+
+        errno = 0;
+        std::size_t numUtilOffset = 0;
+        const uint64_t numUtilResult = NumUtil::praseStrToUint64(str, numUtilOffset);
+        const int numUtilErrno = errno;
+        TST_LOG("Num converted [" << str << "] to [" << numUtilResult << "] with errno ["
+                                  << numUtilErrno << "] and offset [" << numUtilOffset << ']');
+
+        // Compare results.
+        if (stdErrno == ERANGE)
+        {
+            // Overflow case - both should set ERANGE.
+            LOK_ASSERT_EQUAL_CTX(ERANGE, numUtilErrno, str);
+            // For overflow, NumUtil::strtoi should return UINT_MAX.
+            LOK_ASSERT_EQUAL_CTX(std::numeric_limits<uint64_t>::max(), numUtilResult, str);
+        }
+        else if (endptr == str.c_str())
+        {
+            // No conversion - NumUtil::strtoi returns 0 for empty/invalid input.
+            LOK_ASSERT_EQUAL_CTX(0UL, numUtilResult, str);
+        }
+        else
+        {
+            // Valid conversion - results should match (within unsigned range).
+            LOK_ASSERT_EQUAL_CTX(static_cast<uint64_t>(stdResult), numUtilResult, str);
+            LOK_ASSERT_EQUAL_CTX(stdErrno, numUtilErrno, str);
+        }
+
+        // Offset should match endptr position.
+        LOK_ASSERT_EQUAL_CTX(stdOffset, numUtilOffset, str);
+    };
+
+    // Test unsigned numbers with strtoul.
+    compareWithStrtoul("0");
+    compareWithStrtoul("1");
+    compareWithStrtoul("42");
+    compareWithStrtoul("123");
+    compareWithStrtoul("999");
+    compareWithStrtoul("12345");
+
+    // Test large unsigned numbers.
+    compareWithStrtoul("4294967295"); // UINT_MAX.
+
+    // Test with leading whitespace.
+    compareWithStrtoul("  42");
+    compareWithStrtoul("\t123");
+
+    // Test with leading zeros.
+    compareWithStrtoul("0042");
+    compareWithStrtoul("00123");
+
+    // Test with plus sign.
+    compareWithStrtoul("+42");
+    compareWithStrtoul("+123");
+
+    // Test overflow for unsigned (should set errno to ERANGE).
+    compareWithStrtoul("4294967296"); // UINT_MAX + 1.
+    compareWithStrtoul("9999999999999");
+
+    // Test empty and invalid strings.
+    compareWithStrtoul("");
+    compareWithStrtoul("   ");
+    compareWithStrtoul("abc");
+
+    // Test bare signs.
+    compareWithStrtoul("-");
+    compareWithStrtoul("+");
+
+    // Test negative numbers (strtoul wraps these).
+    compareWithStrtoul("-1");
+    compareWithStrtoul("-42");
+
+    // Test whitespace + bare sign.
+    compareWithStrtoul(" -");
+    compareWithStrtoul("\t+");
+}
+
+void NumUtilWhiteBoxTests::testStrtoint64MatchesStrtoll()
+{
+    constexpr std::string_view testname = __func__;
+
+    // Helper lambda to compare NumUtil::strtoll with std::strtoll.
+    auto compareWithStrtoll = [&](const std::string& str)
+    {
+        TST_LOG("Converting [" << str << ']');
+
+        char* endptr = nullptr;
+        errno = 0;
+        const long long stdResult = std::strtoll(str.c_str(), &endptr, 10);
+        const int stdErrno = errno;
+        const std::size_t stdOffset = endptr - str.c_str();
+        TST_LOG("Std converted [" << str << "] to [" << stdResult << "] with errno [" << stdErrno
+                                  << "] and offset [" << stdOffset << ']');
+
+        errno = 0;
+        std::size_t numUtilOffset = 0;
+        const std::int64_t numUtilResult = NumUtil::parseStrToInt64(str, numUtilOffset);
+        const int numUtilErrno = errno;
+        TST_LOG("Num converted [" << str << "] to [" << numUtilResult << "] with errno ["
+                                  << numUtilErrno << "] and offset [" << numUtilOffset << ']');
+
+        // Compare results.
+        if (stdErrno == ERANGE)
+        {
+            // Overflow case - both should set ERANGE.
+            LOK_ASSERT_EQUAL_CTX(ERANGE, numUtilErrno, str);
+            // For overflow, NumUtil::strtoi should return INT64_MIN or INT64_MAX.
+            LOK_ASSERT_CTX(numUtilResult == std::numeric_limits<std::int64_t>::min() ||
+                               numUtilResult == std::numeric_limits<std::int64_t>::max(),
+                           str);
+        }
+        else if (endptr == str.c_str())
+        {
+            // No conversion - NumUtil::strtoi returns 0 for empty/invalid input.
+            LOK_ASSERT_EQUAL_CTX(static_cast<std::int64_t>(0), numUtilResult, str);
+        }
+        else
+        {
+            // Valid conversion - results should match.
+            LOK_ASSERT_EQUAL_CTX(static_cast<std::int64_t>(stdResult), numUtilResult, str);
+            LOK_ASSERT_EQUAL_CTX(stdErrno, numUtilErrno, str);
+        }
+
+        // Offset should match endptr position.
+        LOK_ASSERT_EQUAL_CTX(stdOffset, numUtilOffset, str);
+    };
+
+    // Test basic positive int64_t numbers.
+    compareWithStrtoll("0");
+    compareWithStrtoll("1");
+    compareWithStrtoll("42");
+    compareWithStrtoll("123456789");
+    compareWithStrtoll("1000000000");
+
+    // Test negative int64_t numbers.
+    compareWithStrtoll("-1");
+    compareWithStrtoll("-42");
+    compareWithStrtoll("-123456789");
+    compareWithStrtoll("-1000000000");
+
+    // Test large int64_t numbers.
+    compareWithStrtoll("9223372036854775806"); // INT64_MAX - 1.
+    compareWithStrtoll("9223372036854775807"); // INT64_MAX.
+    compareWithStrtoll("-9223372036854775807"); // INT64_MIN + 1.
+    compareWithStrtoll("-9223372036854775808"); // INT64_MIN.
+
+    // Test int64_t with leading whitespace.
+    compareWithStrtoll("  123456789");
+    compareWithStrtoll("\t-987654321");
+
+    // Test int64_t with leading zeros.
+    compareWithStrtoll("00123456789");
+    compareWithStrtoll("-00987654321");
+
+    // Test int64_t with plus sign.
+    compareWithStrtoll("+123456789");
+    compareWithStrtoll("+0");
+
+    // Test int64_t overflow cases (should set errno to ERANGE).
+    compareWithStrtoll("9223372036854775808"); // INT64_MAX + 1.
+    compareWithStrtoll("-9223372036854775809"); // INT64_MIN - 1.
+    compareWithStrtoll("99999999999999999999");
+
+    // Test int64_t empty and invalid strings.
+    compareWithStrtoll("");
+    compareWithStrtoll("   ");
+    compareWithStrtoll("abc");
+    compareWithStrtoll("-");
+    compareWithStrtoll("+");
+
+    // Test numbers at various magnitudes for int64_t.
+    compareWithStrtoll("1000000000000"); // 1 trillion.
+    compareWithStrtoll("1000000000000000"); // 1 quadrillion.
+    compareWithStrtoll("-1000000000000"); // -1 trillion.
+    compareWithStrtoll("-1000000000000000"); // -1 quadrillion.
+
+    // Test whitespace + bare sign.
+    compareWithStrtoll(" -");
+    compareWithStrtoll("\t+");
+
+    // Test sign followed by non-digit.
+    compareWithStrtoll("-a");
+
+    // Test double signs.
+    compareWithStrtoll("--1");
+
+    // Test trailing text (verifies offset matches endptr).
+    compareWithStrtoll("123abc");
+}
+
+void NumUtilWhiteBoxTests::testStrtouint64MatchesStrtoull()
+{
+    constexpr std::string_view testname = __func__;
+
+    // Helper lambda to compare NumUtil::strtoull with std::strtoull.
+    auto compareWithStrtoull = [&](const std::string& str)
+    {
+        TST_LOG("Converting [" << str << ']');
+
+        char* endptr = nullptr;
+        errno = 0;
+        const unsigned long long stdResult = std::strtoull(str.c_str(), &endptr, 10);
+        const int stdErrno = errno;
+        const std::size_t stdOffset = endptr - str.c_str();
+        TST_LOG("Std converted [" << str << "] to [" << stdResult << "] with errno [" << stdErrno
+                                  << "] and offset [" << stdOffset << ']');
+
+        errno = 0;
+        std::size_t numUtilOffset = 0;
+        const std::uint64_t numUtilResult = NumUtil::praseStrToUint64(str, numUtilOffset);
+        const int numUtilErrno = errno;
+        TST_LOG("Num converted [" << str << "] to [" << numUtilResult << "] with errno ["
+                                  << numUtilErrno << "] and offset [" << numUtilOffset << ']');
+
+        // Compare results.
+        if (stdErrno == ERANGE)
+        {
+            // Overflow case - both should set ERANGE.
+            LOK_ASSERT_EQUAL_CTX(ERANGE, numUtilErrno, str);
+            // For overflow, NumUtil::strtoi should return UINT64_MAX.
+            LOK_ASSERT_EQUAL_CTX(std::numeric_limits<std::uint64_t>::max(), numUtilResult, str);
+        }
+        else if (endptr == str.c_str())
+        {
+            // No conversion - NumUtil::strtoi returns 0 for empty/invalid input.
+            LOK_ASSERT_EQUAL_CTX(static_cast<std::uint64_t>(0), numUtilResult, str);
+        }
+        else
+        {
+            // Valid conversion - results should match.
+            LOK_ASSERT_EQUAL_CTX(static_cast<std::uint64_t>(stdResult), numUtilResult, str);
+            LOK_ASSERT_EQUAL_CTX(stdErrno, numUtilErrno, str);
+        }
+
+        // Offset should match endptr position.
+        LOK_ASSERT_EQUAL_CTX(stdOffset, numUtilOffset, str);
+    };
+
+    // Test basic positive uint64_t numbers.
+    compareWithStrtoull("0");
+    compareWithStrtoull("1");
+    compareWithStrtoull("42");
+    compareWithStrtoull("123456789");
+    compareWithStrtoull("1000000000");
+
+    // Test large uint64_t numbers.
+    compareWithStrtoull("18446744073709551614"); // UINT64_MAX - 1.
+    compareWithStrtoull("18446744073709551615"); // UINT64_MAX.
+
+    // Test uint64_t with leading whitespace.
+    compareWithStrtoull("  123456789");
+    compareWithStrtoull("\t987654321");
+
+    // Test uint64_t with leading zeros.
+    compareWithStrtoull("00123456789");
+    compareWithStrtoull("00987654321");
+
+    // Test uint64_t with plus sign.
+    compareWithStrtoull("+123456789");
+    compareWithStrtoull("+0");
+
+    // Test uint64_t overflow cases (should set errno to ERANGE).
+    compareWithStrtoull("18446744073709551616"); // UINT64_MAX + 1.
+    compareWithStrtoull("99999999999999999999");
+
+    // Test uint64_t empty and invalid strings.
+    compareWithStrtoull("");
+    compareWithStrtoull("   ");
+    compareWithStrtoull("abc");
+
+    // Test numbers at various magnitudes for uint64_t.
+    compareWithStrtoull("1000000000000"); // 1 trillion.
+    compareWithStrtoull("1000000000000000"); // 1 quadrillion.
+    compareWithStrtoull("10000000000000000000"); // 10 quintillion.
+
+    // Test bare signs.
+    compareWithStrtoull("-");
+    compareWithStrtoull("+");
+
+    // Test negative for unsigned.
+    compareWithStrtoull("-1");
+
+    // Test whitespace + bare sign.
+    compareWithStrtoull(" -");
+}
+
+void NumUtilWhiteBoxTests::testStrtoiWithOffset()
+{
+    constexpr std::string_view testname = __func__;
+
+    // Test basic offset parameter usage.
+    {
+        const std::string str = "123";
+        std::size_t offset = 0;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(123, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(3), offset, str); // Offset should be at end.
+    }
+
+    // Test offset starts in middle of string.
+    {
+        const std::string str = "abc123def";
+        std::size_t offset = 3; // Start at '1'.
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(123, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(6), offset, str); // Should stop at 'd'.
+    }
+
+    // Test offset with negative number.
+    {
+        const std::string str = "xyz-456end";
+        std::size_t offset = 3; // Start at '-'.
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(-456, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(7), offset, str); // Should stop at 'e'.
+    }
+
+    // Test offset skips leading whitespace.
+    {
+        const std::string str = "  789";
+        std::size_t offset = 0;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(789, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(5), offset, str); // Should be at end.
+    }
+
+    // Test offset with whitespace after offset position.
+    {
+        const std::string str = "abc  456xyz";
+        std::size_t offset = 3; // Start at first space.
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(456, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(8), offset, str); // Should stop at 'x'.
+    }
+
+    // Test multiple numbers parsed sequentially.
+    {
+        const std::string str = "11 22 33 44 55";
+        std::size_t offset = 0;
+
+        LOK_ASSERT_EQUAL_CTX(11, NumUtil::parseStrToInt32(str, offset), str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(2), offset, str); // At space after "11".
+
+        offset++; // Skip space.
+        LOK_ASSERT_EQUAL_CTX(22, NumUtil::parseStrToInt32(str, offset), str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(5), offset, str);
+
+        offset++; // Skip space.
+        LOK_ASSERT_EQUAL_CTX(33, NumUtil::parseStrToInt32(str, offset), str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(8), offset, str);
+
+        offset++; // Skip space.
+        LOK_ASSERT_EQUAL_CTX(44, NumUtil::parseStrToInt32(str, offset), str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(11), offset, str);
+
+        offset++; // Skip space.
+        LOK_ASSERT_EQUAL_CTX(55, NumUtil::parseStrToInt32(str, offset), str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(14), offset, str);
+    }
+
+    // Test offset with plus sign.
+    {
+        const std::string str = "data+42more";
+        std::size_t offset = 4; // Start at '+'.
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(42, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(7), offset, str); // Should stop at 'm'.
+    }
+
+    // Test offset with zero.
+    {
+        const std::string str = "text0more";
+        std::size_t offset = 4; // Start at '0'.
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(0, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(5), offset, str); // Should stop at 'm'.
+    }
+
+    // Test offset with leading zeros.
+    {
+        const std::string str = "00123";
+        std::size_t offset = 0;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(123, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(5), offset, str);
+    }
+
+    // Test offset stops at non-digit.
+    {
+        const std::string str = "start123abc";
+        std::size_t offset = 5; // Start at '1'.
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(123, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(8), offset, str); // Should stop at 'a'.
+    }
+
+    // Test offset with int64_t.
+    {
+        const std::string str = "9223372036854775807end";
+        std::size_t offset = 0;
+        const std::int64_t result = NumUtil::parseStrToInt64(str, offset);
+        LOK_ASSERT_EQUAL_CTX(std::numeric_limits<std::int64_t>::max(), result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(19), offset, str);
+    }
+
+    // Test offset with negative int64_t.
+    {
+        const std::string str = "xxx-9223372036854775808yyy";
+        std::size_t offset = 3;
+        const std::int64_t result = NumUtil::parseStrToInt64(str, offset);
+        LOK_ASSERT_EQUAL_CTX(std::numeric_limits<std::int64_t>::min(), result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(23), offset, str);
+    }
+
+    // Test offset with uint64_t.
+    {
+        const std::string str = "data18446744073709551615xyz";
+        std::size_t offset = 4;
+        const std::uint64_t result = NumUtil::praseStrToUint64(str, offset);
+        LOK_ASSERT_EQUAL_CTX(std::numeric_limits<std::uint64_t>::max(), result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(24), offset, str);
+    }
+
+    // Test offset with tab whitespace.
+    {
+        const std::string str = "abc\t\t999xyz";
+        std::size_t offset = 3;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(999, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(8), offset, str);
+    }
+
+    // Test offset at boundary - INT32_MAX.
+    {
+        const std::string str = "prefix2147483647suffix";
+        std::size_t offset = 6;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(std::numeric_limits<std::int32_t>::max(), result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(16), offset, str);
+    }
+
+    // Test offset at boundary - INT32_MIN.
+    {
+        const std::string str = "start-2147483648end";
+        std::size_t offset = 5;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(std::numeric_limits<std::int32_t>::min(), result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(16), offset, str);
+    }
+
+    // Test offset with overflowing int32_t.
+    {
+        const std::string str = "9999999999";
+        std::size_t offset = 0;
+        const std::int32_t result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(std::numeric_limits<std::int32_t>::max(), result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(10), offset, str);
+    }
+
+    // Test offset with overflowing uint32_t.
+    {
+        const std::string str = "9999999999";
+        std::size_t offset = 0;
+        const std::uint32_t result = NumUtil::parseStrToUint32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(std::numeric_limits<std::uint32_t>::max(), result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(10), offset, str);
+    }
+
+    // Test offset with uint32_t.
+    {
+        const std::string str = "value4294967295end";
+        std::size_t offset = 5;
+        const std::uint32_t result = NumUtil::parseStrToUint32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(std::numeric_limits<std::uint32_t>::max(), result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(15), offset, str);
+    }
+
+    // Test offset with -0.
+    {
+        const std::string str = "data-0more";
+        std::size_t offset = 4;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(0, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(6), offset, str);
+    }
+
+    // Test offset with +0.
+    {
+        const std::string str = "text+0end";
+        std::size_t offset = 4;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(0, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(6), offset, str);
+    }
+
+    // Test offset returns 0 for empty string.
+    {
+        const std::string str;
+        std::size_t offset = 0;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(0, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(0), offset, str);
+    }
+
+    // Test offset at end of string.
+    {
+        const std::string str = "test";
+        std::size_t offset = 4; // At end.
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(0, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(4), offset, str); // Should stay at end.
+    }
+
+    // Test offset parsing comma-separated values.
+    {
+        const std::string str = "100,200,300,400";
+        std::size_t offset = 0;
+
+        LOK_ASSERT_EQUAL_CTX(100, NumUtil::parseStrToInt32(str, offset), str);
+        offset++; // Skip comma.
+        LOK_ASSERT_EQUAL_CTX(200, NumUtil::parseStrToInt32(str, offset), str);
+        offset++; // Skip comma.
+        LOK_ASSERT_EQUAL_CTX(300, NumUtil::parseStrToInt32(str, offset), str);
+        offset++; // Skip comma.
+        LOK_ASSERT_EQUAL_CTX(400, NumUtil::parseStrToInt32(str, offset), str);
+    }
+
+    // Test offset with negative numbers in sequence.
+    {
+        const std::string str = "-10 -20 -30";
+        std::size_t offset = 0;
+
+        LOK_ASSERT_EQUAL_CTX(-10, NumUtil::parseStrToInt32(str, offset), str);
+        offset++; // Skip space.
+        LOK_ASSERT_EQUAL_CTX(-20, NumUtil::parseStrToInt32(str, offset), str);
+        offset++; // Skip space.
+        LOK_ASSERT_EQUAL_CTX(-30, NumUtil::parseStrToInt32(str, offset), str);
+    }
+
+    // Test offset with overflow sets errno.
+    {
+        const std::string str = "data2147483648more"; // INT32_MAX + 1.
+        std::size_t offset = 4;
+        errno = 0;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(ERANGE, errno, str);
+        LOK_ASSERT_EQUAL_CTX(std::numeric_limits<int>::max(), result, str);
+    }
+
+    // Test offset with underflow sets errno.
+    {
+        const std::string str = "x-2147483649y"; // INT32_MIN - 1.
+        std::size_t offset = 1;
+        errno = 0;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(ERANGE, errno, str);
+        LOK_ASSERT_EQUAL_CTX(std::numeric_limits<int>::min(), result, str);
+    }
+
+    // Test offset parsing continues until non-digit.
+    {
+        const std::string str = "12345abcde67890";
+        std::size_t offset = 0;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(12345, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(5), offset, str); // Should stop at 'a'.
+    }
+
+    // Test offset with mixed whitespace.
+    {
+        const std::string str = " \t \t 999 ";
+        std::size_t offset = 0;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(999, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(8), offset, str);
+    }
+
+    // Test offset: sign at end of string with non-zero offset (exercises bug fix).
+    {
+        const std::string str = "x-";
+        std::size_t offset = 1;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(0, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(1), offset, str); // Offset restored.
+    }
+    {
+        const std::string str = "ab+";
+        std::size_t offset = 2;
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(0, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(2), offset, str); // Offset restored.
+    }
+
+    // Test offset restoration on failure from non-zero offset.
+    {
+        const std::string str = "abcxyz";
+        std::size_t offset = 3; // Start at 'x' — not a digit.
+        const int result = NumUtil::parseStrToInt32(str, offset);
+        LOK_ASSERT_EQUAL_CTX(0, result, str);
+        LOK_ASSERT_EQUAL_CTX(std::size_t(3), offset, str); // Offset restored.
+    }
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(NumUtilWhiteBoxTests);

--- a/test/NumUtilWhiteBoxTests.cpp
+++ b/test/NumUtilWhiteBoxTests.cpp
@@ -1,0 +1,139 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <config.h>
+
+#include <common/NumUtil.hpp>
+#include <common/Util.hpp>
+
+#include <test/lokassert.hpp>
+
+#include <cppunit/TestAssert.h>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <string>
+
+/// Numeric utility unit-tests.
+class NumUtilWhiteBoxTests : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE(NumUtilWhiteBoxTests);
+    CPPUNIT_TEST(testSafeAtoi);
+    CPPUNIT_TEST_SUITE_END();
+
+    void testSafeAtoi();
+};
+
+void NumUtilWhiteBoxTests::testSafeAtoi()
+{
+    constexpr std::string_view testname = __func__;
+
+    // Helper to compare safe_atoi with std::atoi for non-overflow cases.
+    // std::atoi has UB on overflow, so we only compare within int range.
+    auto compareWithAtoi = [&](const char* str)
+    {
+        const int stdResult = std::atoi(str);
+        const int safeResult = NumUtil::safe_atoi(str, std::strlen(str));
+        LOK_ASSERT_EQUAL_CTX(stdResult, safeResult, std::string(str));
+    };
+
+    // Basic positive numbers.
+    compareWithAtoi("0");
+    compareWithAtoi("1");
+    compareWithAtoi("7");
+    compareWithAtoi("42");
+    compareWithAtoi("123");
+    compareWithAtoi("999");
+    compareWithAtoi("12345");
+
+    // Negative numbers.
+    compareWithAtoi("-1");
+    compareWithAtoi("-7");
+    compareWithAtoi("-42");
+    compareWithAtoi("-123");
+    compareWithAtoi("-999");
+    compareWithAtoi("-12345");
+
+    // Plus sign prefix.
+    compareWithAtoi("+7");
+    compareWithAtoi("+42");
+    compareWithAtoi("+0");
+
+    // Leading whitespace.
+    compareWithAtoi("  42");
+    compareWithAtoi("\t123");
+    compareWithAtoi("   -456");
+    compareWithAtoi(" \t +789");
+
+    // Leading zeros.
+    compareWithAtoi("0042");
+    compareWithAtoi("00123");
+    compareWithAtoi("-00456");
+
+    // Trailing non-numeric characters.
+    compareWithAtoi("42xy");
+    compareWithAtoi("123abc");
+    compareWithAtoi("-456def");
+
+    // Zero variants.
+    compareWithAtoi("-0");
+    compareWithAtoi("+0");
+    compareWithAtoi("0000");
+
+    // Single digit numbers.
+    compareWithAtoi("1");
+    compareWithAtoi("9");
+    compareWithAtoi("-1");
+    compareWithAtoi("-9");
+
+    // INT_MAX boundary.
+    compareWithAtoi("2147483647");
+
+    // Empty and invalid strings (atoi returns 0).
+    compareWithAtoi("");
+    compareWithAtoi("abc");
+    compareWithAtoi("   ");
+
+    // Overflow: safe_atoi clamps to INT_MAX / -INT_MAX.
+    LOK_ASSERT_EQUAL(std::numeric_limits<int>::max(), NumUtil::safe_atoi("9999999990", 10));
+    LOK_ASSERT_EQUAL(-std::numeric_limits<int>::max(), NumUtil::safe_atoi("-9999999990", 11));
+    LOK_ASSERT_EQUAL(std::numeric_limits<int>::max(),
+                     NumUtil::safe_atoi("2147483648", 10)); // INT_MAX + 1.
+
+    // Length-limiting (not null-terminated behavior).
+    {
+        std::string s("42");
+        LOK_ASSERT_EQUAL(4, NumUtil::safe_atoi(s.data(), 1));
+    }
+    {
+        std::string s("12345");
+        LOK_ASSERT_EQUAL(123, NumUtil::safe_atoi(s.data(), 3));
+    }
+
+    // Embedded null (safe_atoi uses length, stops at non-digit).
+    {
+        std::string s("123");
+        s[1] = '\0';
+        LOK_ASSERT_EQUAL(1, NumUtil::safe_atoi(s.data(), s.size()));
+    }
+
+    // Null pointer.
+    LOK_ASSERT_EQUAL(0, NumUtil::safe_atoi(nullptr, 0));
+
+    // Zero length.
+    LOK_ASSERT_EQUAL(0, NumUtil::safe_atoi("42", 0));
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION(NumUtilWhiteBoxTests);
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -65,7 +65,6 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testAnonymization);
     CPPUNIT_TEST(testStat);
     CPPUNIT_TEST(testStringCompare);
-    CPPUNIT_TEST(testSafeAtoi);
     CPPUNIT_TEST(testJsonUtilEscapeJSONValue);
     CPPUNIT_TEST(testStateEnum);
     CPPUNIT_TEST(testFindInVector);
@@ -91,7 +90,6 @@ class WhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testAnonymization();
     void testStat();
     void testStringCompare();
-    void testSafeAtoi();
     void testJsonUtilEscapeJSONValue();
     void testStateEnum();
     void testFindInVector();
@@ -852,55 +850,6 @@ void WhiteBoxTests::testStringCompare()
     LOK_ASSERT(!Util::iequal("abc", "abcd"));
 
     LOK_ASSERT(!Util::iequal("abc", 3, "abcd", 4));
-}
-
-void WhiteBoxTests::testSafeAtoi()
-{
-    constexpr std::string_view testname = __func__;
-
-    {
-        std::string s("7");
-        LOK_ASSERT_EQUAL(7, Util::safe_atoi(s.data(), s.size()));
-    }
-    {
-        std::string s("+7");
-        LOK_ASSERT_EQUAL(7, Util::safe_atoi(s.data(), s.size()));
-    }
-    {
-        std::string s("-7");
-        LOK_ASSERT_EQUAL(-7, Util::safe_atoi(s.data(), s.size()));
-    }
-    {
-        std::string s("42");
-        LOK_ASSERT_EQUAL(42, Util::safe_atoi(s.data(), s.size()));
-    }
-    {
-        std::string s("42");
-        LOK_ASSERT_EQUAL(4, Util::safe_atoi(s.data(), 1));
-    }
-    {
-        std::string s("  42");
-        LOK_ASSERT_EQUAL(42, Util::safe_atoi(s.data(), s.size()));
-    }
-    {
-        std::string s("42xy");
-        LOK_ASSERT_EQUAL(42, Util::safe_atoi(s.data(), s.size()));
-    }
-    {
-        // Make sure signed integer overflow doesn't happen.
-        std::string s("9999999990");
-        // Good:       2147483647
-        // Bad:        1410065398
-        LOK_ASSERT_EQUAL(std::numeric_limits<int>::max(), Util::safe_atoi(s.data(), s.size()));
-    }
-    {
-        std::string s("123");
-        s[1] = '\0';
-        LOK_ASSERT_EQUAL(1, Util::safe_atoi(s.data(), s.size()));
-    }
-    {
-        LOK_ASSERT_EQUAL(0, Util::safe_atoi(nullptr, 0));
-    }
 }
 
 void WhiteBoxTests::testJsonUtilEscapeJSONValue()

--- a/tools/map.cpp
+++ b/tools/map.cpp
@@ -787,7 +787,7 @@ int main(int argc, char **argv)
 
         if (*dir_proc->d_name > '0' && *dir_proc->d_name <= '9')
         {
-            const unsigned pid_proc = NumUtil::u64FromString(dir_proc->d_name, 0).first;
+            const unsigned pid_proc = NumUtil::u64FromString(dir_proc->d_name, 0);
 
             snprintf(path_proc, sizeof(path_proc), "/proc/%s/%s", dir_proc->d_name, "cmdline");
             if (read_buffer(cmdline, sizeof(cmdline), path_proc, ' ') &&

--- a/tools/map.cpp
+++ b/tools/map.cpp
@@ -38,6 +38,7 @@
 #include <math.h>
 
 #include <common/HexUtil.hpp>
+#include <common/NumUtil.hpp>
 #include <common/Util.hpp>
 
 #if !defined(__GLIBC__)
@@ -786,7 +787,7 @@ int main(int argc, char **argv)
 
         if (*dir_proc->d_name > '0' && *dir_proc->d_name <= '9')
         {
-            const unsigned pid_proc = Util::u64FromString(dir_proc->d_name, 0).first;
+            const unsigned pid_proc = NumUtil::u64FromString(dir_proc->d_name, 0).first;
 
             snprintf(path_proc, sizeof(path_proc), "/proc/%s/%s", dir_proc->d_name, "cmdline");
             if (read_buffer(cmdline, sizeof(cmdline), path_proc, ' ') &&

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -29,6 +29,7 @@
 #include <FileServer.hpp>
 #include <HttpRequest.hpp>
 #include <common/JsonUtil.hpp>
+#include <common/NumUtil.hpp>
 #include <ProofKey.hpp>
 #include <ProxyRequestHandler.hpp>
 #include <RequestDetails.hpp>
@@ -895,7 +896,7 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
         char* appDocIdBuffer = (char*)malloc(appDocIdLen + 1);
         memcpy(appDocIdBuffer, payload + space + 1, appDocIdLen);
         appDocIdBuffer[appDocIdLen] = '\0';
-        const auto [mobileAppDocId, docIdOk] = Util::u64FromString(appDocIdBuffer, 0);
+        const auto [mobileAppDocId, docIdOk] = NumUtil::u64FromString(appDocIdBuffer, 0);
         if (!docIdOk) {
             LOG_ERR("Bad document ID \"" << appDocIdBuffer << "\" in \"" << std::string_view(payload, len) << "\"");
         }

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -896,9 +896,12 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
         char* appDocIdBuffer = (char*)malloc(appDocIdLen + 1);
         memcpy(appDocIdBuffer, payload + space + 1, appDocIdLen);
         appDocIdBuffer[appDocIdLen] = '\0';
-        const auto [mobileAppDocId, docIdOk] = NumUtil::u64FromString(appDocIdBuffer, 0);
-        if (!docIdOk) {
-            LOG_ERR("Bad document ID \"" << appDocIdBuffer << "\" in \"" << std::string_view(payload, len) << "\"");
+        auto [mobileAppDocId, docIdOk] = NumUtil::u64FromString(appDocIdBuffer);
+        if (!docIdOk)
+        {
+            mobileAppDocId = 0;
+            LOG_ERR("Bad document ID \"" << appDocIdBuffer << "\" in \""
+                                         << std::string_view(payload, len) << "\"");
         }
         free(appDocIdBuffer);
 

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -24,6 +24,7 @@
 #include <common/ConfigUtil.hpp>
 #include <common/HexUtil.hpp>
 #include <common/JsonUtil.hpp>
+#include <common/NumUtil.hpp>
 #include <common/Log.hpp>
 #include <common/Protocol.hpp>
 #include <common/Session.hpp>
@@ -1170,7 +1171,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         // call onTileProcessed on each tileID of tileid1, tileid2, ...
         auto lambda = [this](size_t /*nIndex*/, const std::string_view token)
         {
-            const auto [wireId, res] = Util::i32FromString(token);
+            const auto [wireId, res] = NumUtil::i32FromString(token);
             if (!res)
                 LOG_WRN("Invalid syntax for tileprocessed wireid '" << token << "'");
             onTileProcessed(wireId);

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -21,6 +21,7 @@
 #include <common/Common.hpp>
 #include <common/FileUtil.hpp>
 #include <common/Log.hpp>
+#include <common/NumUtil.hpp>
 #include <common/StringVector.hpp>
 #include <common/Util.hpp>
 #include <wsd/ClientSession.hpp>
@@ -454,10 +455,10 @@ Quarantine::Entry::Entry(const std::string& root, const std::string& filename)
     if (tokens.size() > 3)
     {
         _secondsSinceEpoch =
-            Util::u64FromString(filename.substr(tokens[0]._index, tokens[0]._length), /*def=*/0)
+            NumUtil::u64FromString(filename.substr(tokens[0]._index, tokens[0]._length), /*def=*/0)
                 .first;
 
-        _pid = Util::u64FromString(filename.substr(tokens[1]._index, tokens[1]._length), /*def=*/0)
+        _pid = NumUtil::u64FromString(filename.substr(tokens[1]._index, tokens[1]._length), /*def=*/0)
                    .first;
 
         // Note: this is unreliable since both the dockey and filename can (and often do) contain the Delimiter '_'.
@@ -488,10 +489,10 @@ Quarantine::Entry::Entry(const std::string& root, const std::string& docKey,
     if (tokens.size() >= 3)
     {
         _secondsSinceEpoch =
-            Util::u64FromString(filename.substr(tokens[0]._index, tokens[0]._length), /*def=*/0)
+            NumUtil::u64FromString(filename.substr(tokens[0]._index, tokens[0]._length), /*def=*/0)
                 .first;
 
-        _pid = Util::u64FromString(filename.substr(tokens[1]._index, tokens[1]._length), /*def=*/0)
+        _pid = NumUtil::u64FromString(filename.substr(tokens[1]._index, tokens[1]._length), /*def=*/0)
                    .first;
 
         _filename = filename.substr(tokens[2]._index, tokens[2]._length);

--- a/wsd/QuarantineUtil.cpp
+++ b/wsd/QuarantineUtil.cpp
@@ -455,11 +455,10 @@ Quarantine::Entry::Entry(const std::string& root, const std::string& filename)
     if (tokens.size() > 3)
     {
         _secondsSinceEpoch =
-            NumUtil::u64FromString(filename.substr(tokens[0]._index, tokens[0]._length), /*def=*/0)
-                .first;
+            NumUtil::u64FromString(filename.substr(tokens[0]._index, tokens[0]._length), /*def=*/0);
 
-        _pid = NumUtil::u64FromString(filename.substr(tokens[1]._index, tokens[1]._length), /*def=*/0)
-                   .first;
+        _pid =
+            NumUtil::u64FromString(filename.substr(tokens[1]._index, tokens[1]._length), /*def=*/0);
 
         // Note: this is unreliable since both the dockey and filename can (and often do) contain the Delimiter '_'.
         _docKey = filename.substr(tokens[2]._index,
@@ -489,11 +488,10 @@ Quarantine::Entry::Entry(const std::string& root, const std::string& docKey,
     if (tokens.size() >= 3)
     {
         _secondsSinceEpoch =
-            NumUtil::u64FromString(filename.substr(tokens[0]._index, tokens[0]._length), /*def=*/0)
-                .first;
+            NumUtil::u64FromString(filename.substr(tokens[0]._index, tokens[0]._length), /*def=*/0);
 
-        _pid = NumUtil::u64FromString(filename.substr(tokens[1]._index, tokens[1]._length), /*def=*/0)
-                   .first;
+        _pid =
+            NumUtil::u64FromString(filename.substr(tokens[1]._index, tokens[1]._length), /*def=*/0);
 
         _filename = filename.substr(tokens[2]._index, tokens[2]._length);
 


### PR DESCRIPTION
In an effort to consolidate the string-to-integer converters, we replace the standard `stoi()`, the internal `safe_atoi()`, and others with the equivalent that takes `string_view`. More to follow.

- **wsd: move Util::safe_atoi() to NumUtil namespace**
- **wsd: move Util::\*FromString() functions to NumUtil namespace**
- **wsd: simplify i32FromString and u64FromString**
- **wsd: string-to-integer to unify the various versions**
- **wsd: replace safe_atoi() implementation with NumUtil::strto()**