### PR TITLE
Hovering over large notebookbar buttons doesn't screenread in NVDA

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2186,6 +2186,7 @@ button.menubutton.sidebar > span {
 	right: var(--click-increment);
 	bottom: var(--click-increment);
 	left: var(--click-increment);
+	pointer-events: none;
 }
 
 /* targetting buttons inside of split button */

--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -321,6 +321,7 @@ html[data-theme='dark'] .savemodified.unotoolbutton:not(.notebookbar) .unobutton
 	right: var(--click-increment);
 	bottom: var(--click-increment);
 	left: var(--click-increment);
+	pointer-events: none;
 }
 
 .unotoolbutton.notebookbar.inline:hover {


### PR DESCRIPTION
There is no problem using tab/arrows to navigate to the buttons, then they are read out fine. But on hover, nothing is read on the large buttons like "Columns" or "Slect All" in the Labout tab.

It looks like these ::after things block nvda from seeing the underlying element. They certainly screen after this change on hover and didn't before:

The ::after rules were added in:

commit 74c819e4467fe567c9e6bd9fe8f39e0aef452d4e
Date:   Tue Sep 10 16:45:34 2024 +0200

    feat(UI): Improve split button styling


Change-Id: I8a16097b63ac3a4550754936358a9b389d871fba


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

