### PR TITLE
feat(iOS): add Quick Look provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,8 @@ ios/Mobile/Branding
 ios/Mobile/Resources/Settings.bundle/Root.plist
 ios/Mobile/coolkitconfig.xcu
 
+ios/FakeQuickLook/Info.plist
+
 # symlinks created by configure for the iOS app Xcode project
 lobuilddir-symlink
 pocoinclude-symlink
@@ -155,6 +157,7 @@ zstdinclude-symlink
 zstdlib-symlink
 ICU.dat
 ios/Mobile/Assets.xcassets/AppIcon.appiconset
+ios/FakeQuickLook/Assets.xcassets/Icon.imageset
 
 # build numbers/versions
 BUNDLE-VERSION

--- a/configure.ac
+++ b/configure.ac
@@ -1982,6 +1982,7 @@ AC_CONFIG_FILES([Makefile
 
 if test "$enable_iosapp" = "yes"; then
     AC_CONFIG_FILES([ios/config.h
+                 ios/FakeQuickLook/Info.plist
                  ios/Mobile/Info.plist
                  ios/Mobile/Resources/Settings.bundle/Root.plist])
 fi
@@ -2059,11 +2060,15 @@ AS_IF([test "$ENABLE_IOSAPP" = "true"],
           # symlink, so make it a directory of symlinks to the actual png
           # and json files.
           rm -rf ios/Mobile/Assets.xcassets/AppIcon.appiconset
+          rm -rf ios/FakeQuickLook/Assets.xcassets/Icon.imageset
           mkdir ios/Mobile/Assets.xcassets/AppIcon.appiconset
+          mkdir ios/FakeQuickLook/Assets.xcassets/Icon.imageset
           if test -n "$with_iosapp_appicon"; then
              ln -s "$with_iosapp_appicon"/* ios/Mobile/Assets.xcassets/AppIcon.appiconset
+             ln -s "$with_iosapp_appicon"/* ios/FakeQuickLook/Assets.xcassets/Icon.imageset
           else
              ln -s ios/Mobile/Assets.xcassets/Empty.appiconset/* ios/Mobile/Assets.xcassets/AppIcon.appiconset
+             ln -s ios/Mobile/Assets.xcassets/Empty.appiconset/* ios/FakeQuickLook/Assets.xcassets/Icon.imageset
           fi
        fi
       ],

--- a/ios/ExportOptions/cpci.plist
+++ b/ios/ExportOptions/cpci.plist
@@ -10,6 +10,8 @@
   <dict>
     <key>com.collabora.office.Mobile</key>
     <string>Browserstack distribution</string>
+    <key>com.collabora.office.Mobile.FakeQuickLook</key>
+    <string>Browserstack fakequicklook</string>
   </dict>
 </dict>
 </plist>

--- a/ios/FakeQuickLook/Assets.xcassets/Contents.json
+++ b/ios/FakeQuickLook/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/ios/FakeQuickLook/Info.plist.in
+++ b/ios/FakeQuickLook/Info.plist.in
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>QLIsDataBasedPreview</key>
+			<false/>
+			<key>QLSupportedContentTypes</key>
+			<array>
+				<string>org.oasis-open.opendocument.text</string>
+				<string>com.collabora.office.uti.fodt</string>
+				<string>org.oasis-open.opendocument.spreadsheet</string>
+				<string>org.oasis-open.opendocument.presentation</string>
+				<string>com.collabora.office.uti.vsd</string>
+			</array>
+			<key>QLSupportsSearchableItems</key>
+			<false/>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.quicklook.preview</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).PreviewViewController</string>
+	</dict>
+    <key>COMainAppName</key>
+    <string>@APP_NAME@</string>
+</dict>
+</plist>

--- a/ios/FakeQuickLook/Localizable.xcstrings
+++ b/ios/FakeQuickLook/Localizable.xcstrings
@@ -1,0 +1,12 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "This file can't be previewed" : {
+
+    },
+    "To read or edit this file, open it in %@" : {
+
+    }
+  },
+  "version" : "1.1"
+}

--- a/ios/FakeQuickLook/PreviewViewController.swift
+++ b/ios/FakeQuickLook/PreviewViewController.swift
@@ -1,0 +1,62 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import UIKit
+import QuickLook
+
+class PreviewViewController: UIViewController, QLPreviewingController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+    func preparePreviewOfFile(at url: URL) async throws {
+        let titleText = UILabel();
+        titleText.textAlignment = .center;
+        titleText.text = String(localized: "This file can't be previewed");
+        titleText.font = UIFont(descriptor: titleText.font.fontDescriptor, size: 30);
+        titleText.adjustsFontSizeToFitWidth = true;
+        titleText.adjustsFontForContentSizeCategory = true;
+        titleText.translatesAutoresizingMaskIntoConstraints = false;
+        titleText.minimumScaleFactor = 0.5;
+        titleText.numberOfLines = 0;
+        view.addSubview(titleText);
+        
+        let appName = Bundle.main.infoDictionary?["COMainAppName"] as! String;
+        
+        let subtitleText = UILabel();
+        subtitleText.textAlignment = .center;
+        subtitleText.text = String(localized: "To read or edit this file, open it in \(appName)");
+        subtitleText.font = UIFont(descriptor: subtitleText.font.fontDescriptor, size: -20);
+        subtitleText.adjustsFontSizeToFitWidth = true;
+        subtitleText.adjustsFontForContentSizeCategory = true;
+        subtitleText.translatesAutoresizingMaskIntoConstraints = false;
+        subtitleText.minimumScaleFactor = 0.5;
+        subtitleText.numberOfLines = 0;
+        view.addSubview(subtitleText);
+        
+        let icon = UIImageView()
+        icon.image = UIImage(named: "Icon");
+        icon.translatesAutoresizingMaskIntoConstraints = false;
+        view.addSubview(icon);
+        
+        NSLayoutConstraint.activate([
+            titleText.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            subtitleText.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            icon.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            
+            titleText.leftAnchor.constraint(equalTo: view.leftAnchor, constant: 20),
+            subtitleText.leftAnchor.constraint(equalTo: view.leftAnchor, constant: 20),
+            
+            subtitleText.topAnchor.constraint(equalTo: titleText.lastBaselineAnchor, constant: 10),
+            icon.bottomAnchor.constraint(equalTo: titleText.topAnchor, constant: -10),
+            titleText.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            
+            icon.widthAnchor.constraint(equalToConstant: 128),
+            icon.heightAnchor.constraint(equalToConstant: 128),
+        ]);
+    }
+}

--- a/ios/Mobile.xcodeproj/project.pbxproj
+++ b/ios/Mobile.xcodeproj/project.pbxproj
@@ -96,6 +96,8 @@
 		BEFB1EE121C29CC70081D757 /* L10n.mm in Sources */ = {isa = PBXBuildFile; fileRef = BEFB1EE021C29CC70081D757 /* L10n.mm */; };
 		C78C8ED62E90027E0011B574 /* data in Resources */ = {isa = PBXBuildFile; fileRef = C78C8ED32E9001F00011B574 /* data */; };
 		C79282312DF89BB2001EA43B /* MobileSocket.mm in Sources */ = {isa = PBXBuildFile; fileRef = C79282302DF89BB2001EA43B /* MobileSocket.mm */; };
+		C7CA44012F430DCC0087DA36 /* QuickLook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7CA44002F430DCC0087DA36 /* QuickLook.framework */; };
+		C7CA440D2F430DCC0087DA36 /* FakeQuickLook.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = C7CA43FF2F430DCC0087DA36 /* FakeQuickLook.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		D49B580F2D1077F700E0E607 /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D49B580E2D1077F700E0E607 /* UniformTypeIdentifiers.framework */; };
 		D4A0F3D72D64E86C00472DEE /* CoolURLSchemeHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = D4A0F3D62D64E86C00472DEE /* CoolURLSchemeHandler.mm */; };
 /* End PBXBuildFile section */
@@ -108,7 +110,28 @@
 			remoteGlobalIDString = BE8D77262136762500AC58EA;
 			remoteInfo = Mobile;
 		};
+		C7CA440B2F430DCC0087DA36 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = BE8D771F2136762500AC58EA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C7CA43FE2F430DCC0087DA36;
+			remoteInfo = FakeQuickLook;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		C7CA440E2F430DCC0087DA36 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				C7CA440D2F430DCC0087DA36 /* FakeQuickLook.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		1F957DC12BA82296006C9E78 /* Util-mobile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "Util-mobile.cpp"; sourceTree = "<group>"; };
@@ -1508,13 +1531,26 @@
 		C78C8ED32E9001F00011B574 /* data */ = {isa = PBXFileReference; lastKnownFileType = folder; name = data; path = ../test/data; sourceTree = "<group>"; };
 		C792822F2DF89BB2001EA43B /* MobileSocket.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MobileSocket.h; sourceTree = "<group>"; };
 		C79282302DF89BB2001EA43B /* MobileSocket.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MobileSocket.mm; sourceTree = "<group>"; };
+		C7CA43FF2F430DCC0087DA36 /* FakeQuickLook.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = FakeQuickLook.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		C7CA44002F430DCC0087DA36 /* QuickLook.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuickLook.framework; path = System/Library/Frameworks/QuickLook.framework; sourceTree = SDKROOT; };
 		D49B580E2D1077F700E0E607 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
 		D4A0F3D62D64E86C00472DEE /* CoolURLSchemeHandler.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CoolURLSchemeHandler.mm; sourceTree = "<group>"; };
 		D4A0F3D82D663A0000472DEE /* CoolURLSchemeHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CoolURLSchemeHandler.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		C7CA44112F430DCC0087DA36 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = C7CA43FE2F430DCC0087DA36 /* FakeQuickLook */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		C73BEA622E8429C4009E12D3 /* MobileUITests */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = MobileUITests; sourceTree = "<group>"; };
+		C7CA44022F430DCC0087DA36 /* FakeQuickLook */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (C7CA44112F430DCC0087DA36 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = FakeQuickLook; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1535,6 +1571,14 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C7CA43FC2F430DCC0087DA36 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C7CA44012F430DCC0087DA36 /* QuickLook.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1582,6 +1626,7 @@
 				BEA2835921470A1C00848631 /* WebKit.framework */,
 				BE00F8B6213ED573001CE2D4 /* libz.tbd */,
 				BE00F8B4213ED543001CE2D4 /* libiconv.tbd */,
+				C7CA44002F430DCC0087DA36 /* QuickLook.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -2674,6 +2719,7 @@
 				BE5EB5B5213FE1F900E0826C /* Online */,
 				BE8D77292136762500AC58EA /* Mobile */,
 				C73BEA622E8429C4009E12D3 /* MobileUITests */,
+				C7CA44022F430DCC0087DA36 /* FakeQuickLook */,
 				BE8D77282136762500AC58EA /* Products */,
 				BE00F8B3213ED542001CE2D4 /* Frameworks */,
 			);
@@ -2684,6 +2730,7 @@
 			children = (
 				BE8D77272136762500AC58EA /* Mobile.app */,
 				C73BEA612E8429C4009E12D3 /* MobileUITests.xctest */,
+				C7CA43FF2F430DCC0087DA36 /* FakeQuickLook.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3619,10 +3666,12 @@
 				BE8D77242136762500AC58EA /* Frameworks */,
 				BE8D77252136762500AC58EA /* Resources */,
 				3F88490F29943B7600FBB3E9 /* ShellScript */,
+				C7CA440E2F430DCC0087DA36 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				C7CA440C2F430DCC0087DA36 /* PBXTargetDependency */,
 			);
 			name = Mobile;
 			productName = Mobile;
@@ -3652,13 +3701,35 @@
 			productReference = C73BEA612E8429C4009E12D3 /* MobileUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		C7CA43FE2F430DCC0087DA36 /* FakeQuickLook */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C7CA44122F430DCC0087DA36 /* Build configuration list for PBXNativeTarget "FakeQuickLook" */;
+			buildPhases = (
+				C7CA43FB2F430DCC0087DA36 /* Sources */,
+				C7CA43FC2F430DCC0087DA36 /* Frameworks */,
+				C7CA43FD2F430DCC0087DA36 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				C7CA44022F430DCC0087DA36 /* FakeQuickLook */,
+			);
+			name = FakeQuickLook;
+			packageProductDependencies = (
+			);
+			productName = FakeQuickLook;
+			productReference = C7CA43FF2F430DCC0087DA36 /* FakeQuickLook.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		BE8D771F2136762500AC58EA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1640;
+				LastSwiftUpdateCheck = 2620;
 				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = Collabora;
 				TargetAttributes = {
@@ -3673,6 +3744,9 @@
 					C73BEA602E8429C4009E12D3 = {
 						CreatedOnToolsVersion = 16.4;
 						TestTargetID = BE8D77262136762500AC58EA;
+					};
+					C7CA43FE2F430DCC0087DA36 = {
+						CreatedOnToolsVersion = 26.2;
 					};
 				};
 			};
@@ -3692,6 +3766,7 @@
 			targets = (
 				BE8D77262136762500AC58EA /* Mobile */,
 				C73BEA602E8429C4009E12D3 /* MobileUITests */,
+				C7CA43FE2F430DCC0087DA36 /* FakeQuickLook */,
 			);
 		};
 /* End PBXProject section */
@@ -3740,6 +3815,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C7CA43FD2F430DCC0087DA36 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
@@ -3778,7 +3860,7 @@
 				BE980C592CEB557A00FED7BC /* FileUtil-apple.mm in Sources */,
 				BE5EB5D22140039100E0826C /* COOLWSD.cpp in Sources */,
 				BE5EB5D22140039100E0836C /* KitWSDGlobals.cpp in Sources */,
-                BE5EB5D22140039101E0927D /* dumpWsdState.cpp in Sources */,
+				BE5EB5D22140039101E0927D /* dumpWsdState.cpp in Sources */,
 				BE5EB5D22140039100E0826D /* ClientRequestDispatcher.cpp in Sources */,
 				BEFB1EE121C29CC70081D757 /* L10n.mm in Sources */,
 				BEDCC8992456FFAD00FB02BD /* SceneDelegate.mm in Sources */,
@@ -3834,6 +3916,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C7CA43FB2F430DCC0087DA36 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -3841,6 +3930,11 @@
 			isa = PBXTargetDependency;
 			target = BE8D77262136762500AC58EA /* Mobile */;
 			targetProxy = C73BEA672E8429C4009E12D3 /* PBXContainerItemProxy */;
+		};
+		C7CA440C2F430DCC0087DA36 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C7CA43FE2F430DCC0087DA36 /* FakeQuickLook */;
+			targetProxy = C7CA440B2F430DCC0087DA36 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -3921,6 +4015,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 			};
 			name = Debug;
 		};
@@ -3974,6 +4069,7 @@
 				LOSRCDIR = "$(SOURCE_ROOT)/../lobuilddir-symlink";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -4171,6 +4267,88 @@
 			};
 			name = Release;
 		};
+		C7CA440F2F430DCC0087DA36 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = J4FQ687VJK;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = FakeQuickLook/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = FakeQuickLook;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Collabora. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.collabora.office.Mobile.FakeQuickLook;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		C7CA44102F430DCC0087DA36 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = J4FQ687VJK;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = FakeQuickLook/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = FakeQuickLook;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Collabora. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.collabora.office.Mobile.FakeQuickLook;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -4197,6 +4375,15 @@
 			buildConfigurations = (
 				C73BEA692E8429C4009E12D3 /* Debug */,
 				C73BEA6A2E8429C4009E12D3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		C7CA44122F430DCC0087DA36 /* Build configuration list for PBXNativeTarget "FakeQuickLook" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C7CA440F2F430DCC0087DA36 /* Debug */,
+				C7CA44102F430DCC0087DA36 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
Quick Look is iOS' preview mechanism. There's a strict memory limit, which means we can't load LOKit to render or convert documents, so we previously haven't provided a quick look interface at all.

Nevertheless, Quick Look is required for some apps to be able to open documents. For example, the default iOS calendar doesn't let you open attachments to events unless there is a quick look provider for them. Therefore, we can provide a "Fake Quick Look" provider - really just a CTA to use our app to view the document - which has the function of showing up in these apps and letting you tap the share/open in buttons.

iOS already provides Quick Look for the Microsoft and OOXML formats as part of its system formats. Therefore, we only need to register this for formats that aren't provided by the system.


Change-Id: I79f06c49b2ed541d21ae9855e23620b86a6a6964


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

