### PR TITLE
MultiPageView: React to size changes.

### DIFF
--- a/browser/src/app/ViewLayoutMultiPage.ts
+++ b/browser/src/app/ViewLayoutMultiPage.ts
@@ -335,8 +335,10 @@ class ViewLayoutMultiPage extends ViewLayoutNewBase {
 	public reset() {
 		if (!app.file.writer.pageRectangleList.length) return;
 
-		this.resetViewLayout();
-		this.updateViewData();
+		app.layoutingService.appendLayoutingTask(() => {
+			this.resetViewLayout();
+			this.updateViewData();
+		});
 	}
 
 	public getTotalSideSpace() {


### PR DESCRIPTION
Issue: At the moment this class is informed, the canvas size is not set yet. This results in layouting the view according to previous size.

Fix: Do the reset in layouting cycle.


Change-Id: I7efd202c1990a3f252a0d4555601d9f41fff059b


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

