### PR TITLE
We use UTC in logging so no point in attempting to display the timezone

### DIFF
--- a/common/Log-windows.cpp
+++ b/common/Log-windows.cpp
@@ -35,7 +35,7 @@ void initialize(const std::string& name, const std::string& logLevel, const bool
     const std::time_t t = std::time(nullptr);
     struct tm tm;
     LOG_INF("Initializing " << name << ". UTC time: "
-                            << std::put_time(Util::time_t_to_gmtime(t, tm), "%a %F %T %z")
+                            << std::put_time(Util::time_t_to_gmtime(t, tm), "%a %F %T")
                             << ". Log level is [" << getLevelName() << ']');
 }
 


### PR DESCRIPTION
The struct tm does not contain any timezone information, so using %z in the format passed to std::put_time() will misleadingly use the actual current timezone even if the time being output is in UTC.

(If we do want to have a timezone field as before in the output we should hardcode +0000.)


Change-Id: Ia94cbbfa7b92623c76a28ab06d779d5b1ee4ec41


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

