### PR TITLE
Writer: Deselecting the text with click after selecting whole documen…

### DIFF
--- a/browser/src/app/TextSelectionMiddleware.ts
+++ b/browser/src/app/TextSelectionMiddleware.ts
@@ -45,6 +45,9 @@ class TextSelections {
 		this.active = false;
 		this.start.setShowSection(false);
 		this.end.setShowSection(false);
+
+		// Schedule a redraw if there's not any.
+		app.sectionContainer.requestReDraw();
 	}
 
 	public static activate() {
@@ -91,9 +94,6 @@ class TextSelections {
 	public static setEndRectangle(rectangle: cool.SimpleRectangle) {
 		this.endRectangle = rectangle;
 		this.updateMarkers();
-
-		// Schedule a redraw if there's not any.
-		app.sectionContainer.requestReDraw();
 	}
 
 	private static updateMarkers() {
@@ -144,6 +144,9 @@ class TextSelections {
 			*/
 			this.switchStartEndHandles();
 		}
+
+		// Schedule a redraw if there's not any.
+		app.sectionContainer.requestReDraw();
 	}
 
 	public static switchStartEndHandles() {


### PR DESCRIPTION
…t doesn't redraw.

Reproduce:
* Open Writer file.
* Put the cursor at the end of the file.
* Select all text.
* Click on the end of the file position or use -> arrow key.
* Selection is cleared after doing the prevous step, but the screen is not refreshed.

Fix:
* Redraw also after deselecting the selected text.
* Also move the redraw request for selections, into updateMarkers for better coverage.


Change-Id: I0117ad2c860fe5cde5c513e2864b2a39d70966a2


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

