### PR TITLE
browser: fix double slash in new experimental WebSocket URL

### DIFF
--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -2038,7 +2038,7 @@ function showWelcomeSVG() {
 		global.TheFakeWebSocket = global.socket;
 	} else {
 		if (global.enableExperimentalFeatures) {
-			var websocketURI = global.makeWopiCoolWsUrl(global.makeWsUrl('/cool/'), docParams);
+			var websocketURI = global.makeWopiCoolWsUrl(global.makeWsUrl('/cool'), docParams);
 		} else {
 			// The URL may already contain a query (e.g., 'http://server.tld/foo/wopi/files/bar?desktop=baz') - then just append more params
 			var docParamsPart = docParams ? (global.docURL.includes('?') ? '&' : '?') + docParams : '';

--- a/browser/src/app/Socket.ts
+++ b/browser/src/app/Socket.ts
@@ -229,7 +229,7 @@ class Socket {
 		if (window.enableExperimentalFeatures) {
 			// Use the new Cool WS URL.
 			return window.makeWopiCoolWsUrl(
-				window.makeWsUrl('/cool/'),
+				window.makeWsUrl('/cool'),
 				$.param(map.options.docParams),
 			);
 		} else {

--- a/test/RequestDetailsTests.cpp
+++ b/test/RequestDetailsTests.cpp
@@ -845,7 +845,7 @@ void RequestDetailsTests::testCoolWs()
 
     {
         static const std::string URI =
-            "/cool//"
+            "/cool/"
             "ws?WOPISrc=http%3A%2F%2Flocalhost%2Fnextcloud%2Findex.php%2Fapps%2Frichdocuments%"
             "2Fwopi%2Ffiles%2F593_ocqiesh0cngs&access_token=MN0KXXDv9GJ1wCCLnQcjVQT2T7WrfYpA&"
             "access_token_ttl=0&reuse_cookies=oc_sessionPassphrase%"
@@ -927,7 +927,7 @@ void RequestDetailsTests::testCoolWs()
 
     {
         static const std::string URI =
-            "/cool//"
+            "/cool/"
             "ws?WOPISrc=http%3A%2F%2Flocalhost%2Fnextcloud%2Findex.php%2Fapps%2Frichdocuments%"
             "2Fwopi%2Ffiles%2F6734_ocqiesh0cngs&access_token%3DO87cwh0WlwIawoDkafkqOtVNTygxbiBN%"
             "26access_token_ttl%3D0%26no_a";


### PR DESCRIPTION
 Hi @Ashod,

Your commit 325982cdfd ("wsd: browser: new CoolWS URL") introduces a regression that breaks WebSocket connections when COOL is behind a reverse proxy.

The problem: In browser/src/app/Socket.ts line 232, makeWsUrl('/cool/') passes a trailing slash. Then in  browser/js/global.js, makeWopiCoolWsUrl() concatenates root + '/ws', producing a double slash in the URL:  /cool//ws?WOPISrc=... instead of /cool/ws?WOPISrc=....

Reverse proxies typically have rewrite rules matching /cool/ws to enable WebSocket forwarding (adding Upgrade: websocket and Connection: Upgrade headers). The double slash /cool//ws doesn't match these rules, so the proxy forwards it as a plain HTTP request. Without the Upgrade header, RequestDetails::isWebSocket() returns false on the server side, and the WebSocket upgrade never happens — the connection just dies.

Why CI didn't catch it: The unit test in RequestDetailsTests.cpp that was added with the commit has the double-slash URL /cool//ws?WOPISrc=... baked right into the test. The server-side URL parser tolerates it because the empty segment pushes  ws to position 2, which matches the old equals(2, "ws") check (intended for the legacy /cool/<encoded-doc>/ws format). So the test passes, but it only validates server-side parsing — not end-to-end connectivity through a proxy.

The fix: Remove the trailing slash — change makeWsUrl('/cool/') to makeWsUrl('/cool') in Socket.ts line 232. The same issue exists in global.js line 2040 where global.makeWsUrl('/cool/') is called — that needs fixing too. The unit test URI should also be corrected from /cool//ws to /cool/ws.