### PR TITLE
Add a guard for multiple onNewDocumentTopLeft calls in one cycle.

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -125,6 +125,11 @@ export class CommentSection extends CanvasSectionObject {
 	// To associate comment id with its index in commentList array.
 	private idIndexMap: Map<any, number>;
 
+	// Dirty flag: set by onNewDocumentTopLeft, consumed by onDraw.
+	// Collapses multiple onNewDocumentTopLeft calls into a single layout
+	// pass and avoids the extra requestReDraw that updateDOM would trigger.
+	private _commentPositionDirty: boolean = false;
+
 	private annotationMinSize: number;
 	private annotationMaxSize: number;
 	escapeListener: (e: KeyboardEvent) => void;
@@ -1363,10 +1368,17 @@ export class CommentSection extends CanvasSectionObject {
 				this.sectionProperties.selectedComment.hide();
 		}
 
-		var previousAnimationState = this.disableLayoutAnimation;
-		this.disableLayoutAnimation = true;
-		this.update(false);
-		this.disableLayoutAnimation = previousAnimationState;
+		this._commentPositionDirty = true;
+	}
+
+	public onDraw (frameCount?: number, elapsedTime?: number): void {
+		if (this._commentPositionDirty) {
+			this._commentPositionDirty = false;
+			var previousAnimationState = this.disableLayoutAnimation;
+			this.disableLayoutAnimation = true;
+			this.update(false);
+			this.disableLayoutAnimation = previousAnimationState;
+		}
 	}
 
 	private showHideComments (): void {


### PR DESCRIPTION
Change-Id: Ic02f5eb7d257d026688fb033da18fac8842b3faf


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

