### PR TITLE
a11y: enhance keyboard shortcuts dialog focus handling

### DIFF
--- a/browser/css/helpdialog.css
+++ b/browser/css/helpdialog.css
@@ -151,4 +151,8 @@
 	[data-theme='dark'] span.cool-annotation-menu {
 		filter: invert(1);
 	}
+
+	#keyboard-shortcuts-content:focus-visible {
+		outline: none;
+	}
 }

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -546,6 +546,16 @@ window.L.Map.include({
 				}
 			});
 		});
+
+		if (id === 'keyboard-shortcuts-content') {
+			app.layoutingService.appendLayoutingTask(() => {
+				var contentContainer = document.getElementById('keyboard-shortcuts-content');
+				if (contentContainer) {
+					contentContainer.setAttribute('tabindex', '-1');
+					contentContainer.focus();
+				}
+			});
+		}
 	},
 
 


### PR DESCRIPTION
- enables directly scrolling using arrow keys as soon as keyboard shortcut dialog is opened

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

