### PR TITLE
[co-25.04] cool#13988 redline render mode: switch to gray/blue backgrounds for the labels

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -1501,3 +1501,17 @@ body {
 	background-color: var(--color-insert-marker-background-dark) !important;
 	background: url('images/lc_chartsavetonewtheme.svg') no-repeat center center /20px;
 }
+
+#compare-changes-left-label {
+	position: absolute;
+	text-align: center;
+	background-color: var(--color-main-background);
+	color: rgb(var(--doc-type));
+}
+
+#compare-changes-right-label {
+	position: absolute;
+	text-align: center;
+	background-color: rgb(var(--doc-type));
+	color: var(--color-background-lighter);
+}

--- a/browser/src/canvas/sections/CompareChangesLabelSection.ts
+++ b/browser/src/canvas/sections/CompareChangesLabelSection.ts
@@ -57,19 +57,19 @@ class CompareChangesLabelSection extends HTMLObjectSection {
 		// Be on top of the text cursor.
 		container.style.zIndex = '1001';
 
+		this.leftLabel.id = 'compare-changes-left-label';
+		this.rightLabel.id = 'compare-changes-right-label';
 		this.setupLabel(
 			container,
 			this.leftLabel,
 			this.leftTitle,
 			this.leftSubtitle,
-			'#d63031',
 		);
 		this.setupLabel(
 			container,
 			this.rightLabel,
 			this.rightTitle,
 			this.rightSubtitle,
-			'#00b894',
 		);
 	}
 
@@ -78,13 +78,8 @@ class CompareChangesLabelSection extends HTMLObjectSection {
 		label: HTMLDivElement,
 		title: HTMLDivElement,
 		subtitle: HTMLDivElement,
-		backgroundColor: string,
 	): void {
-		label.style.position = 'absolute';
 		label.style.height = this.labelHeight + 'px';
-		label.style.backgroundColor = backgroundColor;
-		label.style.color = 'white';
-		label.style.textAlign = 'center';
 		title.style.fontSize = '16px';
 		title.style.lineHeight = '16px';
 		subtitle.style.fontSize = '12px';


### PR DESCRIPTION
- **cool#13988 redline render mode: avoid doc name when just viewing tracked changes**
- **cool#13988 redline render mode: switch to gray/blue backgrounds for the labels**
