### PR TITLE
browser: do not let comments get too slim

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -585,7 +585,8 @@ body {
 	-webkit-user-select: text;
 	-ms-user-select: text;
 	z-index: 12;
-	width: 250px;
+	width: min-content;
+	min-width: 250px;
 	transition: left .25s;
 }
 
@@ -667,6 +668,7 @@ body {
 	overflow: auto;
 	scrollbar-color: var(--scrollbar-color);
 	scrollbar-width: var(--scrollbar-width);
+	min-width: 200px;
 }
 
 .cool-annotation-info-collapsed {
@@ -862,10 +864,6 @@ body {
 	width: 100%;
 	overflow: hidden;
 	flex: 1;
-}
-
-.cool-annotation:not(.annotation-pop-up) .cool-annotation-author {
-	max-width: 150px;
 }
 
 .cool-annotation-content-author {

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -371,7 +371,8 @@ export class Comment extends CanvasSectionObject {
 		for (let i = 0; i < this.sectionProperties.children.length; i++) {
 			if (this.sectionProperties.children[i].isContainerVisible())
 				childPositions.push({ id: this.sectionProperties.children[i].sectionProperties.data.id,
-									posY: this.getContainerPosY()});
+					posY: this.sectionProperties.children[i].getContainerPosY()
+				});
 		}
 		childPositions.sort((a, b) => { return a.posY - b.posY; });
 		let lastPosY = this.getContainerPosY() + this.getCommentHeight(false);


### PR DESCRIPTION
Set a minimal width so that comments don't get unreadably slim with many
nested replies.

Also fixed a regression that hided the dotted line connecting a comment
with it's replies.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: Icae8574f3bdcdd26cb7d00f81fa989cd7e287394
