### PR TITLE
over flow group container focus

### DIFF
--- a/browser/src/control/jsdialog/Widget.OverflowGroup.ts
+++ b/browser/src/control/jsdialog/Widget.OverflowGroup.ts
@@ -340,6 +340,7 @@ JSDialog.OverflowGroup = function (
 		parentContainer,
 	);
 	overflowGroupContainer.id = data.id;
+	overflowGroupContainer.setAttribute('tabindex', '-1');
 
 	const overflowGroupInnerContainer = window.L.DomUtil.create(
 		'div',


### PR DESCRIPTION
Change-Id: I73d390ead3460b3f1a9f6114a105f9e083b53449

Changes:
1. add tabindex=-1 for over flow group container to avoid getting focus

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

