### PR TITLE
wsd: fix: wrong viewId sent to the client

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3651,6 +3651,7 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         if (payload == ".uno:NotesMode=true" || payload == ".uno:NotesMode=false" ||
             payload == ".uno:RedlineRenderMode=true" || payload == ".uno:RedlineRenderMode=false")
         {
+            getLOKitDocument()->setView(_viewId);
             std::string status = LOKitHelper::documentStatus(getLOKitDocument()->get());
             sendTextFrame("statusupdate: " + status);
         }


### PR DESCRIPTION
When TrackChanges are on, the edit creates a redline. This causes LOK_CALLBACK_STATE_CHANGED with ".uno:RedlineRenderMode=false" to fire for both views.

A regression from 7bf48566de9324f653fc2e2ca17358c8d24d3563

Problem:
- User-1 changes something in the document
- Callback state change callback triggers with ".uno:RedlineRenderMode"
- Send statusupdate to client with correct viewId
- User-2 gets the same back callback but as we don't set viewId, viewId of
user-1 is sent to the client.

Due to sending wrong viewId to user-2. user-2 sees user-1's author name when inserting comment

Solution:
Add setView call before sending statusupdate to client
