### PR TITLE
Context menu add clipboard sectiona #14519

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -462,14 +462,16 @@ button.leaflet-control-search-next
 #toolbar-up .ui-combobox-button {
 	padding-left: 10px;
 }
-#toolbar-up #fontnamecombobox {
+#toolbar-up #fontnamecombobox,
+#fontnamecombobox.ui-combobox.notebookbar {
 	width: 170px;
 	max-width: 170px;
 	margin: auto 5px;
 }
-#toolbar-up #fontsizecombobox {
+#toolbar-up #fontsizecombobox,
+#fontsizecombobox.ui-combobox {
 	min-width: 90px;
-	width: 90px;
+	width: 112px;
 	margin: auto 4px;
 }
 #fontsizecombobox-dropdown .ui-grid {

--- a/browser/src/control/Control.ContextToolbar.ts
+++ b/browser/src/control/Control.ContextToolbar.ts
@@ -169,6 +169,53 @@ class ContextToolbar extends JSDialogComponent {
 						type: 'container',
 						children: [
 							{
+								id: 'home-cut',
+								type: 'toolitem',
+								text: _UNO('.uno:Cut'),
+								command: '.uno:Cut',
+							} as ToolItemWidgetJSON,
+							{
+								id: 'home-format-paintbrush',
+								type: 'toolitem',
+								text: _UNO('.uno:FormatPaintbrush'),
+								command: '.uno:FormatPaintbrush',
+							} as ToolItemWidgetJSON,
+						],
+						vertical: false,
+					} as ContainerWidgetJSON,
+					{
+						type: 'container',
+						children: [
+							{
+								id: 'home-copy',
+								type: 'toolitem',
+								text: _UNO('.uno:copy'),
+								command: '.uno:copy',
+							} as ToolItemWidgetJSON,
+							{
+								id: 'home-reset-attributes',
+								type: 'toolitem',
+								text: _UNO('.uno:ResetAttributes'),
+								command: '.uno:ResetAttributes',
+							} as ToolItemWidgetJSON,
+						],
+						vertical: false,
+					} as ContainerWidgetJSON,
+				],
+				vertical: true,
+			} as ContainerWidgetJSON,
+			{
+				type: 'separator',
+				id: 'home-fontcombobox-break',
+				orientation: 'vertical',
+			} as SeparatorWidgetJSON,
+			{
+				type: 'container',
+				children: [
+					{
+						type: 'container',
+						children: [
+							{
 								id: 'fontnamecombobox',
 								type: 'combobox',
 								text: currentFontName,
@@ -285,7 +332,7 @@ class ContextToolbar extends JSDialogComponent {
 			} as ContainerWidgetJSON,
 			{
 				type: 'separator',
-				id: 'home-fontcombobox-break',
+				id: 'home-paragraph',
 				orientation: 'vertical',
 			} as SeparatorWidgetJSON,
 			{


### PR DESCRIPTION
Change-Id: I04449535880307c0058d01e7da156ae8bed6f5da


* Resolves: #14519 
* Target version: main

### Summary

- Add clipboard commands to Context menu
- Fix width for #fontnamecombobox and #fontsizecombobox in the Context menu

<img width="1920" height="338" alt="image" src="https://github.com/user-attachments/assets/ecd3752b-c7c1-4f5b-a5e7-7b5181e2e4d1" />
