### PR TITLE
add impress invalidation test

### DIFF
--- a/cypress_test/data/desktop/impress/empty-placeholder.fodp
+++ b/cypress_test/data/desktop/impress/empty-placeholder.fodp
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<office:document xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.presentation">
+  <office:styles>
+    <style:style style:name="Default-outline1" style:family="presentation">
+      <style:graphic-properties draw:stroke="none" draw:fill="none"/>
+    </style:style>
+    <style:style style:name="Default-title" style:family="presentation">
+      <style:graphic-properties draw:stroke="none" draw:fill="none"/>
+    </style:style>
+    <style:presentation-page-layout style:name="AL1T0">
+      <presentation:placeholder presentation:object="title" svg:x="1.4cm" svg:y="0.837cm" svg:width="25.199cm" svg:height="3.506cm"/>
+      <presentation:placeholder presentation:object="outline" svg:x="1.4cm" svg:y="4.914cm" svg:width="25.199cm" svg:height="12.179cm"/>
+    </style:presentation-page-layout>
+  </office:styles>
+  <office:automatic-styles>
+    <style:page-layout style:name="PM1">
+      <style:page-layout-properties fo:margin-top="0cm" fo:margin-bottom="0cm" fo:margin-left="0cm" fo:margin-right="0cm" fo:page-width="28cm" fo:page-height="15.75cm" style:print-orientation="landscape"/>
+    </style:page-layout>
+    <style:style style:name="dp1" style:family="drawing-page"/>
+    <style:style style:name="gr1" style:family="graphic">
+      <style:graphic-properties draw:stroke="none" draw:fill="none" draw:auto-grow-height="true" draw:auto-grow-width="false"/>
+    </style:style>
+  </office:automatic-styles>
+  <office:master-styles>
+    <style:master-page style:name="Default" style:page-layout-name="PM1" draw:style-name="dp1">
+      <draw:frame presentation:style-name="Default-title" draw:layer="backgroundobjects" svg:width="25.199cm" svg:height="3.506cm" svg:x="1.4cm" svg:y="0.837cm" presentation:class="title" presentation:placeholder="true">
+        <draw:text-box/>
+      </draw:frame>
+      <draw:frame presentation:style-name="Default-outline1" draw:layer="backgroundobjects" svg:width="25.199cm" svg:height="12.179cm" svg:x="1.4cm" svg:y="4.914cm" presentation:class="outline" presentation:placeholder="true">
+        <draw:text-box/>
+      </draw:frame>
+    </style:master-page>
+  </office:master-styles>
+  <office:body>
+    <office:presentation>
+      <draw:page draw:name="slide1" draw:style-name="dp1" draw:master-page-name="Default" presentation:presentation-page-layout-name="AL1T0">
+        <draw:frame draw:style-name="gr1" draw:layer="layout" svg:width="25.199cm" svg:height="3.506cm" svg:x="1.4cm" svg:y="0.837cm">
+          <draw:text-box>
+            <text:p>Title</text:p>
+          </draw:text-box>
+        </draw:frame>
+      </draw:page>
+      <draw:page draw:name="slide2" draw:style-name="dp1" draw:master-page-name="Default" presentation:presentation-page-layout-name="AL1T0">
+        <draw:frame presentation:style-name="Default-outline1" draw:layer="layout" svg:width="25.199cm" svg:height="12.179cm" svg:x="1.4cm" svg:y="4.914cm" presentation:class="outline" presentation:placeholder="true">
+          <draw:text-box/>
+        </draw:frame>
+      </draw:page>
+    </office:presentation>
+  </office:body>
+</office:document>

--- a/cypress_test/integration_tests/desktop/impress/invalidations_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/invalidations_spec.js
@@ -1,0 +1,43 @@
+/* global describe it cy beforeEach expect require */
+
+var helper = require('../../common/helper');
+
+describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Impress invalidation tests.', function() {
+
+	beforeEach(function() {
+		cy.viewport(1920, 1080);
+	});
+
+	// Switching to a slide with an empty outline placeholder should not
+	// produce full-slide (EMPTY) invalidations.
+	it('Slide switch invalidation count.', function() {
+		helper.setupAndLoadDocument('impress/empty-placeholder.fodp');
+
+		cy.getFrameWindow().then((win) => {
+			this.win = win;
+		}).then(() => {
+			helper.processToIdle(this.win);
+		}).then(() => {
+			var docLayer = this.win.app.map._docLayer;
+			var emptyCount = 0;
+			var origFn = docLayer.handleInvalidateTilesMsg.bind(docLayer);
+
+			docLayer.handleInvalidateTilesMsg = function(textMsg) {
+				if (textMsg.substring('invalidatetiles:'.length + 1).startsWith('EMPTY'))
+					emptyCount++;
+				origFn(textMsg);
+			};
+
+			// Switch from slide 1 to slide 2 (which has an empty outline placeholder)
+			cy.cGet('#preview-img-part-1').click();
+			return cy.wrap(null).then(() => {
+				helper.processToIdle(this.win);
+			}).then(() => {
+				cy.log('Slide 1->2: ' + emptyCount + ' EMPTY invalidations');
+				expect(emptyCount,
+					'slide 1->2 should have no EMPTY invalidations, got ' + emptyCount)
+					.to.equal(0);
+			});
+		});
+	});
+});


### PR DESCRIPTION
the presence of placeholders like in this test document should not create a full slide invalidation on slide changing


Change-Id: Iaee515780d10ed72506e1d9ac9808e4e04e815d3


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

