### PR TITLE
fix(mobile): make clicks emulate touch event

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1089,6 +1089,13 @@ class CanvasSectionContainer {
 	}
 
 	public onClick (e: MouseEvent) {
+		if (this.touchEventInProgress) {
+			Object.defineProperty(e, 'pointerType', {
+				value: 'touch',
+				writable: false
+			});
+		}
+
 		if (!this.draggingSomething) { // Prevent click event after dragging.
 			if (this.positionOnMouseDown !== null && this.positionOnMouseUp !== null) {
 				this.positionOnClick = this.convertPositionToCanvasLocale(e);


### PR DESCRIPTION
We generate some click events when tapping on the canvas. Unfortunately, these are "Click" events, so always treated as mouse events. This causes some trouble when triggering certain handlers on mobile. For example, a mobile device will have trouble editing an input field in impress since as there is a race between the touch events and click events - it is techncially possible but takes a lot of repeated and very fast tapping.

Overriding the pointerType fixes this.

Unfortunately, the pointerType is readonly - so overriding it isn't possible normally. Thankfully, Object.defineProperty can completely replace even readonly properties, solving the issue...


Change-Id: I9cfa646dbb9ff34551304bf58383f12a6a6a6964


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

