### PR TITLE
windows: fix "access denied" when printing via PrintPDFAndDelete

### DIFF
--- a/windows/coda/PrintPDFAndDelete/PrintPDFAndDelete.cs
+++ b/windows/coda/PrintPDFAndDelete/PrintPDFAndDelete.cs
@@ -60,8 +60,11 @@ namespace PrintPDFAndDelete
 
         static private async Task<List<System.Drawing.Image>> PdfToImage(string path)
         {
-            var storagePdfFile = await Windows.Storage.StorageFile.GetFileFromPathAsync(path);
-            Windows.Data.Pdf.PdfDocument pdfDocument = await Windows.Data.Pdf.PdfDocument.LoadFromFileAsync(storagePdfFile);
+            // Use standard .NET file I/O instead of WinRT GetFileFromPathAsync
+            // to avoid file access broker "access denied" errors on temp files
+            using var fileStream = File.OpenRead(path);
+            using var randomAccessStream = fileStream.AsRandomAccessStream();
+            Windows.Data.Pdf.PdfDocument pdfDocument = await Windows.Data.Pdf.PdfDocument.LoadFromStreamAsync(randomAccessStream);
 
             uint index = 0;
             List<System.Drawing.Image> images = new List<System.Drawing.Image>();


### PR DESCRIPTION
The WinRT GetFileFromPathAsync API uses a file access broker that can deny access to temporary files created by other processes. Replace it with standard .NET File.OpenRead() + AsRandomAccessStream() and load the PDF via LoadFromStreamAsync instead of LoadFromFileAsync.


Change-Id: Id4e2d0d03cd9027e62d875333f9ae8354cfabbe2

It is supposed to solve this issue:

I just tried to print with Collabora Office Desktop. First, I had installed windowsdesktop-runtime-8.0.24-win-x64, no problem. But, after printing, this message appear in a Windows error window : " Error : Access to the path : c:\users\my.profile\AppData\Local\Temp\cool-UEOHpHdVaRzsPjoZ\p.pdf is denied.