### PR TITLE
isInContainer: fix container detection on cgroupv2 systems

### DIFF
--- a/common/security.h
+++ b/common/security.h
@@ -44,6 +44,15 @@ inline int hasUID(const char *userId)
 inline int isInContainer()
 {
 #ifdef __linux__
+    /* Docker creates /.dockerenv */
+    if (access("/.dockerenv", F_OK) == 0)
+        return 1;
+
+    /* Podman creates /run/.containerenv */
+    if (access("/run/.containerenv", F_OK) == 0)
+        return 1;
+
+    /* Legacy cgroups v1 check */
     FILE *cgroup;
     char line[80];
     const char *docker = ":/docker/";


### PR DESCRIPTION
The existing check only looks for ":/docker/" in /proc/self/cgroup, which doesn't appear on systems using cgroups v2. Add checks for /.dockerenv (Docker) and /run/.containerenv (Podman) before falling back to the legacy cgroups v1 check.

Without this fix, ForKit rejects non-"cool" UIDs in containers on modern kernels because isInContainer() incorrectly returns false, breaking OpenShift deployments that assign random UIDs.


Change-Id: I772b9872b93e77a4b0a6974d8b15b95d1f541c05

@Rash419 the hope is that with this the NSS_WRAPPER hack in startup script would be unnecessary. 