### PR TITLE
zoom: set an upper limit of 170% on dynamic zoom

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3168,8 +3168,10 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 			return;
 		}
 
-		if (this.isImpress() && !maxZoom)
-			maxZoom = 10;
+		if (!maxZoom) {
+			if (this.isImpress()) maxZoom = 10;
+			else if (this.isWriter()) maxZoom = 13;
+		}
 
 		if (this._invalidateZoomFirstFit) {
 			recalcFirstFit = true;


### PR DESCRIPTION
After a point, the more we zoom into the document, the less content is visible, therefore it makes sense to have an upper limit.


Change-Id: I08856c29ec285bd8bacaa7b8bef92f2f9e0a67bc


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

