### PR TITLE
calc: add Shuffle command to NotebookBar and Menubar

### DIFF
--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -989,6 +989,7 @@ class Menubar extends window.L.Control {
 				{uno: '.uno:DataSort'},
 				{uno: '.uno:SortAscending'},
 				{uno: '.uno:SortDescending'},
+				{uno: '.uno:Shuffle'},
 				{uno: '.uno:Validation'},
 				{uno: '.uno:Calculate'},
 				{uno: '.uno:ConvertFormulaToValue'},
@@ -1314,6 +1315,7 @@ class Menubar extends window.L.Control {
 				{type: 'separator'},
 				{uno: '.uno:SortAscending'},
 				{uno: '.uno:SortDescending'},
+				{uno: '.uno:Shuffle'},
 				{type: 'separator'},
 				{name: _UNO('.uno:GroupOutlineMenu', 'spreadsheet'), id: 'groupoutlinemenu', type: 'menu', menu: [
 					{uno: '.uno:Group'},

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -2360,6 +2360,24 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 						],
 						'vertical': 'true'
 					},
+					{
+						'type': 'container',
+						'children': [
+							{
+								'type': 'toolbox',
+								'children': [
+									{
+										'id': 'data-shuffle',
+										'type': 'toolitem',
+										'text': _UNO('.uno:Shuffle', 'spreadsheet'),
+										'command': '.uno:Shuffle',
+										'accessibility': { focusBack: true,	combination: 'SH', de: null }
+									}
+								]
+							}
+						],
+						'vertical': 'true'
+					},
 				]
 			},
 			{ type: 'separator', id: 'data-sortdescending-break', orientation: 'vertical' },

--- a/browser/src/unocommands.js
+++ b/browser/src/unocommands.js
@@ -579,6 +579,7 @@ var unoCommandsArray = {
 	'SheetMenu':{spreadsheet:{menu:_('~Sheet'),},},
 	'SheetRightToLeft':{spreadsheet:{context:_('Sheet R~ight-To-Left'),menu:_('R~ight-To-Left'),},},
 	'Show':{spreadsheet:{menu:_('~Show Sheet...'),},},
+	'Shuffle':{spreadsheet:{menu:_('Shuffle'),},},
 	'ShowAnnotations':{global:{menu:_('Comments'),},},
 	'ShowColumn':{spreadsheet:{context:_('S~how Columns'),menu:_('~Show'),},},
 	'ShowDetail':{global:{menu:_('~Show Details'),},},


### PR DESCRIPTION
* Resolves: #14986
* Target version: main

### Summary

New command Shuffle (`Data -> Shuffle`) was added to CO Classic (26.04) but was not available in COOL since it was not yet added to the NotebookBar.

This PR adds the Shuffle command to:
- The **Data** tab in the NotebookBar (as a toolitem in the Sort group, alongside Sort Ascending/Descending)
- The **Data** menu in the classic Menubar (both desktop and mobile spreadsheet views)
- The `unocommands.js` translation registry

Shuffle works similarly to Sort but randomly shuffles elements instead of ordering them, which is useful for statistics.

### Checklist

- [x] All commits have Change-Id
- [x] Documentation (manuals or wiki) has been updated or is not required
