### PR TITLE
Partly revert of 88bb87902: Fix context toolbar's font size dropdown

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -462,6 +462,9 @@ button.leaflet-control-search-next
 #toolbar-up .ui-combobox-button {
 	padding-left: 10px;
 }
+#fontsizecombobox-input-context-toolbar {
+	width: 55px !important;
+}
 #toolbar-up #fontnamecombobox {
 	width: 170px;
 	max-width: 170px;


### PR DESCRIPTION
The width was removed with 88bb87902668a0b06bf377718c737e49abad1cfa

Set again the 55 px otherwise the container sets it to 100% width
making the font size dropdown super lengthy  and with it the context
toolbar.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I1e8739ebea1b3df817e56abd2977659fd27f5ba0
