### PR TITLE
slideshow: fixed type error in texture loading

### DIFF
--- a/browser/src/slideshow/RenderContext.ts
+++ b/browser/src/slideshow/RenderContext.ts
@@ -112,6 +112,11 @@ class RenderContextGl extends RenderContext {
 	): WebGLTexture | ImageBitmap {
 		if (this.isDisposed()) return null;
 
+		if (!image) {
+			app.console.error('RenderContextGl.loadTexture: Invalid image provided');
+			return null;
+		}
+
 		const gl = this.getGl();
 
 		const texture = gl.createTexture();

--- a/browser/src/slideshow/engine/AnimatedElement.ts
+++ b/browser/src/slideshow/engine/AnimatedElement.ts
@@ -509,6 +509,18 @@ class AnimatedElement {
 		layer: ImageBitmap,
 		bounds: BoundingBoxType,
 	): AnimatedObjectType {
+		if (!layer) {
+			window.app.console.error(
+				'AnimatedElement.createBaseElement: layer is null/undefined',
+			);
+			return null;
+		}
+		if (!bounds || bounds.width <= 0 || bounds.height <= 0) {
+			window.app.console.error(
+				`AnimatedElement.createBaseElement: invalid bounds: ${JSON.stringify(bounds)}`,
+			);
+			return null;
+		}
 		const canvas = new OffscreenCanvas(bounds.width, bounds.height);
 		const context = canvas.getContext('2d');
 		context.drawImage(
@@ -597,6 +609,12 @@ class AnimatedElement {
 	}
 
 	private getTextureFromElement(element: AnimatedObjectType) {
+		if (!element || element.width <= 0 || element.height <= 0) {
+			window.app.console.error(
+				`AnimatedElement.getTextureFromElement: invalid element (null or zero-sized)`,
+			);
+			return null;
+		}
 		return this.tfContext.loadTexture(element);
 	}
 


### PR DESCRIPTION
problem:
Exception TypeError: WebGL2RenderingContext.texImage2D: Argument 6 is not valid for any of the 6-argument overloads. emitting event slideshowfollow dispatcheffect RenderContextGl.prototype.loadTexture@http://192.168.1.253:9980/browser/7c5d38d661/src/slideshow/RenderContext.js:83:12


Change-Id: I2b9776f51291c9d885eff49356d08216beee77e3


* Target version: main



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

