### PR TITLE
Fix readonly files opening in edit mode interface

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -428,7 +428,8 @@ window.L.CalcTileLayer = window.L.CanvasTileLayer.extend({
 
 			var firstSelectedPart = (typeof this._selectedPart !== 'number');
 
-			if (statusJSON.readonly) this._map.setPermission('readonly');
+			if (statusJSON.readonly && !this._documentInfo)
+				this._map.setPermission('readonly');
 
 			app.activeDocument.fileSize = new cool.SimplePoint(statusJSON.width, statusJSON.height);
 			app.activeDocument.activeLayout.viewSize = app.activeDocument.fileSize.clone();

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -244,6 +244,9 @@ window.L.ImpressTileLayer = window.L.CanvasTileLayer.extend({
 				}
 			}
 
+			if (statusJSON.readonly && !this._documentInfo)
+				this._map.setPermission('readonly');
+
 			app.activeDocument.fileSize = new cool.SimplePoint(statusJSON.width, statusJSON.height);
 
 			this._docType = statusJSON.type;

--- a/browser/src/layer/tile/WriterTileLayer.js
+++ b/browser/src/layer/tile/WriterTileLayer.js
@@ -114,6 +114,9 @@ window.L.WriterTileLayer = window.L.CanvasTileLayer.extend({
 		if (!statusJSON.width || !statusJSON.height || this._documentInfo === textMsg)
 			return;
 
+		if (statusJSON.readonly && !this._documentInfo)
+			this._map.setPermission('readonly');
+
 		var sizeChanged = statusJSON.width !== app.activeDocument.fileSize.x || statusJSON.height !== app.activeDocument.fileSize.y;
 
 		if (statusJSON.viewid !== undefined) {

--- a/kit/KitHelper.hpp
+++ b/kit/KitHelper.hpp
@@ -123,16 +123,7 @@ namespace LOKitHelper
         resultInfo["lastcolumn"] = std::to_string(lastColumn);
         resultInfo["lastrow"] = std::to_string(lastRow);
 
-        ScopedString value(loKitDocument->pClass->getCommandValues(loKitDocument, ".uno:ReadOnly"));
-        if (value)
-        {
-            const std::string isReadOnly = std::string(value.get());
-
-            bool readOnly = (isReadOnly.find("true") != std::string::npos);
-            resultInfo["readonly"] = readOnly ? "true": "false";
-        }
-
-        value.reset(loKitDocument->pClass->getCommandValues(loKitDocument, ".uno:DefinePrintArea"));
+        ScopedString value(loKitDocument->pClass->getCommandValues(loKitDocument, ".uno:DefinePrintArea"));
         if (value)
         {
             resultInfo["printranges"] = std::string(value.get());
@@ -166,6 +157,15 @@ namespace LOKitHelper
         resultInfo["width"] = std::to_string(width);
         resultInfo["height"] = std::to_string(height);
         resultInfo["viewid"] = std::to_string(viewId);
+
+        ScopedString value(loKitDocument->pClass->getCommandValues(loKitDocument, ".uno:ReadOnly"));
+        if (value)
+        {
+            const std::string isReadOnly = std::string(value.get());
+
+            bool readOnly = (isReadOnly.find("true") != std::string::npos);
+            resultInfo["readonly"] = readOnly ? "true": "false";
+        }
 
         ScopedString values(loKitDocument->pClass->getCommandValues(loKitDocument, ".uno:AllPageSize"));
         if (values)


### PR DESCRIPTION
Bug: Readonly file opens in edit mode interface

When a document has the "Open file read-only" attribute set in other office suite, it should initially open in "Viewing Mode" in Collabora Online, while still allowing the user to manually switch to edit mode.

Previously, this attribute was only handled for spreadsheets because the read-only status was not being fetched for other document types, and the Writer/Impress handlers did not check for this flag.

This commit:
- Ensures the server (KitHelper.hpp) fetches the '.uno:ReadOnly' status for all document types.
- Updates Writer, Impress, and Calc handlers to apply the 'readonly' permission only during initial loading (!this._documentInfo).
- This prevents the UI from incorrectly reverting to read-only mode every time a status update is received (e.g., during typing) while still honoring the initial read-only attribute of the file on disk.

Fixes a bug where such files would open with a non-functional edit UI.

Sample test file: 
[saved-as-read-edit-editmode (2).odt](https://github.com/user-attachments/files/25546095/saved-as-read-edit-editmode.2.odt)


Change-Id: I4ccf7ebfa78f6009e8605c5faabf48cdb41d9c8b


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

