### PR TITLE
net: enforce inactivity timeout for idle HTTP keep-alive connections

### DIFF
--- a/net/NetUtil.hpp
+++ b/net/NetUtil.hpp
@@ -33,8 +33,11 @@ namespace net
 class DefaultValues
 {
 public:
-    /// StreamSocket inactivity timeout in us (3600s default). Zero disables instrument.
+    /// StreamSocket inactivity timeout in us (5s default). Zero disables instrument.
     std::chrono::microseconds inactivityTimeout;
+
+    /// WebSocket inactivity timeout in us (3600s default). Zero disables instrument.
+    std::chrono::microseconds wsInactivityTimeout;
 
     /// Maximum number of concurrent external TCP connections. Zero disables instrument,
     /// limiting the maximum number of connections by the available sockets to the system.

--- a/net/Socket.cpp
+++ b/net/Socket.cpp
@@ -91,7 +91,8 @@ std::unique_ptr<Watchdog> SocketPoll::PollWatchdog;
 
 std::atomic<size_t> StreamSocket::ExternalConnectionCount = 0;
 
-net::DefaultValues net::Defaults = { .inactivityTimeout = std::chrono::seconds(3600),
+net::DefaultValues net::Defaults = { .inactivityTimeout = std::chrono::seconds(5), /* cf. Apache */
+                                     .wsInactivityTimeout = std::chrono::seconds(3600),
                                      .maxExtConnections = 200000 /* arbitrary value to be resolved */ };
 
 constexpr std::string_view Socket::toString(Type t)
@@ -1584,9 +1585,13 @@ bool StreamSocket::checkRemoval(std::chrono::steady_clock::time_point now)
     const auto durLast =
         std::chrono::duration_cast<std::chrono::milliseconds>(now - getLastSeenTime());
 
-    // Timeout criteria: Violate maximum inactivity (default 3600s).
-    const bool isInactive = net::Defaults.inactivityTimeout > std::chrono::microseconds::zero() &&
-        durLast > net::Defaults.inactivityTimeout;
+    // Use the longer WebSocket timeout for upgraded connections.
+    const auto& timeout = isWebSocket() ? net::Defaults.wsInactivityTimeout
+                                        : net::Defaults.inactivityTimeout;
+
+    // Timeout criteria: Violate maximum inactivity.
+    const bool isInactive = timeout > std::chrono::microseconds::zero() &&
+        durLast > timeout;
 
     // Timeout criteria: Shall terminate?
     const bool isTermination = SigUtil::getTerminationFlag();

--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1314,6 +1314,24 @@ public:
         int events = _socketHandler->getPollEvents(now, timeoutMaxMicroS);
         if (!_outBuffer.empty() || _shutdownSignalled)
             events |= POLLOUT;
+
+        // Ensure ppoll wakes in time to enforce inactivity timeout on IP sockets.
+        if (isIPType())
+        {
+            const auto& timeout = isWebSocket() ? net::Defaults.wsInactivityTimeout
+                                                 : net::Defaults.inactivityTimeout;
+            if (timeout > std::chrono::microseconds::zero())
+            {
+                const auto remaining = std::chrono::duration_cast<std::chrono::microseconds>(
+                    timeout - (now - getLastSeenTime()));
+                const int64_t remainUs = remaining.count();
+                if (remainUs > 0)
+                    timeoutMaxMicroS = std::min(timeoutMaxMicroS, remainUs);
+                else
+                    timeoutMaxMicroS = 0; // Already expired, wake immediately.
+            }
+        }
+
         return events;
     }
 
@@ -1680,8 +1698,6 @@ public:
         if (!events && _inBuffer.empty())
             return;
 
-        setLastSeenTime(now);
-
         bool closed = (events & (POLLHUP | POLLERR | POLLNVAL));
 
         if (events & POLLIN)
@@ -1700,11 +1716,16 @@ public:
 #endif
             );
 
-            if (read > 0 && closed)
+            if (read > 0)
             {
-                // We might have outstanding data to read, wait until readIncomingData returns closed state.
-                LOG_DBG("Closed but will drain incoming data per POLLIN");
-                closed = false;
+                setLastSeenTime(now); // Mark active only on actual data received.
+
+                if (closed)
+                {
+                    // We might have outstanding data to read, wait until readIncomingData returns closed state.
+                    LOG_DBG("Closed but will drain incoming data per POLLIN");
+                    closed = false;
+                }
             }
             else if (read < 0 && closed && (last_errno == EAGAIN || last_errno == EINTR))
             {
@@ -1748,6 +1769,7 @@ public:
                 return;
         }
 
+        const size_t outSizeBefore = _outBuffer.size();
         do
         {
             // If we have space for writing and that was requested
@@ -1787,6 +1809,10 @@ public:
                 }
             }
         } while (oldSize != _outBuffer.size());
+
+        // Mark active only when data was actually written to the socket.
+        if (_outBuffer.size() != outSizeBefore)
+            setLastSeenTime(now);
 
         if (closed)
         {

--- a/test/UnitTimeoutInactive.cpp
+++ b/test/UnitTimeoutInactive.cpp
@@ -38,8 +38,10 @@ class UnitTimeoutInactivity : public UnitTimeoutBase0
 
     void configure(Poco::Util::LayeredConfiguration& /* config */) override
     {
-        // net::Defaults.inactivityTimeout = 3600s;
+        // net::Defaults.inactivityTimeout = 5s;
         net::Defaults.inactivityTimeout = 360ms;
+        // net::Defaults.wsInactivityTimeout = 3600s;
+        net::Defaults.wsInactivityTimeout = 360ms;
         //
         // The following WSPing setup would cause ping/pong packages avoiding the inactivity TO
         //   net::Defaults.wsPingAvgTimeout = std::chrono::microseconds(25);

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2012,6 +2012,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
 #endif
     {
         LOG_DBG("net::Defaults: Socket[inactivityTimeout " << net::Defaults.inactivityTimeout
+                << ", wsInactivityTimeout " << net::Defaults.wsInactivityTimeout
                 << ", maxExtConnections " << net::Defaults.maxExtConnections << "]");
     }
 

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -933,6 +933,8 @@ bool FileServerRequestHandler::handleRequest(const HTTPRequest& request,
         http::Response response(http::StatusCode::OK);
         if( requestDetails.closeConnection() )
             response.setConnectionToken(http::Header::ConnectionToken::Close);
+        else
+            response.add("Keep-Alive", "timeout=3");
         hstsHeaders(response);
 
         const auto& config = Application::instance().config();


### PR DESCRIPTION
Wakeup our poll promptly for TCP file-serving timeouts even in debug mode to close inactive HTTP/IP sockets.

Add a separate wsInactivityTimeout (1 hour) for WebSocket connections, keeping the short 5s timeout for plain HTTP keep-alive connections. This prevents Chrome's 6-connection-per-origin limit from blocking WebSocket upgrades when idle HTTP connections consume all slots.

Send a Keep-Alive: timeout=3 header on HTTP file responses so that browsers voluntarily release idle connections promptly.

Change-Id: I981ee1842aaa98d363bc3a525bc89757f9a179df


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

