### PR TITLE
SaveState: don't use missing icon

### DIFF
--- a/browser/src/control/Control.SaveState.ts
+++ b/browser/src/control/Control.SaveState.ts
@@ -28,7 +28,12 @@ class SaveState {
 
 	initialize() {
 		this.saveEle = document.querySelector('[id^="save"].unotoolbutton');
-		this.saveIconEl = this.saveEle.querySelector('img');
+		if (this.saveEle) {
+			this.saveIconEl = this.saveEle.querySelector('img');
+		} else {
+			app.console.debug('SaveState: no save icon - might be hidden');
+			this.saveIconEl = null;
+		}
 	}
 
 	// Function to show the saving status
@@ -44,7 +49,7 @@ class SaveState {
 			const savingText = _('Saving');
 			this.saveEle.style.setProperty('--save-state', `"${savingText}"`);
 			this.saveEle.classList.add('saving');
-			this.saveIconEl.classList.add('rotate-icon'); // Start the icon rotation
+			this.saveIconEl?.classList.add('rotate-icon'); // Start the icon rotation
 			this.saveEle.setAttribute('disabled', 'true'); // Disable the button
 		}
 	}
@@ -55,9 +60,9 @@ class SaveState {
 
 		if (!this.saveEle) this.initialize();
 
-		if (!this.saveEle.classList.contains('savemodified')) {
+		if (this.saveEle && !this.saveEle.classList.contains('savemodified')) {
 			this.saveEle.classList.remove('saving');
-			this.saveIconEl.classList.remove('rotate-icon'); // Stop the icon rotation
+			this.saveIconEl?.classList.remove('rotate-icon'); // Stop the icon rotation
 			// Dynamically set the content string for saved state
 			const savedText = _('Saved');
 			this.saveEle.style.setProperty('--save-state', `"${savedText}"`);


### PR DESCRIPTION
- be sure item is initialized before use
- it can happen we hide save icon due to integration settings

regression from commit 6697c6d13f16ffd5c05600cec5e4cf1ffbd233d1 Don't rely on unstable id for save state widget

backport for: https://github.com/CollaboraOnline/online/pull/14586
