### PR TITLE
exit OverflowManager.onResize early if the size didn't change

### DIFF
--- a/browser/src/control/jsdialog/Widget.OverflowManager.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowManager.ts
@@ -71,6 +71,10 @@ class OverflowManager {
 			'OverflowManager: onResize, scheduledRefresh = ' +
 				(this.scheduledRefresh !== '' ? 'true' : 'false'),
 		);
+
+		// skip spurious resize events where the width hasn't actually changed
+		if (this.lastMaxWidth === window.innerWidth) return;
+
 		this.lastMaxWidth = -1;
 
 		if (this.scheduledRefresh !== '') {


### PR DESCRIPTION
JSDialog.RefreshScrollables() dispatches
window.dispatchEvent(new Event('resize')) frequently and the OverflowManager will auto dismiss dropdowns on a resize so the calc/top_toolbar_spec seems to fail with an inability to click an icon in the toolbar overflow that gets removed on the bogus resizes.


Change-Id: Ic5790acd34f6d6a10ef45b28914a39bfb9a1b4e0


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

