### PR TITLE
Handle UNC paths in CODA-W also for documents passed on the command line

### DIFF
--- a/windows/coda/CODA/CODA.cpp
+++ b/windows/coda/CODA/CODA.cpp
@@ -2219,7 +2219,7 @@ int APIENTRY wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR, int showWindowMode)
         for (int i = 1; i < __argc; i++)
         {
             auto path = Poco::Path(Util::wide_string_to_string(__wargv[i]));
-            filenamesAndUrisToOpen.push_back({ path.getFileName(), Poco::URI(path).toString() });
+            filenamesAndUrisToOpen.push_back({ path.getFileName(), pathToURI(path) });
         }
     }
 


### PR DESCRIPTION
As in my previous commit, use pathToURI(path) instead of Poco::URI(path).toString().


Change-Id: I9f5d4a17f42b24a0c3c1401338180a71e4fddf42


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

