### PR TITLE
Forced-colors: add selector for close widget

### DIFF
--- a/browser/css/forced-colors.css
+++ b/browser/css/forced-colors.css
@@ -25,7 +25,8 @@
 	.document-logo,
 	.ui-tabs-content .unobutton > img,
 	.unotoolbutton.notebookbar .unobutton > img,
-	.unotoolbutton.notebookbar .unobutton {
+	.unotoolbutton.notebookbar .unobutton, 
+	.lokdialog_container .ui-dialog-titlebar-close {
 		forced-color-adjust: none;
 		background-color: #e9e9ed !important;
 	}
@@ -100,7 +101,8 @@
 	[data-theme='dark'] .unotoolbutton.notebookbar .unobutton > img,
 	[data-theme='dark'] .unotoolbutton.notebookbar .unobutton,
 	[data-theme='dark'] .StyleListPanel #TemplatePanel [id] button,
-	[data-theme='dark'] .ui-overflow-group-popup .unobutton > img {
+	[data-theme='dark'] .ui-overflow-group-popup .unobutton > img,
+	[data-theme='dark'] .lokdialog_container .ui-dialog-titlebar-close {
 		background-color: #1E1E1E !important;
 	}
 


### PR DESCRIPTION
Change-Id: I26d81ba78c363ef6c287dd25bf3ecd79f7c9bf9e


* Resolves: # <!-- related github issue -->
* Target version: main

### PREVIEW

<img width="764" height="149" alt="2026-03-04_05-26" src="https://github.com/user-attachments/assets/53795579-bf8a-4f98-8b6f-2ee51167ccd1" />





