### PR TITLE
fix(app:linux): load core before Qt stack

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -24,7 +24,7 @@
 #include <csignal>
 #include <limits>
 
-#if !MOBILEAPP
+#if !MOBILEAPP || defined(QTAPP)
 #include <dlfcn.h>
 #endif
 
@@ -4270,6 +4270,57 @@ std::string anonymizeUrl(const std::string& url)
 #endif
 }
 
+#if !MOBILEAPP || defined(QTAPP)
+
+void* preloadCoreLibrary(const std::string& loTemplate, std::string *loadedLibrary)
+{
+    // we deliberately don't dlclose handle on success, make it
+    // static so static analysis doesn't see this as a leak
+    static void *handle;
+#ifndef __APPLE__
+    std::string libMerged = loTemplate + "/program/libmergedlo.so";
+#else
+    std::string libMerged = loTemplate + "/Contents/Frameworks/libmergedlo.dylib";
+#endif
+    if (File(libMerged).exists())
+    {
+        LOG_TRC("dlopen(" << libMerged << ", RTLD_GLOBAL|RTLD_NOW)");
+        handle = dlopen(libMerged.c_str(), RTLD_GLOBAL|RTLD_NOW);
+        if (!handle)
+        {
+            LOG_FTL("Failed to load " << libMerged << ": " << dlerror());
+            return nullptr;
+        }
+        if (loadedLibrary)
+            *loadedLibrary = std::move(libMerged);
+        return handle;
+    }
+
+#ifndef __APPLE__
+    std::string libSofficeapp = loTemplate + "/program/libsofficeapp.so";
+#else
+    std::string libSofficeapp = loTemplate + "/Contents/Frameworks/libsofficeapp.dylib";
+#endif
+    if (File(libSofficeapp).exists())
+    {
+        LOG_TRC("dlopen(" << libSofficeapp << ", RTLD_GLOBAL|RTLD_NOW)");
+        handle = dlopen(libSofficeapp.c_str(), RTLD_GLOBAL|RTLD_NOW);
+        if (!handle)
+        {
+            LOG_FTL("Failed to load " << libSofficeapp << ": " << dlerror());
+            return nullptr;
+        }
+        if (loadedLibrary)
+            *loadedLibrary = std::move(libSofficeapp);
+        return handle;
+    }
+
+    LOG_FTL("Neither " << libSofficeapp << " or " << libMerged << " exist.");
+    return nullptr;
+}
+
+#endif // !MOBILEAPP || QTAPP
+
 #if !MOBILEAPP
 
 static int receiveURPData(void* context, const signed char* buffer, size_t bytesToWrite)
@@ -4344,49 +4395,9 @@ bool startURP(const std::shared_ptr<lok::Office>& LOKit, void** ppURPContext)
 bool globalPreinit(const std::string &loTemplate)
 {
     std::string loadedLibrary;
-    // we deliberately don't dlclose handle on success, make it
-    // static so static analysis doesn't see this as a leak
-    static void *handle;
-#ifndef __APPLE__
-    std::string libMerged = loTemplate + "/program/libmergedlo.so";
-#else
-    std::string libMerged = loTemplate + "/Contents/Frameworks/libmergedlo.dylib";
-#endif
-    if (File(libMerged).exists())
-    {
-        LOG_TRC("dlopen(" << libMerged << ", RTLD_GLOBAL|RTLD_NOW)");
-        handle = dlopen(libMerged.c_str(), RTLD_GLOBAL|RTLD_NOW);
-        if (!handle)
-        {
-            LOG_FTL("Failed to load " << libMerged << ": " << dlerror());
-            return false;
-        }
-        loadedLibrary = std::move(libMerged);
-    }
-    else
-    {
-#ifndef __APPLE__
-        std::string libSofficeapp = loTemplate + "/program/libsofficeapp.so";
-#else
-        std::string libSofficeapp = loTemplate + "/Contents/Frameworks/libsofficeapp.dylib";
-#endif
-        if (File(libSofficeapp).exists())
-        {
-            LOG_TRC("dlopen(" << libSofficeapp << ", RTLD_GLOBAL|RTLD_NOW)");
-            handle = dlopen(libSofficeapp.c_str(), RTLD_GLOBAL|RTLD_NOW);
-            if (!handle)
-            {
-                LOG_FTL("Failed to load " << libSofficeapp << ": " << dlerror());
-                return false;
-            }
-            loadedLibrary = std::move(libSofficeapp);
-        }
-        else
-        {
-            LOG_FTL("Neither " << libSofficeapp << " or " << libMerged << " exist.");
-            return false;
-        }
-    }
+    static void *handle = preloadCoreLibrary(loTemplate, &loadedLibrary);
+    if (!handle)
+        return false;
 
     LokHookPreInit2* preInit = reinterpret_cast<LokHookPreInit2 *>(dlsym(handle, "lok_preinit_2"));
     if (!preInit)

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -60,6 +60,7 @@ void lokit_main(
 #endif
     std::size_t numericIdentifier);
 
+void* preloadCoreLibrary(const std::string& loTemplate, std::string *loadedLibrary = nullptr);
 bool globalPreinit(const std::string& loTemplate);
 /// Wrapper around private Document::ViewCallback().
 void documentViewCallback(int type, const char* p, void* data);

--- a/qt/coda-qt.cpp
+++ b/qt/coda-qt.cpp
@@ -38,6 +38,8 @@
 
 #include <unistd.h>
 
+void* preloadCoreLibrary(const std::string& loTemplate, std::string *loadedLibrary = nullptr);
+
 const char* user_name = nullptr;
 
 int coolwsd_server_socket_fd = -1;
@@ -129,6 +131,10 @@ namespace
 
 int main(int argc, char** argv)
 {
+    // Load core's bundled libraries early, before QApplication
+    // pulls in the system's potentially older NSS via Qt's stack.
+    preloadCoreLibrary(LO_PATH);
+
     QApplication app(argc, argv);
 
     user_name = getUserName();


### PR DESCRIPTION
load core so that it's preferred libraries are loaded first, shadowing what Qt would have pulled otherwise.

fixes NSS version mismatch that happens when core is built with --without-system-nss and the OS has a older version of NSS installed.


Change-Id: Icbf626c04212034bd144ce72dd1c31b3343da59a


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

