### PR TITLE
clipboard: fix copy/paste with DisableCopy

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -900,14 +900,15 @@ window.L.Clipboard = window.L.Class.extend({
 		} else {
 			const url = this.getMetaURL() + '&MimeType=text/html,text/plain;charset=utf-8';
 
-			const text = (async () => {
+			// It's important in DisableCopy to write something to the clipboard so that future paste actions can trigger an internal paste
+			const text = (this._map['wopi'].DisableCopy ? this._getDisabledCopyStubHtml() : (async () => {
 				if (await check_ === null)
 					throw new Error('Failed check, either wrong command or pending event');
 					// We need to throw an error here rather than just returning so that a failure halts copying the ClipboardItem to the clipboard
 
 				const result = await fetch(url);
 				return await result.text();
-			})();
+			})());
 
 			const clipboardItem = new ClipboardItem({
 				'text/html': this._parseClipboardFetchResult(text, 'text/html', 'html'),
@@ -1088,12 +1089,6 @@ window.L.Clipboard = window.L.Class.extend({
 	// Pull UNO clipboard commands out from menus and normal user input.
 	// We try to massage and re-emit these, to get good security event / credentials.
 	filterExecCopyPaste: function(cmd, params) {
-		if (this._map['wopi'].DisableCopy && (cmd === '.uno:Copy' || cmd === '.uno:Cut' || cmd === '.uno:CopyHyperlinkLocation')) {
-			// perform internal operations
-			app.socket.sendMessage('uno ' + cmd);
-			return true;
-		}
-
 		if (window.ThisIsTheAndroidApp) {
 			// perform internal operations
 			app.socket.sendMessage('uno ' + cmd);
@@ -1133,6 +1128,7 @@ window.L.Clipboard = window.L.Class.extend({
 
 		if (this._map['wopi'].DisableCopy === true)
 		{
+			app.socket.sendMessage('uno .uno:' + unoName);
 			var text = this._getDisabledCopyStubHtml();
 			var plainText = DocUtil.stripHTML(text);
 			if (ev.clipboardData) {

--- a/cypress_test/data/desktop/writer/copy_paste.odt.wopi.json
+++ b/cypress_test/data/desktop/writer/copy_paste.odt.wopi.json
@@ -1,0 +1,3 @@
+{
+  "DisableCopy": true
+}

--- a/cypress_test/integration_tests/desktop/writer/copy_paste_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/copy_paste_spec.js
@@ -65,4 +65,36 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Clipboard operations.', fu
 			expect(json.Values.content).to.equal('foo *bar* baz\n');
 		});
 	});
+
+	it('Copy and Paste text with DisableCopy', function () {
+		helper.setupAndLoadDocument('writer/copy_paste.odt', /* isMultiUser */ false, /* copy .wopi.json */ true);
+		// Select some text
+		helper.selectAllText();
+
+		cy.getFrameWindow().then(win => {
+			const selectionStart = win.TextSelections.getStartRectangle();
+			cy.cGet('#document-container').rightclick(selectionStart.pX1, selectionStart.pY1);
+		});
+
+		helper.setDummyClipboardForCopy();
+
+		cy.cGet('body').contains('.context-menu-link', 'Copy')
+			.click();
+
+		// With DisableCopy active we should not copy to clipboard
+		cy.cGet('#copy-paste-container div p').should('not.have.text', 'text');
+
+		// But paste should still work properly
+		helper.typeIntoDocument('{end}');
+		helper.getCursorPos('left', 'beforePaste');
+		cy.getFrameWindow().then(win => {
+			win.app.map.sendUnoCommand('.uno:Paste');
+			helper.processToIdle(win);
+		});
+		helper.getCursorPos('left', 'afterPaste');
+		cy.get('@beforePaste').then(beforeValue => {
+			cy.get('@afterPaste').should('be.gt', beforeValue);
+		});
+
+	});
 });


### PR DESCRIPTION
Copy and paste shortcuts and buttons behaved inconsistently when the
WOPI option DisableCopy was true. We want copy/cut to always be executed
internally without putting the content on the clipboard and paste to use
the clipboard or the internal command depending on what is most recent.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I4626806f2cabf97f2a163b52d9b5a3b4d928a500
