### PR TITLE
make mobile/calc/bottom_toolbar_spec more reliable

### DIFF
--- a/cypress_test/integration_tests/mobile/calc/bottom_toolbar_spec.js
+++ b/cypress_test/integration_tests/mobile/calc/bottom_toolbar_spec.js
@@ -15,6 +15,10 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 		cy.cGet('#toolbar-down').should('exist');
 
 		calcHelper.clickOnFirstCell();
+
+		cy.getFrameWindow().then(function(win) {
+			this.win = win;
+		});
 	});
 
 	function getTextEndPosForFirstCell() {
@@ -29,6 +33,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 
 	it('Apply bold.', function() {
 		helper.setDummyClipboardForCopy();
+		helper.processToIdle(this.win);
 		mobileHelper.getCompactIcon('Bold').should('not.be.disabled').click();
 		calcHelper.selectEntireSheet();
 		helper.copy();
@@ -37,6 +42,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 
 	it('Apply italic.', function() {
 		helper.setDummyClipboardForCopy();
+		helper.processToIdle(this.win);
 		mobileHelper.getCompactIcon('Italic').should('not.be.disabled').click();
 		calcHelper.selectEntireSheet();
 		helper.copy();
@@ -45,6 +51,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 
 	it('Apply underline.', function() {
 		helper.setDummyClipboardForCopy();
+		helper.processToIdle(this.win);
 		mobileHelper.getCompactIcon('Underline').should('not.be.disabled').click();
 		calcHelper.selectEntireSheet();
 		helper.copy();
@@ -59,6 +66,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 
 	it('Apply font color.', function() {
 		helper.setDummyClipboardForCopy();
+		helper.processToIdle(this.win);
 		cy.cGet('#toolbar-down #fontcolor').should('not.be.disabled').click();
 		mobileHelper.selectFromColorPalette(0, 5);
 		calcHelper.selectEntireSheet();
@@ -68,6 +76,7 @@ describe(['tagmobile', 'tagnextcloud', 'tagproxy'], 'Interact with bottom toolba
 
 	it('Apply highlight color.', function() {
 		helper.setDummyClipboardForCopy();
+		helper.processToIdle(this.win);
 		cy.cGet('#toolbar-down #backcolor').should('not.be.disabled').click();
 		mobileHelper.selectFromColorPalette(0, 5);
 		calcHelper.selectEntireSheet();


### PR DESCRIPTION
Failure context for 'Apply bold.':
        cy:command ✔  assert     expected **<div#test-div-OwnCellCursor>** to exist in the DOM
        cy:command ✔  getFrameWindow     #coolframe
            cy:log ✱  >> assertAddressAfterIdle - start
            cy:log ✱  Param - expectedAddress: A1
        cy:command ✔  wrap       null
        cy:command ✔  assert     .uno:ReportWhenIdle result with idleID 3: expected **{ Object (proxy, thisValue, ...) }** to be an object
        cy:command ✔  cGet       #addressInput input
        cy:command ✔  assert     expected **<input#pos_window-input-address.ui-combobox-content.addressInput.jsdialog>** to have value **A1**
            cy:log ✱  << assertAddressAfterIdle - end
            cy:log ✱  << clickOnFirstCell - end
        cy:command ✔  window
        cy:command ✔  cGet       #toolbar-down .unoBold:visible
        cy:command ✔  assert     expected **<div#bold1.unotoolbutton.jsdialog.ui-content.unospan.unoBold.no-label>** not to be **disabled**
        cy:command ✘  click
        cy:command ✔  fail:
                      Timed out retrying after 10050ms: `cy.click()` failed because this element is `disabled`:
                      `<div class="unotoolbutton jsdialog ui-content unospan unoBold no-label" tabindex="-1" modelid="bold" id="bold1" data-cooltip="Bold (Ctrl+B)">...</div>`
                      Fix this problem, or use `{force: true}` to disable error checking.
                      https://on.cypress.io/element-cannot-be-interacted-with
                      /home/collabora/jenkins/workspace/github_online_master_debug_vs_co-26.04_cypress_mobile/cypress_test/integration_tests/mobile/calc/bottom_toolbar_spec.js:21:71
                        19 |     it('Apply bold.', function () {
                        20 |         helper.setDummyClipboardForCopy();
                      > 21 |         mobileHelper.getCompactIcon('Bold').shoul ...
            cy:log ✱  Finishing test: integration_tests/mobile/calc/bottom_toolbar_spec.js / Interact with bottom toolbar. / Apply bold.
        cy:command ✔  loadavg    94.31 100.25 101.47 56/7137 2512063
Builds:
  - mobile#553 (PR#14698: cypress: follow me slideshow buttons for follower)
  - mobile#628 (PR#14968: Block moving a shape when it is not selected)


Change-Id: I89f34f9fc60464d672125bfacc85613b1d8e8aa1


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

