### PR TITLE
Core side normally sends an invalidateCursor message.

### DIFF
--- a/browser/src/app/TextSelectionMiddleware.ts
+++ b/browser/src/app/TextSelectionMiddleware.ts
@@ -91,6 +91,9 @@ class TextSelections {
 	public static setEndRectangle(rectangle: cool.SimpleRectangle) {
 		this.endRectangle = rectangle;
 		this.updateMarkers();
+
+		// Schedule a redraw if there's not any.
+		app.sectionContainer.requestReDraw();
 	}
 
 	private static updateMarkers() {


### PR DESCRIPTION
But when the cursor is at the end of the text, the invalidation message is not sent for select-all command.
Invalidation message triggers a redraw. Absence of it causes to lack a redraw.
So we trigger a redraw in case of the absence of invalidation message.

This shouldn't effect performance, since this doesn't add a draw request to the queue if there is already one.

Change-Id: I8bf9aecaa473c94032cdcdbd4152b59c1f0dfa7b


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

