### PR TITLE
Revert "Tweak capabilities JSON"

### DIFF
--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -248,7 +248,7 @@
       <macro_security_level desc="Level of Macro security. 1 (Medium) Confirmation required before executing macros from untrusted sources. 0 (Low, not recommended) All macros will be executed without confirmation." type="int" default="1">1</macro_security_level>
       <enable_websocket_urp desc="Should we enable URP (UNO remote protocol) communication over the websocket. This allows full control of the Kit child server to anyone with access to the websocket including executing macros without confirmation or running arbitrary shell commands in the jail." type="bool" default="false">false</enable_websocket_urp>
       <enable_metrics_unauthenticated desc="When enabled, the /cool/getMetrics endpoint will not require authentication." type="bool" default="false">false</enable_metrics_unauthenticated>
-      <server_signature desc="Whether to send server signature in HTTP response headers and capabilities JSON responses" type="bool" default="@SERVER_SIGNATURE@">@SERVER_SIGNATURE@</server_signature>
+      <server_signature desc="Whether to send server signature in HTTP response headers" type="bool" default="@SERVER_SIGNATURE@">@SERVER_SIGNATURE@</server_signature>
     </security>
 
     <certificates>

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -2790,21 +2790,17 @@ std::string getCapabilitiesJson(bool convertToAvailable)
     // Set the Server ID
     capabilities->set("serverId", Util::getProcessIdentifier());
 
-    CONFIG_STATIC const bool sig = ConfigUtil::getBool("security.server_signature", false);
-    if (sig)
-    {
-        // Set the product version
-        capabilities->set("productVersion", Util::getCoolVersion());
+    // Set the product version
+    capabilities->set("productVersion", Util::getCoolVersion());
 
-        // Set the product version hash
-        capabilities->set("productVersionHash", Util::getCoolVersionHash());
+    // Set the product version hash
+    capabilities->set("productVersionHash", Util::getCoolVersionHash());
 
-        // Set the kit version
-        capabilities->set("productKitVersion", COOLWSD::LOKitVersionNumber);
+    // Set the kit version
+    capabilities->set("productKitVersion", COOLWSD::LOKitVersionNumber);
 
-        // Set the kit version hash
-        capabilities->set("productKitVersionHash", COOLWSD::LOKitVersionHash);
-    }
+    // Set the kit version hash
+    capabilities->set("productKitVersionHash", COOLWSD::LOKitVersionHash);
 
     // Set that this is a proxy.php-enabled instance
     capabilities->set("hasProxyPrefix", COOLWSD::IsProxyPrefixEnabled);


### PR DESCRIPTION
For now. External apps depend on the version.

This reverts commit b9630506ee31f9eb4eb1d5198e336bf799d02dbc. This reverts commit bf48b4143802ece6bf816bcb65ee4eb41262b050.

Change-Id: I3a7a7d304af516c23f0f8fab774adf775eb8a7b2

* Resolves: richdocuments#5360
* Target version: main

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

