### PR TITLE
effort to make Insert text hyperlink more reliable

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -267,6 +267,10 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		cy.cGet('#indication').should('exist').should('be.visible');
 		cy.cGet('#name').should('exist').should('be.visible');
 
+		// Wait for the dialog to fully initialize
+		helper.processToIdle(this.win);
+		cy.cGet('#indication-input').should('have.value', 'text text1');
+
 		cy.cGet('#indication-input').type('link');
 		cy.cGet('#target-input').type('www.something.com');
 		cy.cGet('#ok').click();


### PR DESCRIPTION
● 1) Top toolbar tests.
       Insert text hyperlink.:

      Timed out retrying after 10000ms
      + expected - actual

      -'text text1lik'
      +'text text1link'

      at Context.eval (integration_tests/common/helper.js:437:74)


Change-Id: I5140ebed8634ba5e49e14c0838ffebbb35d34c6c


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

