### PR TITLE
cool#13988 redline render mode: show the old file name also with a remote compare

### DIFF
--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -642,6 +642,11 @@ window.L.Map.WOPI = window.L.Handler.extend({
 		}
 		else if (msg.MessageId == 'Action_CompareDocuments') {
 			if (msg.Values) {
+				if (msg.Values.filename) {
+					// Remember old file name for CompareChangesLabelSection.
+					app.writer.compareDocumentOldFileName = msg.Values.filename;
+				}
+
 				this._map.insertURL(msg.Values.url, "comparedocumentsurl");
 			}
 		}

--- a/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
@@ -154,6 +154,35 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		});
 	});
 
+	it('Compare remote documents', function () {
+		// Given a document:
+		desktopHelper.switchUIToNotebookbar();
+		// Switch to the 'Review' tab.
+		cy.cGet('#Review-tab-label').click();
+
+		// When getting an Action_CompareDocuments message with a filename:
+		cy.getFrameWindow().then(function(win) {
+			const message = {
+				'MessageId': 'Action_CompareDocuments',
+				'Values': {
+					'url': 'https://www.example.com/dummy',
+					'filename': 'remote_old.odt',
+				}
+			};
+			win.postMessage(JSON.stringify(message), '*');
+		});
+
+		// Then the doc compare mode left label should show the old document name:
+		// Click on 'Tracking' -> 'View Changes'.
+		cy.cGet('#review-tracking').click();
+		// If this is visible or not is not interesting, we want to assert the resulting
+		// title.
+		cy.cGet('#compare-tracked-change').click({force: true});
+		cy.cGet('#compare-changes-left-title').should(function($el) {
+			expect($el.text()).to.match(/^remote_old\.odt/);
+		});
+	});
+
 	it('View Changes mode has tiles for both modes', function () {
 		// Given a document with tracked changes:
 		desktopHelper.switchUIToNotebookbar();


### PR DESCRIPTION
Compare the current (new) document with a selected (old) document from
the integrator's file storage (URL, not local file), the compare changes
label shows the new file name on both sides.

The local file case was fixed in commit
6681c51c768c5d0fdda7185a5933a4ec73eff807 (cool#13988 redline render
mode: show the old file name in the old label after local compare,
2026-02-17) already.

Luckily image insert provides us with a file picker callback that has a
'filename' field, so we can use that; the URL may be just file content
and a hash-like string, so showing the last segment is not a good idea.

Also add a test for this, similar to how
cypress_test/integration_tests/desktop/writer/copy_paste_spec.js posts
messages to our iframe already.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I00f7c2b06baade3596b31bfcf51496906e23e04e
