### PR TITLE
support multi-selection in Calc cell function menu on the status bar

### DIFF
--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -81,17 +81,19 @@ class StatusBar extends JSDialog.Toolbar {
 				this.map.setZoom(selected[0].scale, null, true /* animate? */);
 			return;
 		} else if (object.id === 'StateTableCellMenu') {
-			// TODO: multi-selection
-			var selected = [];
-			if (data === '1') { // 'None' was clicked, remove all other options
-				selected = ['1'];
-			} else { // Something else was clicked, remove the 'None' option from the array
-				selected = [data];
-			}
+			var clicked = parseInt(data);
+			var current = parseInt(app.map['stateChangeHandler'].getItemValue('.uno:StatusBarFunc')) || 0;
 
-			var value = 0;
-			for (var it = 0; it < selected.length; it++) {
-				value = +value + parseInt(selected[it]);
+			var value;
+			if (clicked === 1) {
+				// 'None' was clicked — clear everything
+				value = 0;
+			} else {
+				// Toggle the clicked bit
+				value = current ^ clicked;
+				// Clear the 'None' bit (1) if any function is now active
+				if (value & ~1)
+					value = value & ~1;
 			}
 
 			var command = {


### PR DESCRIPTION
The status bar cell function menu (Average, Sum, Count, etc.) now supports toggling multiple functions, matching the desktop behavior. Previously clicking a menu item replaced the entire selection with just that one item.

The selection state is a bitmask — use XOR to toggle the clicked bit against the current state from the state change handler. Clicking 'None' clears everything.


Change-Id: Ia08d087cc9f1bbd751b7907809f82c3f407a3071

