### PR TITLE
Use some other descriptive name when URI has empty path

### DIFF
--- a/common/RecentFiles.cpp
+++ b/common/RecentFiles.cpp
@@ -91,14 +91,13 @@ std::string RecentFiles::serialise()
     result = "[ ";
     for (int i = 0; i < _mostRecentlyUsed.size(); i++)
     {
+        Poco::URI uri(_mostRecentlyUsed[i].uri);
         std::vector<std::string> segments;
-        Poco::URI(_mostRecentlyUsed[i].uri).getPathSegments(segments);
-
-        assert(!segments.empty());
+        uri.getPathSegments(segments);
 
         result += "{ "
             "\"uri\": \"" + _mostRecentlyUsed[i].uri + "\", "
-            "\"name\": \"" + JsonUtil::escapeJSONValue(segments.back()) + "\", "
+            "\"name\": \"" + JsonUtil::escapeJSONValue(segments.empty() ? uri.getPathEtc() : segments.back()) + "\", "
             "\"timestamp\": \"" + std::format("{:%FT%TZ}", _mostRecentlyUsed[i].timestamp) + "\""
             " }";
         if (i < _mostRecentlyUsed.size() - 1)


### PR DESCRIPTION
```
(which could happen when the URI has a remote scheme and does not denote a local
file)

Change-Id: I230fc7dcc33d157299329a79c9de9b95676c513b
```


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

