### PR TITLE
cypress: test multi-selection in Calc cell function status bar menu

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/statusbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/statusbar_spec.js
@@ -64,6 +64,40 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Statubar tests.', function
 		cy.cGet('.ui-combobox-entry.selected').contains(/Average|Sum/g);
 	});
 
+	it('Cell function menu multi-selection.', function() {
+		cy.viewport(1280, 720);
+		helper.typeIntoInputField(helper.addressInputSelector, 'A1:A2');
+		cy.cGet('#StateTableCell').should('have.text', 'Average: 15.5; Sum: 31');
+
+		// Default state: Average and Sum are selected
+		desktopHelper.makeZoomItemsVisible();
+		cy.cGet('#StateTableCellMenu .unolabel').contains('Average; Sum');
+
+		// Toggle on Maximum — should add it to the selection
+		cy.cGet('#StateTableCellMenu .arrowbackground').click();
+		cy.cGet('.jsdialog-overlay').should('exist');
+		cy.cGet('body').contains('.ui-combobox-entry', 'Maximum').click();
+		cy.cGet('#StateTableCellMenu .unolabel').contains('Maximum');
+		cy.cGet('#StateTableCell').should('contain.text', 'Max: 21');
+		// Average and Sum should still be there
+		cy.cGet('#StateTableCell').should('contain.text', 'Average: 15.5');
+		cy.cGet('#StateTableCell').should('contain.text', 'Sum: 31');
+
+		// Toggle off Average — should remove it from the selection
+		cy.cGet('#StateTableCellMenu .arrowbackground').click();
+		cy.cGet('.jsdialog-overlay').should('exist');
+		cy.cGet('body').contains('.ui-combobox-entry', 'Average').click();
+		cy.cGet('#StateTableCell').should('not.contain.text', 'Average');
+		cy.cGet('#StateTableCell').should('contain.text', 'Max: 21');
+		cy.cGet('#StateTableCell').should('contain.text', 'Sum: 31');
+
+		// Click None — should clear all selections
+		cy.cGet('#StateTableCellMenu .arrowbackground').click();
+		cy.cGet('.jsdialog-overlay').should('exist');
+		cy.cGet('body').contains('.ui-combobox-entry', 'None').click();
+		cy.cGet('#StateTableCellMenu .unolabel').contains('None');
+	});
+
 	it('Change zoom level.', function() {
 		desktopHelper.resetZoomLevel();
 		desktopHelper.shouldHaveZoomLevel('100');


### PR DESCRIPTION
Verify that the status bar cell function menu supports toggling multiple functions (add Maximum, remove Average) and that clicking 'None' clears all selections.

Change-Id: I7f3b2a1c8e5d4f6b9a0c3e2d1f8a7b6c5d4e3f2

