### PR TITLE
browser: comments: avoid unnecessary y jump when...

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -958,18 +958,17 @@ export class CommentSection extends CanvasSectionObject {
 		const anchorPos = rootComment.sectionProperties.data.anchorSPoint;
 
 		const topLeftArray = anchorPos.toArray();
-		const topLeftVisible = app.isPointVisibleInTheDisplayedArea(topLeftArray);
-		const bottomRightVisible = app.isPointVisibleInTheDisplayedArea([
-			topLeftArray[0] + (this.sectionProperties.commentWidth * app.pixelsToTwips),
+		const topVisible = app.isYVisibleInTheDisplayedArea(topLeftArray[1]);
+		const bottomVisible = app.isYVisibleInTheDisplayedArea(
 			topLeftArray[1] + Math.round(rootComment.getCommentHeight() * app.pixelsToTwips)
-		]);
+		);
 
 		const topBottom = this.getScreenTopBottom();
 
-		if (!topLeftVisible || !bottomRightVisible) {
-			if (!topLeftVisible)
+		if (!topVisible || !bottomVisible) {
+			if (!topVisible)
 				app.activeDocument.activeLayout.scroll(0, topBottom[0] - anchorPos.pY);
-			else if (!bottomRightVisible)
+			else if (!bottomVisible)
 				app.activeDocument.activeLayout.scroll(0, (anchorPos.pY + rootComment.getCommentHeight() - topBottom[1]));
 
 			if (app.map._docLayer._docType === 'spreadsheet' && rootComment) {


### PR DESCRIPTION
...the right end of the comment box is off-screen in a LTR document.

Bug: Consider a calc document where there is a cell say F70 has a comment but the viewport is adjusted so that there is no space to draw the comment box in the horizontal direction but not so in the vertical direction. Hovering over this cell will make the view scroll away from the cell in the vertical direction.

Solution: We are scrolling the view only in the Y direction, so only check if the top and the bottom of the comment box are in the view-area and don't consider the x components for making this decision.

Note: It would be nicer if we scroll horizontally too if left and right of the comment box are outside view-area at least for calc. But that is for the future.


Change-Id: I22c4789a7ec243dc34a4bee51d9ad154876cad4e


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

