### PR TITLE
Fix: building with --disable-ssl on some setups

### DIFF
--- a/common/Anonymizer.hpp
+++ b/common/Anonymizer.hpp
@@ -23,7 +23,7 @@
 #include <unordered_map>
 #include <vector>
 
-#if !MOBILEAPP
+#if ENABLE_SSL
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #endif
@@ -41,7 +41,7 @@ class Anonymizer
 {
     explicit Anonymizer(const std::uint64_t salt, [[maybe_unused]] bool highStrength)
         : _salt(salt)
-#if !MOBILEAPP
+#if ENABLE_SSL
         , _highStrength(highStrength)
 #endif
     {
@@ -123,7 +123,7 @@ public:
         }
 
         std::string res;
-#if !MOBILEAPP
+#if ENABLE_SSL
         if (_highStrength)
         {
             res = highStrengthHash(text);
@@ -163,7 +163,7 @@ private:
         return '#' + Util::encodeId(_prefix++, 0) + '#' + Util::encodeId(hash, 0) + '#';
     }
 
-#if !MOBILEAPP
+#if ENABLE_SSL
     /// Cryptographic one-way hash using PBKDF2-HMAC-SHA512 via OpenSSL.
     /// This is irreversible even with knowledge of the salt, unlike the FNV-1a hash.
     static constexpr int HighStrengthIterations = 10000;
@@ -229,7 +229,7 @@ private:
     /// The salt used to hash.
     const std::uint64_t _salt;
 
-#if !MOBILEAPP
+#if ENABLE_SSL
     /// Whether to use PBKDF2-HMAC-SHA512 (high-strength) instead of FNV-1a.
     const bool _highStrength;
 #endif


### PR DESCRIPTION
After: f8c32ab building with --disable-ssl fails on some setups

Signed-off-by: João Azevedo <joao.azevedo@collabora.com>

Change-Id: I9b437dcfbde580401fd43cd4ed35c562242d7386


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

