### PR TITLE
BACKPORT: config: open MSO files as read-write by default again

### DIFF
--- a/browser/src/docstate.ts
+++ b/browser/src/docstate.ts
@@ -110,8 +110,7 @@
 			pageRectangleList: [], // Array of arrays: [x, y, w, h] (as usual) // twips only. Pixels will be calculated on the fly. Corresponding pixels may change too often.
 		},
 		exportFormats: [], // possible output formats
-		viewModeExtensions:
-			'docx|xlsx|pptx|doc|xls|ppt|docm|xlsm|pptm|dot|xlt|pot|dotx|dotm|xltx|xltm|potx|potm|ppsx',
+		viewModeExtensions: '',
 	},
 	following: {
 		// describes which cursor we follow with the view

--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -227,7 +227,7 @@ static const std::unordered_map<std::string, std::string> DefAppConfig = {
     { "quarantine_files.max_versions_to_maintain", "5" },
     { "quarantine_files.path", "" },
     { "quarantine_files[@enable]", "false" },
-    { "view_mode.file_extensions", "docx|xlsx|pptx|doc|xls|ppt|docm|xlsm|pptm|dot|xlt|pot|dotx|dotm|xltx|xltm|potx|potm|ppsx" },
+    { "view_mode.file_extensions", "" },
     { "remote_asset_config.url", "" },
     { "remote_config.remote_url", "" },
     { "remote_font_config.url", "" },

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -272,7 +272,8 @@
     </user_interface>
 
     <view_mode desc="View mode settings">
-        <file_extensions desc="List of file extensions that should be opened in view mode by default." type="string" default="docx|xlsx|pptx|doc|xls|ppt|docm|xlsm|pptm|dot|xlt|pot|dotx|dotm|xltx|xltm|potx|potm|ppsx"></file_extensions>
+        <!-- Example: "docx|xlsx|pptx|doc|xls|ppt|docm|xlsm|pptm|dot|xlt|pot|dotx|dotm|xltx|xltm|potx|potm|ppsx" -->
+        <file_extensions desc="List of file extensions that should be opened in view mode by default." type="string" default=""></file_extensions>
     </view_mode>
 
     <storage desc="Backend storage">


### PR DESCRIPTION
Backport of config: open MSO files as read-write by default again https://github.com/CollaboraOnline/online/pull/14897

* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

