### PR TITLE
config: open MSO files as read-write by default again

### DIFF
--- a/browser/src/docstate.ts
+++ b/browser/src/docstate.ts
@@ -109,8 +109,7 @@
 			pageRectangleList: [], // Array of arrays: [x, y, w, h] (as usual) // twips only. Pixels will be calculated on the fly. Corresponding pixels may change too often.
 		},
 		exportFormats: [], // possible output formats
-		viewModeExtensions:
-			'docx|xlsx|pptx|doc|xls|ppt|docm|xlsm|pptm|dot|xlt|pot|dotx|dotm|xltx|xltm|potx|potm|ppsx',
+		viewModeExtensions: '',
 	},
 	following: {
 		// describes which cursor we follow with the view

--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -232,7 +232,7 @@ static const std::unordered_map<std::string, std::string> DefAppConfig = {
     { "quarantine_files.max_versions_to_maintain", "5" },
     { "quarantine_files.path", "" },
     { "quarantine_files[@enable]", "false" },
-    { "view_mode.file_extensions", "docx|xlsx|pptx|doc|xls|ppt|docm|xlsm|pptm|dot|xlt|pot|dotx|dotm|xltx|xltm|potx|potm|ppsx" },
+    { "view_mode.file_extensions", "" },
     { "remote_asset_config.url", "" },
     { "remote_config.remote_url", "" },
     { "remote_font_config.url", "" },

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -272,7 +272,8 @@
     </user_interface>
 
     <view_mode desc="View mode settings">
-        <file_extensions desc="List of file extensions that should be opened in view mode by default." type="string" default="docx|xlsx|pptx|doc|xls|ppt|docm|xlsm|pptm|dot|xlt|pot|dotx|dotm|xltx|xltm|potx|potm|ppsx"></file_extensions>
+        <!-- Example: "docx|xlsx|pptx|doc|xls|ppt|docm|xlsm|pptm|dot|xlt|pot|dotx|dotm|xltx|xltm|potx|potm|ppsx" -->
+        <file_extensions desc="List of file extensions that should be opened in view mode by default." type="string" default=""></file_extensions>
     </view_mode>
 
     <storage desc="Backend storage">


### PR DESCRIPTION
This went wrong in commit 50e901fef7525831fc290a34b5d2923d9a54d229 (Add
config option for default to View-Mode file extensions, 2026-03-03); I
assume the intent was to have an option for this where people can enable
this if they want; but instead it changed the default, which is odd.

For context, I originally looked at this because some people complain
that we open DOTX files as ready-only (while DOCX is fine), so really
opening all MSO files read-only would be seen as an instant regression
by some.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I6c62d27c2035fb5d8003640ff4a1073bab632b97
