### PR TITLE
Slideshow: update prev and next buttons state

### DIFF
--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -331,6 +331,9 @@ class SlideShowNavigator {
 			if (this.prevSlide >= this.theMetaPres.numberOfSlides)
 				this.prevSlide = undefined;
 			this.currentSlide = nNewSlide;
+			if (this.presenter.updateControls) {
+				this.presenter.updateControls();
+			}
 
 			if (this.currentSlide === this.prevSlide) {
 				NAVDBG.print(


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
- Disable navigation buttons when the user is following a presenter, preventing them from advancing beyond the presenter's slide.
- Update tooltips to provide status context to the user on prev and next buttons

