### PR TITLE
getCABundleFile started to return null on Fedora 44

### DIFF
--- a/net/Ssl.cpp
+++ b/net/Ssl.cpp
@@ -34,7 +34,8 @@ static const char* getCABundleFile()
         "/etc/pki/tls/certs/ca-bundle.trust.crt",
         "/etc/ssl/certs/ca-certificates.crt",
         "/var/lib/ca-certificates/ca-bundle.pem",
-        "/etc/ssl/cert.pem"
+        "/etc/ssl/cert.pem",
+        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem"
     };
     for (const char* location : locations)
     {


### PR DESCRIPTION
Same as
<https://git.libreoffice.org/core/+/1e9e3d586dc0b1d376c19dcf897d717c6a0a5ae8%5E%21> "GetCABundleFile started to return null on Fedora 44", see <https://fedoraproject.org/wiki/Changes/droppingOfCertPemFile#Scope>.


Change-Id: Ia56de9eb175003a753f1a2d81e384a29fce49e35


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

