### PR TITLE
perf: use unified callback for scroll animation #14984 (25.04)

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -653,6 +653,9 @@ class CanvasSectionContainer {
 		this.drawSections();
 		this.flushLayoutingTasks();
 		this.canvas.style.visibility = 'unset';
+
+		// need to check if we should continue animation
+		this.animate(timestamp);
 	}
 
 	public requestReDraw() {
@@ -2070,7 +2073,7 @@ class CanvasSectionContainer {
 		if (this.continueAnimating) {
 			if (section) section.onAnimate(this.frameCount, this.elapsedTime);
 			this.frameCount++;
-			requestAnimationFrame(this.animate.bind(this));
+			this.requestReDraw();
 		}
 		else {
 			if (section) {


### PR DESCRIPTION
Fixes #14984

- when we animate we use onAnimate callback of some sections
- example of such section is ScrollSection
- after we did the animation we need to schedule next frame and so fat it was done directly by calling requestAnimationFrame
- that was causing the duplication of requests, let's use usual requestReDraw which checks if we already requested a frame
- adjust also a callback so we check at the end if we should schedule another frame

BEFORE:
<img width="1435" height="530" alt="noruler" src="https://github.com/user-attachments/assets/ccdaf109-b11b-44e7-bd1a-a19394b9e51b" />


AFTER:
<img width="806" height="342" alt="after1_noruler" src="https://github.com/user-attachments/assets/41d2085b-922a-44dd-8b66-5aaef3652d1d" />
