### PR TITLE
common, log: avoid invalid downcast on startup

### DIFF
--- a/common/Log-poco.cpp
+++ b/common/Log-poco.cpp
@@ -568,6 +568,11 @@ namespace Log
         if (IsShutdown)
             return false;
 
+        // Check if logger is properly initialized before calling logger()
+        // to avoid invalid downcast from Poco::Logger to GenericLogger.
+        if (!Static.getThreadLocalLogger() && !Static.getLogger())
+            return false;
+
         Log::Level logLevel = GenericLogger::mapToLevel(
             static_cast<Poco::Message::Priority>(logger().getLevel()));
 

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1472,7 +1472,6 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
     // Load view mode file extensions configuration
     COOLWSD::ViewModeFileExtensions = ConfigUtil::getConfigValue<std::string>(
         conf, "view_mode.file_extensions", "");
-    LOG_DBG_S("View mode extensions: [" << COOLWSD::ViewModeFileExtensions << ']');
 
     // Set the log-level after complete initialization to force maximum details at startup.
     LogLevel = ConfigUtil::getConfigValue<std::string>(conf, "logging.level", "trace");
@@ -1614,6 +1613,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
     std::ostringstream ossConfig;
     ossConfig << "Loaded config file [" << configFilePath << "] (non-default values):\n";
     ossConfig << ConfigUtil::getLoggableConfig(conf);
+    LOG_DBG_S("View mode extensions: [" << COOLWSD::ViewModeFileExtensions << ']');
 
     LoggableConfigEntries = ossConfig.str();
     LOG_INF(LoggableConfigEntries);


### PR DESCRIPTION
Run './coolwsd --disable-cool-user-checking --cleanup
--o:logging.level=trace' in an asan/ubsan environment, it results in:
common/Log-poco.cpp:521:16: runtime error: downcast of address 0x507000007250 which does not point to an object of type 'GenericLogger'
0x507000007250: note: object is of type 'Poco::Logger'

Seems this went wrong in commit 50e901fef7525831fc290a34b5d2923d9a54d229
(Add config option for default to View-Mode file extensions,
2026-03-03), which added LOG_DBG_S() in COOLWSD::innerInitialize(), way
before Log::initialize() is executed.

The problem was in Log::isEnabled(), which called logger() before the
logging system was initialized. When no logger is set, logger() called
GenericLogger::get() (which resolves to Poco::Logger::get()), which
returns a Poco::Logger, not a GenericLogger.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ia0a00ea0d9d935b5df2ec8fe7003fe07a8f14096
