### PR TITLE
Fix last save state duration for save icon

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2029,7 +2029,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		$(controls.label).on('click', clickFunction);
 		// We need a way to also handle the custom tooltip for any tool button like save in shortcut bar
 		if (data.isCustomTooltip) {
-			this._handleCutomTooltip(div, builder);
+			this._handleCustomTooltip(div, builder);
 		}
 		else if (!hasLabel || hasShortcut) {
 			$(div).on('mouseenter', mouseEnterFunction);
@@ -2055,8 +2055,10 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		return controls;
 	},
 
-	_handleCutomTooltip: function(elem, builder) {
-		switch (elem.id) {
+	_handleCustomTooltip: function(elem, builder) {
+		// Prefer modelid, fallback to id if modelid is missing
+		const lookupId = elem.getAttribute('modelid') || elem.id;
+		switch (lookupId) {
 			case 'save':
 				$(elem).on('mouseenter', window.touch.mouseOnly(function() {
 					if (builder.map.tooltip)


### PR DESCRIPTION
- Before this patch because now we use modalId attr the handleCustomTooltip method needs to consider ModalId and not elem ModalId
- this patch will fix that and now we can see what is the time difference between last save and current time

<img width="1078" height="550" alt="image" src="https://github.com/user-attachments/assets/b144a324-1f45-4b88-825e-7f5e9f989ff3" />


Change-Id: I809b5624cb41a0be0868e3530b081773771d2fcf


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

