### PR TITLE
fix coolkitconfig.xcu configmgr warnings against recent core

### DIFF
--- a/coolkitconfig.xcu.in
+++ b/coolkitconfig.xcu.in
@@ -33,7 +33,13 @@
 <item oor:path="/org.openoffice.Office.Writer/Content/NonprintingCharacter"><prop oor:name="HiddenParagraph" oor:op="fuse"><value>false</value></prop></item>
 
 <!-- Disable GIO UCP we don't want -->
-<item oor:path="/org.openoffice.ucb.Configuration/ContentProviders/Local/SecondaryKeys/Office/ProviderData/Provider999"><prop oor:name="URLTemplate" oor:op="fuse"><value>NeverMatchAnyUrlSuffix</value></prop></item>
+<item oor:path="/org.openoffice.ucb.Configuration/ContentProviders/Local/SecondaryKeys/Office/ProviderData">
+    <node oor:name="Provider999" oor:op="replace">
+        <prop oor:name="ServiceName"><value/></prop>
+        <prop oor:name="URLTemplate"><value>NeverMatchAnyUrlSuffix</value></prop>
+        <prop oor:name="Arguments"><value/></prop>
+    </node>
+</item>
 
 <!-- Default font for new documents. Most of the languages use 'en' settings. For those that do not, it's better not to touch their settings, because it's unlikely that Calibri (or Carlito) is better than current default. -->
 <item oor:path="/org.openoffice.VCL/DefaultFonts/org.openoffice.VCL:LocalizedDefaultFonts['en']"><prop oor:name="LATIN_HEADING" oor:op="fuse" oor:type="xs:string"><value>Calibri;Carlito;Liberation Sans;Albany AMT;Albany;Arial;Noto Sans;Arimo;Nimbus Sans L;DejaVu Sans;Helvetica;Lucida;Geneva;Helmet;Arial;Noto Sans Unicode MS;Lucida Sans Unicode;Tahoma;SansSerif</value></prop></item>
@@ -85,29 +91,15 @@
             <prop oor:name="Color" oor:op="fuse">
                 <value>12632256</value>
             </prop>
-            <prop oor:name="IsVisible" oor:op="fuse">
-                <value>true</value>
-            </prop>
         </node>
         <node oor:name="AppBackground">
             <prop oor:name="Color" oor:op="fuse">
                 <value>14671838</value>
             </prop>
         </node>
-        <node oor:name="ObjectBoundaries">
-            <prop oor:name="Color" oor:op="fuse">
-                <value>12632256</value>
-            </prop>
-            <prop oor:name="IsVisible" oor:op="fuse">
-                <value>true</value>
-            </prop>
-        </node>
         <node oor:name="TableBoundaries">
             <prop oor:name="Color" oor:op="fuse">
                 <value>12632256</value>
-            </prop>
-            <prop oor:name="IsVisible" oor:op="fuse">
-                <value>true</value>
             </prop>
         </node>
         <node oor:name="Links">
@@ -178,17 +170,9 @@
                 <value>true</value>
             </prop>
         </node>
-        <node oor:name="WriterScriptIndicator">
-            <prop oor:name="Color" oor:op="fuse">
-                <value>32768</value>
-            </prop>
-        </node>
         <node oor:name="WriterSectionBoundaries">
             <prop oor:name="Color" oor:op="fuse">
                 <value>12632256</value>
-            </prop>
-            <prop oor:name="IsVisible" oor:op="fuse">
-                <value>true</value>
             </prop>
         </node>
         <node oor:name="WriterHeaderFooterMark">
@@ -399,29 +383,15 @@
             <prop oor:name="Color" oor:op="fuse">
                 <value>8421504</value>
             </prop>
-            <prop oor:name="IsVisible" oor:op="fuse">
-                <value>true</value>
-            </prop>
         </node>
         <node oor:name="AppBackground">
             <prop oor:name="Color" oor:op="fuse">
                 <value>3355443</value>
             </prop>
         </node>
-        <node oor:name="ObjectBoundaries">
-            <prop oor:name="Color" oor:op="fuse">
-                <value>8421504</value>
-            </prop>
-            <prop oor:name="IsVisible" oor:op="fuse">
-                <value>true</value>
-            </prop>
-        </node>
         <node oor:name="TableBoundaries">
             <prop oor:name="Color" oor:op="fuse">
                 <value>1842204</value>
-            </prop>
-            <prop oor:name="IsVisible" oor:op="fuse">
-                <value>true</value>
             </prop>
         </node>
         <node oor:name="Links">
@@ -492,17 +462,9 @@
                 <value>true</value>
             </prop>
         </node>
-        <node oor:name="WriterScriptIndicator">
-            <prop oor:name="Color" oor:op="fuse">
-                <value>1993273</value>
-            </prop>
-        </node>
         <node oor:name="WriterSectionBoundaries">
             <prop oor:name="Color" oor:op="fuse">
                 <value>6710886</value>
-            </prop>
-            <prop oor:name="IsVisible" oor:op="fuse">
-                <value>true</value>
             </prop>
         </node>
         <node oor:name="WriterHeaderFooterMark">


### PR DESCRIPTION
- Provider999: use oor:op="replace" on the node instead of fusing a property, so it works even when the GIO module is not installed
- Remove ObjectBoundaries node (removed in core, tdf#163856)
- Remove WriterScriptIndicator node (removed in core, tdf#167162)
- Remove IsVisible from DocBoundaries, TableBoundaries, and WriterSectionBoundaries (removed in core, tdf#163856)


Change-Id: I71c24438d0c118bdaebd979e669fde0136b18683

