### PR TITLE
Made Validate Sidebar/Dialogs visible in any file in debug mode

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -482,22 +482,20 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 						'command': '.uno:SidebarDeck.A11yCheckDeck',
 						'accessibility': { focusBack: false, combination: 'A', de: null }
 					} : {},
-				hasAccessibilityCheck ?
 					{
 						'id': 'validatesidebara11y',
 						'type': 'bigcustomtoolitem',
 						'text': _('Validate Sidebar'),
 						'visible': isDebugOn ? 'true' : 'false',
 						'accessibility': { focusBack: true,	combination: 'VS', de: null }
-					} : {},
-				hasAccessibilityCheck ?
+					},
 					{
 						'id': 'validatedialogsa11y',
 						'type': 'bigcustomtoolitem',
 						'text': _('Validate Dialog'),
 						'visible': isDebugOn ? 'true' : 'false',
 						'accessibility': { focusBack: true,	combination: 'VD', de: null }
-					} : {},
+					},
 				hasAccessibilitySupport || hasAccessibilityCheck ?
 					{
 						'id': 'help-accessibility-break',


### PR DESCRIPTION
Change-Id: I6c75c2418a8ccb9d80ed458a995c5d7731d1c537


* Resolves: # Made it so that Validate Sidebar/Dialogs buttons are visible in any kind of file in debug mode. Leads to redundant hasAccessibilityCheck variable.
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

