### PR TITLE
SheetView combobox changed to SelectSheetView in core

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1418,7 +1418,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 										'selectedEntries': [
 											'1'
 										],
-										'command': '.uno:CurrentSheetView',
+										'command': '.uno:SelectSheetView',
 										'accessibility': { focusBack: true,	combination: 'FS', de: null }
 									}
 								]


### PR DESCRIPTION
In core, the UNO command .uno:CurrentSheetView was removed and is not used for the SheetView combobox anymore. The functionality was moved to .uno:SelectSheetView which is a better name and place for this.

Depends on core change: https://gerrit.libreoffice.org/c/core/+/200754