### PR TITLE
Private/rparth07/keyboard shortcut reading

### DIFF
--- a/browser/css/helpdialog.css
+++ b/browser/css/helpdialog.css
@@ -152,7 +152,18 @@
 		filter: invert(1);
 	}
 
-	#keyboard-shortcuts-content:focus-visible {
-		outline: none;
+	#online-help-search-button {
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 5px;
+		margin: 0;
+		width: 32px;
+		height: 32px;
 	}
+}
+
+#online-help-content-box:focus-visible,
+#keyboard-shortcuts-content-box:focus-visible {
+	outline: none;
 }

--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -1,5 +1,8 @@
 <div class="search-container">
     <input size="20" id="online-help-search-input" type="search" aria-label="search" spellcheck="false" />
+    <button id="online-help-search-button" type="button" aria-label="Search">
+      <img src="images/lc_recsearch.svg" alt="Search" />
+    </button>
 </div>
 
 <div id="keyboard-shortcuts-content">

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -502,11 +502,11 @@ window.L.Map.include({
 		var searchInput = document.getElementById('online-help-search-input');
 		searchInput.setAttribute('placeholder',_('Search'));
 		searchInput.setAttribute('aria-label',_('Search'));
-		searchInput.focus(); // auto focus on user input field
 		var helpContentParent = document.getElementsByClassName('ui-dialog-content')[0];
 		var startFilter = false;
 		var isAnyMatchingContent = false;
-		searchInput.addEventListener('input', function () {
+
+		const performSearch = function() {
 			// Hide all elements within the #online-help-content on first key stroke/at start of filter content
 			if (!startFilter || !isAnyMatchingContent) {
 				helpContentParent.style.backgroundColor = 'var(--color-background-dark) !important';
@@ -528,10 +528,23 @@ window.L.Map.include({
 			}
 			else {
 				this.filterResults(searchTerm, isAnyMatchingContent, id);
-				this.focusContainer(id + '-box');
+				this._focusContainer(id + '-box');
 			}
-		}.bind(this));
+		}.bind(this);
 
+		searchInput.addEventListener('keydown', function (e) {
+			if (e.key === 'Enter') {
+				performSearch();
+			}
+		});
+
+		const searchButton = document.getElementById('online-help-search-button');
+		searchButton.addEventListener('click', performSearch);
+		searchButton.addEventListener('keydown', function (e) {
+			if (e.key === 'Enter') {
+				performSearch();
+			}
+		});
 
 		const onlineHelpContent = document.getElementById('online-help-content');
 		const buttons = onlineHelpContent.querySelectorAll('.scroll-button');
@@ -548,17 +561,17 @@ window.L.Map.include({
 			});
 		});
 
-		this.focusContainer(id + '-box');
+		this._focusContainer(id + '-box');
 	},
 
-	focusContainer: function(id) {
-			app.layoutingService.appendLayoutingTask(() => {
+	_focusContainer: function(id) {
+		app.layoutingService.appendLayoutingTask(() => {
 			var contentContainer = document.getElementById(id);
-				if (contentContainer) {
-					contentContainer.setAttribute('tabindex', '-1');
-					contentContainer.focus();
-				}
-			});
+			if (contentContainer) {
+				contentContainer.setAttribute('tabindex', '-1');
+				contentContainer.focus();
+			}
+		});
 	},
 
 	filterResults: function (searchTerm, isAnyMatchingContent, id) {


### PR DESCRIPTION
Changes:
1. [fix: enhance focus handling for keyboard shortcuts dialog](https://github.com/CollaboraOnline/online/commit/1d95c26ff3176e59918190f231fb7d916fbf95e3) 
   - move focus handling logic to separate method to reuse when user performs search
   - this new method now handles both Keyboard short dialog and Online help dialog
2. [fix: implement search functionality in online help and keyboard shortcuts dialog](https://github.com/CollaboraOnline/online/commit/b6176f80bc909bea4f8faca1baa4bb7bf752b9dc) 
   - adds new search button next to input search box
   - adds click and enter keyboard event to search button
   - adds enter keyboard event to search input box
   - enhances styling of search button
   - avoid visible border on focus
   - issue:
      - the search result is not read by the screenreader in keyboard shortcut and online help dialog, so the visually impaired person using it will not know the answer to their search.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required