### PR TITLE
The mobile-edit-button has left the building

### DIFF
--- a/windows/coda/WebDriverThing/Program.cs
+++ b/windows/coda/WebDriverThing/Program.cs
@@ -54,6 +54,7 @@ namespace WebDriverThing
 
         static void openFile(string pathname)
         {
+            Thread.Sleep(1000);
             var driver = connectToWebView2();
 
             FindAndClick(driver, OpenQA.Selenium.By.Id("backstage-open"));
@@ -163,11 +164,9 @@ namespace WebDriverThing
 
             var driver = connectToWebView2();
 
-            // At first, click the button to enable editing.
-            FindAndClick(driver, OpenQA.Selenium.By.Id("mobile-edit-button"));
-
             // Paste text from clipboard with shortcut
             RunOnSTA(() => Clipboard.SetText("hello"));
+            Thread.Sleep(500);
             new Actions(driver).KeyDown(Keys.Control).SendKeys("v").KeyUp(Keys.Control).Perform();
 
             Thread.Sleep(500);


### PR DESCRIPTION
Also add a few more sleeps. At least when debugging this code is awfully fragile, and sleeping a bit here and there seems to help.


Change-Id: I4aadf6fcfb44f12e9ef9d4b78b5a311e7cb8128e


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

