### PR TITLE
css: fix overly broad [Id$='Page'] selector matching checkbuttons

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -1087,7 +1087,7 @@ body {
 	padding: 0px;
 }
 
-.lokdialog.ui-dialog-content [Id$='Page'] {
+.lokdialog.ui-dialog-content [Id$='Page']:not(.checkbutton) {
 	grid-column-gap: 24px;
 }
 

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2910,9 +2910,7 @@ kbd,
 	align-items: center;
 }
 
-/* Writer - Format - Paragraph - Text Flow */
 /* Writer - Format - Paragraph - Tabs */
-#ParagraphPropertiesDialog #textflow #checkAcrossPage.checkbutton,
 #ParagraphPropertiesDialog #labelTP_TABULATOR #ParagraphTabsPage {
 	grid-column-gap: 0;
 }


### PR DESCRIPTION
The CSS rule `.lokdialog.ui-dialog-content [Id$='Page']` was intended for tab page containers but also matched checkbuttons whose id ends with "Page" (e.g. checkAcrossPage in Format > Paragraph > Text Flow), adding unwanted grid-column-gap that misaligned the checkbox.

Add :not(.checkbutton) to exclude checkbox widgets from this rule, and remove the now-unnecessary workaround in jsdialogs.css.


Change-Id: I7c477c84988cc98c5355e886ec17d7985b6a061c

