### PR TITLE
slide copy: unify paste button in slide deck

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -268,16 +268,25 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 				className: 'cool-font',
 				items: {
 					paste: {
-						name: app.IconUtil.createMenuItemLink(_('Paste Slide'), 'Paste'),
+						name: app.IconUtil.createMenuItemLink(_('Paste'), 'Paste'),
 						isHtmlName: true,
 						callback: function(key, options) {
 								if (!nPos)
 									nPos = that._findClickedPart(options.$trigger[0]);
-								that._setPart(that.copiedSlide);
-								that._map.duplicatePage(nPos);
+								if (that.copiedSlide) {
+									// Same-tab paste: use duplicate allows insertion at a position
+									that._setPart(that.copiedSlide);
+									that._map.duplicatePage(nPos);
+								} else {
+									// Cross-tab/browser paste: use system clipboard
+									that._map.setPart(nPos - 1); // new slide is inserted after set slide
+									that._map._clip.filterExecCopyPaste('.uno:Paste');
+								}
 						},
 						visible: function() {
-							return that.copiedSlide;
+							// Show paste if we have a local copied slide OR
+							// the system clipboard API is available (may have content from another tab)
+							return that.copiedSlide || window.L.Browser.clipboardApiAvailable;
 						}
 					},
 					newslide: {


### PR DESCRIPTION
problem:
paste entry in context menu clicked between previews, and on previews both pasted differently

paste when clicked between slide preview was only
visible when slide was copied in the same doc in same tab and failed to consider when the slides were copied from different browser/tab/doc

now all the paste button uses the uno paste command


Change-Id: I0038ade93675da1742e322dc5df1f9601469ef6b


* Target version: main



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

