### PR TITLE
Add LibreOfficeKit.h include around LibreOfficeKitInit.h include

### DIFF
--- a/ios/Mobile/TemplateCollectionViewController.mm
+++ b/ios/Mobile/TemplateCollectionViewController.mm
@@ -11,6 +11,7 @@
 
 #define LIBO_INTERNAL_ONLY
 #import <LibreOfficeKit/LibreOfficeKitInit.h>
+#import <LibreOfficeKit/LibreOfficeKit.h>
 
 #import "ios.h"
 #import "AppDelegate.h"

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -74,6 +74,7 @@
 
 #define LOK_USE_UNSTABLE_API
 #include <LibreOfficeKit/LibreOfficeKitInit.h>
+#include <LibreOfficeKit/LibreOfficeKit.hxx>
 
 #include <Poco/File.h>
 #include <Poco/Exception.h>

--- a/tools/KitClient.cpp
+++ b/tools/KitClient.cpp
@@ -23,6 +23,7 @@
 
 #define LOK_USE_UNSTABLE_API
 #include <LibreOfficeKit/LibreOfficeKitInit.h>
+#include <LibreOfficeKit/LibreOfficeKit.h>
 
 #include <Poco/String.h>
 #include <Poco/TemporaryFile.h>


### PR DESCRIPTION
As a safety measure before removing the include in core's LibreOfficeKitInit.h.

Follow-up after 8e1a29f5a6688e55643ab40f43c6d683443494d7.


Change-Id: I4615a4992c0f4e1d9685bc9c0cd285b6df918e05

* Target version: main

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

