### PR TITLE
kit: fix infinite loop in ClipboardData::read() on empty clipboard file

### DIFF
--- a/common/ClipboardData.hpp
+++ b/common/ClipboardData.hpp
@@ -60,7 +60,7 @@ struct ClipboardData
 
     bool read(std::istream& inStream)
     {
-        while (!inStream.eof())
+        while (!inStream.eof() && !inStream.fail())
         {
             std::string mime, hexLen, newline;
             std::getline(inStream, mime, '\n');

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -1674,7 +1674,14 @@ bool ChildSession::setClipboard(const StringVector& tokens)
             return false;
         }
 
-        SigUtil::addActivity(getId(), "setClipboard " + std::to_string(FileUtil::Stat(clipFile).size()) + " bytes");
+        const auto clipFileSize = FileUtil::Stat(clipFile).size();
+        SigUtil::addActivity(getId(), "setClipboard " + std::to_string(clipFileSize) + " bytes");
+
+        if (clipFileSize == 0)
+        {
+            LOG_WRN("Ignoring empty clipboard file: " << clipFile);
+            return false;
+        }
 
         // See if the data is in the usual mimetype-size-content format or is just plain HTML.
         std::string firstLine;


### PR DESCRIPTION
When setClipboard receives a 0-byte file, the first std::getline sets both eofbit and failbit on the stream. The subsequent seekg(0) clears eofbit (per C++11) but leaves failbit set. ClipboardData::read() then enters an infinite loop: the while(!eof()) condition is always true, but std::getline is a no-op on a failed stream, so the state never changes. The kit process spins until the admin watchdog kills it with SIGABRT.

Fix by checking !inStream.fail() in the read() loop condition, and bail out early in setClipboard() when the file is empty.


Change-Id: I0b00810fb6187646d8e5067fb5c338d20b1030b9

