### PR TITLE
Issue: Tile refreshing problem upon switching to other browser tabs.

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -490,6 +490,8 @@ class TileManager {
 				this.pausedForCoherency = false;
 			}
 			app.sectionContainer.deferDrawing(null);
+			// Ensure that requestReDraw is called at least once. It may not get called in tileReady function.
+			app.sectionContainer.requestReDraw();
 		}
 
 		if (this.nPendingWorkerTasks === 0)
@@ -940,6 +942,15 @@ class TileManager {
 	}
 
 	private static rehydrateCurrentTiles() {
+		// Clear the deferred callback immediately. This function is a one-shot
+		// callback that drains dehydratedCurrentTiles; keeping it registered
+		// causes every subsequent requestReDraw() to invoke it instead of
+		// scheduling a requestAnimationFrame, which freezes the canvas.
+		// Drawing is paused via pauseDrawing()/resumeDrawing() inside
+		// rehydrateTile() until worker bitmaps arrive, so clearing the
+		// callback here does not cause premature draws.
+		app.sectionContainer.deferDrawing(null);
+
 		// If the graphics memory of visible tiles was reclaimed, we have tiles that
 		// have a valid delta cache, but no corresponding bitmap.
 		this.beginTransaction();

--- a/browser/src/app/ViewLayoutMultiPage.ts
+++ b/browser/src/app/ViewLayoutMultiPage.ts
@@ -236,7 +236,9 @@ class ViewLayoutMultiPage extends ViewLayoutNewBase {
 		this.sendClientVisibleArea();
 
 		this.refreshCurrentCoordList();
+		TileManager.beginTransaction();
 		TileManager.checkRequestTiles(this.currentCoordList);
+		TileManager.endTransaction(null);
 
 		// We most likely scrolled the view. We also need to check ruler position.
 		if (app.UI.horizontalRuler) app.UI.horizontalRuler._fixOffset();

--- a/browser/src/canvas/sections/TilesSection.ts
+++ b/browser/src/canvas/sections/TilesSection.ts
@@ -335,8 +335,6 @@ export class TilesSection extends CanvasSectionObject {
 	}
 
 	private drawForViewLayoutMultiPage() {
-		if (!app.activeDocument.activeLayout.areViewTilesReady()) return; // Draw after we have all the tiles.
-
 		const view = app.activeDocument.activeLayout as ViewLayoutMultiPage;
 
 		const visibleCoordList: Array<TileCoordData> = view.getCurrentCoordList();


### PR DESCRIPTION
Fixes:
    Tile refreshing mechanism already pauses drawing while working: Remove "areViewTilesReady" check from "drawForViewLayoutMultiPage".
    "getMissingTiles" function uses beginTransaction and endTransaction while checking the availability of the tiles. "checkRequestTiles" also needs to use the same convention, because "checkRequestTiles" also has calls to "rehydrateTile". Or the draw request may not be issued after tiles are ready.
    "rehydrateCurrentTiles" is assigned to deferDrawing call. It is expected to run only once. Undo the setting of deferDrawing as soon as rehydrateCurrentTiles function starts. So it guards against unexpected interruptions of draw calls. It doesn't have any effect on current logic.
    "endTransactionHandleBitmaps": Ensure that requestReDraw is called at least once. It may not get called in tileReady function.


Change-Id: I3bca62745e63aa6ee33d63c126834d3e7b385d04


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

