### PR TITLE
browser: fix circular dependency on BackstageSVGIcons.js

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -149,7 +149,7 @@ BACKSTAGE_SVG_NAMES = \
 
 BACKSTAGE_SVGS = $(addprefix $(icons_dir)/,$(BACKSTAGE_SVG_NAMES))
 
-$(icons_js): tscompile.done Makefile.am Makefile $(BACKSTAGE_SVGS)
+$(icons_js): Makefile.am Makefile $(BACKSTAGE_SVGS)
 	@mkdir -p "$(dir $@)"
 	@{ \
 	  echo "// AUTO-GENERATED. DO NOT EDIT."; \


### PR DESCRIPTION
```
$(icons_js) is generated purely from SVG files, so it should not 
depend on tscompile.done. The reverse dependency already 
exists correctly: tscompile.done depends on $(COOL_JS_SRC) which 
includes $(icons_js) via COOL_JS_LST.

The circular chain was:
  tscompile.done -> $(COOL_JS_SRC) -> $(icons_js) -> tscompile.done


Change-Id: Ia72fc573535cc5f7513ec4f54b1b7fb439282f48
```
