### PR TITLE
Show drag preview of unselected shapes

### DIFF
--- a/browser/src/canvas/sections/MouseControl.ts
+++ b/browser/src/canvas/sections/MouseControl.ts
@@ -370,9 +370,33 @@ class MouseControl extends CanvasSectionObject {
 				app.LOButtons.left,
 				modifier,
 			);
+
+			this.showShapeDragPreview(dragDistance);
 		}
 
 		app.idleHandler.notifyActive();
+	}
+
+	// Shows unselected shapes drag preview
+	private showShapeDragPreview(dragDistance: number[]): void {
+		const handles = GraphicSelection.handlesSection;
+		if (!handles?.sectionProperties?.svg) return;
+		if (!GraphicSelection.extraInfo?.isDraggable) return;
+
+		handles.sectionProperties.svg.style.left =
+			String((handles.myTopLeft[0] + dragDistance[0]) / app.dpiScale) + 'px';
+		handles.sectionProperties.svg.style.top =
+			String((handles.myTopLeft[1] + dragDistance[1]) / app.dpiScale) + 'px';
+		handles.sectionProperties.svg.style.opacity = '0.5';
+		handles.showSVG();
+	}
+
+	private hideShapeDragPreview(): void {
+		const handles = GraphicSelection.handlesSection;
+		if (!handles?.sectionProperties?.svg) return;
+
+		handles.sectionProperties.svg.style.opacity = '1';
+		handles.hideSVG();
 	}
 
 	onMouseDown(point: cool.SimplePoint, e: MouseEvent): void {
@@ -388,6 +412,8 @@ class MouseControl extends CanvasSectionObject {
 
 	onMouseUp(point: cool.SimplePoint, e: MouseEvent): void {
 		this.refreshPosition(point);
+
+		this.hideShapeDragPreview();
 
 		if (this.mouseDownSent) {
 			this.postCoreMouseEvent(


### PR DESCRIPTION
When dragging starts on an unselected shape, MouseControl owns the
drag because ShapeHandlesSection does not exist yet.  Core selects
the shape in response to our deferred buttondown and sends back a
graphicselection message which creates ShapeHandlesSection and
fetches an SVG.  Once the SVG arrives we can show it as a
semi-transparent drag preview, matching the behavior that
ShapeHandlesSection.onMouseMove provides for already-selected shapes.


Change-Id: If3c6fef682d9b4e2d3778d3acbc884af80b2e2c3


* Resolves: #7821 
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

