### PR TITLE
browser: calc: fix flicker on switching to a sheet...

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -89,6 +89,9 @@ export class CommentSection extends CanvasSectionObject {
 		calcLastTab: number;
 		// Keep a reference to the original set of comments received.
 		calcMasterList: Array<any>;
+		// Has the 'commandstatechanged' msg arrived after a tab switch.
+		// This a precondition for drawing spreadsheet comment marker.
+		calcCommandStateChanged: boolean;
 		commentList: Array<Comment>;
 		selectedComment: Comment | null;
 		calcCurrentComment: Comment | null;
@@ -134,6 +137,7 @@ export class CommentSection extends CanvasSectionObject {
 		this.sectionProperties.docLayer = this.map._docLayer;
 		this.sectionProperties.calcLastTab = -1;
 		this.sectionProperties.calcMasterList = [];
+		this.sectionProperties.calcCommandStateChanged = true;
 		this.sectionProperties.commentList = new Array(0);
 		this.sectionProperties.selectedComment = null;
 		this.sectionProperties.arrow = null;
@@ -171,6 +175,7 @@ export class CommentSection extends CanvasSectionObject {
 		this.map.on('AnnotationScrollDown', this.onAnnotationScrollDown, this);
 
 		this.map.on('commandstatechanged', function (event: any) {
+			this.sectionProperties.calcCommandStateChanged = true;
 			if (event.commandName === '.uno:ShowResolvedAnnotations')
 				this.setViewResolved(event.state === 'true');
 			else if (event.commandName === 'showannotations')
@@ -2553,6 +2558,8 @@ export class CommentSection extends CanvasSectionObject {
 			// To ignore updateparts events without actual change in sheet.
 			return;
 		}
+
+		this.sectionProperties.calcCommandStateChanged = false;
 
 		this.importComments();
 	}

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -1437,7 +1437,10 @@ export class Comment extends CanvasSectionObject {
 				}
 			}
 			else if (app.map._docLayer._docType === 'spreadsheet' &&
-				 parseInt(this.sectionProperties.data.tab) === app.map._docLayer._selectedPart) {
+				 parseInt(this.sectionProperties.data.tab) === app.map._docLayer._selectedPart &&
+				 // Don't draw with stale section myTopLeft after a tab-switch.
+				 // Wait for a 'commandstatechanged'.
+				 this.sectionProperties.commentListSection.sectionProperties.calcCommandStateChanged === true) {
 
 				var cellSize = this.calcOptimumSizeForCalc();
 				if (cellSize[0] !== 0 && cellSize[1] !== 0) { // don't draw notes in hidden cells


### PR DESCRIPTION
...with many comments.

Bug: Open a spreadsheet with at least two sheets, one could be blank and the other with lots of comments. When switching sheet from blank sheet to the sheet with comments, momentarily the comment markers are drawn misplaced and then soon drawn at correct positions, perceived as a flicker.

Solution:
The draw of comment markers just after a sheet-switch but before 'commandstatechanged' message is wrong due to stale myTopLeft array of each comment-section. So just wait for 'commandstatechanged' message before drawing them.


Change-Id: I7e5f0fe379c6bf061720145ab3b03a979273c447


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

