### PR TITLE
make desktop/impress/top_toolbar_spec more reliable

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js
@@ -149,14 +149,13 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 	});
 
 	it('Click shape hyperlink.', function() {
-		// Insert shape
+		// Insert shape - this creates and selects the shape
+		// immediately, no additional click needed to select it.
 		desktopHelper.getCompactIconArrow('DefaultNumbering').click();
 		desktopHelper.getCompactIconArrow('BasicShapes').click();
 		cy.cGet('.col.w2ui-icon.basicshapes_round-quadrat').click();
 		cy.cGet('#test-div-shapeHandlesSection').should('exist');
-
-		// Select shape at center of document
-		impressHelper.clickCenterOfSlide( { } );
+		helper.processToIdle(this.win);
 
 		helper.typeIntoDocument('{ctrl}k');
 		cy.cGet('#target').should('exist').should('be.visible');
@@ -165,6 +164,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Top toolbar tests.', funct
 
 		cy.cGet('#target-input').type('www.something.com');
 		cy.cGet('#ok').click();
+		cy.cGet('#target').should('not.exist');
 
 		helper.processToIdle(this.win);
 


### PR DESCRIPTION
Failure context for 'Click shape hyperlink.':
        cy:command ✔  type       {esc}
        cy:command ✔  cGet       #document-container
        cy:command ✔  assert     expected **0** to equal **0**
        cy:command ✔  cGet       #test-div-shapeHandlesSection
        cy:command ✔  assert     expected **#test-div-shapeHandlesSection** not to exist in the DOM
            cy:log ✱  << removeShapeSelection - end
        cy:command ✔  cGet       #document-container
        cy:command ✔  assert     expected **<div#document-container.notebookbar-active.slide-normal-mode.landscape.parts-preview-document>** to have a length of **1**
        cy:command ✔  cGet       body
        cy:command ✔  click      625.5, 348, {ctrlkey: true}
        cy:command ✔  wrap       null
        cy:command ✔  assert     .uno:ReportWhenIdle result with idleID 19: expected **{ Object (proxy, thisValue, ...) }** to be an object
        cy:command ✔  cGet       [id^="info-modal-label2"]
        cy:command ✘  assert     expected **[id^="info-modal-label2"]** to have text **http://www.something.com/**, but the text was **''**
        cy:command ✔  fail:
                      Timed out retrying after 10000ms: Expected to find element: `[id^="info-modal-label2"]`, but never found it. Queried from:
                                    > cy.get(#coolframe, [object Object]).its(0.contentDocument, [object Object])
                      /home/collabora/jenkins/workspace/github_online_master_debug_vs_co-26.04_cypress_desktop/cypress_test/integration_tests/desktop/impress/top_toolbar_spec.js:123:46
                        121 |         impressHelper.clickCenterOfSlide({ ctrlKey: true });
                        122 |         helper.processToIdle(this.win);
                      > 123 |         cy.cGet('[id^="info-modal-label2"]').should('have.text', 'http://www.something.com/');
                            |                                              ^
                        124 |         cy.cGet( ...
            cy:log ✱  Finishing test: integration_tests/desktop/impress/top_toolbar_spec.js / Top toolbar tests. / Click shape hyperlink.
        cy:command ✔  loadavg    21.77 25.04 32.26 9/6391 3974217
Builds:
  - desktop#674 (PR#14937: use same defaultCommandTimeout for multiuser tests...)
  - desktop#702 (PR#14954: css: unify UI font-family to single --cool-font to...)
  - desktop#710 (PR#14961: cool#14745 Crop handle dragging fix)


Change-Id: I7a16a5450bfeac704d9738f4831e3ee297b677d3


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

