### PR TITLE
test: create tests for master slide templates iconviews and transition iconviews

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/master_slide_iconview_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/master_slide_iconview_spec.js
@@ -5,10 +5,10 @@ var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'Master Slide Iconview Tests', function() {
     const openExpander = () => {
-        cy.cGet('#masterpageall_icons-expand-button').should('exist').should('be.visible');
+        cy.cGet('#masterpageall_icons-expand-button').should('be.visible');
         cy.cGet('#masterpageall_icons-expand-button').click();
         desktopHelper.getDropdown('masterpageall_icons').should('exist');
-        cy.cGet('.jsdialog #masterpageall_icons').should('exist').should('be.visible');
+        cy.cGet('.jsdialog #masterpageall_icons').should('be.visible');
     }
 
     beforeEach(function() {
@@ -16,27 +16,27 @@ describe(['tagdesktop'], 'Master Slide Iconview Tests', function() {
         helper.setupAndLoadDocument('impress/masterpagepreview.odp');
         desktopHelper.switchUIToNotebookbar();
         cy.cGet('#Design-tab-label').click();
-        cy.cGet('#masterpageall_icons').should('exist').should('be.visible');
+        cy.cGet('#masterpageall_icons').should('be.visible');
     });
 
     it('Scroll Up/Down Buttons', function() {
-        cy.cGet('#masterpageall_icons-scroll-up').should('exist').should('be.visible');
-        cy.cGet('#masterpageall_icons-scroll-down').should('exist').should('be.visible');
+        cy.cGet('#masterpageall_icons-scroll-up').should('be.visible');
+        cy.cGet('#masterpageall_icons-scroll-down').should('be.visible');
 
         cy.cGet('.notebookbar #masterpageall_icons-iconview .ui-iconview-entry')
-            .first().should('exist').should('be.visible');
+            .first().should('be.visible');
     });
 
     it('Expander Button', function() {
         openExpander();
         cy.cGet('.jsdialog #masterpageall_icons .ui-iconview-entry')
-            .first().should('exist').should('be.visible');
+            .first().should('be.visible');
     });
 
     it('Resize', function() {
         // verify dropdown closes on width resize
         openExpander();
-        cy.cGet('.jsdialog #masterpageall_icons').should('exist').should('be.visible');
+        cy.cGet('.jsdialog #masterpageall_icons').should('be.visible');
         cy.viewport(650, 1080);
         cy.cGet('.jsdialog #masterpageall_icons').should('not.exist');
 
@@ -45,13 +45,13 @@ describe(['tagdesktop'], 'Master Slide Iconview Tests', function() {
         cy.viewport(1920, 1080);
         openExpander();
         cy.cGet('.jsdialog #masterpageall_icons .ui-iconview-entry')
-            .first().should('exist').should('be.visible');
+            .first().should('be.visible');
 
         // width: 900px
         cy.viewport(900, 1080);
         openExpander();
         cy.cGet('.jsdialog #masterpageall_icons .ui-iconview-entry')
-            .first().should('exist').should('be.visible');
+            .first().should('be.visible');
 
         // NOTE: only 2 master slides in this document — too few for row overflow,
         // so height-based visibility testing wont fire.

--- a/cypress_test/integration_tests/desktop/impress/master_slide_iconview_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/master_slide_iconview_spec.js
@@ -1,0 +1,59 @@
+/* global describe it cy require beforeEach */
+
+var helper = require('../../common/helper');
+var desktopHelper = require('../../common/desktop_helper');
+
+describe(['tagdesktop'], 'Master Slide Iconview Tests', function() {
+    const openExpander = () => {
+        cy.cGet('#masterpageall_icons-expand-button').should('exist').should('be.visible');
+        cy.cGet('#masterpageall_icons-expand-button').click();
+        desktopHelper.getDropdown('masterpageall_icons').should('exist');
+        cy.cGet('.jsdialog #masterpageall_icons').should('exist').should('be.visible');
+    }
+
+    beforeEach(function() {
+        cy.viewport(1920, 1080);
+        helper.setupAndLoadDocument('impress/masterpagepreview.odp');
+        desktopHelper.switchUIToNotebookbar();
+        cy.cGet('#Design-tab-label').click();
+        cy.cGet('#masterpageall_icons').should('exist').should('be.visible');
+    });
+
+    it('Scroll Up/Down Buttons', function() {
+        cy.cGet('#masterpageall_icons-scroll-up').should('exist').should('be.visible');
+        cy.cGet('#masterpageall_icons-scroll-down').should('exist').should('be.visible');
+
+        cy.cGet('.notebookbar #masterpageall_icons-iconview .ui-iconview-entry')
+            .first().should('exist').should('be.visible');
+    });
+
+    it('Expander Button', function() {
+        openExpander();
+        cy.cGet('.jsdialog #masterpageall_icons .ui-iconview-entry')
+            .first().should('exist').should('be.visible');
+    });
+
+    it('Resize', function() {
+        // verify dropdown closes on width resize
+        openExpander();
+        cy.cGet('.jsdialog #masterpageall_icons').should('exist').should('be.visible');
+        cy.viewport(650, 1080);
+        cy.cGet('.jsdialog #masterpageall_icons').should('not.exist');
+
+        // making sure the dialog opens at multiple widths
+        // width: 1920px
+        cy.viewport(1920, 1080);
+        openExpander();
+        cy.cGet('.jsdialog #masterpageall_icons .ui-iconview-entry')
+            .first().should('exist').should('be.visible');
+
+        // width: 900px
+        cy.viewport(900, 1080);
+        openExpander();
+        cy.cGet('.jsdialog #masterpageall_icons .ui-iconview-entry')
+            .first().should('exist').should('be.visible');
+
+        // NOTE: only 2 master slides in this document — too few for row overflow,
+        // so height-based visibility testing wont fire.
+    });
+});

--- a/cypress_test/integration_tests/desktop/impress/transitions_iconview_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/transitions_iconview_spec.js
@@ -1,0 +1,69 @@
+/* global describe it cy require beforeEach */
+
+var helper = require('../../common/helper');
+var desktopHelper = require('../../common/desktop_helper');
+
+describe(['tagdesktop'], 'Transitions Iconview Tests', function() {
+	const openExpander = () => {
+		cy.cGet('#transitions_icons-expand-button').should('exist').should('be.visible');
+		cy.cGet('#transitions_icons-expand-button').click();
+		desktopHelper.getDropdown('transitions_icons').should('exist');
+		cy.cGet('.jsdialog #transitions_icons').should('exist').should('be.visible');
+	}
+
+	beforeEach(function() {
+		cy.viewport(1920, 1080);
+		helper.setupAndLoadDocument('impress/slideshow.odp');
+		desktopHelper.switchUIToNotebookbar();
+		cy.cGet('#Transition-tab-label').click();
+		cy.cGet('#transitions_icons').should('exist').should('be.visible');
+	});
+
+	it('Scroll Up/Down Buttons', function() {
+		cy.cGet('#transitions_icons-scroll-up').should('exist').should('be.visible');
+		cy.cGet('#transitions_icons-scroll-down').should('exist').should('be.visible');
+		cy.cGet('#transitions_icons-iconview_0').should('exist').should('be.visible');
+
+		cy.cGet('#transitions_icons-scroll-down').click();
+		cy.cGet('#transitions_icons-iconview_0').should('exist').should('not.be.visible');
+		cy.cGet('#transitions_icons-scroll-up').click();
+		cy.cGet('#transitions_icons-iconview_0').should('exist').should('be.visible');
+	});
+
+	it('Expander Button', function() {
+		openExpander();
+		cy.cGet('#transitions_icons_28').should('exist').should('be.visible');
+	});
+
+	it('Resize', function() {
+		// verify dropdown closes on width resize
+		openExpander();
+		cy.cGet('.jsdialog #transitions_icons').should('exist').should('be.visible');
+		cy.viewport(650, 1080);
+		cy.cGet('.jsdialog #transitions_icons').should('not.exist');
+
+		// varying widths to make sure responsive nature exists
+		// width 1: 1300px
+		cy.viewport(1300, 1080);
+		openExpander();
+		cy.cGet('#transitions_icons_27').should('exist').should('be.visible');
+		cy.cGet('#transitions_icons_28').should('exist').should('not.be.visible');
+
+		// width 2: 1000px
+		cy.viewport(1000, 1080);
+		openExpander();
+		cy.cGet('#transitions_icons_20').should('exist').should('be.visible');
+		cy.cGet('#transitions_icons_21').should('exist').should('not.be.visible');
+
+		// width 3: 650px
+		cy.viewport(650, 1080);
+		openExpander();
+		cy.cGet('#transitions_icons_13').should('exist').should('be.visible');
+		cy.cGet('#transitions_icons_14').should('exist').should('not.be.visible');
+
+		// height only
+		cy.viewport(650, 570);
+		cy.cGet('#transitions_icons_9').should('exist').should('be.visible');
+		cy.cGet('#transitions_icons_10').should('exist').should('not.be.visible');
+	});
+});

--- a/cypress_test/integration_tests/desktop/impress/transitions_iconview_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/transitions_iconview_spec.js
@@ -5,10 +5,10 @@ var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'Transitions Iconview Tests', function() {
 	const openExpander = () => {
-		cy.cGet('#transitions_icons-expand-button').should('exist').should('be.visible');
+		cy.cGet('#transitions_icons-expand-button').should('be.visible');
 		cy.cGet('#transitions_icons-expand-button').click();
 		desktopHelper.getDropdown('transitions_icons').should('exist');
-		cy.cGet('.jsdialog #transitions_icons').should('exist').should('be.visible');
+		cy.cGet('.jsdialog #transitions_icons').should('be.visible');
 	}
 
 	beforeEach(function() {
@@ -16,29 +16,29 @@ describe(['tagdesktop'], 'Transitions Iconview Tests', function() {
 		helper.setupAndLoadDocument('impress/slideshow.odp');
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('#Transition-tab-label').click();
-		cy.cGet('#transitions_icons').should('exist').should('be.visible');
+		cy.cGet('#transitions_icons').should('be.visible');
 	});
 
 	it('Scroll Up/Down Buttons', function() {
-		cy.cGet('#transitions_icons-scroll-up').should('exist').should('be.visible');
-		cy.cGet('#transitions_icons-scroll-down').should('exist').should('be.visible');
-		cy.cGet('#transitions_icons-iconview_0').should('exist').should('be.visible');
+		cy.cGet('#transitions_icons-scroll-up').should('be.visible');
+		cy.cGet('#transitions_icons-scroll-down').should('be.visible');
+		cy.cGet('#transitions_icons-iconview_0').should('be.visible');
 
 		cy.cGet('#transitions_icons-scroll-down').click();
-		cy.cGet('#transitions_icons-iconview_0').should('exist').should('not.be.visible');
+		cy.cGet('#transitions_icons-iconview_0').should('not.be.visible');
 		cy.cGet('#transitions_icons-scroll-up').click();
-		cy.cGet('#transitions_icons-iconview_0').should('exist').should('be.visible');
+		cy.cGet('#transitions_icons-iconview_0').should('be.visible');
 	});
 
 	it('Expander Button', function() {
 		openExpander();
-		cy.cGet('#transitions_icons_28').should('exist').should('be.visible');
+		cy.cGet('#transitions_icons_28').should('be.visible');
 	});
 
 	it('Resize', function() {
 		// verify dropdown closes on width resize
 		openExpander();
-		cy.cGet('.jsdialog #transitions_icons').should('exist').should('be.visible');
+		cy.cGet('.jsdialog #transitions_icons').should('be.visible');
 		cy.viewport(650, 1080);
 		cy.cGet('.jsdialog #transitions_icons').should('not.exist');
 
@@ -46,24 +46,24 @@ describe(['tagdesktop'], 'Transitions Iconview Tests', function() {
 		// width 1: 1300px
 		cy.viewport(1300, 1080);
 		openExpander();
-		cy.cGet('#transitions_icons_27').should('exist').should('be.visible');
-		cy.cGet('#transitions_icons_28').should('exist').should('not.be.visible');
+		cy.cGet('#transitions_icons_27').should('be.visible');
+		cy.cGet('#transitions_icons_28').should('not.be.visible');
 
 		// width 2: 1000px
 		cy.viewport(1000, 1080);
 		openExpander();
-		cy.cGet('#transitions_icons_20').should('exist').should('be.visible');
-		cy.cGet('#transitions_icons_21').should('exist').should('not.be.visible');
+		cy.cGet('#transitions_icons_20').should('be.visible');
+		cy.cGet('#transitions_icons_21').should('not.be.visible');
 
 		// width 3: 650px
 		cy.viewport(650, 1080);
 		openExpander();
-		cy.cGet('#transitions_icons_13').should('exist').should('be.visible');
-		cy.cGet('#transitions_icons_14').should('exist').should('not.be.visible');
+		cy.cGet('#transitions_icons_13').should('be.visible');
+		cy.cGet('#transitions_icons_14').should('not.be.visible');
 
 		// height only
 		cy.viewport(650, 570);
-		cy.cGet('#transitions_icons_9').should('exist').should('be.visible');
-		cy.cGet('#transitions_icons_10').should('exist').should('not.be.visible');
+		cy.cGet('#transitions_icons_9').should('be.visible');
+		cy.cGet('#transitions_icons_10').should('not.be.visible');
 	});
 });


### PR DESCRIPTION
* Resolves: #13693 
* Target version: main

### Summary
Create two cypress test specs for:
1. Transition iconviews: testing expander button, scroll up and down functionality, and resizing of viewport
2. Master Slide iconviews: testing expander button, scroll up and down functionality, and resizing of viewport

### Screenshots for related tests:

<img width="731" height="898" alt="Screenshot 2026-02-23 at 7 50 01 PM" src="https://github.com/user-attachments/assets/03110bc3-ae52-4e3c-a384-b16b9801806c" />

<img width="731" height="898" alt="Screenshot 2026-02-23 at 7 54 51 PM" src="https://github.com/user-attachments/assets/e876c8d7-375e-46bd-b44d-f4e49b8f10c2" />

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required