### PR TITLE
canvas: be carefull with adding sections

### DIFF
--- a/browser/src/app/DocumentBase.ts
+++ b/browser/src/app/DocumentBase.ts
@@ -61,6 +61,8 @@ class DocumentBase {
 		if (this.activeViewID !== activeViewID) {
 			this.activeViewID = activeViewID;
 			this.activeView.clearTextSelection();
+			// Remove the old active view's section before creating a new one.
+			app.sectionContainer.removeSection(this.activeView.selectionSection.name);
 			this.activeView = new DocumentViewBase(this.activeViewID);
 			this.activeView.setColor(this.activeViewSelectionColor);
 		}

--- a/browser/src/app/DocumentView.ts
+++ b/browser/src/app/DocumentView.ts
@@ -31,6 +31,9 @@ class DocumentViewBase {
 			0,
 			this.color,
 		);
+		// Remove any stale section with the same name so addSection succeeds.
+		if (app.sectionContainer.doesSectionExist(this._selectionSection.name))
+			app.sectionContainer.removeSection(this._selectionSection.name);
 		app.sectionContainer.addSection(this._selectionSection);
 		this._selectionSection.setShowSection(false);
 	}


### PR DESCRIPTION
- we had a bug where selection was not visible in multi-user sessions (but only our own)

- it was easy to reproduce, just opened 3 Writer sessions and tried to select any text in them

- while debugging I found the line in CanvasSectionObject if (this.containerObject) { // Is section added to container. was failing the condition what indicated the selection was not added

- setActiveViewID now removes the old active view's section before creating the new one

- Constructor defensively removes any existing section with the same name before calling addSection

It seems to be regression from commit 737006cc0554334c009d7f94a7508c9b65f10047 Remove _textCSelections and add a DocumentViewBase class instance for current user's text selections.


Change-Id: I861c968d976c38f1fbec7d380848afa7da4e1ff0

