### PR TITLE
add and use helpers::processToIdle for these tests too

### DIFF
--- a/test/UnitInsertDelete.cpp
+++ b/test/UnitInsertDelete.cpp
@@ -110,6 +110,10 @@ UnitBase::TestResult UnitInsertDelete::testInsertDelete()
 
         const std::string slide1Hash = currentPartHashes[0];
 
+        // Wait for core to settle before inserting slides, otherwise
+        // a late status: from load can be consumed by the insert loop.
+        helpers::processToIdle(socket, testname);
+
         // insert 10 slides
         TST_LOG("Inserting 10 slides.");
         for (size_t it = 1; it <= 10; it++)
@@ -125,8 +129,7 @@ UnitBase::TestResult UnitInsertDelete::testInsertDelete()
 
             currentPartHashes = getPartHashCodes(loopStatusJsonObject);
 
-            //FIXME: enable this when fixed
-            //LOK_ASSERT_EQUAL(it + 1, currentPartHashes.size());
+            LOK_ASSERT_EQUAL(it + 1, currentPartHashes.size());
         }
 
         currentPartHashes = drainAndGetPartHashCodes(socket, testname, parser);

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -965,6 +965,35 @@ inline bool sendAndWait(const std::shared_ptr<http::WebSocketSession>& ws,
     return false;
 }
 
+/// Send .uno:ReportWhenIdle and wait for the response, ensuring
+/// all pending core operations have completed.
+inline void processToIdle(const std::shared_ptr<http::WebSocketSession>& ws,
+                          const std::string_view testname,
+                          std::chrono::milliseconds timeout = std::chrono::seconds(10))
+{
+    TST_LOG("Waiting for core to be idle.");
+    sendTextFrame(ws,
+        "uno .uno:ReportWhenIdle {\"idleID\":{\"type\":\"string\",\"value\":\"idle1\"}}",
+        testname);
+    const auto endTime = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < endTime)
+    {
+        const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+            endTime - std::chrono::steady_clock::now());
+        const std::string response =
+            getResponseString(ws, "unocommandresult:", testname, remaining);
+        if (response.empty())
+            break;
+        if (response.find("ReportWhenIdle") != std::string::npos &&
+            response.find("idle1") != std::string::npos)
+        {
+            TST_LOG("Core is idle.");
+            return;
+        }
+    }
+    LOK_ASSERT_FAIL("Timed out waiting for ReportWhenIdle");
+}
+
 /// Drain all events.
 /// Draining happens until nothing is received for @timeoutDrain.
 inline void drain(const std::shared_ptr<http::WebSocketSession>& ws, const std::string& testname,


### PR DESCRIPTION
similar to the use for cypress tests, which was similar to the usage for core UITests

target is the failure of:

[ coolwsd ] TST  UnitInsertDelete [testInsertDelete] (+3746ms): ERROR: Assertion failure: 11 - it != currentPartHashes.size() Expected currentPartHashes.size() [11] == 11 - it [10]| UnitInsertDelete.cpp:138"


Change-Id: Ibe741df65723e3bb23422b015dfbb614e3f436d9


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

