### PR TITLE
jsdialog: be sure action_type is present (backport)

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2314,6 +2314,8 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			return;
 		}
 
+		console.assert(data.action_type);
+
 		switch (data.action_type) {
 		case 'grab_focus':
 			if (typeof control.onFocus === 'function')

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -447,13 +447,8 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 		if (!id) return;
 
 		this.builder.executeAction(this.container, {
-			id: this.builder.windowId,
-			action: 'action',
-			jsontype: 'notebookbar',
-			data: {
-				control_id: id,
-				action_type: show ? 'show' : 'hide',
-			}
+			control_id: id,
+			action_type: show ? 'show' : 'hide',
 		});
 
 		JSDialog.RefreshScrollables();


### PR DESCRIPTION
- this fixes problem with "undefined" action_type when selecting image in Writer (tabbed mode)
- executeAction takes inner data (component already checked top level fields to route it into executor)
- add assert so we can notice it when happens again

backport of: https://github.com/CollaboraOnline/online/pull/14907
(error happens just on selecting the image)