### PR TITLE
cypress: re-enable compare documents tests

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
@@ -127,7 +127,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		helper.expectTextForClipboard('Hello World');
 	});
 
-	it.skip('Compare documents', function () {
+	it('Compare documents', function () {
 		// Given an ~empty (new) document:
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('#Review-tab-label').click();
@@ -154,7 +154,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		});
 	});
 
-	it.skip('Compare remote documents', function () {
+	it('Compare remote documents', function () {
 		// Given a document:
 		desktopHelper.switchUIToNotebookbar();
 		// Switch to the 'Review' tab.


### PR DESCRIPTION
now it is working after the patch ports


Change-Id: If1e0ac8bf9d28bd2565ac19ec73358b0828b7aa7


* Resolves: # <!-- related github issue -->
* Target version: main


