### PR TITLE
cool#14990 document compare: fix lost mode=2 full invalidations

### DIFF
--- a/kit/KitQueue.cpp
+++ b/kit/KitQueue.cpp
@@ -133,6 +133,8 @@ bool extractRectangle(const StringVector& tokens, int& x, int& y, int& w, int& h
     if (tokens.equals(0, "EMPTY,"))
     {
         part = std::atoi(tokens[1].c_str());
+        if (tokens.size() > 2)
+            mode = std::atoi(tokens[2].c_str());
         return true;
     }
 

--- a/test/KitQueueTests.cpp
+++ b/test/KitQueueTests.cpp
@@ -71,6 +71,7 @@ class KitQueueTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testTileDeduplicationOnPush);
     CPPUNIT_TEST(testMultiViewTileQueues);
     CPPUNIT_TEST(testGetCallbackBoolOverload);
+    CPPUNIT_TEST(testCallbackInvalidationEmptyMode);
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -114,6 +115,7 @@ class KitQueueTests : public CPPUNIT_NS::TestFixture
     void testTileDeduplicationOnPush();
     void testMultiViewTileQueues();
     void testGetCallbackBoolOverload();
+    void testCallbackInvalidationEmptyMode();
 
     // Compat helper for tests
     std::string popHelper(KitQueue &queue)
@@ -1226,6 +1228,34 @@ void KitQueueTests::testGetCallbackBoolOverload()
 
     // Queue is empty again.
     LOK_ASSERT(!queue.getCallback(cb));
+}
+
+void KitQueueTests::testCallbackInvalidationEmptyMode()
+{
+    // Given a mode=1 and a mode=2 partial invalidation in the queue:
+    constexpr std::string_view testname = __func__;
+    TilePrioritizer dummy;
+    KitQueue queue(dummy);
+    KitQueue::Callback item;
+    putCallback(queue, "callback all 0 284, 1418, 11105, 275, 0, 1");
+    putCallback(queue, "callback all 0 284, 1418, 11105, 275, 0, 2");
+    LOK_ASSERT_EQUAL(2, static_cast<int>(queue.callbackSize()));
+
+    // When putting mode=1 and mode=2 full invalidations in the queue:
+    putCallback(queue, "callback all 0 EMPTY, 0, 1");
+    putCallback(queue, "callback all 0 EMPTY, 0, 2");
+
+    // Then make sure deduplication results in two full invalidations:
+    // Without the accompanying fix in place, this test would have failed with:
+    // - Expected: 2
+    // - Actual  : 3
+    // i.e. the queue had "284, 1418, 11105, 275, 0, 1", "284, 1418, 11105, 275, 0, 2" and "EMPTY,
+    // 0, 2", which means the EMPTY invalidate for mode=1 was lost.
+    LOK_ASSERT_EQUAL(2, static_cast<int>(queue.callbackSize()));
+    item = queue.getCallback();
+    LOK_ASSERT_EQUAL_STR("EMPTY, 0, 1", item._payload);
+    item = queue.getCallback();
+    LOK_ASSERT_EQUAL_STR("EMPTY, 0, 2", item._payload);
 }
 
 CPPUNIT_TEST_SUITE_REGISTRATION(KitQueueTests);


### PR DESCRIPTION
Open a Writer document, Review -> View Changes on the notebookbar,
delete "A", insert "A", Home, Enter: the left side updates, the right
side does not, which is buggy.

Checking the websocket incoming messages in the browser, there is a full
("EMPTY") invalidate on the left hand side, but the matching invalidate
for the right hand side ("mode=2") is missing. Checking core, we
properly send full invalidates for both modes in
SwView::libreOfficeKitViewInvalidateTilesCallback(), but later this
mode=2 full invalidate is lost. This results in a situation that core
thinks there were not paints since the last full invalidate, so no need
to send later invalidations, since core.git commit
b95a6816555396661d90da02e844d2848b1da3bf (cool#11254 desktop lok: avoid
invalidations if no tiles are sent, 2025-03-05). At the same time
online.git code doesn't request tiles, since it doesn't get the mode=2
full invalidate.

Fix the problem by improving the kit queue deduplication: if we have 2
partial invalidates for mode=1 + mode=2 and we get two full invalidates
for mode=1 + mode=2, then deduplication should keep both mode=1 + mode=2
full invalidates.

So at the end this was indeed not JS client bug, but it wasn't in
core.git, either.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I869ad946d92ec295b1127e30a335872c4c079e79
