### PR TITLE
cool#13988 redline render mode: fix insert/delete tooltip

### DIFF
--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1649,8 +1649,11 @@ class UIManager extends window.L.Control {
 	 */
 	showDocumentTooltip(tooltipInfo: any): void {
 		var split = tooltipInfo.rectangle.split(',');
-		var latlng = this.map._docLayer._twipsToLatLng(new cool.Point(+split[0], +split[1]));
-		var pt = this.map.latLngToContainerPoint(latlng);
+
+		// Go via SimplePoint(), which is aware of the active layout.
+		const point = new cool.SimplePoint(+split[0], +split[1]);
+		const pt = { x: Math.round(point.vX / app.dpiScale), y: Math.round(point.vY / app.dpiScale) };
+
 		var elem = $('.leaflet-layer');
 
 		elem.tooltip();

--- a/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
@@ -221,6 +221,35 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.cGet('.compare-changes-labels').should('not.have.css', 'display', 'none');
 	});
 
+	it('Tooltip position in compare changes mode', function () {
+		// Given a document in compare changes mode:
+		desktopHelper.switchUIToNotebookbar();
+		cy.cGet('#Review-tab-label').click();
+		desktopHelper.getNbIcon('TrackChanges', 'Review').click();
+		cy.cGet('#compare-tracked-change').filter(':visible').click();
+		cy.cGet('.compare-changes-labels').should('not.have.css', 'display', 'none');
+
+		// When faking a tooltip message for a tracked change on the right side:
+		cy.getFrameWindow().then(function(win) {
+			win.app.map.uiManager.showDocumentTooltip({
+				type: 'generaltooltip',
+				text: 'Inserted: LocalUser#0 - 02/11/2026 11:44:56',
+				rectangle: '5785, 2293, 1240, 275',
+			});
+		});
+
+		// Then the tooltip should appear on the right half of the viewport:
+		// Without the accompanying fix in place, this test would have failed, the
+		// tooltip x position was too small (on the left side, outside the right page).
+		// The viewport size is 1400, so the mid point is 700, the good position is 988, the
+		// bad one is 671.
+		cy.cGet('.ui-tooltip').should(function($el) {
+			const left = parseFloat($el.css('left'));
+			const viewportMidpoint = Cypress.config('viewportWidth') / 2;
+			expect(left, 'tooltip left position').to.be.greaterThan(viewportMidpoint);
+		});
+	});
+
 	it.skip('Comment Undo-Redo', function () {
 		for (var n = 0; n < 2; n++) {
 			desktopHelper.getCompactIconArrow('DefaultNumbering').click();


### PR DESCRIPTION
Open a Writer document with tracked changes, Review -> View Changes to
go to doc compare mode, go to an insert with the mouse, the tooltip has
a bad position, X is too small.

Document compare mode uses ViewLayoutCompareChanges. The tooltip
position comes from core as twips coordinates. The current
showDocumentTooltip() in Control.UIManager.ts converts these via the old
Leaflet path (_twipsToLatLng + latLngToContainerPoint) which is not
aware of the compare changes split-view layout.

Fix the problem similar to how commit
6a198e9af054ef9b6f3b353b1c0a6f6f99d7994f (URLPopUp: Use base function
for calc and view coordinates for others., 2026-02-10) fixed URL popups:
go via SimplePoint, its vX calls activeLayout.documentToViewX(this),
which defaults to TileMode.RightSide in compare changes mode, leading to
the correct position.

Also add a test for this.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I4c33d34eceaf0d4a6ba5b3b76f69259185dc6e40
