### PR TITLE
Writer: Hide the shape drag preview on mouse up

### DIFF
--- a/browser/src/canvas/sections/ShapeHandleAnchorSubSection.ts
+++ b/browser/src/canvas/sections/ShapeHandleAnchorSubSection.ts
@@ -79,6 +79,8 @@ class ShapeHandleAnchorSubSection extends HTMLObjectSection {
 			else {
 				this.tableMouseUp(point, e);
 			}
+
+			this.sectionProperties.parentHandlerSection.hideSVG();
 		}
 	}
 


### PR DESCRIPTION
When we drag and drop the anchor if the shape doesn't move at the end shadow shape get stucks on the document.

With this patch we hide the preview on mouse up.


Change-Id: Id78d7de49d181140c37778a30b587364b3db4414


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

