### PR TITLE
Make Action_ResolveComment handler only try to resolve Writer comments

### DIFF
--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -788,7 +788,8 @@ window.L.Map.WOPI = window.L.Handler.extend({
 			this._map.mention.openMentionPopup(list);
 		}
 		else if (msg.MessageId === 'Action_ResolveComment') {
-			if (msg.Values) {
+			// Currently only Writer has "Resolve Comment" feature.
+			if (msg.Values && this._map._docLayer._docType === 'text') {
 				const commentSection = app.sectionContainer.getSectionWithName(app.CSections.CommentList.name);
 				if (commentSection) {
 					const comment = commentSection.getComment(msg.Values.Id);


### PR DESCRIPTION
Only Writer has this functionality, so don't send messages to modules
that can't handle them. Thanks vmiklos for noting that in
https://github.com/CollaboraOnline/online/pull/14841/changes#r2889939783

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I545ec9ccc7062844d2eba99d7a5efe9adf235d5d
