### PR TITLE
Workaround for CODA-W compile error in Release configuration with Poco 1.14.2

### DIFF
--- a/common/Uri.hpp
+++ b/common/Uri.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <string>
+#include <typeinfo>
 #include <utility>
 #include <map>
 

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -16,6 +16,8 @@
 #define LOK_USE_UNSTABLE_API
 #include <LibreOfficeKit/LibreOfficeKitEnums.h>
 
+#include <typeinfo>
+
 #include <Poco/File.h>
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Path.h>

--- a/kit/Kit.hpp
+++ b/kit/Kit.hpp
@@ -11,7 +11,10 @@
 
 #pragma once
 
+#include <typeinfo>
+
 #include <Poco/Util/XMLConfiguration.h>
+
 #include <map>
 #include <string>
 


### PR DESCRIPTION
The `<Poco/Types.h>` file needs to have `<typeinfo>` included, but doesn't include it itself. So include it first in the files that end up including `<Poco/Types.h>`.

Without this, I get:

error : member access into incomplete type 'const type_info'

For some reason this happens only when compiling in Release mode.


Change-Id: Id226d27ad23896e2471e52c1ece492a1412981cd


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

