### PR TITLE
cool#14898 discovery: mark templates as editable, too

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/open_different_file_types_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/open_different_file_types_spec.js
@@ -2,7 +2,7 @@
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
-describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file types', function() {
+describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file types', function() {
 
 	function assertData() {
 		//select all the content of doc
@@ -36,35 +36,41 @@ describe.skip(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Open different file t
 		helper.assertImageSize(480, 122);
 	}
 
-	it('Open doc file', { defaultCommandTimeout: 60000 }, function() {
+	it.skip('Open doc file', { defaultCommandTimeout: 60000 }, function() {
 		helper.setupAndLoadDocument('writer/testfile.doc');
 		assertData();
 	});
 
-	it('Open docx file', { defaultCommandTimeout: 60000 }, function() {
+	it.skip('Open docx file', { defaultCommandTimeout: 60000 }, function() {
 		helper.setupAndLoadDocument('writer/testfile.docx');
 		assertData();
 	});
 
-	it('Open docm file', { defaultCommandTimeout: 60000 }, function() {
+	it.skip('Open docm file', { defaultCommandTimeout: 60000 }, function() {
 		helper.setupAndLoadDocument('writer/testfile.docm');
 		assertData();
 	});
 
-	it('Open fodt file', { defaultCommandTimeout: 60000 }, function() {
+	it.skip('Open fodt file', { defaultCommandTimeout: 60000 }, function() {
 		helper.setupAndLoadDocument('writer/testfile.fodt');
 		assertData();
 	});
 
-	it('Open dot file', { defaultCommandTimeout: 60000 }, function() {
+	it.skip('Open dot file', { defaultCommandTimeout: 60000 }, function() {
 		desktopHelper.openReadOnlyFile('writer/testfile.dot');
 	});
 
-	it('Open dotm file', { defaultCommandTimeout: 60000 }, function() {
+	it.skip('Open dotm file', { defaultCommandTimeout: 60000 }, function() {
 		desktopHelper.openReadOnlyFile('writer/testfile.dotm');
 	});
 
-	it('Open dotx file', { defaultCommandTimeout: 60000 }, function() {
-		desktopHelper.openReadOnlyFile('writer/testfile.dotx');
+	it('Open dotx file', function() {
+		helper.setupAndLoadDocument('writer/testfile.dotx');
+		// Template files should open in edit mode, not read-only.
+		// Without the accompanying fix in place, this test would have failed,
+		// the server sent filemode with readOnly: true for dotx files.
+		// This resulted in having no notebookbar:
+		// assertexpected .notebookbar-scroll-wrapper to have class initialized
+		cy.cGet('#viewModeDropdownButton-button').should('be.visible').should('have.text', 'Editing');
 	});
 });

--- a/discovery.xml
+++ b/discovery.xml
@@ -11,6 +11,7 @@
             <action name="view" default="true" ext="fodt"/>
             <!-- Text template documents -->
             <action name="view" default="true" ext="stw"/>
+            <action name="edit" default="true" ext="ott"/>
             <action name="view" default="true" ext="ott"/>
             <!-- MS Word -->
             <action name="edit" default="true" ext="doc"/>
@@ -21,7 +22,9 @@
             <action name="view" default="true" ext="docx"/>
             <action name="edit" default="true" ext="docm"/>
             <action name="view" default="true" ext="docm"/>
+            <action name="edit" default="true" ext="dotx"/>
             <action name="view" default="true" ext="dotx"/>
+            <action name="edit" default="true" ext="dotm"/>
             <action name="view" default="true" ext="dotm"/>
             <!-- Others -->
             <action name="view" default="true" ext="wpd"/>
@@ -65,6 +68,7 @@
             <action name="view" default="true" ext="fods"/>
             <!-- Spreadsheet template documents -->
             <action name="view" default="true" ext="stc"/>
+            <action name="edit" default="true" ext="ots"/>
             <action name="view" default="true" ext="ots"/>
             <!-- MS Excel -->
             <action name="edit" default="true" ext="xls"/>
@@ -72,7 +76,9 @@
             <action name="edit" default="true" ext="xla"/>
             <action name="view" default="true" ext="xla"/>
             <!-- OOXML spreadsheet -->
+            <action name="edit" default="true" ext="xltx"/>
             <action name="view" default="true" ext="xltx"/>
+            <action name="edit" default="true" ext="xltm"/>
             <action name="view" default="true" ext="xltm"/>
             <action name="edit" default="true" ext="xlsx"/>
             <action name="view" default="true" ext="xlsx"/>
@@ -112,6 +118,7 @@
             <action name="view" default="true" ext="fodp"/>
             <!-- Presentation template documents -->
             <action name="view" default="true" ext="sti"/>
+            <action name="edit" default="true" ext="otp"/>
             <action name="view" default="true" ext="otp"/>
             <!-- MS PowerPoint -->
             <action name="edit" default="true" ext="ppt"/>
@@ -122,7 +129,9 @@
             <action name="view" default="true" ext="pptx"/>
             <action name="edit" default="true" ext="pptm"/>
             <action name="view" default="true" ext="pptm"/>
+            <action name="edit" default="true" ext="potx"/>
             <action name="view" default="true" ext="potx"/>
+            <action name="edit" default="true" ext="potm"/>
             <action name="view" default="true" ext="potm"/>
             <action name="edit" default="true" ext="ppsx"/>
             <action name="view" default="true" ext="ppsx"/>


### PR DESCRIPTION
There was no 'edit' action in the discovery for template file
extensions, probably not intentional.

The testcases restores the previously skipped
writer/open_different_file_types_spec.js suite in the desktop cypress
tests: skip all tests still, except the DOTX test and assert there that
we now open these as read-write.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: If31107ca9038ea3a467a7e89cf06b21ba78fe328
