### PR TITLE
Calc: Hide sheet view tabs in tab bar and handle switching

### DIFF
--- a/browser/src/control/Control.SheetsBar.js
+++ b/browser/src/control/Control.SheetsBar.js
@@ -134,12 +134,16 @@ class SheetsBar {
 				continue;
 			}
 
+			if (app.calc.isPartSheetView(i)) {
+				continue;
+			}
+
 			let displayText = this.partNames[i];
 
 			sheetEntries.push({
 				id: 'selectsheet-' + i,
 				text: displayText,
-				selected: (i === this.selectedPart)
+				selected: (i === this.selectedPart || app.calc.isDefaultPartOfSelectedSheetView(i))
 			});
 		}
 		

--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -148,6 +148,9 @@ window.L.Control.Tabs = window.L.Control.extend({
 		}
 		if (docType === 'spreadsheet') {
 
+			// Track which default part has a sheet view active for tab icon display.
+			app.calc.updateActiveSheetView(selectedPart);
+
 			// Save scroll position
 			var horizScrollPos = 0;
 			var scrollDiv = window.L.DomUtil.get('spreadsheet-tab-scroll');
@@ -202,7 +205,8 @@ window.L.Control.Tabs = window.L.Control.extend({
 				}
 
 				for (var i = 0; i < parts; i++) {
-					if (app.calc.isPartHidden(i))
+					// Skip if hidden or a sheet view (implicitly hidden)
+					if (app.calc.isPartHidden(i) || app.calc.isPartSheetView(i))
 						continue;
 
 					// create a drop zone indicator for the sheet tab
@@ -225,7 +229,7 @@ window.L.Control.Tabs = window.L.Control.extend({
 											this._map.fire('mobilewizard', {data: menuData});
 										} else {
 											$(e.target).trigger('contextmenu');
-                                        }
+										}
 									}
 								};
 							}(i).bind(this));
@@ -257,8 +261,9 @@ window.L.Control.Tabs = window.L.Control.extend({
 						window.L.DomUtil.removeClass(tab, 'spreadsheet-tab-protected');
 					}
 
-					if (app.calc.isPartSheetView(i)) {
-						if (!app.calc.isPartSheetViewSynced(i)) {
+					var sheetViewPart = app.calc.getSheetViewPartForDefaultPart(i);
+					if (sheetViewPart >= 0 && app.calc.hasActiveSheetView(i)) {
+						if (!app.calc.isPartSheetViewSynced(sheetViewPart)) {
 							window.L.DomUtil.addClass(tab, 'spreadsheet-tab-sheetview-unsynced');
 						}
 						else {
@@ -296,7 +301,7 @@ window.L.Control.Tabs = window.L.Control.extend({
 			for (var key in this._spreadsheetTabs) {
 				var part =  parseInt(key.match(/\d+/g)[0]);
 				window.L.DomUtil.removeClass(this._spreadsheetTabs[key], 'spreadsheet-tab-selected');
-				if (part === selectedPart) {
+				if (part === selectedPart || app.calc.isDefaultPartOfSelectedSheetView(part)) {
 					// close auto filter popups on sheet tab selected
 					this._map.fire('closeAutoFilterDialog');
 					this._map.fire('closepopups');

--- a/browser/src/docstate.ts
+++ b/browser/src/docstate.ts
@@ -54,6 +54,7 @@
 		partHashes: null, // hashes used to distinguish parts (we use sheet name)
 		autoFilterCell: null, // The cell of the current autofilter popup.
 		pivotTableFilterCell: null, // The cell of the current pivot table filter popup.
+		partWithActiveSheetView: -1, // Default part index with an active sheet view, or -1 if none.
 	},
 	impress: {
 		partList: null, // Info for parts.

--- a/browser/src/docstatefunctions.js
+++ b/browser/src/docstatefunctions.js
@@ -314,6 +314,89 @@ app.calc.isSelectedPartSheetViewSynced = function () {
 	return app.calc.isPartSheetViewSynced(app.map._docLayer._selectedPart);
 };
 
+// Returns the name of the default sheet a given sheet view part.
+app.calc.getDefaultViewNameForPart = function (part) {
+	if (!app.map._docLayer || !app.map._docLayer._lastStatusJSON) return null;
+	var parts = app.map._docLayer._lastStatusJSON.parts;
+	if (part >= parts.length) return null;
+
+	var partData = parts[part];
+	if (partData.sheetviewid === undefined || partData.sheetviewid < 0)
+		return null;
+
+	var defaultViewHash = partData.defaultviewhash;
+	if (!defaultViewHash) return null;
+
+	for (var i = 0; i < parts.length; i++) {
+		if (parts[i].hash === defaultViewHash) {
+			return parts[i].name;
+		}
+	}
+
+	return null;
+};
+
+// Checks if the given part is the default (base) sheet of the currently selected sheet view.
+app.calc.isDefaultPartOfSelectedSheetView = function (part) {
+	if (!app.map._docLayer || !app.map._docLayer._lastStatusJSON) return false;
+	var selectedPart = app.map._docLayer._selectedPart;
+	if (!app.calc.isPartSheetView(selectedPart)) return false;
+
+	var parts = app.map._docLayer._lastStatusJSON.parts;
+	if (part >= parts.length) return false;
+
+	var selectedPartData = parts[selectedPart];
+	return (
+		selectedPartData.defaultviewhash &&
+		selectedPartData.defaultviewhash === parts[part].hash
+	);
+};
+
+// Returns the sheet view part index that corresponds to the given default (base) part, or -1 if none.
+app.calc.getSheetViewPartForDefaultPart = function (part) {
+	if (!app.map._docLayer || !app.map._docLayer._lastStatusJSON) return -1;
+	var parts = app.map._docLayer._lastStatusJSON.parts;
+	if (part >= parts.length) return -1;
+
+	var partHash = parts[part].hash;
+	if (!partHash) return -1;
+
+	for (var i = 0; i < parts.length; i++) {
+		if (parts[i].sheetviewid >= 0 && parts[i].defaultviewhash === partHash) {
+			return i;
+		}
+	}
+
+	return -1;
+};
+
+// Updates the active sheet view part based on the selected part.
+app.calc.updateActiveSheetView = function (selectedPart) {
+	if (!app.map._docLayer || !app.map._docLayer._lastStatusJSON) return;
+
+	if (app.calc.isPartSheetView(selectedPart)) {
+		var parts = app.map._docLayer._lastStatusJSON.parts;
+		var defaultViewHash = parts[selectedPart].defaultviewhash;
+		if (defaultViewHash) {
+			for (var i = 0; i < parts.length; i++) {
+				if (parts[i].hash === defaultViewHash) {
+					app.calc.partWithActiveSheetView = i;
+					return;
+				}
+			}
+		}
+	}
+
+	// Only clear when navigating back to the default part itself.
+	if (selectedPart === app.calc.partWithActiveSheetView)
+		app.calc.partWithActiveSheetView = -1;
+};
+
+// Checks if the given part has an active sheet view.
+app.calc.hasActiveSheetView = function (part) {
+	return app.calc.partWithActiveSheetView === part;
+};
+
 app.calc.isAnyPartHidden = function () {
 	if (!app.map._docLayer || !app.map._docLayer._lastStatusJSON) return false;
 

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -422,7 +422,7 @@ window.L.CalcTileLayer = window.L.CanvasTileLayer.extend({
 		const statusJSON = JSON.parse(textMsg.replace('status:', '').replace('statusupdate:', ''));
 
 		if (statusJSON.width && statusJSON.height && this._documentInfo !== textMsg) {
-			const temp = this._lastStatusJSON ? Object.assign({}, this._lastStatusJSON): null;
+			const previousStatusJSON = this._lastStatusJSON ? Object.assign({}, this._lastStatusJSON): null;
 			this._lastStatusJSON = statusJSON;
 			this._documentInfo = textMsg;
 
@@ -487,7 +487,7 @@ window.L.CalcTileLayer = window.L.CanvasTileLayer.extend({
 			this._refreshPartHashes(statusJSON);
 
 			// if the number of parts, or order has changed then refresh comment positions
-			if (this._hasPartsCountOrNamesChanged(temp, statusJSON))
+			if (this._hasPartsCountOrNamesChanged(previousStatusJSON, statusJSON))
 				app.socket.sendMessage('commandvalues command=.uno:ViewAnnotationsPosition');
 
 
@@ -512,7 +512,7 @@ window.L.CalcTileLayer = window.L.CanvasTileLayer.extend({
 					this._printRanges[info[i]['sheet']] = info[i]['ranges'];
 			}
 
-			if (firstSelectedPart)
+			if (firstSelectedPart || (previousStatusJSON && previousStatusJSON.selectedpart !== statusJSON.selectedpart))
 				this._switchSplitPanesContext();
 
 			this._map.fire('statusupdated');


### PR DESCRIPTION
Sheet view tabs are now hidden from the tab bar. When a sheet view is active, the corresponding default sheet tab shows a sheet view icon.

Added functions for mapping between sheet view parts and their default parts (sheets), and tracking which part has an active sheet view.

Depends on core changes to be commited first. 