### PR TITLE
fix ruler position in comparechanges layout

### DIFF
--- a/browser/src/control/HRuler.ts
+++ b/browser/src/control/HRuler.ts
@@ -839,6 +839,14 @@ class HRuler extends Ruler {
 			const newValue = rulerOffset + 'px';
 			if (this._rFace.style.marginInlineStart !== newValue)
 				this._rFace.style.marginInlineStart = newValue;
+		} else if (layout.type === 'ViewLayoutCompareChanges') {
+			let rulerOffset =
+				-layout.viewedRectangle.cX1 + this.options.tileMargin * app.getScale();
+			if (layout.type === 'ViewLayoutCompareChanges')
+				rulerOffset += Math.round(
+					layout.documentToViewX(new cool.SimplePoint(0, 0)) / app.dpiScale,
+				);
+			this._rFace.style.marginInlineStart = rulerOffset + 'px';
 		} else {
 			const rulerOffset =
 				-layout.viewedRectangle.cX1 + this.options.tileMargin * app.getScale();


### PR DESCRIPTION
Change-Id: I614530377eaf354d8c553bd604cda9037bd3f371


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

