### PR TITLE
calc notebookbar: add tooltips to InsertCalcTable btn (table styles)

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1809,16 +1809,23 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		if (data.visible === false)
 			div.classList.add('hidden');
 
+		let enabledTooltip = null;
 		const setDisabled = (disabled) => {
 			if (disabled) {
 				div.setAttribute('disabled', 'true');
 				if (button) {
 					button.setAttribute('aria-disabled', true);
 				}
+				if (data.disabledTooltip) {
+					div.setAttribute('data-cooltip', builder._cleanText(data.disabledTooltip));
+				}
 			} else {
 				div.removeAttribute('disabled');
 				if (button) {
 					button.removeAttribute('aria-disabled');
+				}
+				if (data.disabledTooltip && enabledTooltip) {
+					div.setAttribute('data-cooltip', enabledTooltip);
 				}
 			}
 		};
@@ -1916,6 +1923,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			if (data.command && (!tooltip || !tooltip.includes('('))) // Add shortcut to tooltip based on command
 				tooltip = JSDialog.ShortcutsUtil.getShortcut(tooltip, data.command);
 			div.setAttribute('data-cooltip', tooltip);
+			enabledTooltip = tooltip;
 
 			// Set aria-pressed only if:
 			// 1. A real toggle button

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1756,6 +1756,12 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 						'type': 'bigtoolitem',
 						'text': _UNO('.uno:InsertCalcTable', 'spreadsheet'),
 						'command': '.uno:InsertCalcTable',
+						'tooltip': app.LOUtil.isFileODF(this.map)
+							? _('Table styles are only available in .xlsx files')
+							: _('Insert a styled table'),
+						'disabledTooltip': app.LOUtil.isFileODF(this.map)
+							? _('Table styles are only available in .xlsx files')
+							: _('Select a cell range first to insert a styled table'),
 						'accessibility': { focusBack: true,	combination: 'IT', de: null }
 					}
 				]

--- a/cypress_test/integration_tests/desktop/calc/notebookbar_tooltip_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/notebookbar_tooltip_spec.js
@@ -1,0 +1,42 @@
+/* global describe it cy beforeEach require */
+
+var helper = require('../../common/helper');
+var desktopHelper = require('../../common/desktop_helper');
+var calcHelper = require('../../common/calc_helper');
+
+describe(['tagdesktop'], 'Notebookbar tooltip tests (ODS).', function() {
+
+	beforeEach(function() {
+		helper.setupAndLoadDocument('calc/top_toolbar.ods');
+		desktopHelper.switchUIToNotebookbar();
+	});
+
+	it('InsertCalcTable button shows ODS tooltip when disabled', function() {
+		cy.cGet('#Insert-tab-label').click();
+
+		cy.cGet('[modelid="insert-insert-calc-table"]')
+			.should('have.attr', 'disabled');
+		cy.cGet('[modelid="insert-insert-calc-table"]')
+			.should('have.attr', 'data-cooltip', 'Table styles are only available in .xlsx files');
+	});
+});
+
+describe(['tagdesktop'], 'Notebookbar tooltip tests (XLSX).', function() {
+
+	beforeEach(function() {
+		helper.setupAndLoadDocument('calc/testfile.xlsx');
+		desktopHelper.switchUIToNotebookbar();
+	});
+
+	it('InsertCalcTable button shows enabled tooltip when cells are selected', function() {
+		calcHelper.selectCellsInRange('A1:C3');
+
+		cy.cGet('#Insert-tab-label').click();
+
+		cy.cGet('[modelid="insert-insert-calc-table"]')
+			.should('not.have.attr', 'disabled');
+		cy.cGet('[modelid="insert-insert-calc-table"]')
+			.should('have.attr', 'data-cooltip', 'Insert a styled table');
+	});
+
+});


### PR DESCRIPTION
The Table button in the Insert tab only works with .xlsx files since
ODF does not support table styles. Add tooltips that explain this:
- ODS: "Table styles are only available in .xlsx files"
  - Alternatively we could use "Switch to .xlsx format to insert
  table" but I was afraid that could be seen as motivating multiple
  format switches (odf > ooxml -> odf -> ooxml) which is not a good
  recommendation.
- XLSX enabled: "Insert a styled table"
- XLSX disabled: "Select a cell range first to insert a styled table"

Also add generic disabledTooltip support to the JSDialog toolitem
handler, so any button can show a different tooltip when disabled.

Includes Cypress tests for the ODS and XLSX tooltip states.

NOTE: For future plan we should probably reduce the number of steps
until the user can see the Table Design tab: In xlsx, show the Table
Design tab and have all the controls disable until the user selects
multiple cells and then a click in any of the controls of that Tab
would create the table and apply the style in one go.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I6f1fd81319037e7980f7355623c0f17c7892fad4
