### PR TITLE
svg: adjust size when zoom changed

### DIFF
--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -421,6 +421,9 @@ class ShapeHandlesSection extends CanvasSectionObject {
 
 		if (GraphicSelection.hasActiveSelection())
 			this.size = [GraphicSelection.rectangle.pWidth, GraphicSelection.rectangle.pHeight];
+
+		if (this.sectionProperties.svg)
+			this.adjustSVGProperties();
 	}
 
 	isSVGVisible() {


### PR DESCRIPTION
It helps with interactive editing in Impress.

Steps to reproduce bug:
1. open Impress
2. double-click on table or textbox to see selection and activate editing
3. use zoom, + few times, then - few times

Result: table is incorrectly scaled and positioned
Expected: no such glitch

We use svg to render the "editable content" but it had size adjusted only on initial insertion into DOM.