### PR TITLE
[co-25.04] cool#14716 document compare: fix bad tile position after zoom change

### DIFF
--- a/browser/src/app/ViewLayoutCompareChanges.ts
+++ b/browser/src/app/ViewLayoutCompareChanges.ts
@@ -27,9 +27,21 @@ class ViewLayoutCompareChanges extends ViewLayoutNewBase {
 	constructor() {
 		super();
 
+		app.map.on('zoomend', this.onZoomEnd.bind(this));
+
 		this.adjustViewZoomLevel();
 
 		app.layoutingService.appendLayoutingTask(() => this.updateViewData());
+	}
+
+	/// Refresh the view after scroll or zoom change.
+	private refreshView(): void {
+		this.updateViewData();
+		app.sectionContainer.requestReDraw();
+	}
+
+	private onZoomEnd(): void {
+		this.refreshView();
 	}
 
 	public adjustViewZoomLevel() {
@@ -164,8 +176,7 @@ class ViewLayoutCompareChanges extends ViewLayoutNewBase {
 		const scrolled = super.scroll(pX, pY);
 
 		if (scrolled) {
-			this.updateViewData();
-			app.sectionContainer.requestReDraw();
+			this.refreshView();
 		}
 
 		return scrolled;

--- a/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
@@ -307,6 +307,37 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		});
 	});
 
+	it('Zoom out updates visible area in compare changes mode', function () {
+		// Given a document in compare changes mode:
+		desktopHelper.switchUIToNotebookbar();
+		cy.cGet('#Review-tab-label').click();
+		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
+		cy.cGet('#compare-tracked-change').filter(':visible').click();
+		cy.cGet('.compare-changes-labels').should('not.have.css', 'display', 'none');
+
+		// When zooming out:
+		let initialWidth = 0;
+		cy.getFrameWindow().then(function(win) {
+			cy.wrap(null).should(function() {
+				initialWidth = win.app.activeDocument.activeLayout.viewedRectangle.width;
+				expect(initialWidth, 'initial viewedRectangle.width').to.be.greaterThan(0);
+			});
+		});
+		desktopHelper.zoomOut();
+
+		// Then the visible area width (in twips) should increase, since each pixel now covers
+		// more twips at a smaller zoom level:
+		cy.getFrameWindow().then(function(win) {
+			cy.wrap(null).should(function() {
+				let newWidth = win.app.activeDocument.activeLayout.viewedRectangle.width;
+				// Without the accompanying fix in place, this test would have failed, the
+				// visible area was not updated on zoom change: 14689 didn't
+				// increase to 17627
+				expect(newWidth, 'viewedRectangle.width after zoom out').to.be.greaterThan(initialWidth);
+			});
+		});
+	});
+
 	it.skip('Comment Undo-Redo', function () {
 		for (var n = 0; n < 2; n++) {
 			desktopHelper.getCompactIconArrow('DefaultNumbering').click();


### PR DESCRIPTION
Enter the document compare view in Writer using Review -> View Changes
on the notebookbar, zoom out: the left/right change labels and the tiles
are no longer in sync.

Notice that the multi-page view doesn't have this problem and it has
explicit code at browser/src/app/ViewLayoutMultiPage.ts to listen to a
'zoomend' event.

Fix the problem for compare changes view layout similarly. Extract part
of the scroll handler to a separate refreshView() and also from the
'zoomend' event listener.

This way the tiles are in sync with the left/right change labels after a
zoom change.

(cherry picked from commit 38c139612967cec17d6ccc95057264bc670833be)

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I22357cb67387f25ab6e31ff00b12e390ee049bda
