### PR TITLE
[co-25.04] cool#14940 document compare: merge Show and View Changes buttons into a single menu button

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2356,16 +2356,10 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 						'accessibility': { focusBack: true, combination: 'TC', de: null }
 					},
 					{
-						'id': 'review-show-tracked-changes',
-						'type': 'bigtoolitem',
-						'text': _UNO('.uno:ShowTrackedChanges', 'text'),
-						'command': '.uno:ShowTrackedChanges',
-						'accessibility': { focusBack: true, combination: 'SC', de: null }
-					},
-					{
-						'id': 'compare-tracked-change',
-						'type': 'bigcustomtoolitem',
+						'id': 'compare-tracked-change:ViewChangesMenu',
+						'type': 'menubutton',
 						'text': _('View Changes'),
+						'applyCallback': 'comparechanges',
 						'command': 'comparechanges',
 						'accessibility': { focusBack: true, combination: 'CC' }
 					},

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -1781,6 +1781,21 @@ menuDefinitions.set('PasteMenu', [
 	},
 ] as Array<MenuDefinition>);
 
+menuDefinitions.set('ViewChangesMenu', [
+	{
+		id: 'review-show-tracked-changes',
+		img: 'showtrackedchanges',
+		text: _('Inline'),
+		uno: '.uno:ShowTrackedChanges',
+	},
+	{
+		id: 'compare-tracked-change',
+		img: 'comparechanges',
+		text: _('Side by Side'),
+		action: 'comparechanges',
+	},
+] as Array<MenuDefinition>);
+
 menuDefinitions.set('RecordTrackedChangesMenu', [
 	{
 		id: 'review-track-changes-off',

--- a/browser/src/control/jsdialog/Widget.MenuButton.js
+++ b/browser/src/control/jsdialog/Widget.MenuButton.js
@@ -145,8 +145,6 @@ function _menubuttonControl (parentContainer, data, builder) {
 		// make it possible to setup separate callbacks for split button
 		if (isSplitButton) {
 			JSDialog.AddOnClick(control.button, applyCallback);
-			if (control.label)
-				JSDialog.AddOnClick(control.label, applyCallback);
 			if (control.arrow)
 				control.arrow.tabIndex = 0;
 		} else {

--- a/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
@@ -146,7 +146,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.cGet('#AcceptRejectChangesDialog').parents('.jsdialog-window').find('.ui-dialog-titlebar-close').click();
 		cy.cGet('#AcceptRejectChangesDialog').should('not.exist');
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
-		cy.cGet('#compare-tracked-change').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
 
 		// Then the left label should show the old document name:
 		cy.cGet('#compare-changes-left-title').should(function($el) {
@@ -177,7 +177,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.cGet('#review-tracking').click();
 		// If this is visible or not is not interesting, we want to assert the resulting
 		// title.
-		cy.cGet('#compare-tracked-change').click({force: true});
+		cy.cGet('#compare-tracked-change-button').click({force: true});
 		cy.cGet('#compare-changes-left-title').should(function($el) {
 			expect($el.text()).to.match(/^remote_old\.odt/);
 		});
@@ -193,7 +193,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 
 		// When entering doc compare mode via View Changes:
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
-		cy.cGet('#compare-tracked-change').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
 
 		// Then tiles should exist for both mode=1 (LeftSide) and mode=2 (RightSide)
 		// with content:
@@ -226,7 +226,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('#Review-tab-label').click();
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
-		cy.cGet('#compare-tracked-change').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
 		cy.cGet('.compare-changes-labels').should('not.have.css', 'display', 'none');
 
 		// When faking a tooltip message for a tracked change on the right side:
@@ -255,7 +255,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('#Review-tab-label').click();
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
-		cy.cGet('#compare-tracked-change').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
 		cy.cGet('.compare-changes-labels').should('not.have.css', 'display', 'none');
 
 		// When faking a tooltip message with anchor rectangles for a deletion:
@@ -289,7 +289,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		helper.typeIntoDocument('x');
 		cy.cGet('#Review-tab-label').click();
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
-		cy.cGet('#compare-tracked-change').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
 		cy.cGet('.compare-changes-labels').should('not.have.css', 'display', 'none');
 
 		// When double-clicking at the cursor position on the right side to create a selection:
@@ -312,7 +312,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		desktopHelper.switchUIToNotebookbar();
 		cy.cGet('#Review-tab-label').click();
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
-		cy.cGet('#compare-tracked-change').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
 		cy.cGet('.compare-changes-labels').should('not.have.css', 'display', 'none');
 
 		// When zooming out:


### PR DESCRIPTION
Open a Writer document, the Review tab's Tracking section has both
'Show' and 'View Changes' buttons, which is confusing: showing and
viewing is similar.

The underlying action is different: Show will do a Writer core
layout-level show/hide for the redlines; View Changes will toggle
between the JS layout's (normal) ViewLayout vs ViewLayoutCompareChanges.

Fix the problem by replacing the two buttons with a menu button: just
clicking on the button does the JS layout toogle / side-by-side view.
And turn the old Show button into an item in the merge button's menu,
with an Inline label.

This uncovered a problem in Widget.MenuButton.js: the custom JS action
for the main button (not the arrow button -> dropdown items' click
handler) invoked the callback twice: once for the label and once for the
button that contains the label. It seems this was added in commit
361039c528503a9dec47e4f12639a32324848355 (remove-w2ui: reuse MenuButton
for color picker button, 2024-03-18), but given that the click from the
label propagates to the button, this looks not necessary and here it's
actively harmful: we quickly switched to the compare layout and then
back to normal on click. Most such buttons dispatch an UNO command (and
not a JS action), and there this is not a problem in practice. Also
adapt cypress tests for the UI change.

(cherry picked from commit d8972a97ae438600046f1f11e71308643e97eefe)

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I0d3d5592d69c2dde26f02689b7ac11eabdd121cb
