### PR TITLE
fix sidebar a11y cypress test

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1803,9 +1803,9 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 				button.tabIndex = -1; // prevent button from taking focus since container div itself is focusable element
 			button.id = buttonId;
 
-			itemsToSyncWithContainer.push(button);
+			JSDialog.SetupA11yLabelForNonLabelableElement(button, data, builder);
 
-			JSDialog.AddAriaLabel(button, data, builder);
+			itemsToSyncWithContainer.push(button);
 
 			if (!data.accessKey)
 				builder._setAccessKey(button, builder._getAccessKeyFromText(data.text));
@@ -1860,7 +1860,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			}
 
 			// for Accessibility : graphic elements are located within buttons, the img should receive an empty alt
-			if(button.getAttribute('aria-label')){ // if we already set the aria-label then do not go for image alt attr
+			if (button.getAttribute('aria-label') || button.getAttribute('aria-labelledby')){ // if we already set the aria-label or aria-labelledby then do not go for image alt attr
 				buttonImage.alt = '';
 			}
 			else if (buttonImage !== false) {

--- a/browser/src/control/jsdialog/Widget.Containers.ts
+++ b/browser/src/control/jsdialog/Widget.Containers.ts
@@ -161,8 +161,6 @@ JSDialog.toolbox = function (
 		}
 	}
 
-	JSDialog.SetupA11yLabelForNonLabelableElement(toolbox, data, builder);
-
 	const enabledCallback = function (enable: boolean) {
 		for (const j in data.children) {
 			const childId = data.children[j].id;
@@ -186,6 +184,15 @@ JSDialog.toolbox = function (
 	const inlineLabels = builder.options.useInLineLabelsForUnoButtons;
 	if (data.hasVerticalParent === true && data.children.length === 1)
 		builder.options.useInLineLabelsForUnoButtons = true;
+
+	if (data.children.length === 1) {
+		if (!data.children[0].labelledBy && data.labelledBy)
+			data.children[0].labelledBy = data.labelledBy;
+		else if (!data.children[0].aria && data.aria)
+			data.children[0].aria = data.aria;
+	} else {
+		JSDialog.SetupA11yLabelForNonLabelableElement(toolbox, data, builder);
+	}
 
 	builder.build(toolbox, data.children, false);
 

--- a/cypress_test/integration_tests/desktop/writer/a11y_sidebar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_sidebar_spec.js
@@ -48,7 +48,7 @@ describe(['tagdesktop'], 'Accessibility Writer Sidebar Tests', { testIsolation: 
 		runA11yValidation(win);
 	});
 
-	it.skip('PropertyDeck: Graphic Context: (Buggy)', function () {
+	it('PropertyDeck: Graphic Context:', function () {
 		helper.clearAllText({ isTable: true });
 		desktopHelper.insertImage();
 
@@ -56,7 +56,7 @@ describe(['tagdesktop'], 'Accessibility Writer Sidebar Tests', { testIsolation: 
 		runA11yValidation(win);
 	});
 
-	it.skip('Chart (LinePropertyPanel buggy)', function () {
+	it('Chart (LinePropertyPanel)', function () {
 		helper.clearAllText({ isTable: true });
 		cy.then(() => {
 			win.app.map.sendUnoCommand('.uno:InsertObjectChart');
@@ -126,7 +126,7 @@ describe(['tagdesktop'], 'Accessibility Writer Sidebar Tests', { testIsolation: 
 		cy.cGet('div.clipboard').should('have.focus');
 	});
 
-	it.skip('Math (PosSizePropertyPanel buggy)', function () {
+	it('Math (PosSizePropertyPanel)', function () {
 		helper.clearAllText({ isTable: true });
 		cy.then(() => {
 			win.app.map.sendUnoCommand('.uno:InsertObjectStarMath');
@@ -148,7 +148,7 @@ describe(['tagdesktop'], 'Accessibility Writer Sidebar Tests', { testIsolation: 
 		helper.typeIntoDocument('{esc}');
 	});
 
-	it.skip('PropertyDeck: Line Context (Buggy)', function () {
+	it('PropertyDeck: Line Context', function () {
 		cy.then(() => {
 			win.app.map.sendUnoCommand('.uno:Line');
 		});
@@ -159,7 +159,7 @@ describe(['tagdesktop'], 'Accessibility Writer Sidebar Tests', { testIsolation: 
 		runA11yValidation(win);
 	});
 
-	it.skip('PropertyDeck: Fontwork Context: (Buggy)', function () {
+	it('PropertyDeck: Fontwork Context:', function () {
 		cy.then(() => {
 			win.app.map.sendUnoCommand('.uno:FontworkGalleryFloater');
 		});


### PR DESCRIPTION
- move label logic from toolbox(parent container) to uno tool button
- img alt attribute should be empty if parent button also has aria-labelledby

**core patches:**
1. https://gerrit.libreoffice.org/c/core/+/199440

Change-Id: I897b091706fdec2f514e1881063fc74513a50135

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required