### PR TITLE
browser: view-jumps on comments: fix bad parse of cellPos (co-25.04)

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -1896,10 +1896,15 @@ export class CommentSection extends CanvasSectionObject {
 			comment.cellRange = app.map._docLayer._parseCellRange(comment.cellRange);
 		}
 
-		var cellPos = comment.cellRange ? app.map._docLayer._cellRangeToTwipRect(comment.cellRange).toRectangle() : null;
-		comment.rectangles = this.stringToRectangles(comment.textRange || comment.anchorPos || comment.rectangle || cellPos); // Simple array of point arrays [x1, y1, x2, y2].
-		comment.rectanglesOriginal = this.stringToRectangles(comment.textRange || comment.anchorPos || comment.rectangle || cellPos); // This unmodified version will be kept for re-calculations.
-		comment.anchorPos = this.stringToRectangles(comment.anchorPos || comment.rectangle || cellPos)[0];
+		const cellPos = comment.cellRange ? app.map._docLayer._cellRangeToTwipRect(comment.cellRange).toRectangle() : null;
+		const rectangles = this.stringToRectangles(comment.textRange || comment.anchorPos || comment.rectangle); // Simple array of point arrays [x1, y1, x2, y2].
+		if (rectangles.length === 0 && cellPos.length) {
+			rectangles.push(cellPos);
+		}
+		console.assert(rectangles.length, 'Found no rectangles in comment!');
+		comment.rectangles = rectangles;
+		comment.rectanglesOriginal = structuredClone(rectangles);
+		comment.anchorPos = rectangles[0];
 		comment.anchorSPoint = new cool.SimplePoint(comment.anchorPos[0], comment.anchorPos[1]);
 
 		if (app.map._docLayer._docType === 'spreadsheet' && app.map._docLayer.sheetGeometry)


### PR DESCRIPTION
Bug: In a spreadsheet with comments spanning outside single viewport, scroll down to the cell of last comment and hover over it => the view jumps.

Reason: cellPos of the comment in twips is treated as a raw string hence we get incorrect rectangles.


Change-Id: Ie920bb35fc1af0c9ef22f202145ce9ce481bbfe1


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

