### PR TITLE
browser: a11y: fix initial focus visibility in dropdown

### DIFF
--- a/browser/src/control/jsdialog/Util.FocusCycle.js
+++ b/browser/src/control/jsdialog/Util.FocusCycle.js
@@ -45,6 +45,9 @@ function getFocusableElements(container) {
 		ret = container.querySelectorAll('select:not([disabled]):not(.hidden)');
 	if (!ret.length)
 		ret = container.querySelectorAll('button:not([disabled]):not(.hidden)');
+
+	ret = Array.from(ret).filter(function(elem) { return elem.checkVisibility() });
+
 	return ret;
 }
 
@@ -205,7 +208,7 @@ function findNextElementInContainer(container, currentElement, direction) {
 
 	let diffX = 0;
 	let diffY = 0;
-	
+
 	// Ray casting sensitivity for spatial navigation
 	var rayCastingSensitivity = 10; // Pixels
 


### PR DESCRIPTION
The color picker dropdown contains a button with the
display: none property.

Change-Id: I2d63ca3d282de4e9e8791d0ffa34655c57bbd518
Signed-off-by: Henry Castro <hcastro@collabora.com>
