### PR TITLE
browser: calc: comments: avoid view jump on hover

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -977,10 +977,11 @@ export class CommentSection extends CanvasSectionObject {
 		const topBottom = this.getScreenTopBottom();
 
 		if (!topVisible || !bottomVisible) {
+			const topPixels = topTwips * app.twipsToPixels;
 			if (!topVisible)
-				app.activeDocument.activeLayout.scroll(0, topBottom[0] - anchorPos.pY);
+				app.activeDocument.activeLayout.scroll(0, topBottom[0] - topPixels);
 			else if (!bottomVisible)
-				app.activeDocument.activeLayout.scroll(0, (anchorPos.pY + rootComment.getCommentHeight() - topBottom[1]));
+				app.activeDocument.activeLayout.scroll(0, (topPixels + rootComment.getCommentHeight() - topBottom[1]));
 
 			if (app.map._docLayer._docType === 'spreadsheet' && rootComment) {
 				rootComment.positionCalcComment();


### PR DESCRIPTION
Bug: In Calc on hovering over comment cells deep down in the spreadsheet, the view jumps down.

Fix: This due to sending in display-twips into app.isYVisibleInTheDisplayedArea() which expects y-coordinate in print twips. So do the appropriate conversion using sheet geometry.

Also use the appropriate print-twips y value to compute offset to scroll in case there is no room to display the comment.

Change-Id: I87e6eaa1955ea0ee32dde350253a2614b58dad77


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

