### PR TITLE
shortcut label for undo not visible

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -390,7 +390,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 	getHomeTab: function() {
 		var content = [
 			{
-				'id': 'home-undo-redo',
+				'id': 'home-do',
 				'type': 'container',
 				'children': [
 					{

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -586,7 +586,7 @@ window.L.Control.NotebookbarDraw = window.L.Control.NotebookbarImpress.extend({
 	getHomeTab: function() {
 		var content = [
 			{
-				'id': 'home-undo-redo',
+				'id': 'home-do',
 				'type': 'container',
 				'children': [
 					{

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -712,7 +712,7 @@ window.L.Control.NotebookbarImpress = window.L.Control.NotebookbarWriter.extend(
 	getHomeTab: function() {
 		var content = [
 			{
-				'id': 'home-undo-redo',
+				'id': 'home-do',
 				'type': 'container',
 				'children': [
 					{

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -580,7 +580,7 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 	getHomeTab: function() {
 		var content = [
 			{
-				'id': 'home-undo-redo',
+				'id': 'home-do',
 				'type': 'container',
 				'children': [
 					{

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -556,7 +556,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 
 	it.skip('Scroll', function() {
 		// Start all the way on the left side of the toolbar
-		cy.cGet('#Home-container #home-undo-redo').should('be.visible');
+		cy.cGet('#Home-container #home-do').should('be.visible');
 		// TODO: Cypress thinks buttons are visible even though they are not
 		//cy.cGet('#Home-container #home-search-dialog').should('not.be.visible');
 		cy.cGet('#toolbar-up .ui-scroll-left').should('not.be.visible');
@@ -574,7 +574,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 
 		// Now we are all the way on the right side of the toolbar
 		// TODO: Cypress thinks buttons are visible even though they are not
-		//cy.cGet('#Home-container #home-undo-redo').should('not.be.visible');
+		//cy.cGet('#Home-container #home-do').should('not.be.visible');
 		cy.cGet('#Home-container #home-search-dialog').should('be.visible');
 		cy.cGet('#toolbar-up .ui-scroll-left').should('be.visible');
 		cy.cGet('#toolbar-up .ui-scroll-right').should('not.be.visible');
@@ -590,7 +590,7 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 		});
 
 		// Now back on the left side of the toolbar
-		cy.cGet('#Home-container #home-undo-redo').should('be.visible');
+		cy.cGet('#Home-container #home-do').should('be.visible');
 		// TODO: Cypress thinks buttons are visible even though they are not
 		//cy.cGet('#Home-container #home-search-dialog').should('not.be.visible');
 		cy.cGet('#toolbar-up .ui-scroll-left').should('not.be.visible');


### PR DESCRIPTION
while that of redo is visible.

Undo's "ZZ" shortcut label was invisible because the querySelector('[id^="home-undo"]'), intended to match something like "home-undo13", instead matched the parent container of undo and redo called "home-undo-redo".

And the box was ended up underneath Redo's "O" label.

Take the easy route here of renaming "home-undo-redo" to "home-do", so it won't match.


Change-Id: I92bcf92bc69d3205b2066792ab923d1d259fe9a7


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

