### PR TITLE
fix browser logging endpoint: return proper errors, rename to browser-logging

### DIFF
--- a/.gitpod-files/coolwsd-gitpod.xml
+++ b/.gitpod-files/coolwsd-gitpod.xml
@@ -131,7 +131,7 @@
         <path desc="Output path for the Trace Event file, to which they will be written if turned on at run-time" type="string" default="/tmp/coolwsd.trace.json">/tmp/coolwsd.trace.json</path>
     </trace_event>
 
-    <browser_logging desc="Logging in the browser console" default="true">true</browser_logging>
+    <browser_logging desc="When enabled, shows internal console output in the browser's developer console and forwards JS errors to the server log." default="true">true</browser_logging>
 
     <trace desc="Dump commands and notifications for replay. When 'snapshot' is true, the source file is copied to the path first." enable="false">
         <path desc="Output path to hold trace file and docs. Use '%' for timestamp to avoid overwriting. For example: /some/path/to/cooltrace-%.gz" compress="true" snapshot="false"></path>

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -700,7 +700,7 @@ function showWelcomeSVG() {
 			   (global.socket instanceof global.app.definitions.Socket) && global.socket.connected()) {
 			global.socket.sendMessage(log);
 		} else {
-			fetch(global.location.pathname.match(/.*\//) + 'logging.html', {
+			fetch(global.location.pathname.match(/.*\//) + 'browser-logging', {
 				method: 'POST',
 				headers: { 'Content-Type' : 'application/json' },
 				body: global.coolLogging + ' ' + log

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -147,7 +147,7 @@
         <path desc="Output path for the Trace Event file, to which they will be written if turned on at run-time" type="string" default="@COOLWSD_TRACEEVENTFILE@">@COOLWSD_TRACEEVENTFILE@</path>
     </trace_event>
 
-    <browser_logging desc="Logging in the browser console" default="@BROWSER_LOGGING@">@BROWSER_LOGGING@</browser_logging>
+    <browser_logging desc="When enabled, shows internal console output in the browser's developer console and forwards JS errors to the server log." default="@BROWSER_LOGGING@">@BROWSER_LOGGING@</browser_logging>
 
     <trace desc="Dump commands and notifications for replay. When 'snapshot' is true, the source file is copied to the path first." enable="false">
         <path desc="Output path to hold trace file and docs. Use '%' for timestamp to avoid overwriting. For example: /some/path/to/cooltrace-%.gz" compress="true" snapshot="false"></path>

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -419,27 +419,41 @@ bool FileServerRequestHandler::handleRequest(const HTTPRequest& request,
         }
 
 #endif
-        if (request.getMethod() == HTTPRequest::HTTP_POST && endPoint == "logging.html")
+        if (request.getMethod() == HTTPRequest::HTTP_POST && endPoint == "browser-logging")
         {
             const std::string coolLogging = config.getString("browser_logging", "false");
-            if (coolLogging != "false")
+            if (coolLogging == "false")
             {
-                std::string token;
-                Poco::SHA1Engine engine;
-
-                engine.update(COOLWSD::LogToken);
-                std::getline(message, token, ' ');
-
-                if (Poco::DigestEngine::digestToHex(engine.digest()) == token)
-                {
-                    LOG_ERR(message.rdbuf());
-
-                    http::Response httpResponse(http::StatusCode::OK);
-                    FileServerRequestHandler::hstsHeaders(httpResponse);
-                    socket->send(httpResponse);
-                    return true;
-                }
+                sendError(http::StatusCode::Forbidden, requestUri.toString(), socket,
+                          "browser_logging is disabled.", "");
+                return true;
             }
+
+            std::string token;
+            Poco::SHA1Engine engine;
+
+            engine.update(COOLWSD::LogToken);
+            std::getline(message, token, ' ');
+
+            if (Poco::DigestEngine::digestToHex(engine.digest()) != token)
+            {
+                sendError(http::StatusCode::Forbidden, requestUri.toString(), socket,
+                          "Invalid log token.", "");
+                return true;
+            }
+
+            constexpr std::size_t maxLogSize = 4096;
+            std::string logMsg;
+            logMsg.resize(maxLogSize);
+            message.read(logMsg.data(), maxLogSize);
+            logMsg.resize(message.gcount());
+            std::replace(logMsg.begin(), logMsg.end(), '\n', ' ');
+            LOG_ERR("Browser: " << logMsg);
+
+            http::Response httpResponse(http::StatusCode::OK);
+            FileServerRequestHandler::hstsHeaders(httpResponse);
+            socket->send(httpResponse);
+            return true;
         }
 
         if (endPoint == "upload-settings")


### PR DESCRIPTION
The logging.html POST endpoint silently fell through to the static file handler when browser_logging was disabled or the token was invalid, causing spurious "File not found" errors in the logs. Always return an appropriate response: 403 with a reason when disabled or token is wrong, 200 on success. Also rename the endpoint from logging.html to browser-logging to better reflect its purpose.
