### PR TITLE
Add PDF export with options to CODA

### DIFF
--- a/browser/src/control/Control.BackstageView.ts
+++ b/browser/src/control/Control.BackstageView.ts
@@ -822,7 +822,9 @@ class BackstageView extends window.L.Class {
 
 		const format = option.action.startsWith('downloadas-')
 			? option.action.substring('downloadas-'.length)
-			: '';
+			: option.action.startsWith('export')
+				? option.action.substring('export'.length)
+				: '';
 		const extension = format ? `.${format}` : '';
 
 		const icon = this.createElement('div', 'format-icon');
@@ -1358,14 +1360,9 @@ class BackstageView extends window.L.Class {
 		const docType = this.getDocTypeString();
 		const builder = new (window.L.Control.NotebookbarBuilder as any)();
 
-		let downloadAsOpts: ExportOptionItem[] = builder._getDownloadAsSubmenuOpts
+		const downloadAsOpts: ExportOptionItem[] = builder._getDownloadAsSubmenuOpts
 			? builder._getDownloadAsSubmenuOpts(docType) || []
 			: [];
-
-		downloadAsOpts = downloadAsOpts.filter(
-			(option) =>
-				option.action !== 'exportpdf' && option.command !== 'exportpdf',
-		);
 
 		return {
 			exportAs: [],

--- a/browser/src/control/Control.NotebookbarBuilder.js
+++ b/browser/src/control/Control.NotebookbarBuilder.js
@@ -408,7 +408,9 @@ window.L.Control.NotebookbarBuilder = window.L.Control.JSDialogBuilder.extend({
 			if (!window.ThisIsTheAndroidApp)
 				submenuOpts.push({
 					'action': 'exportpdf' ,
-					'text': _('PDF Document (.pdf) as...'),
+					'text': !window.mode.isCODesktop ?
+						_('PDF Document (.pdf) as...') :
+						_('PDF Document (.pdf) with options'),
 					'command': 'exportpdf'
 				});
 		} else if (docType === 'spreadsheet') {
@@ -442,7 +444,9 @@ window.L.Control.NotebookbarBuilder = window.L.Control.JSDialogBuilder.extend({
 			if (!window.ThisIsTheAndroidApp)
 				submenuOpts.push({
 					'action': 'exportpdf' ,
-					'text': _('PDF Document (.pdf) as...'),
+					'text': !window.mode.isCODesktop ?
+						_('PDF Document (.pdf) as...') :
+						_('PDF Document (.pdf) with options'),
 					'command': 'exportpdf'
 				});
 		} else if (docType === 'presentation') {
@@ -476,7 +480,9 @@ window.L.Control.NotebookbarBuilder = window.L.Control.JSDialogBuilder.extend({
 			if (!window.ThisIsTheAndroidApp)
 				submenuOpts.push({
 					'action': 'exportpdf',
-					'text': _('PDF Document (.pdf) as...'),
+					'text': !window.mode.isCODesktop ?
+						_('PDF Document (.pdf) as...') :
+						_('PDF Document (.pdf) with options'),
 					'command': 'exportpdf'
 				});
 			if (window.extraExportFormats.includes('impress_swf'))


### PR DESCRIPTION
Tested in CODA-W, not sure whether it will work in CODA-Q and CODA-M.

Slightly surprised to see that indeed the
output_file_dialog_from_core() hack in CODA-W is needed still for this functionality, so that the user can choose the name and location for the exported PDF also in this case. Good that I had not "cleaned" it away in the meantime while the PDF export with options functionality was missing from CODA-W.


Change-Id: I5f7106dc3317f1251d5c1bdce0d5c3b91a6f33df


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

