### PR TITLE
Let core tell us what tree, treegrid, listbox, grid role a TreeView has

### DIFF
--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -387,6 +387,7 @@ interface TreeWidgetJSON extends WidgetJSON {
 	customEntryRenderer?: boolean;
 	noSearchField?: boolean; // When true, the widget shouldn't have a search field added
 	sortLocally?: boolean; // When true, the widget will run sort algorithm in JS isntead of callback (lists only)
+	role?: string; // ARIA role from core: 'tree', 'treegrid', 'listbox', or 'grid'
 }
 
 interface IconViewEntry {


### PR DESCRIPTION
One advantage of this is that, generally, core knows what an initially empty treeview can be used for, so those shouldn't be miscategorized, and we can be confident that a 'tree' has effectively just one column.

With the addition of 'tree' then a child of that needs to be a treeitem.


Change-Id: Id0540d8682e4ecf2e4a7c1851b1c8505cbb06176


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

