### PR TITLE
Register jsdialog-deferred and wait for that in processToIdle

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -298,12 +298,16 @@ window.L.Control.JSDialog = window.L.Control.extend({
 			let timeoutId = null;
 			const finallyClose = () => {
 				instance.that.close(instance.id, false);
-				clearTimeout(timeoutId);
+				app.timerRegistry.clearTimeout(timeoutId);
 			};
 
 			container.onanimationend = finallyClose;
 			// be sure it will be removed if onanimationend will not be executed
-			timeoutId = setTimeout(finallyClose, 700);
+			timeoutId = app.timerRegistry.setTimeout(
+				'jsdialog-deferred',
+				finallyClose,
+				700,
+			);
 		});
 	},
 

--- a/browser/src/control/jsdialog/Util.MessageRouter.ts
+++ b/browser/src/control/jsdialog/Util.MessageRouter.ts
@@ -51,7 +51,11 @@ class JSDialogMessageRouter {
 				(msgData.jsontype === 'addressinputfield' &&
 					!app.socket._map.addressInputField)
 			) {
-				setTimeout(fireJSDialogEvent, 1000);
+				app.timerRegistry.setTimeout(
+					'jsdialog-deferred',
+					fireJSDialogEvent,
+					1000,
+				);
 				return;
 			} else if (fireJSDialogEvent() === true) {
 				return;

--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -1309,6 +1309,8 @@ function waitUntilLayoutingIsIdle(win) {
 
 function processToIdle(win) {
 	return waitUntilCoreIsIdle(win).then(function() {
+		return waitForTimers(win, 'jsdialog-deferred');
+	}).then(function() {
 		return waitUntilLayoutingIsIdle(win);
 	});
 }


### PR DESCRIPTION
Failure context for 'Search wrap at document end':
            cy:log ✱  >> findNext - start
        cy:command ✔  cGet       #search-button
        cy:command ✔  assert     expected **<button#search-button.ui-pushbutton.jsdialog.button-primary>** not to have attribute **disabled**
        cy:command ✔  cGet       #search-button
        cy:command ✔  click
        cy:command ✔  wrap       null
        cy:command ✔  assert     .uno:ReportWhenIdle result with idleID 42: expected **{ Object (proxy, thisValue, ...) }** to be an object
            cy:log ✱  << findNext - end
            cy:log ✱  >> assertAddressAfterIdle - start
            cy:log ✱  Param - expectedAddress: A1
        cy:command ✔  wrap       null
        cy:command ✔  assert     .uno:ReportWhenIdle result with idleID 43: expected **{ Object (proxy, thisValue, ...) }** to be an object
        cy:command ✔  cGet       #addressInput input
        cy:command ✘  assert     expected **<input#pos_window-input-address.ui-combobox-content.addressInput.jsdialog>** to have value **A1**, but the value was **A2**
        cy:command ✔  fail:
                      Timed out retrying after 10000ms: expected '<input#pos_window-input-address.ui-combobox-content.addressInput.jsdialog>' to have value 'A1', but the value was 'A2'
                      /home/collabora/jenkins/workspace/github_online_master_debug_vs_co-26.04_cypress_desktop/cypress_test/integration_tests/common/calc_helper.js:299:42
                        297 |     cy.log('Param - expectedAddress: ' + expectedAddress);
                        298 |     helper.processToIdle(win);
                      > 299 |     cy.cGet(helper.addressInputSelector).should('have.value', expectedAddress);
                            |                                          ^
                        300 |     cy.log('<< assertAddressAfterIdle - end');
                        301 | }
                        302 | module.exports.clickAtOffset = clickAt ...
            cy:log ✱  Finishing test: integration_tests/desktop/calc/find_dialog_spec.js / Searching via find dialog. / Search wrap at document end
Builds:
  - desktop#681 (PR#14909: Private/timar/fixtoc)
  - desktop#686 (PR#14679: Revert \"cypress: skip some failing tests while po...)
  - desktop#695 (PR#14952: Partly revert of 88bb87902: Fix context toolbar's ...)
  - desktop#702 (PR#14954: css: unify UI font-family to single --cool-font to...)
  - desktop#715 (PR#14947: add and use helpers::processToIdle for these tests...)
  - desktop#716 (PR#14977: these calc dialog pass a11y testing now)


Change-Id: I758dc7418cc884629412ebda09f3fce1734cbc60


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

