### PR TITLE
fix: prevent selected comments going offscreen

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -107,8 +107,7 @@ export class CommentSection extends CanvasSectionObject {
 		show: boolean;
 		showResolved: boolean;
 		[key: string]: any;
-		canvasContainerTop: number; // The top pixel of the document container. Added to positions of comments.
-		canvasContainerLeft: number;
+		canvasContainerBounds: DOMRect;
 	};
 	disableLayoutAnimation: boolean = false;
 
@@ -956,6 +955,10 @@ export class CommentSection extends CanvasSectionObject {
 				selectedComment.updateThreadInfoIndicator();
 			}
 
+			if (app.map._docLayer._docType !== 'spreadsheet') {
+				this.sectionProperties.selectedComment.setContainerPos(true, this.sectionProperties.canvasContainerBounds);
+			}
+
 			this.update();
 		}
 	}
@@ -1027,7 +1030,12 @@ export class CommentSection extends CanvasSectionObject {
 				this.setThreadPopup(this.sectionProperties.selectedComment, false);
 				this.sectionProperties.showSelectedBigger = false;
 			}
+			
+			const previouslySelectedComment = this.sectionProperties.selectedComment;
 			this.sectionProperties.selectedComment = null;
+			if (app.map._docLayer._docType !== 'spreadsheet') {
+				previouslySelectedComment.setContainerPos(true, this.sectionProperties.canvasContainerBounds); // Must be done after we clear the selection since as it resets the z-index based on this...
+			}
 
 			this.update();
 		}
@@ -1991,8 +1999,12 @@ export class CommentSection extends CanvasSectionObject {
 			height = subList[i].getCommentHeight(relayout);
 			lastY = subList[i].sectionProperties.data.anchorSPoint.vY + height < lastY ? subList[i].sectionProperties.data.anchorSPoint.vY: lastY - (height * app.dpiScale);
 
-			subList[i].sectionProperties.container.style.left = String(Math.round(actualPosition[0] / app.dpiScale) + this.sectionProperties.canvasContainerLeft) + 'px';
-			subList[i].sectionProperties.container.style.top = String(Math.round(lastY / app.dpiScale) + this.sectionProperties.canvasContainerTop) + 'px';
+			subList[i].setContainerPos(
+				false,
+				this.sectionProperties.canvasContainerBounds,
+				actualPosition[0] / app.dpiScale,
+				lastY / app.dpiScale
+			);
 
 			if (this.sectionProperties.show != false && !subList[i].isEdit())
 				subList[i].show();
@@ -2053,12 +2065,10 @@ export class CommentSection extends CanvasSectionObject {
 					posX = documentCanvasWidth - commentWidth;
 				}
 
-				subList[i].sectionProperties.container.style.left = String(posX + this.sectionProperties.canvasContainerLeft) + 'px';
-				subList[i].sectionProperties.container.style.top = String(Math.round(lastY / app.dpiScale) + this.sectionProperties.canvasContainerTop) + 'px';
+				subList[i].setContainerPos(false, this.sectionProperties.canvasContainerBounds, posX, lastY / app.dpiScale);
 			}
 			else {
-				subList[i].sectionProperties.container.style.left = String(this.sectionProperties.canvasContainerLeft + Math.round(actualPosition[0] / app.dpiScale)) + 'px';
-				subList[i].sectionProperties.container.style.top = String(Math.round(lastY / app.dpiScale) + this.sectionProperties.canvasContainerTop) + 'px';
+				subList[i].setContainerPos(false, this.sectionProperties.canvasContainerBounds, actualPosition[0] / app.dpiScale, lastY / app.dpiScale);
 			}
 
 			lastY += (subList[i].getCommentHeight(relayout) * app.dpiScale);
@@ -2151,8 +2161,7 @@ export class CommentSection extends CanvasSectionObject {
 			return; // No adjustments for Calc, since only one comment can be shown at a time and that comment is shown at its belonging cell.
 		}
 
-		this.sectionProperties.canvasContainerLeft = document.getElementById('document-container').getBoundingClientRect().left;
-		this.sectionProperties.canvasContainerTop = document.getElementById('document-container').getBoundingClientRect().top;
+		this.sectionProperties.canvasContainerBounds = document.getElementById('document-container').getBoundingClientRect();
 
 		const availableSpace = this.calculateAvailableSpace();
 		if (!this.commentsHiddenOrNotPresent()) {
@@ -2200,6 +2209,10 @@ export class CommentSection extends CanvasSectionObject {
 			}
 			else {
 				lastY = this.loopDown(0, x, topRight[1], relayout);
+			}
+		} else {
+			for (const comment of this.sectionProperties.commentList) {
+				comment.setContainerPos(false, this.sectionProperties.canvasContainerBounds);
 			}
 		}
 		if (relayout)
@@ -2431,8 +2444,7 @@ export class CommentSection extends CanvasSectionObject {
 								// move up
 								const posX = this.sectionProperties.commentList[i].getContainerPosX();
 								const posY = this.sectionProperties.commentList[i].getContainerPosY() - moveUp;
-								this.sectionProperties.commentList[i].sectionProperties.container.style.left = Math.round(posX) + 'px';
-								this.sectionProperties.commentList[i].sectionProperties.container.style.top = Math.round(posY) + 'px';
+								this.sectionProperties.commentList[i].setContainerPos(false, this.sectionProperties.canvasContainerBounds, posX, posY);
 								// increase comment height
 								maxSize += moveUp;
 							}

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -58,6 +58,10 @@ export class Comment extends CanvasSectionObject {
 	cachedIsEdit: boolean = false;
 	hidden: boolean | null = null;
 
+	containerPosX: number = 0;
+	containerPosY: number = 0;
+	canvasContainerBounds: DOMRect = new DOMRect();
+
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public static makeName(data: any): string {
 		return data.id === 'new' ? 'new comment' : 'comment ' + data.id;
@@ -339,6 +343,73 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.menu.annotation = this;
 	}
 
+	public setContainerPos(forceUpdate: boolean, canvasContainerBounds?: DOMRect, left?: number, top?: number): void {
+		if ((<any>window).mode.isMobile()) {
+			return;
+		}
+
+		if (canvasContainerBounds === undefined) {
+			canvasContainerBounds = this.canvasContainerBounds;
+		}
+
+		if (left === undefined) {
+			left = this.containerPosX;
+		}
+
+		if (top === undefined) {
+			top = this.containerPosY;
+		}
+
+		if (this.containerPosX === left
+				&& this.containerPosY === top
+				&& this.canvasContainerBounds.left === canvasContainerBounds.left
+				&& this.canvasContainerBounds.right === canvasContainerBounds.right
+				&& this.canvasContainerBounds.top === canvasContainerBounds.top
+				&& this.canvasContainerBounds.bottom === canvasContainerBounds.bottom
+				&& !forceUpdate
+		) {
+			return;
+		}
+
+		this.containerPosX = left;
+		this.containerPosY = top;
+		this.canvasContainerBounds = canvasContainerBounds;
+
+		left += canvasContainerBounds.left;
+		top += canvasContainerBounds.top;
+
+		if (this.isSelected() || this.isEdit()) {
+			if (left < canvasContainerBounds.left) {
+				left = canvasContainerBounds.left;
+			}
+
+			if (top < canvasContainerBounds.top) {
+				top = canvasContainerBounds.top;
+			}
+
+			const width = this.getCommentWidth() / app.dpiScale;
+			if (left + width > canvasContainerBounds.right) {
+				left = canvasContainerBounds.right - width;
+			}
+
+			const height = this.getCommentHeight();
+			if (top + height > canvasContainerBounds.bottom) {
+				top = canvasContainerBounds.bottom - height;
+			}
+		}
+
+		if (this.isSelected()) {
+			this.sectionProperties.container.style.zIndex = 14;
+		} else if (this.isEdit()) {
+			this.sectionProperties.container.style.zIndex = 13;
+		} else {
+			this.sectionProperties.container.style.zIndex = ''; // Default for .cool-annotation is 12
+		}
+
+		this.sectionProperties.container.style.left = Math.round(left) + 'px';
+		this.sectionProperties.container.style.top = Math.round(top) + 'px';
+	}
+
 	private createReplyHint (commentType: HTMLElement): void {
 		this.sectionProperties.replyHint = window.L.DomUtil.create('p', '', commentType);
 		var small = document.createElement('small');
@@ -354,11 +425,11 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	public getContainerPosX(): number {
-		return parseInt(this.sectionProperties.container.style.left.replace('px', ''));
+		return this.containerPosX;
 	}
 
 	public getContainerPosY(): number {
-		return parseInt(this.sectionProperties.container.style.top.replace('px', ''));
+		return this.containerPosY;
 	}
 
 	public updateChildLines (): void {
@@ -782,6 +853,7 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.nodeReply.style.display = 'none';
 		this.sectionProperties.collapsedInfoNode.style.visibility = '';
 		this.cachedIsEdit = false;
+		this.setContainerPos(true);
 	}
 
 	private showCalc() {
@@ -819,6 +891,7 @@ export class Comment extends CanvasSectionObject {
 			this.sectionProperties.nodeReply.style.display = 'none';
 			this.sectionProperties.contentNode.style.display = '';
 			this.cachedIsEdit = false;
+			this.setContainerPos(true);
 			if (this.isSelected() || !this.isCollapsed) {
 				this.sectionProperties.container.style.visibility = '';
 			}
@@ -875,6 +948,7 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.showSelectedCoordinate = false;
 		window.L.DomUtil.removeClass(this.sectionProperties.container, 'cool-annotation-collapsed-show');
 		this.cachedIsEdit = false;
+		this.setContainerPos(true);
 		this.hidden = true;
 	}
 
@@ -901,6 +975,7 @@ export class Comment extends CanvasSectionObject {
 			this.sectionProperties.nodeModify.style.display = 'none';
 			this.sectionProperties.nodeReply.style.display = 'none';
 			this.cachedIsEdit = false;
+			this.setContainerPos(true);
 		}
 		window.L.DomUtil.removeClass(this.sectionProperties.container, 'cool-annotation-collapsed-show');
 		this.hidden = true;
@@ -1194,8 +1269,12 @@ export class Comment extends CanvasSectionObject {
 		}
 		else {
 			this.sectionProperties.nodeReply.style.display = 'none';
-			if (!this.sectionProperties.nodeModify || this.sectionProperties.nodeModify.style.display === 'none')
+			if (!this.sectionProperties.nodeModify || this.sectionProperties.nodeModify.style.display === 'none') {
 				this.cachedIsEdit = false;
+				if (app.map._docLayer._docType !== 'spreadsheet') {
+					this.setContainerPos(true);
+				}
+			}
 		}
 	}
 
@@ -1251,6 +1330,9 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.nodeModify.style.display = 'none';
 		this.sectionProperties.nodeReply.style.display = '';
 		this.cachedIsEdit = true;
+		if (app.map._docLayer._docType !== 'spreadsheet') {
+			this.setContainerPos(true);
+		}
 		return this;
 	}
 
@@ -1262,6 +1344,9 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.container.style.visibility = '';
 		this.sectionProperties.contentNode.style.display = 'none';
 		this.cachedIsEdit = true;
+		if (app.map._docLayer._docType !== 'spreadsheet') {
+			this.setContainerPos(true);
+		}
 		return this;
 	}
 


### PR DESCRIPTION
Previously comments that were selected or currently being edited could end up offscreen in various ways:

This happened:
- When scrolling the page around
- When inserting a comment offscreen
- When resizing the window
  - This caused particular trouble on mobile, since as onscreen keyboard popups need to resize the iframe to avoid covering any of our actions

To deal with this, I've made the comments track what their position should be, and made them clamp it whenever it's updated. Additionally, I had to make sure their position was updated in some extra scenarios (e.g. when unselecting the comment - as this will now need to change between these behaviors)

Finally, it's possible to have a comment that's selected while a different comment is being edited. In this case we need to pick which comment will display ontop. I've chosen it to be the selected comment since as presumably you're currently looking at it/etc., however the comment being edited will still clamp position - it'll just display below if both comments end up in the same position


Change-Id: I5b9659e6ec08ce759b6a2d4dddacb4d76a6a6964


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

