### PR TITLE
Add Action_ResolveComment PostMessage

### DIFF
--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -787,6 +787,17 @@ window.L.Map.WOPI = window.L.Handler.extend({
 			var list = msg.Values.list;
 			this._map.mention.openMentionPopup(list);
 		}
+		else if (msg.MessageId === 'Action_ResolveComment') {
+			if (msg.Values) {
+				const commentSection = app.sectionContainer.getSectionWithName(app.CSections.CommentList.name);
+				if (commentSection) {
+					const comment = commentSection.getComment(msg.Values.Id);
+					if (comment && comment.sectionProperties.data.resolved !== 'true') {
+						commentSection.resolve(comment);
+					}
+				}
+			}
+		}
 		else if (msg.sender === 'EIDEASY_SINGLE_METHOD_SIGNATURE') {
 			// This is produced by the esign popup.
 			const eSignature = this._map.eSignature;

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -78,6 +78,25 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 		});
 	});
 
+	it('Action_ResolveComment postMessage resolves a comment', function() {
+		desktopHelper.insertComment();
+
+		cy.cGet('.cool-annotation-content-wrapper').should('be.visible');
+		cy.cGet('.cool-annotation-content-resolved').should('have.text', '');
+
+		// Send Action_ResolveComment postMessage with the comment's Id
+		cy.getFrameWindow().then(win => {
+			const message = {
+				'MessageId': 'Action_ResolveComment',
+				'Values': {'Id': '1'}
+			};
+			win.postMessage(JSON.stringify(message), '*');
+		});
+
+		// The comment should now show as resolved
+		cy.cGet('.cool-annotation-content-resolved').should('have.text', 'Resolved');
+	});
+
 	it('Toggle Resolved/Unresolved', function() {
 		desktopHelper.insertComment("unresolved comment", true);
 		cy.cGet('#comment-container-1').should('exist');


### PR DESCRIPTION
With this message sent from a WOPI host, it is possible to specify
which comment (identified by Id) to resolve.

The Id matches the Id sent in Clicked_Comment notification message.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I8ce6796bb4822d09f634a5bf2087bede58b759a3
