### PR TITLE
browser: a11y: fix click not working on UNO tool button

### DIFF
--- a/browser/src/dom/NotebookbarAccessibility.js
+++ b/browser/src/dom/NotebookbarAccessibility.js
@@ -192,7 +192,8 @@ var NotebookbarAccessibility = function() {
 				else if (this.state === 1) {
 					itemWasClicked = true;
 					this.setTabItemDescription(element);
-					element.click();
+					var clickTarget = element.querySelector('button.unobutton') || element;
+					clickTarget.click();
 					if (this.filteredItem && this.filteredItem.focusBack === true) {
 						this.focusToMap();
 					}


### PR DESCRIPTION
The element retrieved by ID is assumed to be a button type,
since .click() is a trusted method that works for some input
elements. However, the main container of the UNO tool button
is a <div> tag, which cannot be clicked programmatically.

Change-Id: I8da5e39ebd1a7277a6d7cc4764bd51a91c110cbb
Signed-off-by: Henry Castro <hcastro@collabora.com>
