### PR TITLE
Remove the non-zstdslidelayer path for slideshows

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2518,11 +2518,8 @@ bool ChildSession::renderNextSlideLayer(SlideCompressor& scomp, const unsigned w
             std::string json = jsonMsg;
             Poco::JSON::Parser parser;
             Poco::JSON::Object::Ptr root = parser.parse(json).extract<Poco::JSON::Object::Ptr>();
-            if (EnableExperimental)
-            {
-                root->set("cacheKey", cacheKey);
-                root->set("isCompressed", isCompressed);
-             }
+            root->set("cacheKey", cacheKey);
+            root->set("isCompressed", isCompressed);
 
             json = JsonUtil::jsonToString(root);
 
@@ -2557,71 +2554,45 @@ bool ChildSession::renderNextSlideLayer(SlideCompressor& scomp, const unsigned w
             if (size_t start = json.find("%IMAGECHECKSUM%"); start != std::string::npos)
                 json.replace(start, 15, std::to_string(pixmapHash));
 
-            if (EnableExperimental) // ZSTD
+            // Use ZSTD to compress the slide layer
+            if (size_t start = json.find("%IMAGETYPE%"); start != std::string::npos)
+                json.replace(start, 11, "zstd");
+
+            root = parser.parse(json).extract<Poco::JSON::Object::Ptr>();
+            root->set("width", width);
+            root->set("height", height);
+            json = JsonUtil::jsonToString(root);
+
+            std::string response = "zstdslidelayer: " + json;
+
+            response += "\n";
+
+            size_t compressed_max_size = ZSTD_COMPRESSBOUND(pixmap->size());
+            size_t max_required_size = response.size() + compressed_max_size;
+            output.resize(max_required_size);
+            std::memcpy(output.data(), response.data(), response.size());
+
+            if (tileMode == LibreOfficeKitTileMode::LOK_TILEMODE_BGRA)
             {
-                if (size_t start = json.find("%IMAGETYPE%"); start != std::string::npos)
-                    json.replace(start, 11, "zstd");
-
-                {
-                    root = parser.parse(json).extract<Poco::JSON::Object::Ptr>();
-                    root->set("width", width);
-                    root->set("height", height);
-                    json = JsonUtil::jsonToString(root);
-                }
-
-                std::string response = "zstdslidelayer: " + json;
-
-                response += "\n";
-
-                size_t compressed_max_size = ZSTD_COMPRESSBOUND(pixmap->size());
-                size_t max_required_size = response.size() + compressed_max_size;
-                output.resize(max_required_size);
-                std::memcpy(output.data(), response.data(), response.size());
-                std::vector<char> compressedOutPut;
-                compressedOutPut.resize(ZSTD_COMPRESSBOUND(pixmap->size()));
-
-                if (tileMode == LibreOfficeKitTileMode::LOK_TILEMODE_BGRA)
-                {
-                    png_row_info rowInfo;
-                    rowInfo.rowbytes = pixmap->size();
-                    // Following function just needs row size to transform from BGRA to RGBA
-                    // We have a flat array so its safe to pass pixmap size as row size
-                    Png::unpremultiply_bgra_data(nullptr, &rowInfo, pixmap->data());
-                }
-                size_t compSize = ZSTD_compress(&output[response.size()], compressed_max_size,
-                                                pixmap->data(), pixmap->size(), -3);
-
-                if (ZSTD_isError(compSize))
-                {
-                    output.resize(0);
-                    LOG_ERR("Failed to compress slidelayer of size " << pixmap->size() << " with "
-                                                                    << ZSTD_getErrorName(compSize));
-                    return;
-                }
-                output.resize(response.size() + compSize);
-
-                LOG_TRC("Compressed slidelayer of size " << pixmap->size() << " to size " << compSize);
+                png_row_info rowInfo;
+                rowInfo.rowbytes = pixmap->size();
+                // Following function just needs row size to transform from BGRA to RGBA
+                // We have a flat array so its safe to pass pixmap size as row size
+                Png::unpremultiply_bgra_data(nullptr, &rowInfo, pixmap->data());
             }
-            else // PNG
+            size_t compSize = ZSTD_compress(&output[response.size()], compressed_max_size,
+                                            pixmap->data(), pixmap->size(), -3);
+
+            if (ZSTD_isError(compSize))
             {
-                if (size_t start = json.find("%IMAGETYPE%"); start != std::string::npos)
-                    json.replace(start, 11, "png");
-
-                std::string response = "slidelayer: " + json;
-
-                response += "\n";
-
-                output.reserve(response.size() + pixmap->size());
-                output.resize(response.size());
-
-                std::memcpy(output.data(), response.data(), response.size());
-
-                if (!Png::encodeSubBufferToPNG(pixmap->data(), 0, 0, width, height, width, height, output, tileMode))
-                {
-                    LOG_ERR("Failed to encode into PNG.");
-                    output.resize(0);
-                }
+                output.resize(0);
+                LOG_ERR("Failed to compress slidelayer of size " << pixmap->size() << " with "
+                                                                << ZSTD_getErrorName(compSize));
+                return;
             }
+            output.resize(response.size() + compSize);
+
+            LOG_TRC("Compressed slidelayer of size " << pixmap->size() << " to size " << compSize);
         });
     return true;
 }


### PR DESCRIPTION
Previously, the experimental flag needed to be set to use the zstd path for slideshows. This commit removes the flag gate and the old PNG path.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

