### PR TITLE
Mark user-facing UI strings for translation

### DIFF
--- a/browser/src/control/Control.AboutDialog.ts
+++ b/browser/src/control/Control.AboutDialog.ts
@@ -424,7 +424,7 @@ class AboutDialog {
 	private contentHasBeenCopiedShowSnackbar() {
 		const timeout = 1000;
 		this.map.uiManager.showSnackbar(
-			'Version information has been copied',
+			_('Version information has been copied'),
 			null,
 			null,
 			timeout,

--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -1525,7 +1525,7 @@ window.L.Control.Zotero = window.L.Control.extend({
 		}
 		this.map.sendUnoCommand(command, parametes, true);
 		this.resetCitation();
-		this.map.uiManager.showSnackbar('Unlinked citations');
+		this.map.uiManager.showSnackbar(_('Unlinked citations'));
 	},
 
 	unlinkCitations: function() {

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -1466,7 +1466,7 @@ window.L.Clipboard = window.L.Class.extend({
 		else {
 			const ctrlText = app.util.replaceCtrlAltInMac('Ctrl');
 			const p = document.createElement('p');
-			p.textContent = 'Your browser has very limited access to the clipboard, so use these keyboard shortcuts:';
+			p.textContent = _('Your browser has very limited access to the clipboard, so use these keyboard shortcuts:');
 			innerDiv.appendChild(p);
 
 			const table = document.createElement('table');
@@ -1500,7 +1500,7 @@ window.L.Clipboard = window.L.Class.extend({
 			table.appendChild(row);
 			for (let i = 0; i < 3; i++) {
 				const cell = document.createElement('td');
-				cell.textContent = i === 0 ? 'Copy': (i === 1 ? 'Cut': 'Paste');
+				cell.textContent = i === 0 ? _('Copy'): (i === 1 ? _('Cut'): _('Paste'));
 				row.appendChild(cell);
 			}
 		}

--- a/browser/src/map/handler/Map.SlideShow.js
+++ b/browser/src/map/handler/Map.SlideShow.js
@@ -57,7 +57,7 @@ window.L.Map.SlideShow = window.L.Handler.extend({
 
 		if (app.impress.areAllSlidesHidden()) {
 			this._map.uiManager.showInfoModal('allslidehidden-modal', _('Empty Slide Show'),
-					'All slides are hidden!', '', _('OK'), function () { }, false, 'allslidehidden-modal-response');
+					_('All slides are hidden!'), '', _('OK'), function () { }, false, 'allslidehidden-modal-response');
 			return;
 		}
 

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -1248,7 +1248,7 @@ class SlideShowPresenter {
 		this._map.uiManager.showInfoModal(
 			'allslidehidden-modal',
 			_('Empty Slide Show'),
-			'All slides are hidden!',
+			_('All slides are hidden!'),
 			'',
 			_('OK'),
 			() => {


### PR DESCRIPTION
Wrap several untranslated UI strings with _() so they can be localized: snackbar messages in About dialog and Zotero, modal dialog text for hidden slides, and clipboard warning dialog text including Copy/Cut/Paste labels.


Change-Id: I68bc393f53c4134c6b3360dc768e2a58272fb58d

