### PR TITLE
private/kendy collabora/macos server

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -22,6 +22,14 @@ elif test `uname -s` = Darwin; then
     libtoolize || glibtoolize || failed "Can't find libtoolize or glibtoolize. Use lode or install it yourself."
 fi
 
+# On macOS with Homebrew, pkg.m4 and other m4 macros may live in a directory
+# that aclocal does not search by default. Add it so that PKG_CHECK_MODULES
+# and similar macros are found.
+if test `uname -s` = Darwin -a -d /opt/homebrew/share/aclocal; then
+    ACLOCAL_PATH="${ACLOCAL_PATH:+$ACLOCAL_PATH:}/opt/homebrew/share/aclocal"
+    export ACLOCAL_PATH
+fi
+
 aclocal || failed "aclocal"
 
 autoheader || failed "autoheader"

--- a/common/SigUtil-server.cpp
+++ b/common/SigUtil-server.cpp
@@ -47,7 +47,7 @@
 #include <thread>
 #include <unistd.h>
 
-#if defined(__GLIBC__)
+#if defined(__GLIBC__) || defined(MACOS)
 #  include <execinfo.h>
 #endif
 
@@ -473,7 +473,7 @@ void resetTerminationFlags()
 
     void dumpBacktrace()
     {
-#if defined(__GLIBC__)
+#if defined(__GLIBC__) || defined(MACOS)
         signalLog("\nBacktrace ");
         signalLogNumber(static_cast<std::size_t>(getpid()));
         if (VersionInfo)

--- a/common/Util-server.cpp
+++ b/common/Util-server.cpp
@@ -61,6 +61,7 @@ const char* startsWith(const char* line, const char* tag, std::size_t tagLen)
     return nullptr;
 }
 
+#ifdef __linux__
 std::size_t getFromCGroup(const std::string& group, const std::string& key)
 {
     std::size_t num = 0;
@@ -146,6 +147,7 @@ std::size_t getFromCGroupV2(const std::string& key)
     }
     return num;
 }
+#endif // __linux__
 } // namespace
 
 namespace Util

--- a/configure.ac
+++ b/configure.ac
@@ -15,11 +15,6 @@ AC_SUBST([ARFLAGS], [cr])
 
 AC_CONFIG_MACRO_DIR([m4])
 
-# We don't want to require pkg-config and PKG_CHECK_MODULES on macOS
-# It may be missing, and then we'd generate broken shell code; but
-# let's guard against accidental use.
-m4_if(m4_esyscmd_s([uname -s]),Darwin,[m4_define([PKG_CHECK_MODULES],[AC_MSG_ERROR([It's not expected to use [PKG_CHECK_MODULES] on macOS, please fix configure.ac and make pkg-config a requirement if you really need it.])])],[])
-
 COOLWSD_VERSION_MAJOR=`echo $VERSION | awk -F. '{print $1}'`
 COOLWSD_VERSION_MINOR=`echo $VERSION | awk -F. '{print $2}'`
 COOLWSD_VERSION_MICRO=`echo $VERSION | awk -F. '{print $3}'`

--- a/kit/DeltaSimd.c
+++ b/kit/DeltaSimd.c
@@ -20,13 +20,11 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdint.h>
-#ifndef _WIN32
-#include <endian.h>
-#endif
 
 #include "DeltaSimd.h"
 
 #if ENABLE_SIMD
+#  include <endian.h>
 #  include <immintrin.h>
 
 #define DEBUG_LUT 0

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -297,8 +297,13 @@ bool haveCorrectCapabilities()
 #else
 bool haveCorrectCapabilities()
 {
+#if defined(MACOS)
+    // No capability infrastructure on macOS, jailing works differently.
+    return true;
+#else
     // chroot() can only be called by root
     return getuid() == 0;
+#endif
 }
 #endif // HAVE_LIBCAP
 

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -845,7 +845,7 @@ Document::~Document()
         session.second->resetDocManager();
     }
 
-#if defined(IOS) || defined(MACOS) || defined(_WIN32) || defined(QTAPP)
+#if MOBILEAPP
     DocumentData::deallocate(_mobileAppDocId);
 #endif
 
@@ -2099,7 +2099,7 @@ std::shared_ptr<lok::Document> Document::load(const std::shared_ptr<ChildSession
         const auto duration = std::chrono::steady_clock::now() - start;
         const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
         LOG_DBG("Returned lokit::documentLoad(" << anonymizeUrl(url) << ") in " << elapsed);
-#if defined(IOS) || defined(MACOS) || defined(_WIN32) || defined(QTAPP)
+#if MOBILEAPP
         DocumentData::get(_mobileAppDocId).loKitDocument = _loKitDocument.get();
         {
             std::unique_lock<std::mutex> docBrokersLock(DocBrokersMutex);
@@ -2926,7 +2926,7 @@ static void addRecording(const std::string &recording, bool force)
     traceEventRecords[force ? 0 : 1].push_back(recording + "\n");
 }
 
-#if !defined(QTAPP) && !defined(MACOS) && !defined(_WIN32) // ie. normal server
+#if !MOBILEAPP // ie. normal server
 void TraceEvent::emitOneRecordingIfEnabled(const std::string &recording)
 {
     addRecording(recording, true);
@@ -2936,7 +2936,7 @@ void TraceEvent::emitOneRecording(const std::string &recording)
 {
     addRecording(recording, false);
 }
-#endif // !defined(QTAPP) && !defined(MACOS) && !defined(_WIN32)
+#endif // !MOBILEAPP
 
 #else
 
@@ -2965,7 +2965,7 @@ std::shared_ptr<DocumentBroker> getDocumentBrokerForAndroidOnly()
 
 KitSocketPoll::KitSocketPoll() : SocketPoll("kit")
 {
-#if defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)
+#if MOBILEAPP && (defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32))
     termination = std::make_shared<KitSocketPoll::TerminationData>();
     termination->flag = false;
 #endif
@@ -2998,7 +2998,7 @@ std::shared_ptr<KitSocketPoll> KitSocketPoll::create() // static
 {
     std::shared_ptr<KitSocketPoll> result(new KitSocketPoll());
 
-#if defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)
+#if MOBILEAPP && (defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32))
     {
         std::unique_lock<std::mutex> lock(KSPollsMutex);
         KSPolls.push_back(result);
@@ -3147,7 +3147,7 @@ bool pushToMainThread(LibreOfficeKitCallback cb, int type, const char *p, void *
     return KitSocketPoll::pushToMainThread(cb, type, p, data);
 }
 
-#if defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)
+#if MOBILEAPP && (defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32))
 
 std::mutex KitSocketPoll::KSPollsMutex;
 std::condition_variable KitSocketPoll::KSPollsCV;
@@ -3173,7 +3173,7 @@ int pollCallback([[maybe_unused]] void* data, int timeoutUs)
 
     if (timeoutUs < 0)
         timeoutUs = SocketPoll::DefaultPollTimeoutMicroS.count();
-#if !defined(IOS) && !defined(QTAPP) && !defined(MACOS) && !defined(_WIN32)
+#if !(MOBILEAPP && (defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)))
     if (!data)
         return 0;
     else
@@ -3229,7 +3229,7 @@ bool anyInputCallback(void* data, int mostUrgentPriority)
 } // namespace
 
 bool KitSocketPoll::kitHasAnyInput([[maybe_unused]] int mostUrgentPriority) {
-#if !defined(IOS) && !defined(QTAPP) && !defined(MACOS) && !defined(_WIN32)
+#if !(MOBILEAPP && (defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)))
     const std::shared_ptr<Document>& document = getDocument();
 
     if (document)
@@ -3286,7 +3286,7 @@ void wakeCallback(void* data)
 } // namespace
 
 void KitSocketPoll::kitWakeup() {
-#if !defined(IOS) && !defined(QTAPP) && !defined(MACOS) && !defined(_WIN32)
+#if !(MOBILEAPP && (defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)))
     wakeup();
 #else
     std::unique_lock<std::mutex> lock(KitSocketPoll::KSPollsMutex);
@@ -3382,7 +3382,7 @@ void copyCertificateDatabaseToTmp(Poco::Path const& jailPath)
 
 #endif
 
-#if defined(QTAPP) || defined(MACOS) || defined(_WIN32)
+#if MOBILEAPP && (defined(QTAPP) || defined(MACOS) || defined(_WIN32))
 
 // with "unipoll" thread that calls lok_init_2 ends up holding the yield mutex in InitVCL()
 // lok::Office:runLoop then spawned in another thread ends up stuck. To prevent that call lok_init_2
@@ -3418,7 +3418,7 @@ std::future<LibreOfficeKit*> initKitRunLoopThread(const std::shared_ptr<KitSocke
             }).detach();
         return future;
 }
-#endif // QTAPP
+#endif // MOBILEAPP && (QTAPP || MACOS || _WIN32)
 void lokit_main(
 #if !MOBILEAPP
                 const std::string& childRoot,
@@ -3697,7 +3697,7 @@ void lokit_main(
                 return true;
             };
 
-#ifndef __FreeBSD__
+#ifdef __linux__
             const uid_t origuid = geteuid();
             const gid_t origgid = getegid();
 
@@ -4139,7 +4139,7 @@ void lokit_main(
         Log::setDisabledAreas(LogDisabledAreas);
 #endif
 
-#if !defined(IOS) && !defined(QTAPP) && !defined(MACOS) && !defined(_WIN32)
+#if !(MOBILEAPP && (defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)))
         startMainLoop(kit, loKit, mainKit);
 
         // Trap the signal handler, if invoked,
@@ -4148,7 +4148,7 @@ void lokit_main(
 
         // Let forkit handle the jail cleanup.
 
-#else // IOS or QTAPP or MACOS or _WIN32
+#else // MOBILEAPP CODA apps
         auto const termination = mainKit->termination;
 #if defined(QTAPP) || defined(MACOS) || defined(_WIN32)
         // Release the mainKit KitSocketPoll instance early here, so that its destructor will

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -188,7 +188,7 @@ public:
     static bool pushToMainThread(LibreOfficeKitCallback callback, int type, const char* p,
                                  void* data);
 
-#if defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)
+#if MOBILEAPP && (defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32))
     static std::mutex KSPollsMutex;
     static std::condition_variable KSPollsCV;
     static std::vector<std::weak_ptr<KitSocketPoll>> KSPolls;

--- a/kit/KitWebSocket.cpp
+++ b/kit/KitWebSocket.cpp
@@ -93,7 +93,7 @@ void KitWebSocketHandler::handleMessage(const std::vector<char>& data)
 
         if (!_document)
         {
-#if !defined(IOS) && !defined(QTAPP) && !defined(MACOS) && !defined(_WIN32)
+#if !(MOBILEAPP && (defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)))
             Util::setThreadName("kit" SHARED_DOC_THREADNAME_SUFFIX + docId);
 #endif
             _document = std::make_shared<Document>(
@@ -133,7 +133,7 @@ void KitWebSocketHandler::handleMessage(const std::vector<char>& data)
         }
         else
         {
-#if defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)
+#if MOBILEAPP && (defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32))
             LOG_INF("Setting our KitSocketPoll's termination flag due to 'exit' command.");
             std::unique_lock<std::mutex> lock(_ksPoll->termination->mutex);
             _ksPoll->termination->flag = true;
@@ -214,7 +214,7 @@ void KitWebSocketHandler::onDisconnect()
                 << "] connection lost without exit arriving from wsd. Setting TerminationFlag");
         SigUtil::setTerminationFlag();
     }
-#if defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)
+#if MOBILEAPP && (defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32))
     {
         std::unique_lock<std::mutex> lock(_ksPoll->termination->mutex);
         _ksPoll->termination->flag = true;

--- a/test/HttpRequestTests.cpp
+++ b/test/HttpRequestTests.cpp
@@ -485,7 +485,7 @@ static void compare(const Poco::Net::HTTPResponse& pocoResponse, const std::stri
     LOK_ASSERT_EQUAL_MESSAGE("hasContentLength", pocoResponse.hasContentLength(),
                              httpResponse.header().hasContentLength());
     if (checkBody && pocoResponse.hasContentLength())
-        LOK_ASSERT_EQUAL_MESSAGE("ContentLength", pocoResponse.getContentLength(),
+        LOK_ASSERT_EQUAL_MESSAGE("ContentLength", (int64_t)pocoResponse.getContentLength(),
                                  httpResponse.header().getContentLength());
 }
 

--- a/test/HttpWhiteBoxTests.cpp
+++ b/test/HttpWhiteBoxTests.cpp
@@ -343,7 +343,7 @@ void HttpWhiteBoxTests::testRequestParserValidPostIncomplete()
     {
         // Should return 0 to signify that data is incomplete.
         LOK_ASSERT_EQUAL(http::Request::Stage::RequestLine, req.stage());
-        LOK_ASSERT_EQUAL_MESSAGE("i = " << i << " of " << data.size() - 1, 0L,
+        LOK_ASSERT_EQUAL_MESSAGE("i = " << i << " of " << data.size() - 1, int64_t(0),
                                  req.readData(data.c_str(), i));
     }
 
@@ -364,7 +364,7 @@ void HttpWhiteBoxTests::testRequestParserValidPostIncomplete()
     {
         // Should return 0 to signify that data is incomplete.
         LOK_ASSERT_EQUAL(http::Request::Stage::Header, req.stage());
-        LOK_ASSERT_EQUAL_MESSAGE("i = " << i << " of " << data.size() - 1, 0L,
+        LOK_ASSERT_EQUAL_MESSAGE("i = " << i << " of " << data.size() - 1, int64_t(0),
                                  req.readData(data.c_str(), i));
     }
 
@@ -593,7 +593,7 @@ void HttpWhiteBoxTests::testMultiPartDataParser()
         std::string fragment = data.substr(0, i);
         LOK_ASSERT_EQUAL_MESSAGE("At " << i << ": " << fragment
                                        << "\n----\nPart: " << multipartBody,
-                                 0L, multipart.readPart(fragment, multipartHeader, multipartBody));
+                                 int64_t(0), multipart.readPart(fragment, multipartHeader, multipartBody));
     }
 
     constexpr int64_t firstPartOffset = 435;
@@ -621,7 +621,7 @@ void HttpWhiteBoxTests::testMultiPartDataParser()
         std::string fragment = data.substr(firstPartOffset, i);
         LOK_ASSERT_EQUAL_MESSAGE("At " << i << ": " << fragment
                                        << "\n----\nPart: " << multipartBody,
-                                 0L, multipart.readPart(fragment, multipartHeader, multipartBody));
+                                 int64_t(0), multipart.readPart(fragment, multipartHeader, multipartBody));
     }
 
     // Parse the second part.

--- a/test/LoggingWhiteBoxTests.cpp
+++ b/test/LoggingWhiteBoxTests.cpp
@@ -15,6 +15,8 @@
 
 #include <config.h>
 
+#include <unistd.h>
+
 #include <common/Log.hpp>
 #include <common/Util.hpp>
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -396,7 +396,7 @@ CLEANUP_COMMAND=if test -s ../coolwsd; then echo "Cleaning up..." && ../coolwsd 
 if HAVE_LO_PATH
 check-local:
 	@$(CLEANUP_COMMAND)
-	@UNITTEST=1 ./fakesockettest 2> test.log || (cat test.log && /bin/false)
+	@UNITTEST=1 ./fakesockettest 2> test.log || (cat test.log && false)
 	@fc-cache "@LO_PATH@"/share/fonts/truetype
 	@echo "Done test check-local"
 
@@ -423,7 +423,7 @@ all-local: unittest
 	@echo "Test output is in `pwd`/test.log and is displayed on failure."
 	@echo
 	@fc-cache "@LO_PATH@"/share/fonts/truetype
-	@UNITTEST=1 ${top_builddir}/test/unittest --cert-path ${abs_top_srcdir}/etc 2> test.log || (cat test.log && /bin/false)
+	@UNITTEST=1 ${top_builddir}/test/unittest --cert-path ${abs_top_srcdir}/etc 2> test.log || (cat test.log && false)
 	@echo "Done test all-local"
 	@$(CLEANUP_COMMAND)
 

--- a/test/NetUtilWhiteBoxTests.cpp
+++ b/test/NetUtilWhiteBoxTests.cpp
@@ -49,7 +49,7 @@ void NetUtilWhiteBoxTests::testBufferClass()
     Buffer buf;
     LOK_ASSERT_EQUAL(0UL, buf.size());
     LOK_ASSERT_EQUAL(true, buf.empty());
-    LOK_ASSERT_EQUAL(static_cast<const char*>(nullptr), buf.getBlock());
+    LOK_ASSERT(buf.getBlock() == nullptr);
     buf.eraseFirst(buf.size());
     LOK_ASSERT_EQUAL(0UL, buf.size());
     LOK_ASSERT_EQUAL(true, buf.empty());

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -961,7 +961,7 @@ std::shared_ptr<ChildProcess> getNewChild_Blocks(const std::shared_ptr<SocketPol
 #else // MOBILEAPP
     const auto timeout = std::chrono::hours(100);
 
-#if defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)
+#if MOBILEAPP
     assert(mobileAppDocId > 0 && "Unexpected to have no mobileAppDocId in the mobile build");
 #endif
 
@@ -1243,6 +1243,7 @@ void COOLWSD::requestTerminateSpareKits()
     }
 }
 
+#ifdef __linux__
 // Due to the possibility of enterMountingNS failing at an intermediate stage
 // after entering a usernamespace, but unable to enter a useful mounting namespace
 // do a test mount in another separate child whose failure don't affect the parent
@@ -1293,8 +1294,9 @@ bool COOLWSD::testMountingNSInFork()
     LOG_DBG("testMountingNSInFork status: " << std::hex << status << std::dec);
     return status == 1;
 }
+#endif // __linux__
 
-void COOLWSD::setupChildRoot(const bool UseMountNamespaces)
+void COOLWSD::setupChildRoot([[maybe_unused]] const bool UseMountNamespaces)
 {
     JailUtil::disableBindMounting(); // Default to assume failure
     JailUtil::disableMountNamespaces();
@@ -1313,6 +1315,7 @@ void COOLWSD::setupChildRoot(const bool UseMountNamespaces)
         // Do the setup in a fork so we have no other threads running which
         // disrupt creation of linux namespaces
 
+#ifdef __linux__
         if (UseMountNamespaces)
         {
             // setupChildRoot does a test bind mount + umount to see if that fully works
@@ -1329,6 +1332,7 @@ void COOLWSD::setupChildRoot(const bool UseMountNamespaces)
             else
                 LOG_ERR("creating usernamespace for mount user failed.");
         }
+#endif // __linux__
 
         // Setup the jails.
         JailUtil::cleanupJails(CleanupChildRoot);
@@ -3719,8 +3723,10 @@ void COOLWSD::innerMain()
     remoteConfigThread->start();
 #endif
 
-#if !defined(IOS) && !defined(MACOS) && !defined(_WIN32) && !defined(QTAPP)
+#if !(MOBILEAPP && (defined(IOS) || defined(MACOS) || defined(_WIN32) || defined(QTAPP)))
     // Force a uniform UTF-8 locale for ourselves & our children.
+    // CODA apps (IOS, MACOS, _WIN32, QTAPP) handle locale themselves,
+    // but Android, WASM, and server builds need this.
     char* locale = std::setlocale(LC_ALL, "C.UTF-8");
     if (!locale)
     {
@@ -3735,7 +3741,7 @@ void COOLWSD::innerMain()
         LOG_INF("Locale is set to " << std::string(locale));
         ::setenv("LC_ALL", locale, 1);
     }
-#endif // !IOS && !MACOS && !_WIN32 && !QTAPP
+#endif
 
 #if !MOBILEAPP
     // We use the same option set for both parent and child coolwsd,

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1915,6 +1915,9 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
     bool UseMountNamespaces = true;
 
     NoCapsForKit = Util::isKitInProcess() ||
+#if !HAVE_LIBCAP
+                   true ||
+#endif
                    !ConfigUtil::getConfigValue<bool>(conf, "security.capabilities", true);
     if (NoCapsForKit && UseMountNamespaces)
     {
@@ -2080,6 +2083,9 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
     NoSeccomp =
         Util::isKitInProcess() || !ConfigUtil::getConfigValue<bool>(conf, "security.seccomp", true);
     NoCapsForKit = Util::isKitInProcess() ||
+#if !HAVE_LIBCAP
+                   true ||
+#endif
                    !ConfigUtil::getConfigValue<bool>(conf, "security.capabilities", true);
     AdminEnabled = ConfigUtil::getConfigValue<bool>(conf, "admin_console.enable", true);
     IndirectionServerEnabled =

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -234,7 +234,7 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
 
     if constexpr (!Util::isMobileApp())
         assert(_mobileAppDocId == 0 && "Unexpected to have mobileAppDocId in the non-mobile build");
-#if defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)
+#if MOBILEAPP
     assert(_mobileAppDocId > 0 && "Unexpected to have no mobileAppDocId in a mobile app");
 #endif
 

--- a/wsd/PlatformUnix.hpp
+++ b/wsd/PlatformUnix.hpp
@@ -15,8 +15,8 @@
 
 #pragma once
 
-// macOS can be both server and mobile, so let's include it here, too
-#if defined(MACOS)
+// macOS can be both server and mobile; macos.h is only for the MOBILEAPP case
+#if defined(MACOS) && MOBILEAPP
 #include "macos.h"
 #endif
 


### PR DESCRIPTION
- **macOS: allow configure to work for server builds**
- **Move endian.h include inside ENABLE_SIMD guard**
- **macOS: guard Linux-specific cgroup functions with __linux__**
- **macOS: fix MOBILEAPP vs platform guards for server builds**
- **macOS: add missing unistd.h include in LoggingWhiteBoxTests**
- **macOS: fix int64_t vs long type mismatches in HTTP tests**
- **macOS: fix nullptr const char* streaming crash in Buffer test**
- **macOS: use bare false instead of /bin/false in test Makefile**
- **macOS: skip capability check in haveCorrectCapabilities**
- **macOS: force NoCapsForKit when libcap is not available**
- **macOS: enable backtrace in signal handler**
