### PR TITLE
fix "Event handling delayed" for desktop apps

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -249,10 +249,13 @@ WORKER_NODE_MODULES_JS =\
 $(DIST_FOLDER)/src/layer/tile/TileWorker.js: \
 	$(srcdir)/src/layer/tile/CanvasTileWorker.js.m4 \
 	$(srcdir)/src/layer/tile/CanvasTileWorkerSrc.js \
+	$(DIST_FOLDER)/src/layer/tile/CanvasTileUtils.js \
 	$(WORKER_NODE_MODULES_JS)
 
 	$(QUIET_M4) m4 -PE -DDEBUG=$(ENABLE_DEBUG) \
+		-DMOBILEAPP=$(ENABLE_MOBILEAPP) \
 		-DNODE_MODULES_JS=$(subst $(SPACE),$(COMMA),$(WORKER_NODE_MODULES_JS)) \
+		-DTILEUTILS_JS=$(DIST_FOLDER)/src/layer/tile/CanvasTileUtils.js \
 		-DWORKER_JS=$(srcdir)/src/layer/tile/CanvasTileWorkerSrc.js \
 		$(srcdir)/src/layer/tile/CanvasTileWorker.js.m4 > $@
 

--- a/browser/src/app/LOUtil.ts
+++ b/browser/src/app/LOUtil.ts
@@ -231,8 +231,12 @@ class LOUtil {
 	public static getURL(path: string): string {
 		if (path === '') return '';
 		const customWindow = window as any;
-		if (customWindow.host === '' && customWindow.serviceRoot === '')
-			return path; // mobile app
+		if (customWindow.host === '' && customWindow.serviceRoot === '') {
+			// Mobile / desktop app: return a relative path so it resolves
+			// against the page's file:// origin rather than the filesystem root.
+			if (path.startsWith('/')) return path.substring(1);
+			return path;
+		}
 
 		let url = customWindow.makeHttpUrl('/browser/' + customWindow.versionPath);
 		if (path.substr(0, 1) !== '/') url += '/';

--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -259,7 +259,7 @@ class TileManager {
 	private static afterFirstTileTasks: Array<AfterFirstTileTask> = [];
 
 	public static initialize() {
-		if (window.Worker && !(window as any).ThisIsAMobileApp) {
+		if (window.Worker && (!(window as any).ThisIsAMobileApp || (window as any).mode.isCODesktop())) {
 			window.app.console.info('Creating CanvasTileWorkers');
 			for (let i = 0; i < 4; ++i) {
 				this.workers.push(

--- a/browser/src/layer/tile/CanvasTileWorker.js.m4
+++ b/browser/src/layer/tile/CanvasTileWorker.js.m4
@@ -10,5 +10,8 @@ m4_dnl node_modules
 m4_foreachq([fileNode],[NODE_MODULES_JS],[
 m4_syscmd([cat ]fileNode)
 ])
+m4_dnl bundled utilities for mobile/desktop apps (no server to resolve importScripts URLs)
+m4_ifelse(MOBILEAPP, [true], [m4_syscmd([cat ]TILEUTILS_JS)
+])
 m4_dnl bundled worker
 m4_syscmd([cat ]WORKER_JS)

--- a/browser/src/layer/tile/CanvasTileWorkerSrc.js
+++ b/browser/src/layer/tile/CanvasTileWorkerSrc.js
@@ -16,9 +16,12 @@
 if ('undefined' === typeof window) {
 	self.L = {};
 
-	importScripts(
-		'%SERVICE_ROOT%/browser/%VERSION%/src/layer/tile/CanvasTileUtils.js',
-	);
+	// CanvasTileUtils is bundled inline for mobile/desktop app builds
+	if (typeof cool === 'undefined' || !cool.CanvasTileUtils) {
+		importScripts(
+			'%SERVICE_ROOT%/browser/%VERSION%/src/layer/tile/CanvasTileUtils.js',
+		);
+	}
 
 	let tileImageCache = new Map(); // Map<string, Uint8Array>
 

--- a/windows/coda/CODA/CODA.cpp
+++ b/windows/coda/CODA/CODA.cpp
@@ -1537,8 +1537,12 @@ static void openCOOLWindow(const FilenameAndUri& filenameAndUri, DocumentMode mo
 
     auto options = Microsoft::WRL::Make<CoreWebView2EnvironmentOptions>();
 
+    // Required for instantiating new Web Workers, which otherwise fail with a
+    // cross-origin SecurityError because file:// gets origin 'null'.
+    std::wstring additionalArgs = L"--allow-file-access-from-files";
     if (enableWebDriver)
-        options->put_AdditionalBrowserArguments(L"--remote-debugging-port=9222");
+        additionalArgs += L" --remote-debugging-port=9222";
+    options->put_AdditionalBrowserArguments(additionalArgs.c_str());
 
     CreateCoreWebView2EnvironmentWithOptions(
         nullptr,


### PR DESCRIPTION
Desktop apps (Linux, Windows, macOS) had web workers disabled. This forces all tile delta decompression to run synchronously on the main thread, easily exceeding 250ms with large tile batches and triggering the "Event handling delayed" popup. (edit to clarify: You need to [enable](https://collaboraonline.github.io/post/debug-code/#:~:text=test%20Collabora%20Online.-,Triple%20click,-In%20the%20About) tile debugging overlay to see the popup)

Fix by inlining CanvasTileUtils.js into TileWorker.js at build time for MOBILEAPP builds. Worker creation is gated on isCODesktop() so only desktop apps spawn workers - iOS and Android remain excluded.