### PR TITLE
browser: fire Doc_PartChanged on updateparts and pagenumberchanged

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4189,8 +4189,7 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 			if (this._selectedPart !== partToSelect) {
 				this._selectedPart = partToSelect;
 				app.socket.sendMessage('setclientpart part=' + this._selectedPart);
-				// Fire updateparts for postMessage listeners (e.g. Doc_PartChanged)
-				this._map.fire('updateparts', {
+				this._map.fire('setpart', {
 					selectedPart: this._selectedPart,
 					parts: this._parts,
 					docType: this._docType

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -4189,6 +4189,12 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 			if (this._selectedPart !== partToSelect) {
 				this._selectedPart = partToSelect;
 				app.socket.sendMessage('setclientpart part=' + this._selectedPart);
+				// Fire updateparts for postMessage listeners (e.g. Doc_PartChanged)
+				this._map.fire('updateparts', {
+					selectedPart: this._selectedPart,
+					parts: this._parts,
+					docType: this._docType
+				});
 			}
 			this._preview._scrollToPart();
 			this.highlightCurrentPart(partToSelect);

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -225,7 +225,11 @@ window.L.ImpressTileLayer = window.L.CanvasTileLayer.extend({
 		if (part !== this._selectedPart) {
 			this._map.deselectAll(); // Deselect all first. This is a single selection.
 			this._map.setPart(part, true);
-			this._map.fire('setpart', {selectedPart: this._selectedPart});
+			this._map.fire('setpart', {
+				selectedPart: this._selectedPart,
+				parts: this._parts,
+				docType: this._docType
+			});
 		}
 	},
 
@@ -308,7 +312,11 @@ window.L.ImpressTileLayer = window.L.CanvasTileLayer.extend({
 				app.activeDocument.activeModes = [mode];
 				this._map.fire('impressmodechanged', {mode: mode});
 
-				this._map.fire('updateparts', {});
+				this._map.fire('updateparts', {
+					selectedPart: this._selectedPart,
+					parts: this._parts,
+					docType: this._docType
+				});
 
 				if (refreshAnnotation)
 					app.socket.sendMessage('commandvalues command=.uno:ViewAnnotations');

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -263,18 +263,20 @@ window.L.Map = window.L.Evented.extend({
 			fireDocPartChanged(e.currentPage, e.pages, e.docType);
 		}, this);
 
-		this.on('updateparts', function(e) {
-			if (!e) {
+		this.on('setpart', function(e) {
+			if (!e || e.selectedPart === undefined || e.parts === undefined || e.docType === undefined) {
 				return;
 			}
 
-			// Fall back to the docLayer's current values so we still emit Doc_PartChanged
-			var docLayer = this._docLayer;
-			var selectedPart = e.selectedPart !== undefined ? e.selectedPart : (docLayer ? docLayer._selectedPart : undefined);
-			var parts = e.parts !== undefined ? e.parts : (docLayer ? docLayer._parts : undefined);
-			var docType = e.docType !== undefined ? e.docType : (docLayer ? docLayer._docType : undefined);
+			fireDocPartChanged(e.selectedPart, e.parts, e.docType);
+		}, this);
 
-			fireDocPartChanged(selectedPart, parts, docType);
+		this.on('updateparts', function(e) {
+			if (!e || e.selectedPart === undefined || e.parts === undefined || e.docType === undefined) {
+				return;
+			}
+
+			fireDocPartChanged(e.selectedPart, e.parts, e.docType);
 		}, this);
 
 		this.on('commandstatechanged', function(e) {

--- a/cypress_test/integration_tests/common/postmessage_helper.js
+++ b/cypress_test/integration_tests/common/postmessage_helper.js
@@ -1,0 +1,59 @@
+/* global cy expect */
+
+function stubParentPostMessage(aliasName = 'postMessage') {
+	cy.getFrameWindow().then(win => {
+		cy.stub(win.parent, 'postMessage').as(aliasName);
+	});
+}
+
+function parsePostedMessage(rawMessage) {
+	if (typeof rawMessage === 'string') {
+		try {
+			return JSON.parse(rawMessage);
+		} catch (e) {
+			return null;
+		}
+	}
+
+	return rawMessage;
+}
+
+function resetDocPartChangedCache(map) {
+	map._lastPart = -1;
+	map._lastPartCount = -1;
+	map._lastPartDocType = '';
+}
+
+function expectDocPartChanged(options = {}, aliasName = 'postMessage') {
+	const expectedParts = options.parts || [];
+	const minPartCount = options.minPartCount || 1;
+	const expectedDocType = options.docType;
+	const expectedCount = options.count;
+
+	cy.get('@' + aliasName).should(stub => {
+		const docPartMessages = stub.getCalls()
+			.map(call => parsePostedMessage(call.args[0]))
+			.filter(msg => msg && msg.MessageId === 'Doc_PartChanged' && msg.Values);
+
+		if (expectedCount !== undefined)
+			expect(docPartMessages.length, 'unexpected Doc_PartChanged count').to.equal(expectedCount);
+
+		expectedParts.forEach(function(part) {
+			const found = docPartMessages.some(function(msg) {
+				return msg.Values.Part === part
+					&& Number.isInteger(msg.Values.PartCount)
+					&& msg.Values.PartCount >= minPartCount
+					&& (expectedDocType === undefined || msg.Values.DocType === expectedDocType);
+			});
+
+			expect(found, 'Doc_PartChanged for part ' + part + ' was not posted').to.be.true;
+		});
+	});
+}
+
+const _stubParentPostMessage = stubParentPostMessage;
+export { _stubParentPostMessage as stubParentPostMessage };
+const _expectDocPartChanged = expectDocPartChanged;
+export { _expectDocPartChanged as expectDocPartChanged };
+const _resetDocPartChangedCache = resetDocPartChangedCache;
+export { _resetDocPartChangedCache as resetDocPartChangedCache };

--- a/cypress_test/integration_tests/desktop/calc/doc_partchanged_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/doc_partchanged_spec.js
@@ -1,0 +1,39 @@
+/* global describe it cy beforeEach */
+
+import { setupAndLoadDocument } from '../../common/helper';
+import { stubParentPostMessage, expectDocPartChanged, resetDocPartChangedCache } from '../../common/postmessage_helper';
+
+describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Calc Doc_PartChanged postMessage', function() {
+
+	beforeEach(function() {
+		setupAndLoadDocument('calc/focus.ods');
+	});
+
+	it('emits on updateparts', function() {
+		stubParentPostMessage();
+
+		cy.get('@postMessage').then(stub => {
+			stub.resetHistory();
+		});
+
+		cy.getFrameWindow().then(win => {
+			var map = win.app.map;
+			var docLayer = map._docLayer;
+			var partCount = Number.isInteger(docLayer._parts) && docLayer._parts > 0 ? docLayer._parts : 1;
+
+			resetDocPartChangedCache(map);
+
+			map.fire('updateparts', {
+				selectedPart: 0,
+				parts: partCount,
+				docType: docLayer._docType
+			});
+		});
+
+		expectDocPartChanged({
+			count: 1,
+			parts: [1],
+			minPartCount: 1
+		});
+	});
+});

--- a/cypress_test/integration_tests/desktop/draw/doc_partchanged_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/doc_partchanged_spec.js
@@ -1,0 +1,39 @@
+/* global describe it cy beforeEach */
+
+import { setupAndLoadDocument } from '../../common/helper';
+import { stubParentPostMessage, expectDocPartChanged, resetDocPartChangedCache } from '../../common/postmessage_helper';
+
+describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Draw Doc_PartChanged postMessage', function() {
+
+	beforeEach(function() {
+		setupAndLoadDocument('draw/navigator.odg');
+	});
+
+	it('emits on setpart', function() {
+		stubParentPostMessage();
+
+		cy.get('@postMessage').then(stub => {
+			stub.resetHistory();
+		});
+
+		cy.getFrameWindow().then(win => {
+			var map = win.app.map;
+			var docLayer = map._docLayer;
+			var partCount = Number.isInteger(docLayer._parts) && docLayer._parts > 0 ? docLayer._parts : 1;
+
+			resetDocPartChangedCache(map);
+
+			map.fire('setpart', {
+				selectedPart: 0,
+				parts: partCount,
+				docType: docLayer._docType
+			});
+		});
+
+		expectDocPartChanged({
+			count: 1,
+			parts: [1],
+			minPartCount: 1
+		});
+	});
+});

--- a/cypress_test/integration_tests/desktop/impress/doc_partchanged_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/doc_partchanged_spec.js
@@ -1,0 +1,66 @@
+/* global describe it cy beforeEach expect */
+
+import { setupAndLoadDocument } from '../../common/helper';
+import { stubParentPostMessage, expectDocPartChanged, resetDocPartChangedCache } from '../../common/postmessage_helper';
+
+describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Impress Doc_PartChanged postMessage', function() {
+
+	beforeEach(function() {
+		setupAndLoadDocument('impress/slide_navigation.odp');
+	});
+
+	it('emits for setpart, updateparts and pagenumberchanged event paths', function() {
+		stubParentPostMessage();
+
+		cy.get('@postMessage').then(stub => {
+			stub.resetHistory();
+		});
+
+		cy.getFrameWindow().then(win => {
+			var map = win.app.map;
+			var docLayer = map._docLayer;
+
+			expect(docLayer._parts).to.be.gte(2);
+			expect(docLayer._docType).to.equal('presentation');
+
+			resetDocPartChangedCache(map);
+
+			map.fire('setpart', {
+				selectedPart: 1,
+				parts: docLayer._parts,
+				docType: docLayer._docType
+			});
+
+			map.fire('setpart', {
+				selectedPart: 1,
+				parts: docLayer._parts,
+				docType: docLayer._docType
+			});
+
+			map.fire('setpart', {
+				selectedPart: 1
+			});
+
+			map.fire('updateparts', {
+				selectedPart: 0,
+				parts: docLayer._parts,
+				docType: docLayer._docType
+			});
+
+			map.fire('updateparts', {});
+
+			map.fire('pagenumberchanged', {
+				currentPage: 1,
+				pages: docLayer._parts,
+				docType: docLayer._docType
+			});
+		});
+
+		expectDocPartChanged({
+			count: 3,
+			parts: [1, 2],
+			minPartCount: 2,
+			docType: 'presentation'
+		});
+	});
+});

--- a/cypress_test/integration_tests/desktop/impress/slide_navigation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/slide_navigation_spec.js
@@ -30,4 +30,26 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide Navigation', functio
         helper.assertFocus('id', 'preview-img-part-0');
         cy.cGet('#preview-img-part-0').should('have.class', 'preview-img-currentpart');
     });
+
+    it('Slide change emits Doc_PartChanged postMessage', function() {
+        cy.getFrameWindow().then(win => {
+            cy.stub(win.parent, 'postMessage').as('postMessage');
+        });
+
+        cy.cGet('#preview-img-part-1').click();
+
+        cy.get('@postMessage').should(stub => {
+            const found = stub.getCalls().some(call => {
+                const msg = JSON.parse(call.args[0]);
+                return msg.MessageId === 'Doc_PartChanged'
+                    && msg.Values
+                    && msg.Values.Part === 2
+                    && Number.isInteger(msg.Values.PartCount)
+                    && msg.Values.PartCount >= 2
+                    && msg.Values.DocType === 'presentation';
+            });
+
+            expect(found, 'Doc_PartChanged was not posted for slide change').to.be.true;
+        });
+    });
 });

--- a/cypress_test/integration_tests/desktop/impress/slide_navigation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/slide_navigation_spec.js
@@ -30,26 +30,4 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Slide Navigation', functio
         helper.assertFocus('id', 'preview-img-part-0');
         cy.cGet('#preview-img-part-0').should('have.class', 'preview-img-currentpart');
     });
-
-    it('Slide change emits Doc_PartChanged postMessage', function() {
-        cy.getFrameWindow().then(win => {
-            cy.stub(win.parent, 'postMessage').as('postMessage');
-        });
-
-        cy.cGet('#preview-img-part-1').click();
-
-        cy.get('@postMessage').should(stub => {
-            const found = stub.getCalls().some(call => {
-                const msg = JSON.parse(call.args[0]);
-                return msg.MessageId === 'Doc_PartChanged'
-                    && msg.Values
-                    && msg.Values.Part === 2
-                    && Number.isInteger(msg.Values.PartCount)
-                    && msg.Values.PartCount >= 2
-                    && msg.Values.DocType === 'presentation';
-            });
-
-            expect(found, 'Doc_PartChanged was not posted for slide change').to.be.true;
-        });
-    });
 });

--- a/cypress_test/integration_tests/desktop/writer/doc_partchanged_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/doc_partchanged_spec.js
@@ -1,0 +1,39 @@
+/* global describe it cy beforeEach */
+
+import { setupAndLoadDocument } from '../../common/helper';
+import { stubParentPostMessage, expectDocPartChanged, resetDocPartChangedCache } from '../../common/postmessage_helper';
+
+describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Writer Doc_PartChanged postMessage', function() {
+
+	beforeEach(function() {
+		setupAndLoadDocument('writer/focus.odt');
+	});
+
+	it('emits on pagenumberchanged', function() {
+		stubParentPostMessage();
+
+		cy.get('@postMessage').then(stub => {
+			stub.resetHistory();
+		});
+
+		cy.getFrameWindow().then(win => {
+			var map = win.app.map;
+			var docLayer = map._docLayer;
+			var pageCount = Number.isInteger(docLayer._pages) && docLayer._pages > 0 ? docLayer._pages : 1;
+
+			resetDocPartChangedCache(map);
+
+			map.fire('pagenumberchanged', {
+				currentPage: 0,
+				pages: pageCount,
+				docType: docLayer._docType
+			});
+		});
+
+		expectDocPartChanged({
+			count: 1,
+			parts: [1],
+			minPartCount: 1
+		});
+	});
+});


### PR DESCRIPTION
Change-Id: I86ec9ebdf8dd2541cb6ef3d734fad48e91486870

* Target version: main

### Summary

This PR adds the Doc_PartChanged type for postMessage.

Motivation:
Collabora did not disclose any information about the current progress in the file.
While working on large documents, it would be really useful to allow the host to store the last accessed page/part, allowing the user to continue where they left off.

Attached is the video of how it could be used by the host:

https://github.com/user-attachments/assets/25f768cd-b8d8-4570-8970-075ede4076c5



### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

