### PR TITLE
Impress Issue: Flickering after changing text and pressing ESC.

### DIFF
--- a/browser/src/canvas/sections/ShapeHandlesSection.ts
+++ b/browser/src/canvas/sections/ShapeHandlesSection.ts
@@ -565,9 +565,11 @@ class ShapeHandlesSection extends CanvasSectionObject {
 		for (let i = 0; i < this.sectionProperties.subSections.length; i++)
 			this.sectionProperties.subSections[i].setShowSection(this.showSection);
 
-		if (this.showSection)
-			this.showSVG();
-		else
+		// Don't call showSVG() here: the SVG overlay may contain stale
+		// content from a previous render.  A new shapeselectioncontent
+		// message will arrive and setSVG() will set the up-to-date SVG.
+		// The overlay is only made visible on demand (e.g. during drag).
+		if (!this.showSection)
 			this.hideSVG();
 	}
 


### PR DESCRIPTION
Reason: While setting the visibility of the section, we are also making SVG visible. SVG can contain stale content at the time.
Showing it shows the user old content for a split second. It feels like flickering.

Solution: We don't need to show the SVG there anyway. It is shown while dragging or resizing, and there is already a call to showSVG for those actions.


Change-Id: I37e404cbdac42167c50e3c052b96c82989205d80


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

