### PR TITLE
don't steal focus on launching integrator dialogs

### DIFF
--- a/browser/src/control/jsdialog/Widget.MenuButton.js
+++ b/browser/src/control/jsdialog/Widget.MenuButton.js
@@ -112,7 +112,8 @@ function _menubuttonControl (parentContainer, data, builder) {
 					return true;
 				} else if (eventType === 'selected' && entry && entry.action) {
 					app.dispatcher.dispatch(entry.action);
-					JSDialog.CloseDropdown(dropdownId);
+					const opensExternal = entry.action.startsWith('exportas-') || entry.action.startsWith('saveas-');
+					JSDialog.CloseDropdown(dropdownId, opensExternal);
 					return true;
 				} else if (eventType === 'selected' && entry && entry.id) {
 					builder.callback('menubutton', 'select', control.container, entry.id, builder);


### PR DESCRIPTION
there is a race here and online might win again the intergator and steal focus away from those dialogs, so don't take focus on saveas- and exportas-


Change-Id: Ic43518df483917d6f65343544e1bda7f0868e842


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

