### PR TITLE
impress: fetch the slide preview after pasting

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -651,6 +651,8 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 
 			// insert after selectedFrame
 			selectedFrame.parentNode.insertBefore(newFrame, selectedFrame.nextSibling);
+
+			this._onScroll(); // Load previews
 		}
 	},
 


### PR DESCRIPTION
problem:
when the slide is pasted from a different doc/browser/tab slide is added into the slide sorter but preview thumbnail is not updated.

this was caused because fetching of the preview was never called and it was invoked only when the previews were scrolled


Change-Id: I08f57e376cb7302427b4ce77a734f92a5ed6b5c6


* Target version: main


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

