### PR TITLE
test: improve stability of unit-timeout_inactive with sanitizers

### DIFF
--- a/test/UnitTimeoutInactive.cpp
+++ b/test/UnitTimeoutInactive.cpp
@@ -183,7 +183,7 @@ UnitBase::TestResult UnitTimeoutInactivity::testWS(bool forceInactivityTO)
         LOK_ASSERT_EQUAL(true, session->isConnected());
 
         if (forceInactivityTO) {
-            std::this_thread::sleep_for( net::Defaults.inactivityTimeout * 2 );
+            pollDisconnected(net::Defaults.inactivityTimeout * 20, *session);
         }
         TST_LOG("Test: XX2: connected " << session->isConnected());
         session->sendMessage("ping");


### PR DESCRIPTION
Sanitizers generate code which runs slowly, and this test failed a lot
(but not always) in that environment.

It seems what happens is: test sleeps for a fixed inactivityTimeout * 2
(720ms), hoping the server disconnects in that timeframe. If the server
sends a message during that, the inactivity timer resets. When this
test fails, then these messages only finish ~130ms before the end of the
sleep, so the inactivity timeout doesn't kick in yet. And then we send a
"ping" message, so the socket will be still connected, since our "ping"
resets the inactivity timer. This leads to an assert fail:
[ coolwsd ] TST  testWS (+11815ms): ERROR: Assertion failure: 0UL != connected Expected connected [1] == 0UL [0]| UnitTimeoutInactive.cpp:210

Fix this by not sleeping for a fixed time, but rather use
pollDisconnected(), to make sure that by the time we send our "ping",
the socket is disconnected.

If the websocket never disconnects due to a timeout, the test would
still fail this way.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I629e0f662ab175aeb581d4715422a0f3fef53066
