### PR TITLE
a11y: Fix aria-pressed state for sidebar deck buttons

### DIFF
--- a/browser/src/control/Control.Sidebar.ts
+++ b/browser/src/control/Control.Sidebar.ts
@@ -54,9 +54,27 @@ class Sidebar extends SidebarBase {
 
 		const deckPref: { [key: string]: string } = {};
 		decks.forEach((deck: string) => {
-			deckPref[deck] = currentDeck === deck ? 'true' : 'false';
+			const isActive = currentDeck === deck ? 'true' : 'false';
+			deckPref[deck] = isActive;
+			const command = this.commandForDeck(deck);
+			if (command) {
+				this.map.fire('commandstatechanged', {
+					commandName: command,
+					state: isActive,
+				});
+			}
 		});
 		this.map.uiManager.setDocTypeMultiplePrefs(deckPref);
+	}
+
+	closeSidebar() {
+		if (this.targetDeckCommand) {
+			this.map.fire('commandstatechanged', {
+				commandName: this.targetDeckCommand,
+				state: 'false',
+			});
+		}
+		super.closeSidebar();
 	}
 
 	commandForDeck(deckId: string): string {


### PR DESCRIPTION
a11y: Fix aria-pressed state for sidebar deck buttons

The sidebar deck toggle buttons (e.g., SidebarDeck.PropertyDeck) had aria-pressed always set to false because core does not send deck-specific commandstatechanged events. The _unoToolButton listener for .uno:SidebarDeck.PropertyDeck never fires, so aria-pressed remains false even when the deck is active.

Fix this by firing commandstatechanged for all deck commands in updateSidebarPrefs - the active deck gets 'true', and all others get 'false'. Also override closeSidebar to fire 'false' for the target deck command when closing.

<img width="215" height="327" alt="Screenshot from 2026-02-19 16-37-50" src="https://github.com/user-attachments/assets/6e1243aa-ac8d-4439-a388-49e240415c31" />

Before: Sidebar toggle not highlighted even sidebar open

Now: Sidebar toggle is highlighted if sidebar deck open.

Change-Id: I178ab88a0505a76df8bec03fb199b7f4b6842a45



* Resolves: # <!-- related github issue -->
* Target version: main
