### PR TITLE
Do not start in viewing mode in CODA

### DIFF
--- a/browser/src/control/Permission.js
+++ b/browser/src/control/Permission.js
@@ -1,4 +1,4 @@
-/* -*- js-indent-level: 8 -*- */
+/* -*- js-indent-level: 8; fill-column: 100 -*- */
 /*
  * Copyright the Collabora Online contributors.
  *
@@ -48,7 +48,14 @@ window.L.Map.include({
 				});
 
 				// temporarily, before the user touches the floating action button
-				this._enterReadOnlyMode('readonly');
+
+				// At least for CODA no mobile-edit-button (a.k.a. floating action
+				// button) is displayed and we do not want to always start in
+				// "viewing" mode.
+				if (window.mode.isCODesktop)
+					this._enterEditMode(perm);
+				else
+					this._enterReadOnlyMode('readonly');
 			}
 			else if (this.options.canTryLock) {
 				// This is a success response to an attempt to lock using mobile-edit-button


### PR DESCRIPTION
The logic around read-only/view/edit modes is a quite hairy and spread here and there, so I did not have the courage to change behaviour for anything except CODA in this one specific place.


Change-Id: Id657a2063d93b117d55056d209847335f5e64d85


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

