### PR TITLE
Add MCP endpoint for stateless batch APIs over JSON-RPC 2.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -197,6 +197,7 @@ coolwsd_sources = \
                   wsd/FileServer.cpp \
                   wsd/FileServerUtil.cpp \
                   wsd/HostUtil.cpp \
+                  wsd/McpHandler.cpp \
                   wsd/ProofKey.cpp \
                   wsd/ProxyProtocol.cpp \
                   wsd/ProxyRequestHandler.cpp \

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -212,6 +212,9 @@
 
       <!-- this setting radically changes how online works, it should not be used in a production environment -->
       <proxy_prefix type="bool" default="false" desc="Enable a ProxyPrefix to be passed-in through which to redirect requests">false</proxy_prefix>
+      <mcp desc="Model Context Protocol settings.">
+        <api_key type="string" default="" desc="API key for MCP endpoint. When set, clients must include Authorization: Bearer header. When empty, MCP endpoint is disabled."></api_key>
+      </mcp>
     </net>
 
     <ssl desc="SSL settings">

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -78,6 +78,7 @@ all_la_unit_tests = \
 	unit-calc.la \
 	unit-wopi-temp.la \
 	unit-convert.la \
+	unit-mcp.la \
 	unit-timeout.la \
 	unit-copy-paste-writer.la \
 	unit-render-shape.la \
@@ -160,6 +161,7 @@ test_base_sources = \
 	HttpWhiteBoxTests.cpp \
 	KitQueueTests.cpp \
 	LoggingWhiteBoxTests.cpp \
+	McpHandlerTests.cpp \
 	NetUtilWhiteBoxTests.cpp \
 	NumUtilWhiteBoxTests.cpp \
 	RequestDetailsTests.cpp \
@@ -260,6 +262,7 @@ unit_copy_paste_writer_la_SOURCES = UnitCopyPasteWriter.cpp
 unit_copy_paste_writer_la_LIBADD = $(CPPUNIT_LIBS)
 unit_convert_la_SOURCES = UnitConvert.cpp
 unit_convert_csv_la_SOURCES = UnitConvertCSV.cpp
+unit_mcp_la_SOURCES = UnitMcp.cpp
 unit_convert_to_password_protected_la_SOURCES = UnitConvertToPasswordProtected.cpp
 unit_initial_load_fail_la_SOURCES = UnitInitialLoadFail.cpp
 unit_initial_load_fail_la_LIBADD = $(CPPUNIT_LIBS)

--- a/test/McpHandlerTests.cpp
+++ b/test/McpHandlerTests.cpp
@@ -1,0 +1,188 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * White-box unit tests for MCP response utilities.
+ */
+
+#include <config.h>
+
+#include <test/lokassert.hpp>
+
+#include <wsd/McpResponseUtil.hpp>
+
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Array.h>
+#include <Poco/JSON/Parser.h>
+
+#include <cppunit/extensions/HelperMacros.h>
+
+#include <string>
+
+namespace
+{
+
+/// Parse a JSON string and return the root object.
+Poco::JSON::Object::Ptr parseJson(const std::string& json)
+{
+    Poco::JSON::Parser parser;
+    auto result = parser.parse(json);
+    return result.extract<Poco::JSON::Object::Ptr>();
+}
+
+} // anonymous namespace
+
+/// McpResponseUtil unit tests.
+class McpHandlerTests : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE(McpHandlerTests);
+
+    CPPUNIT_TEST(testMakeJsonRpcError);
+    CPPUNIT_TEST(testMakeJsonRpcErrorCodes);
+    CPPUNIT_TEST(testWrapJsonResult);
+    CPPUNIT_TEST(testWrapJsonResultEmbedding);
+    CPPUNIT_TEST(testWrapBinaryResult);
+    CPPUNIT_TEST(testWrapBinaryResultMimeType);
+
+    CPPUNIT_TEST_SUITE_END();
+
+    void testMakeJsonRpcError();
+    void testMakeJsonRpcErrorCodes();
+    void testWrapJsonResult();
+    void testWrapJsonResultEmbedding();
+    void testWrapBinaryResult();
+    void testWrapBinaryResultMimeType();
+};
+
+void McpHandlerTests::testMakeJsonRpcError()
+{
+    constexpr std::string_view testname = __func__;
+
+    std::string response = McpResponseUtil::makeJsonRpcError("5", -32600, "Invalid Request");
+    auto obj = parseJson(response);
+
+    LOK_ASSERT_EQUAL_STR("2.0", obj->getValue<std::string>("jsonrpc"));
+    LOK_ASSERT_EQUAL_STR("5", obj->getValue<std::string>("id"));
+
+    auto error = obj->getObject("error");
+    LOK_ASSERT(error != nullptr);
+    LOK_ASSERT_EQUAL(-32600, error->getValue<int>("code"));
+    LOK_ASSERT_EQUAL_STR("Invalid Request", error->getValue<std::string>("message"));
+}
+
+void McpHandlerTests::testMakeJsonRpcErrorCodes()
+{
+    constexpr std::string_view testname = __func__;
+
+    // Parse error
+    auto obj = parseJson(McpResponseUtil::makeJsonRpcError("1", -32700, "Parse error"));
+    LOK_ASSERT_EQUAL(-32700, obj->getObject("error")->getValue<int>("code"));
+
+    // Method not found
+    obj = parseJson(McpResponseUtil::makeJsonRpcError("2", -32601, "Method not found"));
+    LOK_ASSERT_EQUAL(-32601, obj->getObject("error")->getValue<int>("code"));
+
+    // Invalid params
+    obj = parseJson(McpResponseUtil::makeJsonRpcError("3", -32602, "Invalid params"));
+    LOK_ASSERT_EQUAL(-32602, obj->getObject("error")->getValue<int>("code"));
+
+    // Internal error
+    obj = parseJson(McpResponseUtil::makeJsonRpcError("4", -32603, "Internal error"));
+    LOK_ASSERT_EQUAL(-32603, obj->getObject("error")->getValue<int>("code"));
+}
+
+void McpHandlerTests::testWrapJsonResult()
+{
+    constexpr std::string_view testname = __func__;
+
+    std::string jsonBody = "{\"headings\":[\"Chapter 1\",\"Chapter 2\"]}";
+    std::string response = McpResponseUtil::wrapJsonResult("10", jsonBody);
+    auto obj = parseJson(response);
+
+    LOK_ASSERT_EQUAL_STR("2.0", obj->getValue<std::string>("jsonrpc"));
+    LOK_ASSERT_EQUAL_STR("10", obj->getValue<std::string>("id"));
+
+    auto result = obj->getObject("result");
+    LOK_ASSERT(result != nullptr);
+
+    auto content = result->getArray("content");
+    LOK_ASSERT(content != nullptr);
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), content->size());
+
+    auto item = content->getObject(0);
+    LOK_ASSERT_EQUAL_STR("text", item->getValue<std::string>("type"));
+    LOK_ASSERT_EQUAL_STR(jsonBody, item->getValue<std::string>("text"));
+}
+
+void McpHandlerTests::testWrapJsonResultEmbedding()
+{
+    constexpr std::string_view testname = __func__;
+
+    // Verify that special characters in JSON are preserved correctly.
+    std::string jsonBody = "{\"key\":\"value with \\\"quotes\\\"\"}";
+    std::string response = McpResponseUtil::wrapJsonResult("11", jsonBody);
+    auto obj = parseJson(response);
+
+    auto content = obj->getObject("result")->getArray("content");
+    auto item = content->getObject(0);
+    LOK_ASSERT_EQUAL_STR(jsonBody, item->getValue<std::string>("text"));
+}
+
+void McpHandlerTests::testWrapBinaryResult()
+{
+    constexpr std::string_view testname = __func__;
+
+    const char data[] = "Hello PDF";
+    std::string response =
+        McpResponseUtil::wrapBinaryResult("20", data, sizeof(data) - 1, "application/pdf");
+    auto obj = parseJson(response);
+
+    LOK_ASSERT_EQUAL_STR("2.0", obj->getValue<std::string>("jsonrpc"));
+    LOK_ASSERT_EQUAL_STR("20", obj->getValue<std::string>("id"));
+
+    auto result = obj->getObject("result");
+    LOK_ASSERT(result != nullptr);
+
+    auto content = result->getArray("content");
+    LOK_ASSERT(content != nullptr);
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), content->size());
+
+    auto item = content->getObject(0);
+    LOK_ASSERT_EQUAL_STR("resource", item->getValue<std::string>("type"));
+
+    auto resource = item->getObject("resource");
+    LOK_ASSERT(resource != nullptr);
+    LOK_ASSERT_EQUAL_STR("application/pdf", resource->getValue<std::string>("mimeType"));
+    LOK_ASSERT(resource->has("blob"));
+
+    // "Hello PDF" in base64 is "SGVsbG8gUERG"
+    std::string blob = resource->getValue<std::string>("blob");
+    LOK_ASSERT_EQUAL_STR("SGVsbG8gUERG", blob);
+}
+
+void McpHandlerTests::testWrapBinaryResultMimeType()
+{
+    constexpr std::string_view testname = __func__;
+
+    const char data[] = "\x89PNG";
+    std::string response =
+        McpResponseUtil::wrapBinaryResult("30", data, sizeof(data) - 1, "image/png");
+    auto obj = parseJson(response);
+
+    auto resource =
+        obj->getObject("result")->getArray("content")->getObject(0)->getObject("resource");
+    LOK_ASSERT_EQUAL_STR("image/png", resource->getValue<std::string>("mimeType"));
+    LOK_ASSERT_EQUAL_STR("data:image/png;base64,", resource->getValue<std::string>("uri"));
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION(McpHandlerTests);
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitMcp.cpp
+++ b/test/UnitMcp.cpp
@@ -1,0 +1,342 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Integration test for MCP (Model Context Protocol) endpoint.
+ */
+
+#include <config.h>
+
+#include <iostream>
+
+#include <Common.hpp>
+#include <Protocol.hpp>
+#include <Unit.hpp>
+#include <common/FileUtil.hpp>
+#include <common/Util.hpp>
+#include <common/base64.hpp>
+#include <helpers.hpp>
+
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Array.h>
+#include <Poco/JSON/Parser.h>
+#include <Poco/Net/HTTPServerRequest.h>
+#include <Poco/Net/HTMLForm.h>
+#include <Poco/StreamCopier.h>
+#include <Poco/Util/LayeredConfiguration.h>
+
+#include <fstream>
+
+using namespace std::literals;
+
+namespace
+{
+
+/// Parse a JSON string and return the root object.
+Poco::JSON::Object::Ptr parseJson(const std::string& json)
+{
+    Poco::JSON::Parser parser;
+    auto result = parser.parse(json);
+    return result.extract<Poco::JSON::Object::Ptr>();
+}
+
+/// Send a JSON-RPC request to /cool/mcp and return the response body.
+std::string sendMcpRequest(Poco::Net::HTTPClientSession& session, const std::string& jsonBody,
+                           const std::string& apiKey = "test-mcp-key")
+{
+    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/mcp");
+    request.setContentType("application/json");
+    request.setContentLength(jsonBody.size());
+    if (!apiKey.empty())
+        request.set("Authorization", "Bearer " + apiKey);
+
+    std::ostream& os = session.sendRequest(request);
+    os << jsonBody;
+
+    Poco::Net::HTTPResponse response;
+    std::istream& rs = session.receiveResponse(response);
+    std::string body;
+    Poco::StreamCopier::copyToString(rs, body);
+    return body;
+}
+
+/// Read a test file and return its contents as a base64-encoded string.
+std::string readFileAsBase64(const std::string& path)
+{
+    std::ifstream ifs(path, std::ios::binary);
+    std::string data((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    return macaron::Base64::Encode(data);
+}
+
+} // anonymous namespace
+
+// Inside the WSD process
+class UnitMcp : public UnitWSD
+{
+    bool _workerStarted;
+    std::thread _worker;
+
+public:
+    UnitMcp()
+        : UnitWSD("UnitMcp")
+        , _workerStarted(false)
+    {
+        setHasKitHooks();
+        setTimeout(1h);
+    }
+
+    ~UnitMcp()
+    {
+        LOG_INF("Joining MCP test worker thread\n");
+        _worker.join();
+    }
+
+    void configure(Poco::Util::LayeredConfiguration& config) override
+    {
+        UnitWSD::configure(config);
+
+        config.setBool("ssl.enable", true);
+        config.setInt("per_document.limit_load_secs", 30);
+        config.setBool("storage.filesystem[@allow]", false);
+
+        // Enable MCP endpoint by setting an API key.
+        config.setString("net.mcp.api_key", "test-mcp-key");
+    }
+
+    void invokeWSDTest() override
+    {
+        if (_workerStarted)
+            return;
+        _workerStarted = true;
+        std::cerr << "Starting MCP test thread ...\n";
+        _worker = std::thread([this] {
+            std::cerr << "MCP test thread started\n";
+            std::unique_ptr<Poco::Net::HTTPClientSession> session(
+                helpers::createSession(Poco::URI(helpers::getTestServerURI())));
+            session->setTimeout(Poco::Timespan(30, 0));
+
+            // Test 1: initialize round-trip
+            {
+                std::string body =
+                    R"({"jsonrpc":"2.0","id":"1","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{}}})";
+                std::string response = sendMcpRequest(*session, body);
+                TST_LOG("initialize response: " << response);
+
+                auto obj = parseJson(response);
+                if (obj->getValue<std::string>("jsonrpc") != "2.0" ||
+                    obj->getValue<std::string>("id") != "1" || !obj->has("result"))
+                {
+                    TST_LOG("initialize: bad response structure");
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+
+                auto result = obj->getObject("result");
+                if (!result->has("protocolVersion") || !result->has("serverInfo") ||
+                    !result->has("capabilities"))
+                {
+                    TST_LOG("initialize: missing result fields");
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+                TST_LOG("initialize: OK");
+            }
+
+            // Test 2: tools/list round-trip
+            {
+                std::string body = R"({"jsonrpc":"2.0","id":"2","method":"tools/list"})";
+                std::string response = sendMcpRequest(*session, body);
+                TST_LOG("tools/list response: " << response);
+
+                auto obj = parseJson(response);
+                auto result = obj->getObject("result");
+                if (!result || !result->has("tools"))
+                {
+                    TST_LOG("tools/list: missing tools");
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+
+                auto tools = result->getArray("tools");
+                if (tools->size() != 4)
+                {
+                    TST_LOG("tools/list: expected 4 tools, got " << tools->size());
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+                TST_LOG("tools/list: OK");
+            }
+
+            // Test 3: error - unknown tool
+            {
+                std::string body =
+                    R"({"jsonrpc":"2.0","id":"3","method":"tools/call","params":{"name":"nonexistent","arguments":{}}})";
+                std::string response = sendMcpRequest(*session, body);
+                TST_LOG("unknown tool response: " << response);
+
+                auto obj = parseJson(response);
+                if (!obj->has("error"))
+                {
+                    TST_LOG("unknown tool: expected error response");
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+                TST_LOG("unknown tool error: OK");
+            }
+
+            // Test 4: error - missing data argument
+            {
+                std::string body =
+                    R"({"jsonrpc":"2.0","id":"4","method":"tools/call","params":{"name":"convert_document","arguments":{"format":"pdf"}}})";
+                std::string response = sendMcpRequest(*session, body);
+                TST_LOG("missing data response: " << response);
+
+                auto obj = parseJson(response);
+                if (!obj->has("error"))
+                {
+                    TST_LOG("missing data: expected error response");
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+                TST_LOG("missing data error: OK");
+            }
+
+            // Test 5: extract_document_structure with a real document
+            {
+                std::string testDocPath = std::string(TDOC) + "/hello.odt";
+                std::string base64Doc = readFileAsBase64(testDocPath);
+
+                std::string body =
+                    R"({"jsonrpc":"2.0","id":"5","method":"tools/call","params":{"name":"extract_document_structure","arguments":{"data":")" +
+                    base64Doc + R"(","filename":"hello.odt"}}})";
+                std::string response = sendMcpRequest(*session, body);
+                TST_LOG("extract_document_structure response length: " << response.size());
+
+                auto obj = parseJson(response);
+                if (obj->has("error"))
+                {
+                    TST_LOG("extract_document_structure: got error: "
+                            << obj->getObject("error")->getValue<std::string>("message"));
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+
+                if (obj->getValue<std::string>("id") != "5" || !obj->has("result"))
+                {
+                    TST_LOG("extract_document_structure: bad response structure");
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+
+                auto result = obj->getObject("result");
+                if (!result->has("content"))
+                {
+                    TST_LOG("extract_document_structure: missing content");
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+                TST_LOG("extract_document_structure: OK");
+            }
+
+            // Test 6: convert_document ODT to PDF
+            {
+                std::string testDocPath = std::string(TDOC) + "/hello.odt";
+                std::string base64Doc = readFileAsBase64(testDocPath);
+
+                std::string body =
+                    R"({"jsonrpc":"2.0","id":"6","method":"tools/call","params":{"name":"convert_document","arguments":{"data":")" +
+                    base64Doc + R"(","filename":"hello.odt","format":"pdf"}}})";
+                std::string response = sendMcpRequest(*session, body);
+                TST_LOG("convert_document response length: " << response.size());
+
+                auto obj = parseJson(response);
+                if (obj->has("error"))
+                {
+                    TST_LOG("convert_document: got error: "
+                            << obj->getObject("error")->getValue<std::string>("message"));
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+
+                if (obj->getValue<std::string>("id") != "6" || !obj->has("result"))
+                {
+                    TST_LOG("convert_document: bad response structure");
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+
+                auto result = obj->getObject("result");
+                auto content = result->getArray("content");
+                if (!content || content->size() == 0)
+                {
+                    TST_LOG("convert_document: missing content");
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+
+                auto item = content->getObject(0);
+                if (item->getValue<std::string>("type") != "resource")
+                {
+                    TST_LOG("convert_document: expected resource type");
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+
+                auto resource = item->getObject("resource");
+                if (!resource->has("blob") || !resource->has("mimeType"))
+                {
+                    TST_LOG("convert_document: missing blob or mimeType");
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+
+                // Verify the blob is non-empty base64 data.
+                std::string blob = resource->getValue<std::string>("blob");
+                if (blob.empty())
+                {
+                    TST_LOG("convert_document: empty blob");
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+
+                // Decode and check it starts with %PDF.
+                std::string decoded;
+                std::string err = macaron::Base64::Decode(blob, decoded);
+                if (!err.empty() || decoded.substr(0, 4) != "%PDF")
+                {
+                    TST_LOG("convert_document: blob does not decode to PDF");
+                    exitTest(TestResult::Failed);
+                    return;
+                }
+                TST_LOG("convert_document: OK (PDF size: " << decoded.size() << " bytes)");
+            }
+
+            exitTest(TestResult::Ok);
+        });
+    }
+};
+
+// Inside the forkit & kit processes
+class UnitKitMcp : public UnitKit
+{
+public:
+    UnitKitMcp()
+        : UnitKit("UnitKitMcp")
+    {
+        setTimeout(1h);
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitMcp(); }
+
+UnitBase* unit_create_kit(void) { return new UnitKitMcp(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -41,6 +41,7 @@
 #include <net/NetUtil.hpp>
 #include <net/Uri.hpp>
 #include <wsd/ClientRequestDispatcher.hpp>
+#include <wsd/McpHandler.hpp>
 #include <wsd/DocumentBroker.hpp>
 #include <wsd/RequestVettingStation.hpp>
 
@@ -2293,6 +2294,40 @@ bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
             return true;
         }
         return false;
+    }
+
+    if (requestDetails.equals(1, "mcp"))
+    {
+        std::string configuredKey = ConfigUtil::getConfigValue<std::string>(
+            "net.mcp.api_key", "");
+        if (configuredKey.empty())
+        {
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::NotFound, socket);
+            return true;
+        }
+
+        std::string authHeader = request.get("Authorization", "");
+        const std::string prefix = "Bearer ";
+        bool valid = false;
+        if (authHeader.size() > prefix.size() &&
+            authHeader.compare(0, prefix.size(), prefix) == 0)
+        {
+            const std::string key = authHeader.substr(prefix.size());
+            // Constant-time comparison to prevent timing attacks.
+            valid = (key.size() == configuredKey.size());
+            for (std::size_t i = 0; i < key.size() && i < configuredKey.size(); ++i)
+                valid &= (key[i] == configuredKey[i]);
+        }
+        if (!valid)
+        {
+            HttpHelper::sendErrorAndShutdown(
+                http::StatusCode::Unauthorized, socket,
+                std::string_view(), "WWW-Authenticate: Bearer\r\n");
+            return true;
+        }
+
+        std::string body(std::istreambuf_iterator<char>(message), {});
+        return McpHandler::handleRequest(body, socket, disposition, _id);
     }
 
     if (requestDetails.equals(2, "insertfile"))

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -36,8 +36,12 @@
 #include <wsd/COOLWSD.hpp>
 #include <wsd/DocumentBroker.hpp>
 #include <wsd/FileServer.hpp>
+#include <wsd/McpResponseUtil.hpp>
 #include <wsd/TileDesc.hpp>
 
+#include <common/base64.hpp>
+
+#include <Poco/JSON/Array.h>
 #include <Poco/JSON/Parser.h>
 #include <Poco/MemoryStream.h>
 #include <Poco/Net/HTTPResponse.h>
@@ -45,6 +49,7 @@
 #include <Poco/URI.h>
 
 #include <cctype>
+#include <fstream>
 #include <ios>
 #include <map>
 #include <memory>
@@ -3040,6 +3045,14 @@ ClientSession::handleOpenDocKitToClientMessage(const std::shared_ptr<Message>& p
         LOG_TRC("Sending extracted link targets response.");
         if (!saveAsSocket)
             LOG_ERR("Error in extractedlinktargets: not in isConvertTo mode");
+        else if (_mcpContext)
+        {
+            std::string body = McpResponseUtil::wrapJsonResult(
+                _mcpContext->jsonRpcId, payload->jsonString());
+            http::Response httpResponse(http::StatusCode::OK);
+            httpResponse.setBody(body, "application/json");
+            saveAsSocket->sendAndShutdown(httpResponse);
+        }
         else
         {
             http::Response httpResponse(http::StatusCode::OK);
@@ -3059,6 +3072,14 @@ ClientSession::handleOpenDocKitToClientMessage(const std::shared_ptr<Message>& p
         LOG_TRC("Sending extracted document structure response.");
         if (!saveAsSocket)
             LOG_ERR("Error in extracteddocumentstructure: not in isConvertTo mode");
+        else if (_mcpContext)
+        {
+            std::string body = McpResponseUtil::wrapJsonResult(
+                _mcpContext->jsonRpcId, payload->jsonString());
+            http::Response httpResponse(http::StatusCode::OK);
+            httpResponse.setBody(body, "application/json");
+            saveAsSocket->sendAndShutdown(httpResponse);
+        }
         else
         {
             http::Response httpResponse(http::StatusCode::OK);
@@ -3078,6 +3099,14 @@ ClientSession::handleOpenDocKitToClientMessage(const std::shared_ptr<Message>& p
         LOG_TRC("Sending transformed document structure response.");
         if (!saveAsSocket)
             LOG_ERR("Error in transformeddocumentstructure: not in isConvertTo mode");
+        else if (_mcpContext)
+        {
+            std::string body = McpResponseUtil::wrapJsonResult(
+                _mcpContext->jsonRpcId, payload->jsonString());
+            http::Response httpResponse(http::StatusCode::OK);
+            httpResponse.setBody(body, "application/json");
+            saveAsSocket->sendAndShutdown(httpResponse);
+        }
         else
         {
             http::Response httpResponse(http::StatusCode::OK);
@@ -3309,17 +3338,65 @@ bool ClientSession::handleSaveAs(const std::shared_ptr<Message>& payload,
         {
             LOG_TRC("Sending file: " << resultURL.getPath());
 
-            const std::string fileName = Poco::Path(resultURL.getPath()).getFileName();
-            http::Response response(http::StatusCode::OK);
-            FileServerRequestHandler::hstsHeaders(response);
-            if (!fileName.empty())
-                response.set("Content-Disposition", "attachment; filename=\"" + fileName + '"');
-            response.setContentType("application/octet-stream");
-
             if (!saveAsSocket)
+            {
                 LOG_ERR("Error saveas socket missing in isConvertTo mode");
+            }
+            else if (_mcpContext)
+            {
+                // MCP mode: read the file, base64-encode it, wrap in JSON-RPC.
+                std::ifstream ifs(resultURL.getPath(), std::ios::binary);
+                std::string fileData((std::istreambuf_iterator<char>(ifs)),
+                                     std::istreambuf_iterator<char>());
+
+                const std::string fileName = Poco::Path(resultURL.getPath()).getFileName();
+                std::string mimeType = "application/octet-stream";
+                // Set a more specific MIME type for common formats.
+                const std::string ext = Poco::Path(fileName).getExtension();
+                if (ext == "pdf")
+                    mimeType = "application/pdf";
+                else if (ext == "docx")
+                    mimeType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+                else if (ext == "xlsx")
+                    mimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+                else if (ext == "pptx")
+                    mimeType = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+                else if (ext == "odt")
+                    mimeType = "application/vnd.oasis.opendocument.text";
+                else if (ext == "ods")
+                    mimeType = "application/vnd.oasis.opendocument.spreadsheet";
+                else if (ext == "odp")
+                    mimeType = "application/vnd.oasis.opendocument.presentation";
+                else if (ext == "odg")
+                    mimeType = "application/vnd.oasis.opendocument.graphics";
+                else if (ext == "rtf")
+                    mimeType = "application/rtf";
+                else if (ext == "html")
+                    mimeType = "text/html";
+                else if (ext == "txt" || ext == "csv")
+                    mimeType = "text/plain";
+                else if (ext == "png")
+                    mimeType = "image/png";
+                else if (ext == "svg")
+                    mimeType = "image/svg+xml";
+
+                std::string body = McpResponseUtil::wrapBinaryResult(
+                    _mcpContext->jsonRpcId, fileData.data(), fileData.size(), mimeType);
+                http::Response response(http::StatusCode::OK);
+                response.setBody(body, "application/json");
+                saveAsSocket->sendAndShutdown(response);
+            }
             else
+            {
+                const std::string fileName = Poco::Path(resultURL.getPath()).getFileName();
+                http::Response response(http::StatusCode::OK);
+                FileServerRequestHandler::hstsHeaders(response);
+                if (!fileName.empty())
+                    response.set("Content-Disposition",
+                                 "attachment; filename=\"" + fileName + '"');
+                response.setContentType("application/octet-stream");
                 HttpHelper::sendFileAndShutdown(saveAsSocket, resultURL.getPath(), response);
+            }
         }
 
         // Conversion is done, cleanup this fake session.

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -35,6 +35,14 @@
 
 class DocumentBroker;
 
+/// Context for MCP (Model Context Protocol) JSON-RPC requests.
+/// When set on a ClientSession, response handlers wrap results in JSON-RPC envelopes.
+struct McpContext
+{
+    std::string jsonRpcId; // The JSON-RPC request id
+    std::string toolName;  // Which MCP tool was called
+};
+
 /// Represents a session to a COOL client, in the WSD process.
 class ClientSession final : public Session
 {
@@ -170,6 +178,9 @@ public:
         _saveAsSocket = socket;
         _isConvertTo = static_cast<bool>(socket);
     }
+
+    /// Set MCP context so response handlers wrap results in JSON-RPC envelopes.
+    void setMcpContext(McpContext ctx) { _mcpContext = std::move(ctx); }
 
     std::shared_ptr<DocumentBroker> getDocumentBroker() const { return _docBroker.lock(); }
 
@@ -515,6 +526,9 @@ private:
 
     /// If Session is for convert-to
     bool _isConvertTo;
+
+    /// MCP context - when set, response handlers wrap results in JSON-RPC envelopes
+    std::optional<McpContext> _mcpContext;
 
     Poco::SharedPtr<Poco::JSON::Object> _viewSettingsJSON;
 };

--- a/wsd/McpHandler.cpp
+++ b/wsd/McpHandler.cpp
@@ -1,0 +1,648 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * MCP (Model Context Protocol) handler implementation.
+ * Exposes existing stateless batch APIs as MCP tools via JSON-RPC 2.0.
+ */
+
+#include <config.h>
+
+#include "McpHandler.hpp"
+#include "McpResponseUtil.hpp"
+
+#include <ClientSession.hpp>
+#include <COOLWSD.hpp>
+#include <common/FileUtil.hpp>
+#include <common/JailUtil.hpp>
+#include <common/JsonUtil.hpp>
+#include <common/Log.hpp>
+#include <common/Util.hpp>
+#include <common/base64.hpp>
+#include <net/HttpHelper.hpp>
+#include <wsd/DocumentBroker.hpp>
+#include <wsd/SpecialBrokers.hpp>
+
+#include <Poco/JSON/Array.h>
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Parser.h>
+#include <Poco/Path.h>
+#include <Poco/URI.h>
+
+#include <fstream>
+#include <mutex>
+#include <sstream>
+
+extern std::map<std::string, std::shared_ptr<DocumentBroker>> DocBrokers;
+extern std::mutex DocBrokersMutex;
+
+namespace
+{
+
+/// Build a JSON Schema object describing an input parameter.
+Poco::JSON::Object::Ptr makeParam(const std::string& type, const std::string& description)
+{
+    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object;
+    obj->set("type", type);
+    obj->set("description", description);
+    return obj;
+}
+
+/// Build a complete MCP tool definition.
+Poco::JSON::Object::Ptr makeTool(const std::string& name, const std::string& description,
+                                  std::initializer_list<std::pair<std::string, Poco::JSON::Object::Ptr>> params,
+                                  std::initializer_list<std::string> required)
+{
+    Poco::JSON::Object::Ptr properties = new Poco::JSON::Object;
+    for (const auto& p : params)
+        properties->set(p.first, p.second);
+
+    Poco::JSON::Array::Ptr reqArr = new Poco::JSON::Array;
+    for (const auto& r : required)
+        reqArr->add(r);
+
+    Poco::JSON::Object::Ptr inputSchema = new Poco::JSON::Object;
+    inputSchema->set("type", "object");
+    inputSchema->set("properties", properties);
+    inputSchema->set("required", reqArr);
+
+    Poco::JSON::Object::Ptr tool = new Poco::JSON::Object;
+    tool->set("name", name);
+    tool->set("description", description);
+    tool->set("inputSchema", inputSchema);
+    return tool;
+}
+
+/// Map an MCP tool name to the internal request type used by getConvertToBrokerImplementation.
+std::string toolNameToRequestType(const std::string& toolName)
+{
+    if (toolName == "convert_document")
+        return "convert-to";
+    if (toolName == "extract_link_targets")
+        return "extract-link-targets";
+    if (toolName == "extract_document_structure")
+        return "extract-document-structure";
+    if (toolName == "transform_document_structure")
+        return "transform-document-structure";
+    return std::string();
+}
+
+/// Create a broker for the given request type and parameters.
+std::shared_ptr<ConvertToBroker>
+createBroker(const std::string& requestType, const std::string& fromPath,
+             const Poco::URI& uriPublic, const std::string& docKey,
+             const std::string& format, const std::string& options,
+             const std::string& lang, const std::string& filter,
+             const std::string& transformJSON)
+{
+    if (requestType == "convert-to")
+        return std::make_shared<ConvertToBroker>(fromPath, uriPublic, docKey, format, options, lang);
+    if (requestType == "extract-link-targets")
+        return std::make_shared<ExtractLinkTargetsBroker>(fromPath, uriPublic, docKey, lang);
+    if (requestType == "extract-document-structure")
+        return std::make_shared<ExtractDocumentStructureBroker>(fromPath, uriPublic, docKey, lang,
+                                                                 filter);
+    if (requestType == "transform-document-structure")
+    {
+        std::string fmt = format;
+        if (fmt.empty())
+            fmt = Poco::Path(fromPath).getExtension();
+        return std::make_shared<TransformDocumentStructureBroker>(fromPath, uriPublic, docKey, fmt,
+                                                                   lang, transformJSON);
+    }
+    return nullptr;
+}
+
+/// Decode base64 data and write it to a temp file. Returns the file path, or empty on error.
+std::string decodeToTempFile(const std::string& base64Data, const std::string& filename)
+{
+    std::string decoded;
+    std::string error = macaron::Base64::Decode(base64Data, decoded);
+    if (!error.empty())
+    {
+        LOG_ERR("MCP: base64 decode failed: " << error);
+        return std::string();
+    }
+
+    // Create temp directory the same way ConvertToPartHandler does.
+    std::string tempDir = FileUtil::createRandomTmpDir(
+        COOLWSD::ChildRoot + JailUtil::CHILDROOT_TMP_INCOMING_PATH);
+    if (tempDir.empty())
+    {
+        LOG_ERR("MCP: failed to create temp directory");
+        return std::string();
+    }
+
+    std::string cleanName = Util::cleanupFilename(filename);
+    if (cleanName.empty())
+        cleanName = "incoming_file";
+
+    Poco::Path tempPath = Poco::Path::forDirectory(tempDir + '/');
+    tempPath.setFileName(Poco::Path(cleanName).getFileName());
+
+    std::string filePath = tempPath.toString();
+    std::ofstream ofs(filePath, std::ios::binary);
+    if (!ofs.is_open())
+    {
+        LOG_ERR("MCP: failed to open temp file: " << filePath);
+        return std::string();
+    }
+    ofs.write(decoded.data(), decoded.size());
+    ofs.close();
+
+    LOG_TRC("MCP: wrote " << decoded.size() << " bytes to " << filePath);
+    return filePath;
+}
+
+/// Write raw data to a temp file in the incoming directory. Returns the file path, or empty on error.
+std::string writeToTempFile(const std::string& data, const std::string& filename)
+{
+    std::string tempDir = FileUtil::createRandomTmpDir(
+        COOLWSD::ChildRoot + JailUtil::CHILDROOT_TMP_INCOMING_PATH);
+    if (tempDir.empty())
+    {
+        LOG_ERR("MCP: failed to create temp directory");
+        return std::string();
+    }
+
+    std::string cleanName = Util::cleanupFilename(filename);
+    if (cleanName.empty())
+        cleanName = "incoming_file";
+
+    Poco::Path tempPath = Poco::Path::forDirectory(tempDir + '/');
+    tempPath.setFileName(Poco::Path(cleanName).getFileName());
+
+    std::string filePath = tempPath.toString();
+    std::ofstream ofs(filePath, std::ios::binary);
+    if (!ofs.is_open())
+    {
+        LOG_ERR("MCP: failed to open temp file: " << filePath);
+        return std::string();
+    }
+    ofs.write(data.data(), data.size());
+    ofs.close();
+
+    LOG_TRC("MCP: wrote " << data.size() << " bytes to " << filePath);
+    return filePath;
+}
+
+/// Fetch a file from a URI and copy it to a temp file. Returns the file path, or empty on error.
+/// Supports file:// and http(s):// schemes.
+std::string fetchUriToTempFile(const std::string& uriStr)
+{
+    Poco::URI parsed(uriStr);
+    const std::string& scheme = parsed.getScheme();
+
+    // Derive filename from the last path component.
+    std::string name = Poco::Path(parsed.getPath()).getFileName();
+    if (name.empty())
+        name = "incoming_file";
+
+    if (scheme == "file")
+    {
+        const std::string& localPath = parsed.getPath();
+        std::ifstream ifs(localPath, std::ios::binary);
+        if (!ifs.is_open())
+        {
+            LOG_ERR("MCP: failed to open local file: " << localPath);
+            return std::string();
+        }
+        std::string content((std::istreambuf_iterator<char>(ifs)),
+                            std::istreambuf_iterator<char>());
+        return writeToTempFile(content, name);
+    }
+
+    if (scheme == "http" || scheme == "https")
+    {
+        auto httpSession = http::Session::create(uriStr);
+        httpSession->setTimeout(std::chrono::seconds(30));
+
+        http::Request httpRequest(parsed.getPathAndQuery());
+        const std::shared_ptr<const http::Response> httpResponse =
+            httpSession->syncRequest(httpRequest);
+
+        if (!httpResponse->done() ||
+            httpResponse->state() != http::Response::State::Complete ||
+            httpResponse->statusLine().statusCode() != http::StatusCode::OK)
+        {
+            LOG_ERR("MCP: HTTP fetch failed for URI: " << uriStr);
+            return std::string();
+        }
+
+        return writeToTempFile(httpResponse->getBody(), name);
+    }
+
+    LOG_ERR("MCP: unsupported URI scheme: " << scheme);
+    return std::string();
+}
+
+/// Send a JSON-RPC response as HTTP and shutdown the socket.
+void sendJsonRpcResponse(const std::shared_ptr<StreamSocket>& socket, const std::string& body)
+{
+    http::Response httpResponse(http::StatusCode::OK);
+    httpResponse.set("Content-Type", "application/json");
+    httpResponse.setBody(body, "application/json");
+    socket->sendAndShutdown(httpResponse);
+}
+
+/// Extract a string value from a JSON object, or return a default.
+std::string getString(const Poco::JSON::Object::Ptr& obj, const std::string& key,
+                      const std::string& def = std::string())
+{
+    if (obj && obj->has(key))
+        return obj->getValue<std::string>(key);
+    return def;
+}
+
+} // anonymous namespace
+
+std::string McpHandler::handleInitialize(const std::string& requestId)
+{
+    Poco::JSON::Object::Ptr serverInfo = new Poco::JSON::Object;
+    serverInfo->set("name", "collabora-online");
+    serverInfo->set("version", Util::getCoolVersion());
+
+    Poco::JSON::Object::Ptr toolsCap = new Poco::JSON::Object;
+    Poco::JSON::Object::Ptr capabilities = new Poco::JSON::Object;
+    capabilities->set("tools", toolsCap);
+
+    Poco::JSON::Object::Ptr result = new Poco::JSON::Object;
+    result->set("protocolVersion", "2025-03-26");
+    result->set("serverInfo", serverInfo);
+    result->set("capabilities", capabilities);
+
+    Poco::JSON::Object::Ptr response = new Poco::JSON::Object;
+    response->set("jsonrpc", "2.0");
+    response->set("id", requestId);
+    response->set("result", result);
+
+    std::ostringstream oss;
+    response->stringify(oss);
+    return oss.str();
+}
+
+std::string McpHandler::handleToolsList(const std::string& requestId)
+{
+    Poco::JSON::Array::Ptr tools = new Poco::JSON::Array;
+
+    tools->add(makeTool(
+        "convert_document",
+        "Convert a document to a different format. Returns the converted file as "
+        "base64-encoded binary.\n\n"
+        "Supported input formats - Writer: odt, docx, doc, rtf, txt, html, md, fodt, wpd, pages. "
+        "Calc: ods, xlsx, xls, csv, fods, numbers. "
+        "Impress: odp, pptx, ppt, fodp, key. "
+        "Draw: odg, svg, vsdx, pub, png, pdf.\n\n"
+        "Supported output formats - Writer: odt, docx, pdf, rtf, txt, html, png. "
+        "Calc: ods, xlsx, csv, pdf, html, png. "
+        "Impress: odp, pptx, pdf, html, svg, png. "
+        "Draw: odg, pdf, svg, png.",
+        {{"uri", makeParam("string",
+            "URI of the input file (file:// or http://). Alternative to 'data' - provide one or the other.")},
+         {"data", makeParam("string",
+            "Base64-encoded input file content. Not needed when 'uri' is provided.")},
+         {"filename", makeParam("string",
+            "Original filename with extension (e.g. 'report.odt'). "
+            "The extension determines the input format. Not needed when 'uri' is provided.")},
+         {"format", makeParam("string",
+            "Target output format (e.g. 'pdf', 'docx', 'pptx', 'html', 'txt', 'png', 'csv', 'svg')")},
+         {"options", makeParam("string",
+            "Export filter options as JSON. "
+            "For PDF: {\"PageRange\":{\"type\":\"string\",\"value\":\"1,3-5\"}}, "
+            "{\"Watermark\":{\"type\":\"string\",\"value\":\"DRAFT\"}}, "
+            "{\"SelectPdfVersion\":{\"type\":\"long\",\"value\":2}} for PDF/A-2b, "
+            "{\"EncryptFile\":{\"type\":\"boolean\",\"value\":\"true\"},"
+            "\"DocumentOpenPassword\":{\"type\":\"string\",\"value\":\"secret\"}}. "
+            "For CSV: comma-separated filter codes (e.g. '44,34,76' for comma separator, "
+            "quote delimiter, UTF-8). "
+            "For spreadsheet-to-PDF: {\"SinglePageSheets\":{\"type\":\"boolean\","
+            "\"value\":\"true\"}} to fit each sheet on one page.")},
+         {"lang", makeParam("string",
+            "BCP 47 language tag for locale-dependent formatting (e.g. 'en-US', 'de-DE')")}},
+        {"format"}));
+
+    tools->add(makeTool(
+        "extract_link_targets",
+        "Extract all link targets from a document. Returns a JSON object with "
+        "categories: Headings, Bookmarks, Tables, Frames, Images, Sections, "
+        "OLE objects, Drawing objects. Each entry maps a name to a target string "
+        "(e.g. \"Table1\": \"Table1|table\"). These targets can be used to open the "
+        "document at a specific position.",
+        {{"uri", makeParam("string",
+            "URI of the input file (file:// or http://). Alternative to 'data' - provide one or the other.")},
+         {"data", makeParam("string",
+            "Base64-encoded input file content. Not needed when 'uri' is provided.")},
+         {"filename", makeParam("string",
+            "Original filename with extension (e.g. 'report.odt'). "
+            "The extension determines the input format. Not needed when 'uri' is provided.")},
+         {"lang", makeParam("string",
+            "BCP 47 language tag for locale-dependent formatting (e.g. 'en-US', 'de-DE')")}},
+        {}));
+
+    tools->add(makeTool(
+        "extract_document_structure",
+        "Extract the structural outline of a document as JSON. "
+        "For Writer: headings, sections, tables, frames, images, bookmarks, content controls. "
+        "For Calc: sheet names. "
+        "For Impress: slide names, object names per slide. "
+        "Useful for understanding document layout before applying transformations.",
+        {{"uri", makeParam("string",
+            "URI of the input file (file:// or http://). Alternative to 'data' - provide one or the other.")},
+         {"data", makeParam("string",
+            "Base64-encoded input file content. Not needed when 'uri' is provided.")},
+         {"filename", makeParam("string",
+            "Original filename with extension (e.g. 'report.odt'). "
+            "The extension determines the input format. Not needed when 'uri' is provided.")},
+         {"filter", makeParam("string",
+            "Filter results to a specific structure type. "
+            "For Impress: 'slides'. For Writer: 'contentcontrol'. "
+            "Omit to get the full structure.")},
+         {"lang", makeParam("string",
+            "BCP 47 language tag for locale-dependent formatting (e.g. 'en-US', 'de-DE')")}},
+        {}));
+
+    tools->add(makeTool(
+        "transform_document_structure",
+        "Transform a document's structure using a JSON command sequence and return "
+        "the modified document. Supports Impress slide operations (insert, delete, "
+        "duplicate, reorder, rename slides; change layouts; set text on placeholders; "
+        "format text with UNO commands), Writer/Calc content control updates, and "
+        "arbitrary UNO commands. Provide a base document (can be a blank ODP for "
+        "creating presentations from scratch) and a transform JSON.",
+        {{"uri", makeParam("string",
+            "URI of the input file (file:// or http://). Alternative to 'data' - provide one or the other.")},
+         {"data", makeParam("string",
+            "Base64-encoded input file content. Not needed when 'uri' is provided.")},
+         {"filename", makeParam("string",
+            "Original filename with extension (e.g. 'presentation.odp'). "
+            "The extension determines the input format. Not needed when 'uri' is provided.")},
+         {"transform", makeParam("string",
+            R"(JSON transformation commands. The top-level object can contain "Transforms" and/or "UnoCommand" objects in any order.
+
+--- Impress/ODP Presentations ---
+
+For presentations, use {"Transforms": {"SlideCommands": [...]}} where SlideCommands is an array of operations applied in order. There is always a "current slide" (default: index 0) that most commands act on.
+
+Navigation:
+- {"JumpToSlide": N} - jump to 0-based slide index; use "last" for last slide
+- {"JumpToSlideByName": "name"} - jump to named slide
+
+Slide management (inserts after current slide and jumps to new slide):
+- {"InsertMasterSlide": N} - insert slide based on master slide at index N
+- {"InsertMasterSlideByName": "name"} - insert slide by master slide name
+- {"DeleteSlide": N} - delete slide at index; use "" for current slide
+- {"DuplicateSlide": N} - duplicate slide at index; use "" for current
+- {"MoveSlide": N} - move current slide to position N
+- {"MoveSlide.X": N} - move slide at index X to position N
+- {"RenameSlide": "name"} - rename current slide (must be unique)
+
+Layout (applied to current slide):
+- {"ChangeLayoutByName": "name"} - set layout by name
+- {"ChangeLayout": N} - set layout by numeric ID
+Layout names: AUTOLAYOUT_TITLE (title+subtitle, id=0), AUTOLAYOUT_TITLE_CONTENT (title+content, id=1), AUTOLAYOUT_TITLE_2CONTENT (title+2 content, id=3), AUTOLAYOUT_TITLE_CONTENT_2CONTENT (id=12), AUTOLAYOUT_TITLE_CONTENT_OVER_CONTENT (id=14), AUTOLAYOUT_TITLE_2CONTENT_CONTENT (id=15), AUTOLAYOUT_TITLE_2CONTENT_OVER_CONTENT (id=16), AUTOLAYOUT_TITLE_4CONTENT (id=18), AUTOLAYOUT_TITLE_ONLY (title only, id=19), AUTOLAYOUT_NONE (blank, id=20), AUTOLAYOUT_ONLY_TEXT (centered text, id=32), AUTOLAYOUT_TITLE_6CONTENT (id=34), AUTOLAYOUT_VTITLE_VCONTENT (vertical, id=28), AUTOLAYOUT_VTITLE_VCONTENT_OVER_VCONTENT (id=27), AUTOLAYOUT_TITLE_VCONTENT (id=29), AUTOLAYOUT_TITLE_2VTEXT (id=30)
+
+Text content:
+- {"SetText.N": "text"} - set text of placeholder N on current slide (0=title, 1=first content, 2=second content, etc.). Use \n for paragraph breaks.
+
+Object selection:
+- {"MarkObject": N} - select object at index on current slide
+- {"UnMarkObject": N} - deselect object at index
+
+Rich text editing:
+- {"EditTextObject.N": [...]} - edit text object N with sub-commands:
+  - {"SelectText": []} - select all text; [para] selects paragraph; [para,startChar,endPara,endChar] selects range; [para,char] positions cursor
+  - {"SelectParagraph": N} - select paragraph N
+  - {"InsertText": "text"} - insert/replace text at selection
+  - {"UnoCommand": "cmd"} - apply UNO command to selection
+
+Tested UNO commands for text formatting:
+Toggle: .uno:Bold, .uno:Italic, .uno:Underline, .uno:Strikeout, .uno:Shadowed, .uno:SuperScript, .uno:SubScript
+Lists: .uno:DefaultBullet, .uno:DefaultNumbering (affect whole paragraphs)
+Alignment: .uno:LeftPara, .uno:CenterPara, .uno:RightPara, .uno:JustifyPara
+Color: .uno:Color {"Color.Color":{"type":"long","value":RGB_INT}}
+Background: .uno:CharBackColor {"CharBackColor.Color":{"type":"long","value":RGB_INT}}
+
+Top-level UNO commands (outside SlideCommands, works for all doc types):
+{"UnoCommand": {"name": ".uno:CommandName", "arguments": {"ArgName": {"type": "string|long|boolean", "value": "..."}}}}
+Example - enable change tracking:
+{"UnoCommand": {"name": ".uno:TrackChanges", "arguments": {"TrackChanges": {"type": "boolean", "value": "true"}}}}
+
+--- Writer/Calc Content Controls ---
+
+For Writer/Calc, address content control items by selector:
+{"Transforms": {"ContentControls.ByIndex.0": {"content": "new value"}}}
+Selectors: ContentControls.ByIndex.N, ContentControls.ByTag.tagname, ContentControls.ByAlias.aliasname. Use extract_document_structure with filter="contentcontrol" first to discover available controls.
+
+Example - create a 3-slide presentation from a blank ODP:
+{"Transforms":{"SlideCommands":[{"ChangeLayoutByName":"AUTOLAYOUT_TITLE"},{"SetText.0":"Quarterly Report"},{"SetText.1":"Q1 2026"},{"InsertMasterSlide":0},{"ChangeLayoutByName":"AUTOLAYOUT_TITLE_CONTENT"},{"SetText.0":"Revenue"},{"SetText.1":"Revenue grew 15% year over year"},{"InsertMasterSlide":0},{"ChangeLayoutByName":"AUTOLAYOUT_TITLE_CONTENT"},{"SetText.0":"Next Steps"},{"SetText.1":"Focus on expansion into new markets"}]}})")},
+         {"format", makeParam("string",
+            "Output format for the transformed document (e.g. 'odp', 'pptx', 'pdf'). "
+            "Defaults to the input file's format.")},
+         {"lang", makeParam("string",
+            "BCP 47 language tag for locale-dependent formatting (e.g. 'en-US', 'de-DE')")}},
+        {"transform"}));
+
+    Poco::JSON::Object::Ptr result = new Poco::JSON::Object;
+    result->set("tools", tools);
+
+    Poco::JSON::Object::Ptr response = new Poco::JSON::Object;
+    response->set("jsonrpc", "2.0");
+    response->set("id", requestId);
+    response->set("result", result);
+
+    std::ostringstream oss;
+    response->stringify(oss);
+    return oss.str();
+}
+
+bool McpHandler::handleRequest(const std::string& body,
+                               const std::shared_ptr<StreamSocket>& socket,
+                               SocketDisposition& disposition,
+                               const std::string& id)
+{
+    Poco::JSON::Object::Ptr request;
+    if (!JsonUtil::parseJSON(body, request) || !request)
+    {
+        sendJsonRpcResponse(socket,
+                            McpResponseUtil::makeJsonRpcError("null", -32700, "Parse error"));
+        return true;
+    }
+
+    // Validate JSON-RPC envelope.
+    std::string jsonrpc = getString(request, "jsonrpc");
+    if (jsonrpc != "2.0")
+    {
+        sendJsonRpcResponse(
+            socket, McpResponseUtil::makeJsonRpcError("null", -32600, "Invalid Request: missing or wrong jsonrpc field"));
+        return true;
+    }
+
+    std::string requestId = getString(request, "id", "null");
+    std::string method = getString(request, "method");
+
+    if (method.empty())
+    {
+        sendJsonRpcResponse(
+            socket, McpResponseUtil::makeJsonRpcError(requestId, -32600, "Invalid Request: missing method"));
+        return true;
+    }
+
+    // Handle synchronous methods.
+    if (method == "initialize")
+    {
+        sendJsonRpcResponse(socket, handleInitialize(requestId));
+        return true;
+    }
+
+    if (method == "tools/list")
+    {
+        sendJsonRpcResponse(socket, handleToolsList(requestId));
+        return true;
+    }
+
+    if (method == "notifications/initialized")
+    {
+        // Client notification after initialize - no response needed per MCP spec,
+        // but we still need to send something since HTTP requires a response.
+        http::Response httpResponse(http::StatusCode::OK);
+        httpResponse.setBody("{}", "application/json");
+        socket->sendAndShutdown(httpResponse);
+        return true;
+    }
+
+    if (method != "tools/call")
+    {
+        sendJsonRpcResponse(
+            socket, McpResponseUtil::makeJsonRpcError(requestId, -32601, "Method not found: " + method));
+        return true;
+    }
+
+    // tools/call - extract tool name and arguments.
+    Poco::JSON::Object::Ptr params;
+    if (request->has("params"))
+        params = request->getObject("params");
+
+    if (!params || !params->has("name"))
+    {
+        sendJsonRpcResponse(
+            socket, McpResponseUtil::makeJsonRpcError(requestId, -32602, "Invalid params: missing tool name"));
+        return true;
+    }
+
+    std::string toolName = params->getValue<std::string>("name");
+    std::string requestType = toolNameToRequestType(toolName);
+    if (requestType.empty())
+    {
+        sendJsonRpcResponse(
+            socket, McpResponseUtil::makeJsonRpcError(requestId, -32602, "Unknown tool: " + toolName));
+        return true;
+    }
+
+    Poco::JSON::Object::Ptr arguments;
+    if (params->has("arguments"))
+        arguments = params->getObject("arguments");
+
+    std::string base64Data = getString(arguments, "data");
+    std::string uri = getString(arguments, "uri");
+
+    if (base64Data.empty() && uri.empty())
+    {
+        sendJsonRpcResponse(
+            socket, McpResponseUtil::makeJsonRpcError(requestId, -32602, "Invalid params: missing data or uri argument"));
+        return true;
+    }
+
+    std::string filename = getString(arguments, "filename");
+    std::string format = getString(arguments, "format");
+    std::string options = getString(arguments, "options");
+    std::string lang = getString(arguments, "lang");
+    std::string filter = getString(arguments, "filter");
+
+    // When uri is provided, derive filename from URI path if not explicitly given.
+    if (!uri.empty() && filename.empty())
+    {
+        Poco::URI parsed(uri);
+        filename = Poco::Path(parsed.getPath()).getFileName();
+    }
+    if (filename.empty())
+        filename = "document";
+
+    std::string transformJSON;
+    if (arguments->has("transform"))
+    {
+        std::string transform = arguments->getValue<std::string>("transform");
+        Poco::URI::encode(transform, "", transformJSON);
+    }
+
+    // convert_document requires a format.
+    if (requestType == "convert-to" && format.empty())
+    {
+        sendJsonRpcResponse(
+            socket, McpResponseUtil::makeJsonRpcError(requestId, -32602, "Invalid params: convert_document requires format"));
+        return true;
+    }
+
+    // Get the input file - either from URI or base64 data.
+    std::string fromPath;
+    if (!uri.empty())
+        fromPath = fetchUriToTempFile(uri);
+    else
+        fromPath = decodeToTempFile(base64Data, filename);
+
+    if (fromPath.empty())
+    {
+        sendJsonRpcResponse(
+            socket, McpResponseUtil::makeJsonRpcError(requestId, -32603, "Internal error: failed to obtain input file"));
+        return true;
+    }
+
+    Poco::URI uriPublic = RequestDetails::sanitizeLocalPath(fromPath);
+    const std::string docKey = RequestDetails::getDocKey(uriPublic);
+
+    std::unique_lock<std::mutex> docBrokersLock(DocBrokersMutex);
+
+    LOG_DBG("MCP: New DocumentBroker for docKey [" << docKey << "].");
+    auto docBroker = createBroker(requestType, fromPath, uriPublic, docKey, format, options, lang,
+                                  filter, transformJSON);
+    if (!docBroker)
+    {
+        docBrokersLock.unlock();
+        StatelessBatchBroker::removeFile(fromPath);
+        sendJsonRpcResponse(
+            socket, McpResponseUtil::makeJsonRpcError(requestId, -32603, "Internal error: failed to create broker"));
+        return true;
+    }
+
+    COOLWSD::cleanupDocBrokers();
+
+    DocBrokers.emplace(docKey, docBroker);
+    LOG_TRC("MCP: Have " << DocBrokers.size() << " DocBrokers after inserting [" << docKey << "].");
+
+    // Set the MCP context on the broker before starting conversion.
+    // startConversion will create the ClientSession and forward it.
+    auto mcpCtx = std::make_unique<McpContext>();
+    mcpCtx->jsonRpcId = requestId;
+    mcpCtx->toolName = toolName;
+    docBroker->setMcpContext(std::move(mcpCtx));
+
+    AdditionalFilePocoUris emptyUris;
+    if (!docBroker->startConversion(disposition, id, emptyUris))
+    {
+        LOG_WRN("MCP: Failed to create Client Session with id [" << id << "] on docKey [" << docKey
+                                                                  << "].");
+        COOLWSD::cleanupDocBrokers();
+    }
+
+    // Response will come asynchronously through the broker/session response handlers.
+    return false;
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/McpHandler.hpp
+++ b/wsd/McpHandler.hpp
@@ -1,0 +1,45 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * MCP (Model Context Protocol) handler for JSON-RPC over HTTP.
+ * Exposes existing stateless batch APIs as MCP tools.
+ */
+
+#pragma once
+
+#include <Socket.hpp>
+
+#include <memory>
+#include <string>
+
+class SocketDisposition;
+
+/// Handles MCP JSON-RPC requests at the /cool/mcp endpoint.
+class McpHandler
+{
+public:
+    /// Handle a JSON-RPC request body. Returns true if the response was sent
+    /// synchronously (initialize, tools/list, errors). Returns false if the
+    /// request was dispatched to a broker and the response will come later.
+    static bool handleRequest(const std::string& body,
+                              const std::shared_ptr<StreamSocket>& socket,
+                              SocketDisposition& disposition,
+                              const std::string& id);
+
+    /// Build the JSON-RPC response for the "initialize" method.
+    static std::string handleInitialize(const std::string& requestId);
+
+    /// Build the JSON-RPC response for the "tools/list" method.
+    static std::string handleToolsList(const std::string& requestId);
+};
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/McpResponseUtil.hpp
+++ b/wsd/McpResponseUtil.hpp
@@ -1,0 +1,102 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Utility functions for building MCP (Model Context Protocol) JSON-RPC responses.
+ */
+
+#pragma once
+
+#include <common/base64.hpp>
+
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Array.h>
+
+#include <sstream>
+#include <string>
+
+namespace McpResponseUtil
+{
+
+/// Build a JSON-RPC result that wraps a JSON string as MCP text content.
+inline std::string wrapJsonResult(const std::string& id, const std::string& jsonBody)
+{
+    Poco::JSON::Object::Ptr content = new Poco::JSON::Object;
+    content->set("type", "text");
+    content->set("text", jsonBody);
+
+    Poco::JSON::Array::Ptr contentArray = new Poco::JSON::Array;
+    contentArray->add(content);
+
+    Poco::JSON::Object::Ptr result = new Poco::JSON::Object;
+    result->set("content", contentArray);
+
+    Poco::JSON::Object::Ptr response = new Poco::JSON::Object;
+    response->set("jsonrpc", "2.0");
+    response->set("id", id);
+    response->set("result", result);
+
+    std::ostringstream oss;
+    response->stringify(oss);
+    return oss.str();
+}
+
+/// Build a JSON-RPC result that wraps binary data as a base64-encoded MCP resource.
+inline std::string wrapBinaryResult(const std::string& id, const char* data, std::size_t size,
+                                    const std::string& mimeType)
+{
+    std::string encoded = macaron::Base64::Encode(std::string_view(data, size));
+
+    Poco::JSON::Object::Ptr resource = new Poco::JSON::Object;
+    resource->set("uri", "data:" + mimeType + ";base64,");
+    resource->set("mimeType", mimeType);
+    resource->set("blob", encoded);
+
+    Poco::JSON::Object::Ptr content = new Poco::JSON::Object;
+    content->set("type", "resource");
+    content->set("resource", resource);
+
+    Poco::JSON::Array::Ptr contentArray = new Poco::JSON::Array;
+    contentArray->add(content);
+
+    Poco::JSON::Object::Ptr result = new Poco::JSON::Object;
+    result->set("content", contentArray);
+
+    Poco::JSON::Object::Ptr response = new Poco::JSON::Object;
+    response->set("jsonrpc", "2.0");
+    response->set("id", id);
+    response->set("result", result);
+
+    std::ostringstream oss;
+    response->stringify(oss);
+    return oss.str();
+}
+
+/// Build a JSON-RPC error response.
+inline std::string makeJsonRpcError(const std::string& id, int code, const std::string& message)
+{
+    Poco::JSON::Object::Ptr error = new Poco::JSON::Object;
+    error->set("code", code);
+    error->set("message", message);
+
+    Poco::JSON::Object::Ptr response = new Poco::JSON::Object;
+    response->set("jsonrpc", "2.0");
+    response->set("id", id);
+    response->set("error", error);
+
+    std::ostringstream oss;
+    response->stringify(oss);
+    return oss.str();
+}
+
+} // namespace McpResponseUtil
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/SpecialBrokers.cpp
+++ b/wsd/SpecialBrokers.cpp
@@ -128,6 +128,10 @@ bool ConvertToBroker::startConversion(SocketDisposition& disposition, const std:
                                                      additionalFileUrisPublic);
     _clientSession->construct();
 
+    // Forward MCP context to the session if set.
+    if (_mcpContext)
+        _clientSession->setMcpContext(std::move(*_mcpContext));
+
     docBroker->setupTransfer(
         disposition,
         [docBroker](const std::shared_ptr<Socket>& moveSocket)

--- a/wsd/SpecialBrokers.hpp
+++ b/wsd/SpecialBrokers.hpp
@@ -20,6 +20,7 @@
 #error This file should be excluded from Mobile App builds
 #endif // MOBILEAPP
 
+#include <wsd/ClientSession.hpp>
 #include <wsd/DocumentBroker.hpp>
 
 #include <cstddef>
@@ -27,8 +28,6 @@
 #include <string>
 
 #include <Poco/URI.h>
-
-class ClientSession;
 
 class StatelessBatchBroker : public DocumentBroker
 {
@@ -55,6 +54,9 @@ class ConvertToBroker : public StatelessBatchBroker
     const std::string _inFilterOptions;
     const std::string _lang;
 
+    /// Optional MCP context to forward to the client session on conversion start.
+    std::unique_ptr<McpContext> _mcpContext;
+
 public:
     /// Construct DocumentBroker with URI and docKey
     ConvertToBroker(const std::string& uri, const Poco::URI& uriPublic, const std::string& docKey,
@@ -64,6 +66,9 @@ public:
 
     /// _lang accessors
     const std::string& getLang() { return _lang; }
+
+    /// Set MCP context to forward to the client session on conversion start.
+    void setMcpContext(std::unique_ptr<McpContext> ctx) { _mcpContext = std::move(ctx); }
 
     /// Move socket to this broker for response & do conversion
     bool startConversion(SocketDisposition& disposition, const std::string& id, const AdditionalFilePocoUris& additionalFileUrisPublic);


### PR DESCRIPTION
Expose the existing stateless batch APIs (convert-to, extract link targets, extract document structure, transform document structure) as MCP tools over JSON-RPC 2.0 so AI assistants can use them directly.

The endpoint is gated by a Bearer token matched against the net.mcp.api_key config value. When no key is configured the endpoint is disabled and returns 404.

Input documents can be passed as base64 data or as file/http/https URIs. Responses from the broker are wrapped in JSON-RPC envelopes by forwarding an McpContext through ConvertToBroker to ClientSession.

Includes unit tests for the handler and an integration test that exercises convert and extract end-to-end.

Change-Id: I7dafd56cb2c232031624ae266bc35f0e2fa95e14
* Target version: main


