### PR TITLE
cool#14059 implement follow user feature in Impress

### DIFF
--- a/browser/src/canvas/CanvasSectionObject.ts
+++ b/browser/src/canvas/CanvasSectionObject.ts
@@ -221,6 +221,13 @@ class CanvasSectionObject {
 			(point[1] >= this.myTopLeft[1] && point[1] <= this.myTopLeft[1] + this.size[1]))
 	}
 
+	goToSection() {
+		const point = new cool.SimplePoint(this.position[0] * app.pixelsToTwips, this.position[1] * app.pixelsToTwips);
+		var isNewCursorVisible = app.isPointVisibleInTheDisplayedArea(point.toArray());
+		if (!isNewCursorVisible)
+			app.map._docLayer.scrollToPos(point);
+	}
+
 	// All below functions should be included in their respective section definitions (or other classes), not here.
 	isCalcRTL(): boolean { return; }
 	setViewResolved(on: boolean): void { return; }

--- a/browser/src/canvas/sections/OtherViewGraphicSelectionSection.ts
+++ b/browser/src/canvas/sections/OtherViewGraphicSelectionSection.ts
@@ -111,6 +111,19 @@ class OtherViewGraphicSelectionSection extends CanvasSectionObject {
         else return false;
     }
 
+    public static doesViewExist(viewId: number): boolean {
+        const name = OtherViewGraphicSelectionSection.sectionNamePrefix + viewId;
+        return app.sectionContainer.doesSectionExist(name);
+    }
+
+    public static getViewSection(viewId: number): OtherViewGraphicSelectionSection | null {
+        if (OtherViewGraphicSelectionSection.doesViewExist(viewId)) {
+            const name = OtherViewGraphicSelectionSection.sectionNamePrefix + viewId;
+            return app.sectionContainer.getSectionWithName(name) as OtherViewGraphicSelectionSection;
+        }
+        return null;
+    }
+
     public static updateVisibilities() {
         for (let i = 0; i < OtherViewGraphicSelectionSection.sectionPointers.length; i++) {
             const section = OtherViewGraphicSelectionSection.sectionPointers[i];

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1637,9 +1637,13 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 
 		app.definitions.otherViewGraphicSelectionSection.addOrUpdateGraphicSelectionIndicator(viewId, strTwips, parseInt(obj.part), obj.mode !== undefined ? parseInt(obj.mode): 0);
 
-		if (this.isCalc()) {
-			this._saveMessageForReplay(textMsg, viewId);
+		if (app.getFollowedViewId() === viewId && app.isFollowingUser()) {
+			if (this.isImpress() || this.isDraw() || this.isWriter()) {
+				this.goToOtherUserView(viewId);
+			}
 		}
+
+		this._saveMessageForReplay(textMsg, viewId);
 	},
 
 	_onCellCursorMsg: function (textMsg) {
@@ -1867,7 +1871,7 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 		TextCursorSection.addOrUpdateOtherViewCursor(viewId, username, rectangle, parseInt(obj.part), mode);
 
 		if (app.getFollowedViewId() === viewId && (app.isFollowingEditor() || app.isFollowingUser())) {
-			if (this._map.getDocType() === 'text' || this._map.getDocType() === 'presentation') {
+			if (this.isWriter() || this.isImpress() || this.isDraw()) {
 				this.goToViewCursor(viewId);
 			}
 			else if (this._map.getDocType() === 'spreadsheet') {
@@ -3021,6 +3025,19 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 		}
 	},
 
+	// Jump to view of user with given *viewId*
+	goToOtherUserView: function(viewId) {
+		const graphicSection = OtherViewGraphicSelectionSection.getViewSection(viewId);
+
+		if (graphicSection) {
+			if (this._selectedPart !== graphicSection.sectionProperties.part) {
+				this._map.deselectAll();
+				this._map.setPart(graphicSection.sectionProperties.part);
+			}
+			graphicSection.goToSection();
+		}
+	},
+
 	goToViewCursor: function(viewId) {
 		if (viewId === this._viewId) {
 			this._onUpdateCursor();
@@ -3029,12 +3046,16 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 
 		const section = TextCursorSection.getViewCursorSection(viewId);
 
-		if (section && section.showSection) {
-			const point = new cool.SimplePoint(section.position[0] * app.pixelsToTwips, section.position[1] * app.pixelsToTwips);
-			var isNewCursorVisible = app.isPointVisibleInTheDisplayedArea(point.toArray());
-			if (!isNewCursorVisible)
-				this.scrollToPos(point);
-			app.definitions.cursorHeaderSection.showCursorHeader(viewId);
+		if (section) {
+			if ((this.isImpress() || this.isDraw()) && this._selectedPart !== section.sectionProperties.part) {
+				this._map.deselectAll();
+				this._map.setPart(section.sectionProperties.part);
+			}
+
+			if (section.showSection) {
+				section.goToSection();
+				app.definitions.cursorHeaderSection.showCursorHeader(viewId);
+			}
 		}
 	},
 
@@ -3462,7 +3483,8 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 				'graphicviewselection',
 			] : [
 				'textviewselection',
-				'invalidateviewcursor'
+				'invalidateviewcursor',
+				'graphicviewselection'
 			];
 
 			this._printTwipsMessagesForReplay = new window.L.MessageStore(ownViewTypes, otherViewTypes);

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -1713,8 +1713,10 @@ window.L.Map = window.L.Evented.extend({
 
 		if (this.getDocType() === 'spreadsheet') {
 			this._docLayer.goToCellViewCursor(id);
-		} else if (this.getDocType() === 'text' || this.getDocType() === 'presentation') {
+		} else if (this.getDocType() === 'text') {
 			this._docLayer.goToViewCursor(id);
+		} else if (this.getDocType() === 'presentation' || this.getDocType() === 'drawing') {
+			this._docLayer.goToOtherUserView(id);
 		}
 	},
 


### PR DESCRIPTION
In case of following a specific user, the change in view will be triggered when that user switches to a different slide, selects/edits a shape or text.

In case of following editor, the change in view will only be triggered when the editor selects/edits text.


Change-Id: I755a56bacd98c1ef5c5371cc8b4fec2dc4492251


* Resolves: #14059 
* Target version: main

### Summary

<table>
<tr>
 <td> Follow user
 <td> 

https://github.com/user-attachments/assets/893a9057-be97-4e53-8002-88860b0fb85c


<tr>
 <td> Follow editor
 <td> 

https://github.com/user-attachments/assets/ab3c430a-9a2e-4edc-a217-88c0bdcd0582


</table>





### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

