### PR TITLE
fix(a11y): Add accessibility key for Translate button in Review tab

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2188,7 +2188,8 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 					'id': 'review-translate',
 					'type': 'bigtoolitem',
 					'text': _UNO('.uno:Translate', 'text'),
-					'command': '.uno:Translate'
+					'command': '.uno:Translate',
+					'accessibility': { focusBack: false, combination: 'ZT', de: null }
 				}: {},
 			{
 				'type': 'container',


### PR DESCRIPTION
Change-Id: Ide32fdcd9f3c3d5ac2a9be6f10eff50540eca17d


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

