### PR TITLE
CanvasSectionContainer: Clear mouse positions when window loses focus.

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -230,6 +230,7 @@ class CanvasSectionContainer {
 		this.canvas.ontouchcancel = this.onTouchCancel.bind(this);
 		this.canvas.ondrop = this.onDrop.bind(this);
 		this.canvas.ondragover = this.onDragOver.bind(this);
+		window.addEventListener('blur', this.onWindowBlur.bind(this));
 
 		// Some explanation first.
 		// When the user uses the mouse wheel for scrolling, different browsers use different technics for calculating the deltaY and deltaX values.
@@ -1310,6 +1311,31 @@ class CanvasSectionContainer {
 			if (windowSection.interactable)
 				windowSection.onMouseEnter(null, e);
 		}
+	}
+
+	// When the browser window/tab loses focus during a drag, we never receive the mouseup event.
+	// This leaves draggingSomething=true and sections (e.g. MouseControl) never send 'buttonup' to the core.
+	// This may cause a stuck selection in some cases.
+	private onWindowBlur () {
+		if (!this.draggingSomething)
+			return;
+
+		// Propagate a synthetic mouseUp to the section that received the original
+		// mouseDown so it can clean up (e.g. MouseControl sends 'buttonup' to core).
+		if (this.sectionOnMouseDown) {
+			var section: CanvasSectionObject = this.getSectionWithName(this.sectionOnMouseDown);
+			if (section) {
+				var position = this.positionOnMouseUp || this.mousePosition || this.positionOnMouseDown;
+				// Create a synthetic MouseEvent so section handlers can safely access
+				// event properties (e.g. stopPropagation, modifiers).
+				var syntheticEvent = new MouseEvent('mouseup', { button: 0, buttons: 0 });
+				this.propagateOnMouseUp(section, this.convertPositionToSectionLocale(section, position), syntheticEvent);
+			}
+		}
+
+		this.clearMousePositions();
+		this.mousePosition = null;
+		this.mouseIsInside = false;
 	}
 
 	public onTouchStart (e: TouchEvent) { // Should be ignored unless this.draggingSomething = true.


### PR DESCRIPTION
When user starts an event that lasts for some time, like dragging, CanvasSectionContainer assumes that it will handle the event until the end. If user starts an event and then the window loses focus, CanvasSectionContainer can not end the event.

Example scenario:
* Start selecting text.
* While holding the mouse button, use CTRL+TAB (or similar, based on OS) to switch to another tab.
* Now the click event has not ended yet and the focused window has changed.
* From the OS point, everything is normal.
* FROM CSC point of view, mouse button is still pressed.
* If user releases the button before returning to the document page, CSC will not handle the mouse up event.

Possible Issues:
* This already causes stuck selection issue.
* There may be some other issues with moving the shapes etc.

Fix:
* Try to end the mouse event gracefully if a dragging event is started when window loses focus.


Change-Id: I71e6a014e25a02dd56ac8b585a5be128af68942a


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

