### PR TITLE
Fix invisible buttons user applies custom OS-level color settings

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -183,6 +183,7 @@ COOL_CSS_LST =\
 	$(srcdir)/css/btns.css \
 	$(srcdir)/css/notebookbar.css \
 	$(srcdir)/css/jssidebar.css \
+	$(srcdir)/css/forced-colors.css \
 	$(srcdir)/css/override-smartmenus.css \
 	$(srcdir)/css/jquery-ui-lightness.css \
 	$(srcdir)/css/infobar.css \

--- a/browser/css/forced-colors.css
+++ b/browser/css/forced-colors.css
@@ -1,0 +1,35 @@
+@media (forced-colors: active) {
+
+  /* Active notebookbar tab: box-shadow is stripped, use border-bottom */
+  .ui-tab.selected.notebookbar {
+    border-bottom: 2px solid Highlight !important;
+    box-shadow: none !important;
+  }
+  .ui-tab.selected.notebookbar:hover {
+    box-shadow: none !important;
+    border-bottom: 2px solid Highlight !important;
+  }
+  .ui-tab.notebookbar:hover {
+    box-shadow: none !important;
+    border-bottom: 2px solid ButtonBorder !important;
+  }
+
+  /* Preserve SVG toolbar icons */
+  .w2ui-icon,
+  .unoSave.savemodified .unobutton img,
+  .savemodified.unotoolbutton .unobutton img,
+  .StyleListPanel #TemplatePanel button,
+  .document-logo {
+    forced-color-adjust: none;
+  }
+
+  /* Restore native checkboxes (OS renders in user's HC colors) */
+  input[type='checkbox'].autofilter,
+  .jsdialog input[type='checkbox'] {
+    appearance: auto !important;
+    -webkit-appearance: auto !important;
+    -moz-appearance: auto !important;
+    background: none !important;
+  }
+
+}


### PR DESCRIPTION
Due to custom color settings possible to set at os level, example:
MS Windows Settings > Accessibility > Themes > Create new Theme or
edit a theme and set the text: #03FF80 and background #0200A0, the
essential, information bearing graphical controls and labels are no
longer sufficiently visible. as a result.

This them can make the browser strips box-shadow, gradients, and
background-images. This made the active notebookbar tab invisible, toolbar SVG icons
disappear, and custom checkboxes lose their check marks.

It's hard to fix this but at least we can make sure we don't depend on
shadows and instead depend on borders.

For the icons we should simply ignore the OS theme and thus disable
that via media query.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4cc7439537bdf6cd9fe18fbd10dab23d7ce5db1d
