### PR TITLE
Fix opening of documents in UNC paths in CODA-W

### DIFF
--- a/browser/src/control/Control.BackstageView.ts
+++ b/browser/src/control/Control.BackstageView.ts
@@ -580,11 +580,18 @@ class BackstageView extends window.L.Class {
 		const url = new URL(uri);
 		let fullPath = url.pathname;
 
-		// On Windows a file: URI looks like this: file:///C:/Users/tml/foo.odt .
-		// URL::pathname has a leading slash and is thus not valid as a pathname, we need to
-		// strip that slash away.
+		// On Windows a file: URI for a local file looks like this:
+		// file:///C:/Users/tml/foo.odt .  URL::pathname has a leading slash and is thus not
+		// valid as a pathname, we need to strip that slash away.
 		if (window.ThisIsTheWindowsApp && fullPath[0] === '/' && fullPath[2] === ':')
 			fullPath = fullPath.slice(1);
+
+		// On Windows, a file: URI for a UNC path looks like this:
+		// file://server/share/sibdur/foo.odt . We obviously want to show the complete UNC
+		// path for the directory where the document is, and the "server" path is in
+		// url.host.
+		if (window.ThisIsTheWindowsApp && url.host !== '')
+			fullPath = '//' + url.host + fullPath;
 
 		// We want to show a more native pathname with backslashes instead of the slashes as
 		// used in file URIs.

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -1979,7 +1979,13 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
 {
     const std::string sessionId = session->getId();
 
+#ifdef _WIN32
+    // For this to work with UNC paths, we need to use getDocURL() here, which is the original full
+    // URL including the server. getJailedFilePath() ignores the server.
+    const std::string& uri = session->getDocURL();
+#else
     const std::string& uri = session->getJailedFilePath();
+#endif
     const std::string& uriAnonym = session->getJailedFilePathAnonym();
     const std::string& userName = session->getUserName();
     const std::string& userNameAnonym = session->getUserNameAnonym();

--- a/windows/coda/CODA/CODA.cpp
+++ b/windows/coda/CODA/CODA.cpp
@@ -916,6 +916,17 @@ static void exchangeMonitors(WindowData& data)
     enter_full_screen(data, monitors[newPresentationMonitor].hMonitor, false);
 }
 
+static std::string pathToURI(const Poco::Path& path)
+{
+    auto uri = Poco::URI(path);
+
+    if (path.getNode() == "")
+        return uri.toString();
+
+    uri.setHost(path.getNode());
+    return uri.toString();
+}
+
 static std::vector<FilenameAndUri> fileOpenDialog()
 {
     IFileOpenDialog* dialog;
@@ -964,7 +975,7 @@ static std::vector<FilenameAndUri> fileOpenDialog()
             SUCCEEDED(item->GetDisplayName(SIGDN_FILESYSPATH, &fileSysPath)))
         {
             auto path = Poco::Path(Util::wide_string_to_string(std::wstring(fileSysPath)));
-            result.push_back({ path.getFileName(), Poco::URI(path).toString() });
+            result.push_back({ path.getFileName(), pathToURI(path) });
             CoTaskMemFree(fileSysPath);
             item->Release();
         }


### PR DESCRIPTION
Files accessed through UNC paths have URIs of the format file://server/share/subdir/foo.odt .  The annoying back and forth conversion between file paths and URIs in the COOL code causes the server part to be easily lost. Work around the problem with minimal changes in a few places.

(In server-based COOL, in the mobile apps, and in CODA-Q and CODA-M we only handle file URIs with an empty server part.)

Introduce a new function pathToURI() to CODA.cpp. Use it so far just when opening a document. Probably the other cases where we use Poco::URI(path).toString() where path is a Poco::Path also are broken when UNC paths are involved. Later.

Also make sure the recent documents in the backstage show the full UNC path when necessary.


Change-Id: I6e27da330a1e330bce3b367c8f3875a38432f613


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

