### PR TITLE
set an empty LOK_ALLOWED_EXTREF_PATHS for online server

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2313,6 +2313,10 @@ void COOLWSD::setLokitEnvironmentVariables(const Poco::Util::LayeredConfiguratio
         }
 #endif
     }
+
+#if !MOBILEAPP
+    setenv("LOK_ALLOWED_EXTREF_PATHS", "", true);
+#endif
 }
 
 void COOLWSD::initializeSSL()


### PR DESCRIPTION
There's currently nothing useful inside a jail that a user can link to from a document to that will be in a new jail the next time its opened.


Change-Id: I6cd466e249f5c64ca97e6d4e2da343d805c50288


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

