### PR TITLE
Fix sluggish load of spreadsheet with 37K+ comments

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -990,8 +990,8 @@ export class CommentSection extends CanvasSectionObject {
 	public unselect (): void {
 		if (this.sectionProperties.selectedComment && this.sectionProperties.selectedComment.sectionProperties.data.id != 'new') {
 			for (const comment of this.sectionProperties.commentList) {
-				if ($(comment.sectionProperties.container).hasClass('annotation-active'))
-					$(comment.sectionProperties.container).removeClass('annotation-active');
+				if (window.L.DomUtil.hasClass(comment.sectionProperties.container, 'annotation-active'))
+					window.L.DomUtil.removeClass(comment.sectionProperties.container, 'annotation-active');
 			}
 
 			if (app.map._docLayer._docType === 'spreadsheet')


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
Fix sluggish load of multi tab spreadsheet with 37K+ comments.

1. importComments(): is called with comments for all sheets, so store
       the master-list in the commentlist section and supply only the
       comments for the current sheet to importComments() every real sheet
       switch.
    
2. Pause drawing during importComments() during sheet switch else
       updating canvas-sections datastructure on addition of
       each comment-section is expensive.

3. Use DomUtil.hasClass instead of jquery version.


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

