### PR TITLE
MOBILEAPP lokit_main userInterface parameter is unused

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -3432,7 +3432,6 @@ void lokit_main(
                 bool sysTemplateIncomplete,
 #else
                 int docBrokerSocket,
-                const std::string& userInterface,
 #endif
                 std::size_t numericIdentifier
                 )

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -49,7 +49,7 @@ void lokit_main(
     bool noSeccomp, bool useMountNamespaces, bool queryVersionInfo, bool displayVersion,
     bool sysTemplateIncomplete,
 #else
-    int docBrokerSocket, const std::string& userInterface,
+    int docBrokerSocket,
 #endif
     std::size_t numericIdentifier);
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -938,7 +938,7 @@ std::shared_ptr<ChildProcess> getNewChild_Blocks(const std::shared_ptr<SocketPol
 
                     // Ugly to have that static global PrisonerServerSocketFD, Otoh we know
                     // there is just one COOLWSD object. (Even in real Online.)
-                    lokit_main(PrisonerServerSocketFD, COOLWSD::UserInterface, mobileAppDocId);
+                    lokit_main(PrisonerServerSocketFD, mobileAppDocId);
                 }).detach();
 #endif // MOBILEAPP
 


### PR DESCRIPTION
...since 8a0f454d513e189d9e47ecfe480cb16ad675ac5f "coda-m: Use the iOS/Qt approach to multi-documents on macOS too"

> @@ -3957,7 +3957,7 @@ void lokit_main(
>
>  #else // MOBILEAPP
>
> -#if !defined(IOS) && !defined(QTAPP)
> +#if !MOBILEAPP
>          // Was not done by the preload.
>          // For iOS we call it in -[AppDelegate application: didFinishLaunchingWithOptions:]
>          setupKitEnvironment(userInterface);

turned its only use into dead code, for all configurations


Change-Id: Ib95c5c706027d2bcb98f04ee3bd44f9010a8c3d8


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

