### PR TITLE
add a way to allow a combobox to set the focus on activating an entry

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -87,7 +87,7 @@ window.L.Control.JSDialog = window.L.Control.extend({
 		return builder;
 	},
 
-	close: function(id, sendCloseEvent) {
+	close: function(id, sendCloseEvent, focusHandled) {
 		if (id !== undefined && this.dialogs[id]) {
 			const dialog = this.dialogs[id];
 			if (!sendCloseEvent && dialog.overlay && !dialog.isSubmenu) {
@@ -99,7 +99,7 @@ window.L.Control.JSDialog = window.L.Control.extend({
 				clearTimeout(dialog.timeoutId);
 
 			if (dialog.isPopup)
-				this.closePopover(id, sendCloseEvent);
+				this.closePopover(id, sendCloseEvent, focusHandled);
 			else
 				this.closeDialog(id, sendCloseEvent);
 			return true;
@@ -163,7 +163,7 @@ window.L.Control.JSDialog = window.L.Control.extend({
 
 	// sendCloseEvent means that we only send a command to the server
 	// we want to kill HTML popup when we receive feedback from the server
-	closePopover: function(id, sendCloseEvent) {
+	closePopover: function(id, sendCloseEvent, focusHandled) {
 		if (id === undefined || !this.dialogs[id]) {
 			app.console.warn('missing popover data');
 			return;
@@ -190,12 +190,14 @@ window.L.Control.JSDialog = window.L.Control.extend({
 				popupParent._onDropDown(false);
 
 			// Need to change focus to last element before we clear the current dialog
-			this.focusToLastElement(id);
+			if (!focusHandled)
+				this.focusToLastElement(id);
 			this.clearDialog(id);
 			return;
 		}
 
-		this.focusToLastElement(id);
+		if (!focusHandled)
+			this.focusToLastElement(id);
 	},
 
 	onCloseAll: function() {
@@ -864,9 +866,9 @@ window.L.Control.JSDialog = window.L.Control.extend({
 			const dialogs = Object.keys(this.dialogs);
 			const hadOpenedDialog = dialogs.length > 0;
 
-			const didClose = this.close(instance.id, false);
+			const didClose = this.close(instance.id, false, instance.focusHandled);
 
-			if (didClose) {
+			if (didClose && !instance.focusHandled) {
 				// Manage focus
 				this.focusAfterClose(hadOpenedDialog, dialogs);
 			}

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -24,6 +24,18 @@ window.L.Control.NotebookbarBuilder = window.L.Control.JSDialogBuilder.extend({
 	},
 
 	_overrideHandlers: function() {
+		var builder = this;
+		const comboboxesFocusingDocument = ['fontnamecombobox', 'fontsizecombobox', 'styles'];
+		this.callback = function(objectType, eventType, object, data, builderArg) {
+			if (eventType === 'selected'
+				&& comboboxesFocusingDocument.indexOf(object.id) >= 0) {
+				builder._defaultCallbackHandler(objectType, eventType, object, data, builderArg);
+				builder.map.focus();
+				return 'focusHandled';
+			}
+			return builder._defaultCallbackHandler(objectType, eventType, object, data, builderArg);
+		};
+
 		this._controlHandlers['bigtoolitem'] = this._bigtoolitemHandler;
 		this._controlHandlers['combobox'] = this._comboboxControl;
 		this._controlHandlers['exportmenubutton'] = this._exportMenuButton;

--- a/browser/src/control/jsdialog/Util.Dropdown.ts
+++ b/browser/src/control/jsdialog/Util.Dropdown.ts
@@ -262,12 +262,13 @@ JSDialog.OpenDropdown = function (
 	});
 };
 
-JSDialog.CloseDropdown = function (id: string) {
+JSDialog.CloseDropdown = function (id: string, focusHandled?: boolean) {
 	window.L.Map.THIS.fire('jsdialog', {
 		data: {
 			id: _createDropdownId(id),
 			jsontype: 'dialog',
 			action: 'close',
+			focusHandled: focusHandled === true,
 		},
 	});
 };

--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -312,15 +312,19 @@ JSDialog.combobox = function (parentContainer, data, builder) {
 		var parentBuilder = builder;
 		var callback = function(objectType, eventType, object, data) {
 			// send command with correct WindowId (from parent, not dropdown)
+			let result;
 			if (eventType !== 'close')
-				parentBuilder.callback(objectType, eventType, object, data, parentBuilder);
+				result = parentBuilder.callback(objectType, eventType, object, data, parentBuilder);
 
 			// close after selection
 			if (eventType === 'selected') {
 				container.onSelect(_extractPos(data));
 				container.onSetText(_extractText(data));
 
-				JSDialog.CloseDropdown(comboboxId);
+				// Pass through if the parent callback has already set the focus
+				// somewhere that shouldn't be changed by the CloseDropdown, e.g.
+				// toolbar font name/size
+				JSDialog.CloseDropdown(comboboxId, result === 'focusHandled');
 			}
 
 			return true;


### PR DESCRIPTION
The compact toolbar, Control.TopToolbar.js already attempted this for the fontname, fontsize, style dropdowns. But that was clobbered by the later default async focus-moving handlers.

So return an explicit 'focusHandled' from the handler to indicate that focus was taken care of and leave it alone, make the compact toolbars handlers use that and keep their in-document focus preference.

Explicitly pass that to the ondropdown, close things so they leave that focus alone.

Then for the notebookbar do the same special casing thing as the compact toolbar does for the fontname/fontsize dropdowns.


Change-Id: I4e438658863dac68c6116e2bfaf1650c3bca255c


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

