### PR TITLE
We do want to be able to export as PDF also in CODA-W

### DIFF
--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -394,15 +394,13 @@ window.L.Control.NotebookbarBuilder = window.L.Control.JSDialogBuilder.extend({
 					'action': !window.ThisIsAMobileApp ? 'exportepub' : 'downloadas-epub',
 					'text': _('EPUB (.epub)'),
 					'command': !window.ThisIsAMobileApp ? 'exportepub' : 'downloadas-epub'
-				}
-			];
-			if (!window.ThisIsTheWindowsApp)
-				// In CODA-W surely just the PDF save with options should be enough
-				submenuOpts.push({
+				},
+				{
 					'action': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf',
 					'text': _('PDF Document (.pdf)'),
 					'command': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf'
-				});
+				}
+			];
 			submenuOpts.push({
 				'action': 'downloadas-html',
 				'text': _('HTML File (.html)')
@@ -434,15 +432,13 @@ window.L.Control.NotebookbarBuilder = window.L.Control.JSDialogBuilder.extend({
 				{
 					'action': 'downloadas-html',
 					'text': _('HTML File (.html)')
-				}
-			];
-			if (!window.ThisIsTheWindowsApp)
-				// As for 'text'
-				submenuOpts.push({
+				},
+				{
 					'action': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf',
 					'text': _('PDF Document (.pdf)'),
 					'command': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf'
-				});
+				}
+			];
 			if (!window.ThisIsTheAndroidApp)
 				submenuOpts.push({
 					'action': 'exportpdf' ,
@@ -470,15 +466,13 @@ window.L.Control.NotebookbarBuilder = window.L.Control.JSDialogBuilder.extend({
 				{
 					'action': 'downloadas-html',
 					'text': _('HTML Document (.html)')
-				}
-			];
-			if (!window.ThisIsTheWindowsApp)
-				// As for 'text'
-				submenuOpts.push({
+				},
+				{
 					'action': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf',
 					'text': _('PDF Document (.pdf)'),
 					'command': !window.ThisIsAMobileApp ? 'exportdirectpdf' : 'downloadas-pdf',
-				});
+				}
+			];
 			if (!window.ThisIsTheAndroidApp)
 				submenuOpts.push({
 					'action': 'exportpdf',


### PR DESCRIPTION
Whatever reason was behind bypassing that for CODA-W does not exist any more.


Change-Id: I1df6fc413b89d900a82bdf54782f4dfe5ae305a3


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

