### PR TITLE
Document zoom: Disable animation while zooming.

### DIFF
--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -683,6 +683,11 @@ window.L.Map = window.L.Evented.extend({
 			return this;
 		}
 
+		// Do not animate zoom in multi-page or compare changes view.
+		if (animate && app.activeDocument &&
+			['ViewLayoutMultiPage', 'ViewLayoutCompareChanges'].includes(app.activeDocument.activeLayout.type))
+			animate = false;
+
 		var curCenter = this.getCenter();
 		if (this._docLayer && this._docLayer._docType === 'spreadsheet') {
 			// for spreadsheets, when the document is smaller than the viewing area

--- a/browser/src/map/handler/Map.Scroll.js
+++ b/browser/src/map/handler/Map.Scroll.js
@@ -119,6 +119,14 @@ window.L.Map.Scroll = window.L.Handler.extend({
 
 		this._stopZoomInterpolateRAFAt = this._zoomScrollTime.valueOf() + this._map.options.wheelZoomStepEndAfter;
 
+		// In multi-page or compare changes view, skip animation and zoom directly.
+		if (app.activeDocument && app.activeDocument.activeLayout &&
+			['ViewLayoutMultiPage', 'ViewLayoutCompareChanges'].includes(app.activeDocument.activeLayout.type)) {
+			map.setZoom(this._zoom, null, false);
+			this._zoomScrollTime = undefined;
+			return;
+		}
+
 		if (newAnimation) {
 			this._inZoomAnimation = true;
 			this._map._docLayer.preZoomAnimation(this._zoomCenter);


### PR DESCRIPTION
Issue: User is presented the normal view's tile layou while zooming in multi page or compare changes view. Zoom animation takes an old path that we need to upgrade. This is the first step for better animation.


Change-Id: Ie783d49b82750ce685f82aa32bddc572ba79611a


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

