### PR TITLE
No need to explicitly NUL-terminate, CryptBinaryToStringA() already does

### DIFF
--- a/windows/coda/CODA/CODA.cpp
+++ b/windows/coda/CODA/CODA.cpp
@@ -314,9 +314,12 @@ static void send2JS(const HWND hWnd, const char* buffer, int length)
 
     DWORD base64len = length * 2 + 100;
     std::vector<char> base64(base64len);
-    CryptBinaryToStringA((BYTE*)buffer, length, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF,
-                         base64.data(), &base64len);
-    base64[base64len] = '\0';
+    if (!CryptBinaryToStringA((BYTE*)buffer, length, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF,
+                              base64.data(), &base64len))
+    {
+        LOG_ERR("CryptBinaryToStringA failed: " << GetLastError());
+        return;
+    }
 
     if (binaryMessage)
         LOG_TRC("To execute in JS: " << pretext << "stuff" << posttext);


### PR DESCRIPTION
Besides, the vector is already full with NUL characters after contruction.

Also check for the very unlikely possibility that
CryptBinaryToStringA() fails.


Change-Id: Ib5f05ded476ef3994c4ba2fd25b21d7d7ca32d5b


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

