### PR TITLE
A single coolwsd with at least 130 wopi servers

### DIFF
--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -249,6 +249,7 @@ static const std::unordered_map<std::string, std::string> DefAppConfig = {
     { "security.server_signature", "false" },
     { "server_name", "" },
     { "serverside_config.idle_timeout_secs", "3600" },
+    { "serverside_config.max_idle_subforkits", "5" },
     { "ssl.ca_file_path", COOLWSD_CONFIGDIR "/ca-chain.cert.pem" },
     { "ssl.cert_file_path", COOLWSD_CONFIGDIR "/cert.pem" },
     { "ssl.cipher_list", "" },

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -345,6 +345,7 @@
 
     <serverside_config>
         <idle_timeout_secs desc="The maximum number of seconds before unloading an idle sub forkit. Defaults to 1 hour." type="uint" default="3600">3600</idle_timeout_secs>
+        <max_idle_subforkits desc="The maximum number of recently-used idle sub forkits to keep alive. Defaults to 5." type="uint" default="5">5</max_idle_subforkits>
     </serverside_config>
 
     <remote_config>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -472,30 +472,53 @@ void COOLWSD::cleanupDocBrokers()
                                                              3600);
 
         // consider shutting down unused subforkits
-        for (auto it = SubForKitProcs.begin(); it != SubForKitProcs.end(); )
+        // Always drop those older than IdleServerSettingsTimeoutSecs, and cap
+        // the remainder to a reasonable number of recently-used entries.
+        CONFIG_STATIC const size_t MaxRecentlyUsedSubForKits =
+            ConfigUtil::getConfigValue<size_t>("serverside_config.max_idle_subforkits", 5);
+
+        // idle candidates: pair of (idle duration, configId)
+        std::vector<std::pair<std::chrono::steady_clock::duration, std::string>> idleCandidates;
+
+        for (const auto& [configId, subForKitProc] : SubForKitProcs)
         {
-            // copy as it will be used after erase()
-            std::string configId = it->first;
 
             if (configId.empty()) {
                 // ignore primordial forkit
-                ++it;
             } else if (activeConfigs.contains(configId)) {
                 LOG_DBG("subforkit " << configId << " has active document, keep it");
-                ++it;
             } else if (OutstandingForks[configId] > 0) {
                 LOG_DBG("subforkit " << configId << " has a pending fork underway, keep it");
-                ++it;
+            } else {
+                auto idleDuration = now - LastSubForKitBrokerExitTimes[configId];
+                idleCandidates.emplace_back(idleDuration, configId);
             }
-            else if (now - LastSubForKitBrokerExitTimes[configId] < IdleServerSettingsTimeoutSecs)
+        }
+
+        // sort shortest-idle first so we keep the most recently used
+        std::sort(idleCandidates.begin(), idleCandidates.end());
+
+        size_t recentlyUsedKept = 0;
+        for (const auto& [idleDuration, configId] : idleCandidates)
+        {
+            if (idleDuration >= IdleServerSettingsTimeoutSecs)
             {
-                LOG_DBG("subforkit " << configId << " recently used, keep it");
-                ++it;
+                LOG_DBG("subforkit " << configId << " is unused, dropping it");
+                auto it = SubForKitProcs.find(configId);
+                assert(it != SubForKitProcs.end());
+                dropSubForKit(it);
+            }
+            else if (recentlyUsedKept >= MaxRecentlyUsedSubForKits)
+            {
+                LOG_DBG("subforkit " << configId << " recently used but excess idle subforkit, dropping it");
+                auto it = SubForKitProcs.find(configId);
+                assert(it != SubForKitProcs.end());
+                dropSubForKit(it);
             }
             else
             {
-                LOG_DBG("subforkit " << configId << " is unused, dropping it");
-                it = dropSubForKit(it);
+                LOG_DBG("subforkit " << configId << " recently used, keep it");
+                ++recentlyUsedKept;
             }
         }
 


### PR DESCRIPTION
At peak subforkit count there are:

91 subforkits
54 have an active document
30 unused, but recently used
1 unused, not recently used

When there are many unused subforkits, reduce those to a configurable (default 5) most recently used level.


Change-Id: I17ab9dcc1eaed699ea428abadef97fbd256083c5


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

