### PR TITLE
ARM64 NEON SIMD acceleration for tile delta and RGBA/BGRA conversion

### DIFF
--- a/common/Simd.cpp
+++ b/common/Simd.cpp
@@ -19,20 +19,29 @@
 #include <Simd.hpp>
 
 #if ENABLE_SIMD
-#  include <immintrin.h>
+#  if !defined(__aarch64__)
+#    include <immintrin.h>
+#  endif
 #endif
 
 namespace simd {
 
 bool HasAVX2 = false;
+bool HasNeon = false;
+bool IsEnabled = false;
 
 bool init()
 {
 #if ENABLE_SIMD
+#  if defined(__aarch64__)
+    HasNeon = true; // NEON is mandatory on ARM64
+#  else
     __builtin_cpu_init();
     HasAVX2 = __builtin_cpu_supports ("avx2");
+#  endif
 #endif
-    return HasAVX2;
+    IsEnabled = HasAVX2 || HasNeon;
+    return IsEnabled;
 }
 
 };

--- a/common/Simd.hpp
+++ b/common/Simd.hpp
@@ -14,6 +14,8 @@
 namespace simd {
     bool init();
     extern bool HasAVX2;
+    extern bool HasNeon;
+    extern bool IsEnabled;
 };
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/configure.ac
+++ b/configure.ac
@@ -1666,22 +1666,43 @@ fi
 AC_SUBST(ENABLE_EMSCRIPTENAPP)
 
 has_simd=no
-if test "$mobile_app" != "true"; then
-    # Check for SIMD / AVX2 acceleration compile-time goodness
-    SIMD_CFLAGS="-mavx2 -O3"
-    AC_MSG_CHECKING([whether $CC has AVX2 SIMD support])
+# Check for SIMD / AVX2 acceleration compile-time goodness
+SIMD_CFLAGS="-mavx2 -O3"
+AC_MSG_CHECKING([whether $CC has AVX2 SIMD support])
 
+save_CFLAGS=$CFLAGS
+AC_LANG_PUSH([C])
+CFLAGS="$CFLAGS $SIMD_CFLAGS"
+
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+    #include <immintrin.h>
+    int main () {
+        __builtin_cpu_init();
+        __m256i vec = _mm256_set1_epi32(0);
+        (void)vec;
+        return __builtin_cpu_supports ("avx2");
+    }])],
+    [has_simd=yes],
+    [has_simd=no])
+
+AC_LANG_POP([C])
+CFLAGS=$save_CFLAGS
+
+AC_MSG_RESULT([${has_simd}])
+
+if test "$has_simd" = "no"; then
+    # Check for ARM64 NEON (always available on aarch64)
+    SIMD_CFLAGS="-O3"
+    AC_MSG_CHECKING([whether $CC has ARM64 NEON SIMD support])
     save_CFLAGS=$CFLAGS
     AC_LANG_PUSH([C])
     CFLAGS="$CFLAGS $SIMD_CFLAGS"
-
     AC_COMPILE_IFELSE([AC_LANG_SOURCE([
-        #include <immintrin.h>
-        int main () {
-            __builtin_cpu_init();
-            __m256i vec = _mm256_set1_epi32(0);
-            (void)vec;
-            return __builtin_cpu_supports ("avx2");
+        #include <arm_neon.h>
+        int main() {
+            uint32x4_t v = vdupq_n_u32(0);
+            (void)v;
+            return 0;
         }])],
         [has_simd=yes],
         [has_simd=no])

--- a/kit/Delta.hpp
+++ b/kit/Delta.hpp
@@ -247,7 +247,7 @@ class DeltaGenerator {
             auto* scratch = static_cast<uint32_t*>(alloca(sizeof(uint32_t) * width));
 
             bool done = false;
-            if (simd::HasAVX2 && width == 256)
+            if (simd::IsEnabled && width == 256)
             {
                 done = simd_initPixRowSimd(from, scratch, &_rleSize, _rleMask);
 
@@ -529,7 +529,7 @@ class DeltaGenerator {
             std::memcpy(dest, srcBytes, count * 4);
             break;
         case LOK_TILEMODE_BGRA:
-            if (simd::HasAVX2 &&
+            if (simd::IsEnabled &&
                 simd_copyRowSwapRB(dest, srcBytes, count))
                 break;
 

--- a/kit/DeltaSimd.c
+++ b/kit/DeltaSimd.c
@@ -24,10 +24,83 @@
 #include "DeltaSimd.h"
 
 #if ENABLE_SIMD
+
+#if defined(__aarch64__)
+#  include <arm_neon.h>
+#  if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#    define htole64(x) (x)
+#  else
+#    error Endianity not defined
+#  endif
+#else
 #  include <endian.h>
 #  include <immintrin.h>
+#endif
 
 #define DEBUG_LUT 0
+
+#if defined(__aarch64__)
+
+// 16-entry LUT for packing 4 pixels (4-bit mask)
+static uint8x16_t neon_lut[16];
+
+void init_gather_lut()
+{
+    for (unsigned int pattern = 0; pattern < 16; ++pattern)
+    {
+        unsigned int i = 0, src = 0;
+        uint8_t indices[16];
+        memset(indices, 0, sizeof(indices));
+
+        for (uint32_t bitToCheck = 1; bitToCheck < 16; bitToCheck <<= 1)
+        {
+            if (!(pattern & bitToCheck)) // set bit is a duplicate -> ignore
+            {
+                // Each pixel is 4 bytes, so byte indices are src*4 .. src*4+3
+                unsigned int base = src * 4;
+                indices[i * 4 + 0] = base + 0;
+                indices[i * 4 + 1] = base + 1;
+                indices[i * 4 + 2] = base + 2;
+                indices[i * 4 + 3] = base + 3;
+                i++;
+            }
+            src++;
+        }
+        // Pad remaining slots to copy first pixel
+        while (i < 4)
+        {
+            indices[i * 4 + 0] = 0;
+            indices[i * 4 + 1] = 1;
+            indices[i * 4 + 2] = 2;
+            indices[i * 4 + 3] = 3;
+            i++;
+        }
+
+        neon_lut[pattern] = vld1q_u8(indices);
+    }
+}
+
+// Compare 4 pixels, return 4-bit mask (1 = equal)
+static uint64_t diffMask(uint32x4_t prev, uint32x4_t curr)
+{
+    // Compare: 0xFFFFFFFF where equal, 0 where different
+    uint32x4_t cmp = vceqq_u32(prev, curr);
+
+    // Narrow 32-bit to 16-bit, then 16-bit to 8-bit
+    uint16x4_t narrow16 = vmovn_u32(cmp);
+    uint8x8_t narrow8 = vmovn_u16(vcombine_u16(narrow16, vdup_n_u16(0)));
+
+    // Extract bits: AND with positional bit values, then sum each group
+    // narrow8 lanes 0..3 hold 0xFF or 0x00 for each pixel
+    static const uint8_t bit_pos_data[8] = { 1, 2, 4, 8, 0, 0, 0, 0 };
+    uint8x8_t bit_pos = vld1_u8(bit_pos_data);
+    uint8x8_t masked = vand_u8(narrow8, bit_pos);
+
+    // Sum the first 4 lanes to get the 4-bit mask
+    return vaddv_u8(masked);
+}
+
+#else // x86-64 AVX2
 
 // set of control data bytes for vperd
 static __m256i vpermd_lut[256];
@@ -90,7 +163,9 @@ static uint64_t diffMask(__m256i prev, __m256i curr)
     return _mm256_movemask_ps(m256);
 }
 
-#endif
+#endif // __aarch64__ vs x86-64
+
+#endif // ENABLE_SIMD
 
 void simd_deltaInit(void)
 {
@@ -116,6 +191,54 @@ int simd_initPixRowSimd(const uint32_t *from, uint32_t *scratch, size_t *scratch
 
     const uint32_t* block = from;
     uint32_t* dest = scratch;
+
+#if defined(__aarch64__)
+
+    uint32x4_t prev = vdupq_n_u32(0); // transparent
+
+    for (unsigned int x = 0; x < 256; x += 4) // 4 pixels per cycle
+    {
+        uint32x4_t curr = vld1q_u32(block + x);
+
+        // Build shifted version: [prev[3], curr[0], curr[1], curr[2]]
+        uint32x4_t shifted = vextq_u32(prev, curr, 3);
+
+        // Turn that into a bit-mask
+        uint64_t newMask = diffMask(shifted, curr);
+        assert(newMask < 16);
+
+        // Invert bitmask for counting non-same pixels
+        uint32_t newMaskInverse = ~newMask & 0x0f;
+
+        // We pack two 4-bit masks into each byte of rleMaskBlock.
+        // Even iterations (x/4 even) go in the low nibble,
+        // odd iterations (x/4 odd) go in the high nibble.
+        unsigned int halfIdx = x >> 2;
+        unsigned int byteIdx = halfIdx >> 1;
+        if (halfIdx & 1)
+            rleMaskBlock[byteIdx] |= (uint8_t)(newMask << 4);
+        else
+            rleMaskBlock[byteIdx] = (uint8_t)newMask;
+
+        // Shuffle the pixels and pack them using byte-level LUT
+        uint8x16_t curr_bytes = vreinterpretq_u8_u32(curr);
+        uint8x16_t packed = vqtbl1q_u8(curr_bytes, neon_lut[newMask]);
+
+        unsigned int countBitsUnset = __builtin_popcount(newMaskInverse);
+        assert(countBitsUnset <= 4);
+
+        // Store packed pixels (over-store is safe, we have enough space)
+        vst1q_u8((uint8_t *)dest, packed);
+
+        // Move on for the next run
+        dest += countBitsUnset;
+
+        // Stash current for use next time around
+        prev = curr;
+    }
+
+#else // x86-64 AVX2
+
     __m256i prev = _mm256_setzero_si256(); // transparent
 
     for (unsigned int x = 0; x < 256; x += 8) // 8 pixels per cycle
@@ -175,6 +298,9 @@ int simd_initPixRowSimd(const uint32_t *from, uint32_t *scratch, size_t *scratch
         // stash current for use next time around
         prev = curr;
     }
+
+#endif // __aarch64__ vs x86-64
+
     *scratchLen += dest - scratch;
 
     // a no-op for LE architectures - ~everyone.
@@ -192,6 +318,38 @@ int simd_copyRowSwapRB(unsigned char *dest, const unsigned char *src, unsigned i
     (void)dest; (void)src; (void)count;
     return 0;
 #else // ENABLE_SIMD
+
+#if defined(__aarch64__)
+
+    // Shuffle mask to swap R and B within each 32-bit pixel (4 pixels at a time)
+    static const uint8_t swap_mask_data[16] = {
+        2, 1, 0, 3,  6, 5, 4, 7,  10, 9, 8, 11,  14, 13, 12, 15
+    };
+    uint8x16_t swapMask = vld1q_u8(swap_mask_data);
+
+    size_t i = 0;
+    size_t bytes = count * 4;
+
+    // Process 16 bytes (4 pixels) at a time
+    for (; i + 16 <= bytes; i += 16)
+    {
+        uint8x16_t srcVec = vld1q_u8(src + i);
+        uint8x16_t swapped = vqtbl1q_u8(srcVec, swapMask);
+        vst1q_u8(dest + i, swapped);
+    }
+
+    // Handle remaining pixels (< 4) with scalar code
+    for (; i < bytes; i += 4)
+    {
+        dest[i + 0] = src[i + 2];  // R <- B
+        dest[i + 1] = src[i + 1];  // G <- G
+        dest[i + 2] = src[i + 0];  // B <- R
+        dest[i + 3] = src[i + 3];  // A <- A
+    }
+    return 1;
+
+#else // x86-64 AVX2
+
     // Shuffle mask to swap R and B within each 32-bit pixel:
     // BGRA [B,G,R,A] -> RGBA [R,G,B,A] means: byte 2->0, 1->1, 0->2, 3->3
     const __m256i shuffleMask = _mm256_set_epi8(
@@ -228,6 +386,9 @@ int simd_copyRowSwapRB(unsigned char *dest, const unsigned char *src, unsigned i
         dest[i + 3] = src[i + 3];  // A <- A
     }
     return 1;
+
+#endif // __aarch64__ vs x86-64
+
 #endif // ENABLE_SIMD
 }
 


### PR DESCRIPTION
The SIMD code was AVX2-only (x86-64), so ARM64 always fell back to
scalar C++. Add NEON implementations of the same three entry points
using 128-bit (4 pixel) operations.

Remove the mobile_app gate around SIMD detection in configure.ac since
it only existed because the code was x86-specific. With NEON support,
SIMD now works on all ARM64 platforms including iOS and macOS apps.

Signed-off-by: Jan Holesovsky <kendy@collabora.com>
Change-Id: Ibe54006dfa9758e695152c3775f497802cdad06a
