### PR TITLE
Issue: Current zoom is not sent to the core side in multi page and co…

### DIFF
--- a/browser/src/app/ViewLayoutCompareChanges.ts
+++ b/browser/src/app/ViewLayoutCompareChanges.ts
@@ -104,6 +104,7 @@ class ViewLayoutCompareChanges extends ViewLayoutNewBase {
 		if (app.map._docLayer?._cursorMarker)
 			app.map._docLayer._cursorMarker.update();
 
+		app.map._docLayer._sendClientZoom();
 		this.sendClientVisibleArea();
 
 		this.refreshCurrentCoordList();

--- a/browser/src/app/ViewLayoutMultiPage.ts
+++ b/browser/src/app/ViewLayoutMultiPage.ts
@@ -232,6 +232,7 @@ class ViewLayoutMultiPage extends ViewLayoutNewBase {
 		if (app.map._docLayer?._cursorMarker)
 			app.map._docLayer._cursorMarker.update();
 
+		app.map._docLayer._sendClientZoom();
 		this.sendClientVisibleArea();
 
 		this.refreshCurrentCoordList();


### PR DESCRIPTION
…mpare changes views.

Resulting with the missing tiles.

Fix: Send the client zoom while updating the view data.

This also seems to fix below issue for me:
* Switch to compare-changes view.
* Scroll down.
* Tiles are not rendered until user clicks somewhere.


Change-Id: Ib6970982e694100d0a85289c32ca4c52c518c738


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

