### PR TITLE
Move settings around by file instead of in memory

### DIFF
--- a/test/TestWopiFileServer.hpp
+++ b/test/TestWopiFileServer.hpp
@@ -547,29 +547,24 @@ void handleSettingsRequest(const Poco::Net::HTTPRequest& request, const std::str
         FilePartHandler partHandler;
         Poco::Net::HTMLForm form(request, message, partHandler);
         const std::string& fileName = partHandler.getFileName();
-        const std::string& fileContent = partHandler.getFileContent();
+        const std::string& uploadedFilePath = partHandler.getFilePath();
 
-        if (fileName.empty() || fileContent.empty())
+        if (fileName.empty() || uploadedFilePath.empty())
         {
             http::Response httpResponse(http::StatusCode::BadRequest);
             socket->send(httpResponse);
             LOG_ERR("No valid file uploaded.");
         }
 
-        LOG_INF("File uploaded: " << fileName << ", Size: " << fileContent.size() << " bytes");
+        LOG_INF("File uploaded: " << fileName << " from [" << uploadedFilePath << ']');
 
-        std::streamsize size = fileContent.size();
-
-        std::ofstream outfile;
         // TODO: hardcoded save to shared directory, add support for user directory
         // when adminIntegratorSettings allow it
         const std::string testSharedDir = "test/data/presets/shared";
         Poco::File(testSharedDir).createDirectories();
         LOG_DBG("Saving uploaded file[" << fileName << "] to directory[" << testSharedDir << ']');
 
-        outfile.open(testSharedDir + '/' + fileName, std::ofstream::binary);
-        outfile.write(fileContent.data(), size);
-        outfile.close();
+        FileUtil::copyFileTo(uploadedFilePath, testSharedDir + '/' + fileName);
 
         std::string timestamp = Util::getIso8601FracformatTime(std::chrono::system_clock::now());
         std::string body = R"({"LastModifiedTime": ")" + timestamp + "\" }";

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -24,6 +24,7 @@
 #include <common/ConfigUtil.hpp>
 #include <common/Crypto.hpp>
 #include <common/FileUtil.hpp>
+#include <common/JailUtil.hpp>
 #include <common/JsonUtil.hpp>
 #include <common/LangUtil.hpp>
 #include <common/Log.hpp>
@@ -1594,9 +1595,24 @@ void FilePartHandler::handlePart(const Poco::Net::MessageHeader& header, std::is
             if (endPos != std::string::npos)
                 _fileName = _fileName.substr(0, endPos);
 
-            std::ostringstream oss;
-            Poco::StreamCopier::copyStream(stream, oss);
-            _fileContent = oss.str();
+            std::string dirPath = FileUtil::createRandomTmpDir(
+                COOLWSD::ChildRoot + JailUtil::CHILDROOT_TMP_INCOMING_PATH) + '/';
+            _filePath = dirPath + "upload";
+
+            std::ofstream fileStream;
+            fileStream.open(_filePath, std::ios::binary);
+            if (fileStream.good())
+            {
+                Poco::StreamCopier::copyStream(stream, fileStream);
+                fileStream.close();
+                _fileDir = std::make_shared<FileUtil::OwnedFile>(std::move(dirPath), true);
+            }
+            else
+            {
+                LOG_ERR("Unable to open [" << _filePath << "] for FilePartHandler streaming");
+                _filePath.clear();
+                FileUtil::removeFile(dirPath);
+            }
         }
     }
 }
@@ -1838,8 +1854,8 @@ void FileServerRequestHandler::uploadFileToIntegrator(const Poco::Net::HTTPReque
 
     const std::string& shortMessage = "Failed to upload preset file.";
     const std::string& fileName = partHandler.getFileName();
-    const std::string& fileContent = partHandler.getFileContent();
-    if (fileName.empty() || fileContent.empty())
+    const std::string& uploadedFilePath = partHandler.getFilePath();
+    if (fileName.empty() || uploadedFilePath.empty())
     {
         sendError(http::StatusCode::BadRequest, getRequestPath(request), socket, shortMessage,
                   "No valid file uploaded.");
@@ -1874,15 +1890,17 @@ void FileServerRequestHandler::uploadFileToIntegrator(const Poco::Net::HTTPReque
     httpRequest.setVerb(http::Request::VERB_POST);
 
     httpRequest.set("Content-Type", "application/octet-stream");
-    httpRequest.setBody(fileContent);
+    httpRequest.setBodyFile(uploadedFilePath);
 
     auto httpSession = StorageConnectionManager::getHttpSession(wopiUri);
 
     std::weak_ptr<StreamSocket> socketWeak(socket);
 
+    auto uploadedFileOwnership = partHandler.getFileOwnership();
+
     http::Session::FinishedCallback finishedCallback =
         [fileName, uriAnonym, socketWeak, requestPath = getRequestPath(request),
-         shortMessage](const std::shared_ptr<http::Session>& wopiSession)
+         shortMessage, uploadedFileOwnership](const std::shared_ptr<http::Session>& wopiSession)
     {
         std::shared_ptr<StreamSocket> destSocket = socketWeak.lock();
         if (!destSocket)

--- a/wsd/FileServer.hpp
+++ b/wsd/FileServer.hpp
@@ -18,6 +18,7 @@
 
 #include <COOLWSD.hpp>
 #include <ConfigUtil.hpp>
+#include <FileUtil.hpp>
 #include <HttpRequest.hpp>
 #include <Poco/Net/PartHandler.h>
 #include <Socket.hpp>
@@ -249,11 +250,17 @@ class FilePartHandler : public Poco::Net::PartHandler
 public:
     void handlePart(const Poco::Net::MessageHeader& header, std::istream& stream) override;
     const std::string& getFileName() const { return _fileName; }
-    const std::string& getFileContent() const { return _fileContent; }
+    const std::string& getFilePath() const { return _filePath; }
+    /// Take shared ownership of the temp dir (and file within it).
+    /// Caller keeps this alive until the file is no longer needed.
+    std::shared_ptr<FileUtil::OwnedFile> getFileOwnership() const { return _fileDir; }
 
 private:
     std::string _fileName;
-    std::string _fileContent;
+    /// Path to temp file containing the uploaded content.
+    std::string _filePath;
+    /// Temp directory holding the file, removed recursively on destruction.
+    std::shared_ptr<FileUtil::OwnedFile> _fileDir;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Change-Id: I98f8ff55ad58a751fcc8f5f24928d6f489a6e782


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

