### PR TITLE
Fix symlink creation for relative out-of-tree builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1875,11 +1875,23 @@ if test "$srcdir" != '.'; then
              as_fn_error $? "cannot create directory $dirname"
 
        rm -f "$dst_dir"
-       src_dir=$srcdir/$dst_dir
+       case $srcdir in
+         /*)
+           src_dir=$srcdir/$dst_dir
+           ;;
+         *)
+           dir=$(dirname "$dst_dir")
+           if test "$dir" = .; then
+             src_dir=$srcdir/$dst_dir
+           else
+             src_dir=$(printf %s "$dir" | sed -e 's|[[^/]]*|..|g')/$srcdir/$dst_dir
+           fi
+           ;;
+       esac
        echo "linking $src_dir to $dst_dir"
        ln -s "$src_dir" "$dst_dir" 2>/dev/null ||
           ln "$src_dir" "$dst_dir" 2>/dev/null ||
-             cp -p "$src_dir" "$dst_dir" ||
+             cp -p "$srcdir/$dst_dir" "$dst_dir" ||
                 as_fn_error $? "cannot link or copy $src_dir to $dst_dir"
    done
 fi])


### PR DESCRIPTION
...where a relative `../online/configure` had left broken symlinks like

> browser/node_shrinkpack -> ../online/browser/node_shrinkpack

instead of the correct

> browser/node_shrinkpack -> ../../online/browser/node_shrinkpack


Change-Id: I67a8cd8ae91e6ba4ec1e30003add03cadb2d7659


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

