### PR TITLE
flatpak: use shallow submodule clones for core

### DIFF
--- a/qt/flatpak/com.collaboraoffice.Office.json
+++ b/qt/flatpak/com.collaboraoffice.Office.json
@@ -44,7 +44,12 @@
         {
 	  "type": "git",
 	  "url" : "https://gerrit.libreoffice.org/core",
-	  "branch": "distro/collabora/co-26.04"
+	  "branch": "distro/collabora/co-26.04",
+	  "disable-submodules": true
+        },
+        {
+          "type": "shell",
+          "commands": ["git submodule update --init --depth 1"]
         },
         {
           "url": "https://dev-www.libreoffice.org/src/cairo-1.18.4.tar.xz",


### PR DESCRIPTION
The translations submodule alone is ~14 GB at full depth. Disable automatic submodule checkout and do a shallow init instead.


Change-Id: I9b01b53a019120de7a129295fbf54b9157ec077f
