### PR TITLE
slideshow: fix Follow Presenter jumping to previous slide on re-follow

### DIFF
--- a/browser/src/slideshow/engine/SlideShowNavigator.ts
+++ b/browser/src/slideshow/engine/SlideShowNavigator.ts
@@ -253,9 +253,10 @@ class SlideShowNavigator {
 		if (this.presenter.isFollowing()) return;
 		this.presenter.setFollowing(true);
 		// const currentEffect = this.currentLeaderEffect;
-		if (this.currentLeaderSlide === this.currentSlide)
-			this.slideShowHandler.rewindAllEffects();
-		else this.displaySlide(this.currentLeaderSlide, true);
+		if (this.currentLeaderSlide === this.currentSlide) {
+			if (this.slideShowHandler.hasAnyEffectStarted())
+				this.slideShowHandler.rewindAllEffects();
+		} else this.displaySlide(this.currentLeaderSlide, true);
 		this.slideShowHandler.skipNEffects(this.currentLeaderEffect);
 	}
 


### PR DESCRIPTION
Change-Id: I259b30b517cb53636bceac0c7a7e2dfcf2e6ae79

Regression from: https://github.com/CollaboraOnline/online/pull/14497

* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
- Attendees re-following the presenter while already on the same slide were unexpectedly moved to the previous slide.
- followLeaderSlide() triggered rewindAllEffects(), which fell back to rewindToPreviousSlide() when no effects had started, causing the slide jump.
- Added a guard using hasAnyEffectStarted() before calling rewindAllEffects().
- If no effects have started, animation state is synchronized via skipNEffects() instead.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

