### PR TITLE
[Backport] fix(a11y): Add accessibility key for Translate button in Review tab

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2188,7 +2188,8 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 					'id': 'review-translate',
 					'type': 'bigtoolitem',
 					'text': _UNO('.uno:Translate', 'text'),
-					'command': '.uno:Translate'
+					'command': '.uno:Translate',
+					'accessibility': { focusBack: false, combination: 'ZT', de: null }
 				}: {},
 			{
 				'type': 'container',


### PR DESCRIPTION
Change-Id: Ide32fdcd9f3c3d5ac2a9be6f10eff50540eca17d


* Resolves: # <!-- related github issue -->
* Target version: distro/collabora/co-25.04

### Summary
backport for PR: https://github.com/CollaboraOnline/online/pull/14892
