### PR TITLE
Color picker: fix duplicate command on Enter key

### DIFF
--- a/browser/src/control/jsdialog/Widget.ColorPicker.ts
+++ b/browser/src/control/jsdialog/Widget.ColorPicker.ts
@@ -168,6 +168,7 @@ function createColor(
 	});
 	color.addEventListener('keydown', (event: KeyboardEvent) => {
 		if (event.code === 'Enter') {
+			event.preventDefault();
 			handleColorSelection(
 				event.target as HTMLElement, // The clicked element
 				builder, // Pass the builder object


### PR DESCRIPTION
Insert table -> Miscellaneous -> Color picker to select color using keyboard (enter) then erlier was default color would override to default color and now it would work normal.
 
before: 

[Screencast from 2026-02-25 20-47-18.webm](https://github.com/user-attachments/assets/5c899e20-a988-43db-9ec3-25542526dc88)



Change-Id: I6b4be87cc4070ef281829c9e999544c7bce982fd


* Resolves: # <!-- related github issue -->
* Target version: main

