### PR TITLE
a11y: all dialogs are now passing for calc

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/a11y_dialog_spec.js
@@ -35,11 +35,11 @@ const allCalcDialogs = [
     '.uno:InsertCell',
     '.uno:InsertObjectChart',
     '.uno:InsertSparkline',
-    // '.uno:JumpToTable',
+    '.uno:JumpToTable',
     '.uno:Move?FromContextMenu:bool=true&MoveOrCopySheetDialog:bool=true&ContextMenuIndex=0',
     '.uno:MovingAverageDialog',
     '.uno:PageFormatDialog',
-    // '.uno:Protect',
+    '.uno:Protect',
     '.uno:RegressionDialog',
     '.uno:RowHeight',
     '.uno:SamplingDialog',
@@ -62,13 +62,6 @@ const excludedCommonDialogs = [
 
 // don't pass yet
 const buggyCalcDialogs = [
-    '.uno:DataFilterSpecialFilter',
-    '.uno:DataFilterStandardFilter',
-    '.uno:DefineDBName',
-    '.uno:EditPrintArea',
-    '.uno:FunctionDialog',
-    '.uno:PageFormatDialog',
-    '.uno:Validation',
 ];
 
 describe(['tagdesktop'], 'Accessibility Calc Dialog Tests', { testIsolation: false }, function () {


### PR DESCRIPTION
Change-Id: I204f4d60eeb8e845acfd5417749a4426819b8bb7

Core patches:
1. https://gerrit.libreoffice.org/c/core/+/201916 (Abandoned as https://gerrit.libreoffice.org/c/core/+/201663 - solves this)
2. https://gerrit.libreoffice.org/c/core/+/201917
3. https://gerrit.libreoffice.org/c/core/+/201918

All dialogs are now passing for calc.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

