### PR TITLE
browser: a11y: fix shortcut for invisible button

### DIFF
--- a/browser/src/dom/NotebookbarAccessibilityDefinitions.js
+++ b/browser/src/dom/NotebookbarAccessibilityDefinitions.js
@@ -158,10 +158,11 @@ var NotebookbarAccessibilityDefinitions = function() {
 			if (!element)
 			{
 				const button = document.querySelector('[modelid="'+ toolOption.id + '"] .unobutton');
-				toolOption.id = button ? button.id : toolOption.id + '-button';
+				toolOption.id = button && button.checkVisibility() ? button.id : toolOption.id + '-button';
 			}
-			else
+			else if (element.checkVisibility()) {
 				toolOption.id += '-button';
+			}
 
 			selectedDefinitions[toolOption.id] = {
 				focusBack : toolOption.accessibility.focusBack,


### PR DESCRIPTION
Some CSS custom properties set the share button's
display to none, so check visibility before adding
an accessibility shortcut.

Change-Id: Ia3a401e781bbcd9bd839ff1dadf1e4afbf576065
Signed-off-by: Henry Castro <hcastro@collabora.com>
