### PR TITLE
Fix document mode label color (Edit/view mode)

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -461,6 +461,7 @@ label.notebookbar.ui-checkbox-label {
 .has-label.has-dropdown:not(.inline) .unolabel {
 	display: inline-block;
 	clear: both;
+	color: var(--color-main-text);
 }
 
 /* adding focus to tab in notebookbar */


### PR DESCRIPTION
- in dark mode the lable is not visible
- this small patch will fix that

before:
<img width="193" height="189" alt="image" src="https://github.com/user-attachments/assets/78f460a5-4284-4689-8dce-2680b166381f" />

After:

<img width="393" height="369" alt="image" src="https://github.com/user-attachments/assets/5f208142-2ee7-4321-a3e0-4f48e78a328a" />


Change-Id: Ib4d503dd1399ae405528c4d81a570b92db72393f


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

