### PR TITLE
canvas sections: log when failed to add section

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1962,6 +1962,8 @@ class CanvasSectionContainer {
 			if (docLayer && docLayer.isCalcRTL())
 				return true;
 
+			app.console.error(
+				'SectionContainer: addSectionFunctions failed for ' + (section ? section.name : 'unknown'));
 			return false;
 		}.bind(section);
 	}


### PR DESCRIPTION
- it didn't show the fail on case:
  1. open writer, select some text
  2. open another session, select some text
  3. open 3rd session, your selection is not visible

related to: https://github.com/CollaboraOnline/online/pull/14612