### PR TITLE
cool#14745 Crop handle dragging fix

### DIFF
--- a/browser/src/canvas/sections/ShapeHandleScalingSubSection.ts
+++ b/browser/src/canvas/sections/ShapeHandleScalingSubSection.ts
@@ -177,6 +177,9 @@ class ShapeHandleScalingSubSection extends CanvasSectionObject {
 	}
 
 	private doWeKeepRatio(e: MouseEvent) {
+		if (this.sectionProperties.cropModeEnabled)
+			return false;
+
 		let keep = e.ctrlKey && e.shiftKey;
 
 		// For images, the keepRatio shortcut works the opposite way.


### PR DESCRIPTION
Crop and resize shared the same code path, causing crop handles to incorrectly change shape width/height. Fixed by checking if we are cropping in doWeKeepRatio.

Change-Id: I0d0d5408ec8c0304f03c4cdf527659a063c12fcb

