### PR TITLE
fix: add aria-label for shape icon to be recognize by screen reader

### DIFF
--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -620,6 +620,7 @@ function insertShapes(shapeType, grid = document.getElementsByClassName('inserts
 				col.className = 'col w2ui-icon ' + shape.img;
 				col.dataset.uno = shape.uno;
 				col.setAttribute('data-cooltip', shape.text);
+				col.setAttribute('aria-label', shape.text);
 				window.L.control.attachTooltipEventListener(col, map);
 				col.tabIndex = 0;
 				col.setAttribute('index', r + ':' + c);


### PR DESCRIPTION
Change-Id: If558558553d68147d8ff4e5468b3bad94478d482

Changes:
- This adds accessible name for Shape icons.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

