### PR TITLE
brower: a11y: fix focus loss after dropdown closes

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -221,7 +221,14 @@ window.L.Control.JSDialog = window.L.Control.extend({
 			}
 
 			try {
-				dialog.lastFocusedElement.focus();
+				if (dialog.lastFocusedElement.isConnected) {
+					dialog.lastFocusedElement.focus();
+				} else {
+					var focusId = document.getElementById(dialog.lastFocusedElementId);
+					if (focusId) {
+						focusId.focus();
+					}
+				}
 			}
 			catch (error) {
 				app.console.debug('Cannot focus last element in dialog with id: ' + id);
@@ -821,8 +828,10 @@ window.L.Control.JSDialog = window.L.Control.extend({
 		// Save last focused element, we will set the focus back to this element after this popup is closed.
 		if (this.dialogs[instance.id] && this.dialogs[instance.id].lastFocusedElement) {
 			instance.lastFocusedElement = this.dialogs[instance.id].lastFocusedElement;
+			instance.lastFocusedElementId = this.dialogs[instance.id].lastFocusedElementId;
 		} else if (!this.dialogs[instance.id] || !this.dialogs[instance.id].lastFocusedElement) { // Avoid to reset while updates.
 			instance.lastFocusedElement = document.activeElement;
+			instance.lastFocusedElementId = document.activeElement.id;
 		}
 
 		instance.callback = e.callback;


### PR DESCRIPTION
We save lastFocusedElement every time a dialog or dropdown opens.
However, during the interaction, the server can update the elements,
and our approach is to recreate them.
As a result, the saved lastFocusedElement reference stays in memory
but is no longer connected to the DOM.

Change-Id: I177a2b0d6283de553aa7fbb08db09c10513c6a09
Signed-off-by: Henry Castro <hcastro@collabora.com>
