### PR TITLE
Fix sluggish load of spreadsheet with 37K+ comments (for co-25.04)

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -990,8 +990,8 @@ export class CommentSection extends CanvasSectionObject {
 	public unselect (): void {
 		if (this.sectionProperties.selectedComment && this.sectionProperties.selectedComment.sectionProperties.data.id != 'new') {
 			for (const comment of this.sectionProperties.commentList) {
-				if ($(comment.sectionProperties.container).hasClass('annotation-active'))
-					$(comment.sectionProperties.container).removeClass('annotation-active');
+				if (window.L.DomUtil.hasClass(comment.sectionProperties.container, 'annotation-active'))
+					window.L.DomUtil.removeClass(comment.sectionProperties.container, 'annotation-active');
 			}
 
 			if (app.map._docLayer._docType === 'spreadsheet')


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
Fix sluggish load of spreadsheet with 37K+ comments

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

