### PR TITLE
Forced-colors: fix backgroud color overide

### DIFF
--- a/browser/css/forced-colors.css
+++ b/browser/css/forced-colors.css
@@ -27,7 +27,7 @@
 	.unotoolbutton.notebookbar .unobutton > img,
 	.unotoolbutton.notebookbar .unobutton {
 		forced-color-adjust: none;
-		background-color: #e9e9ed;
+		background-color: #e9e9ed !important;
 	}
 
 	/* Restore native checkboxes (OS renders in user's HC colors) */
@@ -47,7 +47,7 @@
 	/* Dropdown arrows */
 	.unoarrow, .menubutton .arrow, .ui-listbox-arrow {
 		forced-color-adjust: none;
-		border-top-color: #e9e9ed;
+		border-top-color: #e9e9ed !important;
 	}
 
 	/* Restore original Sidebar expanders */
@@ -101,7 +101,7 @@
 	[data-theme='dark'] .unotoolbutton.notebookbar .unobutton,
 	[data-theme='dark'] .StyleListPanel #TemplatePanel [id] button,
 	[data-theme='dark'] .ui-overflow-group-popup .unobutton > img {
-		background-color: #1E1E1E;
+		background-color: #1E1E1E !important;
 	}
 
 	[data-theme='dark'] .cool-annotation-menu,
@@ -115,7 +115,7 @@
 	[data-theme='dark'] .unoarrow,
 	[data-theme='dark'] .menubutton .arrow,
 	[data-theme='dark'] .ui-listbox-arrow {
-		border-top-color: #1E1E1E;
+		border-top-color: #FFFF;
 	}
 
 	/* Dark mode: restore brightness for sidebar expanders (filter: none


### PR DESCRIPTION
Change-Id: I6ced70a7b45f247f8222956bf0b62ccf7ec8f77e


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
- Add !important to forced-colors background rules to ensure they are not overridden by other theme styles.
- Elements fixed are Darkmode, Sidebar, Dropdown arrows

### PREIVEW

<img width="1307" height="130" alt="2026-03-02_17-56" src="https://github.com/user-attachments/assets/51001389-5a9b-41e2-8e4a-1cb8c71892df" />

<img width="1457" height="126" alt="2026-03-02_17-57" src="https://github.com/user-attachments/assets/9dc922d9-cfef-4ce1-82cb-3296021bbf71" />


