### PR TITLE
css: fix double scrollbar regression in listbox dropdown

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -3009,7 +3009,7 @@ kbd,
 
 /* Listbox UI grid */
 .jsdialog.ui-grid[role='listbox']:not(:has(> .ui-iconview)) {
-	max-height: 99vh;
+	max-height: min(470px, 45vh);
 }
 
 .jsdialog.ui-grid[role='listbox'] {


### PR DESCRIPTION
Commit 9d20cb22b0 accidentally changed max-height from min(470px, 45vh) to 99vh as part of an unrelated color picker change, re-introducing the double scrollbar issue that was fixed in PR #13426.


Change-Id: I10351d0668f38a01b12ebaba69e6d02f0ff9fb88
