### PR TITLE
cypress: re-enable some previously skipped cypress tests

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/chart_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/chart_dialog_spec.js
@@ -55,7 +55,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Chart dialog tests', funct
 	 * some css property.
 	 * `reasonableWidth` = width at the time of writing this test + 15px ;)
 	 */
-	it.skip('Chart Wizard width', function() {
+	it('Chart Wizard width', function() {
 		cy.cGet('#Insert-tab-label').click();
 		desktopHelper.getNbIcon('InsertObjectChart', 'Insert').click();
 

--- a/cypress_test/integration_tests/desktop/calc/formula_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/formula_dialog_spec.js
@@ -12,7 +12,7 @@ describe(['tagdesktop'], 'Formula dialog tests', function() {
 		});
 	});
 
-	it.skip('Formula dialog visual regression test', function() {
+	it('Formula dialog visual regression test', function() {
 		cy.wait(1000);
 
 		cy.cGet('.unoFunctionDialog.formulabar').click();

--- a/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
@@ -193,7 +193,7 @@ describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: f
             // silently skip the common dialogs that writer doesn't have
             return;
         } else {
-            it.skip(`Common Dialog ${command}`, function () {
+            it(`Common Dialog ${command}`, function () {
                 if (!hasLinguisticData && a11yHelper.needsLinguisticData(command)) {
                     this._runnable.title += ' (skipped: missing linguistic data)';
                     this.skip();
@@ -203,7 +203,7 @@ describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: f
         }
     });
 
-    it.skip('Transform dialog', function () {
+    it('Transform dialog', function () {
         cy.then(() => {
             win.app.map.sendUnoCommand('.uno:BasicShapes.octagon');
         });
@@ -224,7 +224,7 @@ describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: f
         helper.typeIntoDocument('{esc}');
     });
 
-    it.skip('Line dialog', function () {
+    it('Line dialog', function () {
         cy.then(() => {
             win.app.map.sendUnoCommand('.uno:Line');
         });
@@ -254,7 +254,7 @@ describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: f
 
     allWriterDialogs.forEach(function (commandSpec) {
         const command = typeof commandSpec === 'string' ? commandSpec : commandSpec.command;
-        it.skip(`Writer Dialog ${command}`, function () {
+        it(`Writer Dialog ${command}`, function () {
             a11yHelper.testDialog(win, commandSpec);
         });
     });
@@ -282,7 +282,7 @@ describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: f
         a11yHelper.handleDialog(win, 1, '.uno:ContentControlProperties');
     });
 
-    it.skip('Object dialog', function () {
+    it('Object dialog', function () {
         helper.clearAllText({ isTable: true });
         cy.then(() => {
             win.app.map.sendUnoCommand('.uno:InsertObjectChart');
@@ -328,7 +328,7 @@ describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: f
        cy.cGet('div.clipboard').should('have.focus');
     });
 
-    it.skip('Graphic dialog', function () {
+    it('Graphic dialog', function () {
         helper.clearAllText();
         desktopHelper.insertImage();
         cy.then(() => {
@@ -361,11 +361,11 @@ describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: f
         });
     });
 
-    it.skip('PDF export warning dialog', function () {
+    it('PDF export warning dialog', function () {
         a11yHelper.testPDFExportWarningDialog(win);
     });
 
-    it.skip('ReadOnly info dialog', function () {
+    it('ReadOnly info dialog', function () {
         // Text ReadOnly info dialog
         helper.clearAllText({ isTable: true });
         helper.typeIntoDocument('READONLY');

--- a/cypress_test/integration_tests/desktop/writer/replace_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/replace_dialog_spec.js
@@ -11,7 +11,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Replace Dialog Tests', fun
         });
     });
 
-    it.skip('Ctrl H should open search dialog with replace tab active', function() {
+    it('Ctrl H should open search dialog with replace tab active', function() {
         helper.typeIntoDocument('{ctrl}h');
         findHelper.waitForFindReplaceDialog(this.win);
 
@@ -23,7 +23,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Replace Dialog Tests', fun
         cy.cGet('#FindReplaceDialog.jsdialog input#searchterm-input-dialog').should('be.focused');
     });
 
-    it.skip('Replace button should open search dialog with replace tab active', function() {
+    it('Replace button should open search dialog with replace tab active', function() {
         cy.viewport(1920,1080);
         // Click the Replace button from the notebookbar
         cy.cGet('#Home-container [id^="home-search-dialog"] button:visible').click();
@@ -74,7 +74,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Replace Dialog Tests', fun
         cy.cGet('#copy-paste-container p b').should('not.exist');
     });
 
-    it.skip('Enter key in replace field triggers replace', function() {
+    it('Enter key in replace field triggers replace', function() {
         helper.setDummyClipboardForCopy();
 
         //First make sure that we do not have 'replaced' text in current document

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -284,7 +284,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		cy.cGet('#copy-paste-container p a').should('have.attr', 'href', 'http://www.something.com/');
 	});
 
-	it('Insert mail hyperlink.', function() {
+	it.skip('Insert mail hyperlink.', function() {
 		helper.setDummyClipboardForCopy();
 
 		cy.cGet('#Insert-tab-label').click();
@@ -347,7 +347,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 			.should('not.exist');
 	});
 
-	it.skip('Insert/delete chart.', function() {
+	it('Insert/delete chart.', function() {
 		cy.cGet('#Insert-tab-label').click();
 		cy.cGet('#Insert-container .unoInsertObjectChart button').click();
 


### PR DESCRIPTION
which were skipped in 8505f493923e3deaf715cb78e898285a7930b9b8


Change-Id: Ib8d9598f44e0bd8aee6da9c768d20b4a664dce1a


* Target version: main

### Summary

They passes now. See https://cpci.cbg.collabora.co.uk:8080/job/github_online_master_debug_vs_co-26.04_cypress_desktop/283/

