### PR TITLE
MOBILEAPP: -Werror,-Wunused-private-field

### DIFF
--- a/common/Anonymizer.hpp
+++ b/common/Anonymizer.hpp
@@ -39,9 +39,11 @@
 /// will have a different prefix counter.
 class Anonymizer
 {
-    explicit Anonymizer(const std::uint64_t salt, bool highStrength)
+    explicit Anonymizer(const std::uint64_t salt, [[maybe_unused]] bool highStrength)
         : _salt(salt)
+#if !MOBILEAPP
         , _highStrength(highStrength)
+#endif
     {
     }
 
@@ -227,8 +229,10 @@ private:
     /// The salt used to hash.
     const std::uint64_t _salt;
 
+#if !MOBILEAPP
     /// Whether to use PBKDF2-HMAC-SHA512 (high-strength) instead of FNV-1a.
     const bool _highStrength;
+#endif
 
     /// The prefix counter.
     std::atomic<unsigned> _prefix;


### PR DESCRIPTION
...after 49f77cc12eab1dfd564de18c063ab5634140eebd "Guard OpenSSL high-strength anonymizer with !MOBILEAPP"


Change-Id: I76b08aa836ad7b4bf84205fcc213e1f5010e4296


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

