### PR TITLE
lc_notesmode: update icon for light and dark mode

### DIFF
--- a/browser/images/dark/lc_notesmode.svg
+++ b/browser/images/dark/lc_notesmode.svg
@@ -1,9 +1,7 @@
 <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M5 3V21H19V3H5Z" fill="#3A3A38"/>
 <path d="M4 2V22H20V2H4ZM5 3H19V21H5V3Z" fill="#FAFAFA"/>
-<path d="M18 4H6V5V7V8H18V7V5V4ZM17 5V7H7V5H17Z" fill="#FAFAFA"/>
-<path d="M6 10H18V11H6V10Z" fill="#FAFAFA"/>
+<path d="M18 4H6V5V9V10H18V9V5V4ZM17 5V9H7V5H17Z" fill="#FAFAFA"/>
 <path d="M6 13H18V14H6V13Z" fill="#FAFAFA"/>
-<path d="M6 16H18V17H6V16Z" fill="#FAFAFA"/>
-<path d="M6 19H18V20H6V19Z" fill="#FAFAFA"/>
+<path d="M6 17H18V18H6V17Z" fill="#FAFAFA"/>
 </svg>

--- a/browser/images/lc_notesmode.svg
+++ b/browser/images/lc_notesmode.svg
@@ -1,1 +1,7 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="m5 3v18h14v-18z" fill="#fafafa"/><g fill="#3a3a38"><path d="m4 2v20h16v-20zm1 1h14v18h-14z"/><path d="m18 4h-12v1 2 1h12v-1-2zm-1 1v2h-10v-2z"/><path d="m6 10h12v1h-12z"/><path d="m6 13h12v1h-12z"/><path d="m6 16h12v1h-12z"/><path d="m6 19h12v1h-12z"/></g></svg>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 3V21H19V3H5Z" fill="#FAFAFA"/>
+<path d="M4 2V22H20V2H4ZM5 3H19V21H5V3Z" fill="#3A3A38"/>
+<path d="M18 4H6V5V9V10H18V9V5V4ZM17 5V9H7V5H17Z" fill="#3A3A38"/>
+<path d="M6 13H18V14H6V13Z" fill="#3A3A38"/>
+<path d="M6 17H18V18H6V17Z" fill="#3A3A38"/>
+</svg>


### PR DESCRIPTION
Simplified the lc_notesmode icon by reducing the number of lines for better visual clarity. Updated both light and dark version

Change-Id: I3c56b4b01b1168fa8297b24b196626a83235f04d
Signed-off-by: Ivana Koron <ivana.koron@collabora.com>

