### PR TITLE
Integrator Settings: Refactor view settings to split Zotero and Document Signing

### DIFF
--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -1429,90 +1429,129 @@ class SettingIframe {
 			return;
 		}
 
-		let viewContainer = document.getElementById('view-section');
-		if (viewContainer) {
-			viewContainer.remove();
-		}
-
-		viewContainer = document.createElement('div');
-		viewContainer.id = 'view-section';
-		viewContainer.classList.add('section');
-
-		viewContainer.appendChild(this.createHeading(_('View Settings')));
-		viewContainer.appendChild(this.createParagraph(_('Adjust view settings.')));
-
-		const divContainer = document.createElement('div');
-		divContainer.id = 'view-editor';
-		viewContainer.appendChild(divContainer);
-
-		const fieldset = document.createElement('fieldset');
-		fieldset.classList.add('view-settings-fieldset');
-		divContainer.appendChild(fieldset);
-
-		fieldset.appendChild(this.createLegend(_('Option')));
-
-		const allViewSettingsKeys: (keyof ViewSettings)[] = [
-			'zoteroAPIKey',
-			'signatureCert',
-			'signatureKey',
-			'signatureCa',
-		];
-
-		for (const key of allViewSettingsKeys) {
-			const label = this._viewSettingLabels[key];
-			if (!label) {
-				continue;
-			}
-
-			// Add Zotero section with description
-			if (key === 'zoteroAPIKey') {
-				fieldset.appendChild(this.createHeading('Zotero'));
-				const zoteroDescription = this.createParagraph(
-					_(
-						'To use Zotero specify your API key here. You can create your API key in your ',
-					),
-				);
-				zoteroDescription.className = 'view-setting-description';
-
-				const zoteroAccountLink = document.createElement('a');
-				zoteroAccountLink.href = 'https://www.zotero.org/settings/keys';
-				zoteroAccountLink.target = '_blank';
-				zoteroAccountLink.textContent = _('Zotero account API settings');
-
-				zoteroDescription.appendChild(zoteroAccountLink);
-
-				fieldset.appendChild(zoteroDescription);
-				fieldset.appendChild(this.createViewSettingsTextBox(key, data, true));
-			}
-			// Add Document Signing section with description (only once for first field)
-			else if (key === 'signatureCert') {
-				fieldset.appendChild(this.createHeading(_('Document Signing')));
-				const signingDesc = document.createElement('p');
-				signingDesc.className = 'view-setting-description';
-				signingDesc.textContent = _(
-					'To use document signing, specify your signing certificate, key and CA chain here.',
-				);
-				fieldset.appendChild(signingDesc);
-				fieldset.appendChild(
-					this.createViewSettingsTextBox(key, data, false, true),
-				);
-			}
-			// Add remaining signature fields with smaller labels
-			else if (key === 'signatureKey' || key === 'signatureCa') {
-				fieldset.appendChild(
-					this.createViewSettingsTextBox(key, data, false, true),
-				);
-			}
-		}
-
-		viewContainer.appendChild(this.createViewSettingActions());
-		settingsContainer.appendChild(viewContainer);
+		this.generateZoteroUI(data, settingsContainer);
+		this.generateDocSigningUI(data, settingsContainer);
 	}
 
-	private createLegend(text: string): HTMLLegendElement {
-		const legend = document.createElement('legend');
-		legend.textContent = text;
-		return legend;
+	private generateZoteroUI(data: ViewSettings, settingsContainer: HTMLElement) {
+		const oldZoteroContainer = document.getElementById('zotero-section');
+
+		const zoteroContainer = document.createElement('div');
+		zoteroContainer.id = 'zotero-section';
+		zoteroContainer.classList.add('section');
+
+		zoteroContainer.appendChild(this.createHeading('Zotero'));
+		const zoteroDescription = this.createParagraph(
+			_(
+				'To use Zotero specify your API key here. You can create your API key in your ',
+			),
+		);
+		zoteroDescription.className = 'view-setting-description';
+
+		const zoteroAccountLink = document.createElement('a');
+		zoteroAccountLink.href = 'https://www.zotero.org/settings/keys';
+		zoteroAccountLink.target = '_blank';
+		zoteroAccountLink.textContent = _('Zotero account API settings');
+
+		zoteroDescription.appendChild(zoteroAccountLink);
+		zoteroContainer.appendChild(zoteroDescription);
+
+		const zoteroDivContainer = document.createElement('div');
+		zoteroDivContainer.id = 'zotero-editor';
+		zoteroContainer.appendChild(zoteroDivContainer);
+
+		zoteroDivContainer.appendChild(
+			this.createViewSettingsTextBox('zoteroAPIKey', data, true),
+		);
+
+		zoteroContainer.appendChild(
+			this.createSettingsActions(
+				'zotero',
+				'Zotero Settings',
+				'viewsetting.json',
+				() => {
+					const defaultSettings = this.getDefaultViewSettings();
+					return {
+						...this._viewSetting,
+						zoteroAPIKey: defaultSettings.zoteroAPIKey,
+					};
+				},
+				() => this._viewSetting,
+				(settings) =>
+					this.uploadViewSettingFile(
+						'viewsetting.json',
+						JSON.stringify(settings),
+					),
+			),
+		);
+		if (oldZoteroContainer) {
+			oldZoteroContainer.replaceWith(zoteroContainer);
+		} else {
+			settingsContainer.appendChild(zoteroContainer);
+		}
+	}
+
+	private generateDocSigningUI(
+		data: ViewSettings,
+		settingsContainer: HTMLElement,
+	) {
+		const oldDocSigningContainer = document.getElementById(
+			'doc-signing-section',
+		);
+
+		const docSigningContainer = document.createElement('div');
+		docSigningContainer.id = 'doc-signing-section';
+		docSigningContainer.classList.add('section');
+
+		docSigningContainer.appendChild(this.createHeading(_('Document Signing')));
+		const signingDesc = document.createElement('p');
+		signingDesc.className = 'view-setting-description';
+		signingDesc.textContent = _(
+			'To use document signing, specify your signing certificate, key and CA chain here.',
+		);
+		docSigningContainer.appendChild(signingDesc);
+
+		const docSigningDivContainer = document.createElement('div');
+		docSigningDivContainer.id = 'doc-signing-editor';
+		docSigningContainer.appendChild(docSigningDivContainer);
+
+		docSigningDivContainer.appendChild(
+			this.createViewSettingsTextBox('signatureCert', data, false, true),
+		);
+		docSigningDivContainer.appendChild(
+			this.createViewSettingsTextBox('signatureKey', data, false, true),
+		);
+		docSigningDivContainer.appendChild(
+			this.createViewSettingsTextBox('signatureCa', data, false, true),
+		);
+
+		docSigningContainer.appendChild(
+			this.createSettingsActions(
+				'document-signing',
+				'Document Signing Settings',
+				'viewsetting.json',
+				() => {
+					const defaultSettings = this.getDefaultViewSettings();
+					return {
+						...this._viewSetting,
+						signatureCert: defaultSettings.signatureCert,
+						signatureKey: defaultSettings.signatureKey,
+						signatureCa: defaultSettings.signatureCa,
+					};
+				},
+				() => this._viewSetting,
+				(settings) =>
+					this.uploadViewSettingFile(
+						'viewsetting.json',
+						JSON.stringify(settings),
+					),
+			),
+		);
+		if (oldDocSigningContainer) {
+			oldDocSigningContainer.replaceWith(docSigningContainer);
+		} else {
+			settingsContainer.appendChild(docSigningContainer);
+		}
 	}
 
 	private createViewSettingsTextBox(
@@ -1531,21 +1570,6 @@ class SettingIframe {
 			data,
 			skipHeading,
 			isSmallHeading,
-		);
-	}
-
-	private createViewSettingActions(): HTMLDivElement {
-		return this.createSettingsActions(
-			'viewsettings',
-			'View Settings',
-			'viewsetting.json',
-			() => this.getDefaultViewSettings(),
-			() => this._viewSetting,
-			(settings) =>
-				this.uploadViewSettingFile(
-					'viewsetting.json',
-					JSON.stringify(settings),
-				),
 		);
 	}
 
@@ -1842,9 +1866,9 @@ class SettingIframe {
 		const actionsContainer = document.createElement('div');
 		actionsContainer.classList.add('xcu-editor-actions');
 
-		const resetButton = this.createButtonWithIcon(
+		const resetButton = this.createButtonWithText(
 			`${prefix}-reset-button`,
-			'reset',
+			_('Reset'),
 			_(`Reset to default ${settingsName}`),
 			['button--vue-secondary', `${prefix}-reset-icon`],
 			async (button) => {
@@ -1859,7 +1883,6 @@ class SettingIframe {
 				await uploadSettings(defaultSettings);
 				button.disabled = false;
 			},
-			true,
 		);
 		actionsContainer.appendChild(resetButton);
 


### PR DESCRIPTION
Change-Id: I5531042baecce09b1b65a6828f9473978f057f0e


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
- Split the combined "View Settings" section into two distinct sections "Zotero" and "Document Signing".
- Updated the "Reset" button across the settings editor to use a "Reset" text label instead of a reset icon

### PREVIEW

<img width="709" height="547" alt="2026-03-18_14-04" src="https://github.com/user-attachments/assets/5efbe4bc-0449-4054-ac81-f675d66940c0" />





