### PR TITLE
browser: devX: type app.map and fix all errors

### DIFF
--- a/browser/src/app/A11yValidator.ts
+++ b/browser/src/app/A11yValidator.ts
@@ -348,7 +348,9 @@ class A11yValidator {
 			return;
 		}
 
-		const errorCount = this.validateContainer(currentSidebar.container);
+		const container = currentSidebar.getContainer();
+		Util.ensureValue(container);
+		const errorCount = this.validateContainer(container);
 
 		if (errorCount === 0) {
 			console.error('A11yValidator: sidebar passed all checks');

--- a/browser/src/app/Debug.ts
+++ b/browser/src/app/Debug.ts
@@ -61,14 +61,14 @@ class DebugManager {
 
 	private tileOverlaysOn: boolean;
 
-	private tileInvalidationsOn: boolean;
+	public tileInvalidationsOn: boolean;
 	private _tileInvalidationMessages: Map<number, string>;
 	private _tileInvalidationId: number;
 	private _tileInvalidationKeypressQueue: number[];
 	private _tileInvalidationKeypressTimes: DebugTimeArray;
 	private _tileInvalidationTimeoutId: TimeoutHdl;
 
-	private tileDataOn: boolean;
+	public tileDataOn: boolean;
 	private _tileDataTotalMessages: number;
 	private _tileDataTotalLoads: number;
 	private _tileDataTotalUpdates: number;

--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -2127,7 +2127,8 @@ class TileManager {
 					tile.updateCount++;
 					this.nullDeltaUpdate++;
 					if (app.map._docLayer._emptyDeltaDiv) {
-						app.map._docLayer._emptyDeltaDiv.innerText = this.nullDeltaUpdate;
+						app.map._docLayer._emptyDeltaDiv.innerText =
+							this.nullDeltaUpdate.toString();
 					}
 					if (app.map._debug.tileDataOn) {
 						app.map._debug.tileDataAddUpdate();

--- a/browser/src/app/iface/Clipboard.Interface.ts
+++ b/browser/src/app/iface/Clipboard.Interface.ts
@@ -1,3 +1,5 @@
 interface ClipboardInterface {
 	setKey(key: string): void;
+	onComplexSelection(text?: string): void;
+	[key: string]: any;
 }

--- a/browser/src/app/iface/DocLayer.Interface.ts
+++ b/browser/src/app/iface/DocLayer.Interface.ts
@@ -17,7 +17,15 @@ interface PainterInterface {
 	_removeSplitsSection(): void;
 	_addDebugOverlaySection(): void;
 	_removeDebugOverlaySection(): void;
+	_paintContext(): {
+		viewBounds: cool.Bounds;
+		paneBoundsList: cool.Bounds[];
+		paneBoundsActive: boolean;
+		splitPos: cool.Point;
+	};
 }
+
+type MapUpdaterType = (newMapCenterLatLng: LatLngLike) => void;
 
 interface DocLayerInterface {
 	_toolbarCommandValues: any;
@@ -32,7 +40,7 @@ interface DocLayerInterface {
 	isCalcRTL(): boolean;
 
 	_pixelsToTwips(cssPix: cool.PointLike): cool.PointLike;
-	_latLngToTwips(latlng: { lat: number; lng: number }): cool.Point;
+	_latLngToTwips(latlng: LatLngLike): cool.Point;
 
 	_postMouseEvent(
 		typ: string,
@@ -58,4 +66,71 @@ interface DocLayerInterface {
 	options: {
 		tileWidthTwips: number;
 	};
+
+	sheetGeometry?: cool.SheetGeometry;
+	_cellSelectionArea?: cool.SimpleRectangle;
+	scrollToPos(pos: { x: number; y: number } | LatLngLike): void;
+
+	_selectedPart: number;
+	_oleCSelections: CSelections;
+	_shapeGridOffset: cool.SimplePoint;
+	getFiledBasedViewVerticalOffset(): number;
+	focus(acceptInput?: boolean): void;
+	_updateCursorAndOverlay(): void;
+	_twipsToPixels(twips: cool.Point): cool.Point;
+	_allowViewJump(): boolean;
+	_selectionContentRequest?: TimeoutHdl;
+	recalculateZoomOnResize(): void;
+	_splitPanesContext?: cool.SplitPanesContext;
+	getSplitPanesContext(): cool.SplitPanesContext | undefined;
+	_moveInProgress: boolean;
+	_moveTileRequests: string[];
+	_debug: DebugManager;
+	_canonicalIdInitialized: boolean;
+	_gotFirstCellCursor?: boolean;
+	_sendClientZoom(forceUpdate?: boolean): void;
+	_emptyDeltaDiv?: HTMLDivElement;
+	_partHeightTwips: number;
+	_isZooming: boolean;
+	_spaceBetweenParts: number;
+	_partWidthTwips: number;
+	_parts: number;
+	_fitWidthZoom(
+		e?: { oldSize: number; newsize: number },
+		maxZoom?: number,
+		recalcFirstFit?: boolean,
+	): void;
+	_corePixelsToTwips(corePixels: { x: number; y: number }): cool.Point;
+	// Is this still in user?
+	_ySplitter: any;
+	_xSplitter: any;
+	_cursorMarker?: Cursor;
+	_syncTileContainerSize(force?: boolean): boolean;
+	_postSelectTextEvent(type: string, x: number, y: number): void;
+	_viewId: number;
+	_openCommentWizard(annotation?: cool.Comment): void;
+	_parseCellRange(cellRange: string): cool.Bounds;
+	_cellRangeToTwipRect(cellRange: cool.Bounds): cool.Bounds;
+	preZoomAnimation(pinchStartCenter: LatLngLike): void;
+	zoomStep(zoom: number, newCenter: LatLngLike): void;
+	zoomStepEnd(
+		zoom: number,
+		newCenter: LatLngLike,
+		mapUpdater: MapUpdaterType,
+		runAtFinish: () => void,
+		noGap?: boolean,
+	): void;
+	postZoomAnimation(): void;
+	_checkSelectedPart(): void;
+	requestNewFiledBasedViewTiles(): void;
+	_docPixelSize: cool.PointLike;
+	_closeMobileWizard(): void;
+	_openMobileWizard(data: WidgetJSON): void;
+
+	// TODO: window.L.Control.PartsPreview.
+	_preview?: any;
+	getCommentWizardStructure(
+		menuStructure?: WidgetJSON,
+		onlyThread?: any,
+	): WidgetJSON;
 }

--- a/browser/src/app/iface/Map.Interface.ts
+++ b/browser/src/app/iface/Map.Interface.ts
@@ -16,6 +16,11 @@ interface CRSInterface {
 	scale(zoom: number): number;
 }
 
+interface LatLngLike {
+	lat: number;
+	lng: number;
+}
+
 interface MapInterface extends Evented {
 	_docLayer: DocLayerInterface;
 	uiManager: UIManager;
@@ -31,11 +36,11 @@ interface MapInterface extends Evented {
 	): void;
 
 	stateChangeHandler: {
-		getItemValue(unoCmd: string): string;
+		getItemValue(unoCmd: string): any;
 		setItemValue(unoCmd: string, value: any): void;
 	};
 
-	sendUnoCommand(unoCmd: string): void;
+	sendUnoCommand(unoCmd: string, json?: any, force?: boolean): void;
 
 	getDocType(): 'text' | 'presentation' | 'spreadsheet' | 'drawing';
 	isText(): boolean;
@@ -43,7 +48,7 @@ interface MapInterface extends Evented {
 
 	getDocSize(): cool.Point;
 	getSize(): cool.Point;
-	getCenter(): { lat: number; lng: number };
+	getCenter(): LatLngLike;
 	_getCurrentFontName(): string;
 
 	_docLoadedOnce: boolean;
@@ -77,6 +82,9 @@ interface MapInterface extends Evented {
 		BaseFileName: string;
 		HideExportOption: boolean;
 		UserCanWrite: boolean;
+		HideChangeTrackingControls: boolean;
+		EnableRemoteLinkPicker: boolean;
+		HideSaveOption: boolean;
 	};
 
 	loadDocument(socket?: SockInterface): void;
@@ -104,7 +112,7 @@ interface MapInterface extends Evented {
 	isLockedUser(): boolean;
 	isRestrictedUser(): boolean;
 
-	focus(): void;
+	focus(acceptInput?: boolean): void;
 	editorHasFocus(): boolean;
 
 	_fireInitComplete(condition: string): void;
@@ -124,4 +132,96 @@ interface MapInterface extends Evented {
 	userList: UserList;
 	sidebar: Sidebar;
 	getViewColor(viewId: number): number;
+
+	// TODO fix types:
+	jsdialog: any;
+	zotero: any;
+
+	_cacheSVG: string[];
+	calcInputBarHasFocus(): boolean;
+	lockAccessibilityOn(): void;
+	getPixelBounds(center?: LatLngLike, zoom?: number): cool.Bounds;
+	getPixelBoundsCore(center?: LatLngLike, zoom?: number): cool.Bounds;
+	_partsDirection: number;
+	getZoomScale(toZoom: number, fomZoom?: number): number;
+	_docLoaded: boolean;
+	contextToolbar?: ContextToolbar;
+	getSplitPanesContext(): cool.SplitPanesContext | undefined;
+	getScaleZoom(scale: number, fromZoom?: number): number;
+	scrollingIsHandled: boolean;
+	showComments(on?: boolean): void;
+	showResolvedComments(on?: boolean): void;
+	navigator: NavigatorPanel;
+	setPart(
+		part: number | string,
+		external?: boolean,
+		calledFromSetPartHandler?: boolean,
+	): void;
+	mouseEventToLatLng(e: any): LatLngLike;
+	_limitZoom(zoom: number): number;
+	setView(
+		center: [number, number],
+		zoom?: number,
+		reset?: boolean,
+	): MapInterface;
+	isViewReadOnly(viewid: number): boolean;
+	scrollHandler: typeof window.L.Map.Scroll;
+	context?: { appId: string; context: string };
+	eSignature?: cool.ESignature;
+
+	// TODO: Fix type.
+	formulabar: any;
+	backstageView: any;
+	topToolbar: any;
+	statusBar: any;
+
+	mobileSearchBar: MobileSearchBar;
+	_disableDefaultAction: Record<string, boolean>;
+	save(
+		dontTerminateEdit: boolean,
+		dontSaveIfUnmodified: boolean,
+		extendedData?: string,
+	): void;
+	_everModified: boolean;
+	print(options?: string): void;
+	openRevisionHistory(): void;
+	openShare(): void;
+	showHelp(id: string): void;
+	openSaveAs(format?: string): void;
+	downloadAs(
+		name: string,
+		format?: string,
+		options?: string | null,
+		id?: string,
+	): void;
+	insertComment(): void;
+	zoomIn(delta: number, options?: any, animate?: boolean): MapInterface;
+	zoomOut(delta: number, options?: any, animate?: boolean): MapInterface;
+	cancelSearch(): void;
+	goToPage(page: string): void;
+	serverAuditDialog?: ServerAuditDialog;
+	_lockAccessibilityOn: boolean;
+	setAccessibilityState(enable: boolean): void;
+
+	// TODO: L.Map.Keyboard
+	keyboard: any;
+
+	onFormulaBarBlur(): void;
+	onFormulaBarFocus(): void;
+	formulabarBlur(): void;
+	formulabarFocus(): void;
+	formulabarSetDirty(): void;
+	_functionWizardData: WidgetJSON;
+
+	insertPage: ((nPos?: number) => void) & { scrollToEnd: boolean };
+	deletePage(nPos?: number): void;
+	duplicatePage(pos?: number): void;
+	slideShowPresenter?: SlideShowPresenter;
+	hideSlide(): void;
+	showSlide(): void;
+	sidebarFromNotebookbar: SidebarFromNotebookbarPanel;
+	mobileTopBar?: MobileTopBar;
+
+	// TODO: window.L.control.lokDialog
+	dialog: any;
 }

--- a/browser/src/canvas/sections/ShapeHandleScalingSubSection.ts
+++ b/browser/src/canvas/sections/ShapeHandleScalingSubSection.ts
@@ -180,7 +180,7 @@ class ShapeHandleScalingSubSection extends CanvasSectionObject {
 		let keep = e.ctrlKey && e.shiftKey;
 
 		// For images, the keepRatio shortcut works the opposite way.
-		if (app.map.context.context === 'Graphic')
+		if (app.map.context && app.map.context.context === 'Graphic')
 			keep = !keep;
 
 		return keep;

--- a/browser/src/canvas/sections/SplitterLinesSection.ts
+++ b/browser/src/canvas/sections/SplitterLinesSection.ts
@@ -61,9 +61,11 @@ class SplitterLinesSection extends CanvasSectionObject {
 	private setBoxGradient(splitPos: any, isVertical: boolean) {
 		let selectionBackgroundGradient = null;
 
+		Util.ensureValue(app.map._docLayer.sheetGeometry);
 		// last row geometry data will be a good for setting deafult raw height
-		const spanlist =
-			app.map._docLayer.sheetGeometry.getRowsGeometry()._visibleSizes._spanlist;
+		const spanlist = app.map._docLayer.sheetGeometry
+			.getRowsGeometry()
+			.getVisibleSizes()._spanlist;
 		const rowData = spanlist[spanlist.length - 1];
 
 		// Create a linear gradient based on the extracted color stops

--- a/browser/src/control/Control.AboutDialog.ts
+++ b/browser/src/control/Control.AboutDialog.ts
@@ -215,7 +215,7 @@ class AboutDialog {
 			link.addEventListener('click', (e: MouseEvent) => {
 				e.preventDefault();
 				app.socket.sendMessage('uno .uno:WidgetTestDialog');
-				app.map.uiManager.closeModal('modal-dialog-about-dialog-box', false);
+				app.map.uiManager.closeModal('modal-dialog-about-dialog-box');
 			});
 
 			elements.jsDialog.appendChild(label);

--- a/browser/src/control/Control.ESignatureDialog.ts
+++ b/browser/src/control/Control.ESignatureDialog.ts
@@ -221,6 +221,7 @@ namespace cool {
 				const countryCode =
 					this.availableCountries[countries.selectedIndex].code;
 				this.close();
+				Util.ensureValue(app.map.eSignature);
 				app.map.eSignature.handleSelectedProvider(countryCode, providerId);
 			} else if (eventType === 'selected' && object.id === 'countrylb') {
 				// The selected country changed, update the list of providers

--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -1951,7 +1951,7 @@ class Menubar extends window.L.Control {
 					} else {
 						$(aItem).removeClass(constChecked);
 					}
-					if (this.options.math.includes(unoCommand) && app.map.context.context !== 'Math') {
+					if (this.options.math.includes(unoCommand) && app.map.context && app.map.context.context !== 'Math') {
 						$(aItem).addClass('disabled');
 					}
 				} else if (type === 'action') { // enable all except fullscreen on windows
@@ -2290,7 +2290,10 @@ class Menubar extends window.L.Control {
 				};
 				app.map.sendUnoCommand('.uno:InsertSignatureLine', args);
 				const finishMessage = _('The signature line can now be moved or resized as needed.');
-				const finishFunc = () => app.map.eSignature.insert();
+				const finishFunc = () => {
+					Util.ensureValue(app.map.eSignature);
+					app.map.eSignature.insert();
+				};
 				app.map.uiManager.showSnackbar(finishMessage, _('Finish electronic signing'), finishFunc, -1);
 			} else {
 				app.map.sendUnoCommand('.uno:InsertSignatureLine');

--- a/browser/src/control/jsdialog/Component.Base.ts
+++ b/browser/src/control/jsdialog/Component.Base.ts
@@ -30,6 +30,10 @@ abstract class JSDialogComponent {
 		this.model = new JSDialogModelState(name);
 	}
 
+	public getContainer(): HTMLElement | undefined {
+		return this.container;
+	}
+
 	/// connects component to the JSDialogMessageRouter
 	protected registerMessageHandlers() {
 		this.map.on('jsdialogupdate', this.onJSUpdate, this);

--- a/browser/src/global.d.ts
+++ b/browser/src/global.d.ts
@@ -196,7 +196,7 @@ interface AppInterface {
 	colorPalettes: any; // TODO declare according to Widget.ColorPicker.ts
 	colorNames: any; // TODO declare according to Widget.ColorPicker.ts
 	console: Console;
-	map: any; // TODO should be window.L.Map
+	map: MapInterface; // TODO should be window.L.Map
 	// file defined in: src/docstate.ts
 	file: {
 		editComment: boolean;

--- a/browser/src/layer/tile/SheetGeometry.ts
+++ b/browser/src/layer/tile/SheetGeometry.ts
@@ -577,6 +577,10 @@ export class SheetDimension {
 		this._visibleSizes = undefined;
 	}
 
+	public getVisibleSizes(): SpanList {
+		return this._visibleSizes;
+	}
+
 	public getInvisibleSpanList(): BoolSpanList { return this._invisibleSpanList; }
 
 	public update(jsonObject: SheetDimensionCoreData): boolean {

--- a/browser/src/slideshow/SlideShowPresenter.ts
+++ b/browser/src/slideshow/SlideShowPresenter.ts
@@ -134,7 +134,7 @@ class SlideShowPresenter {
 	private _slideControlsTimer: ReturnType<typeof setTimeout> | null = null;
 	private _slideShowHandler: SlideShowHandler;
 	private _slideShowNavigator: SlideShowNavigator;
-	private _metaPresentation: MetaPresentation;
+	public _metaPresentation: MetaPresentation;
 	private _startSlide: number;
 	private _startEffect: number;
 	private _presentationInfoChanged: boolean = false;

--- a/browser/src/slideshow/engine/MetaPresentation.ts
+++ b/browser/src/slideshow/engine/MetaPresentation.ts
@@ -12,8 +12,8 @@
  */
 
 class MetaPresentation {
-	private docWidth: number;
-	private docHeight: number;
+	public docWidth: number;
+	public docHeight: number;
 	private _numberOfSlides: number;
 	private firstSlideHash: string;
 	private lastSlideHash: string;


### PR DESCRIPTION
... as a stopgap solution till converting L.Map and L.*Layer.

First use case is: all typescript code using map via app.map directly or
indirectly, get exact types of the methods/properties of map and some of
its deeper internal structures. So if someone incorrectly passes some
wrong type data to its methods will be caught at compile time. Secondly
in IDEs using LSP will show correct auto-complete of map's public
interior as the developer types 'app.map.' in one of the existing
typescript code.

The core change of this patch is just in global.d.ts. The other changes
are needed to satisfy fully typed requirements of map properties/methods
we now use in typescript code

Change-Id: I79c55de4e0cf5a87f011d007ebcf2f770fdc1ef4


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

