### PR TITLE
cypress: fix flaky ReadOnly info dialog a11y test

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
@@ -373,6 +373,8 @@ describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: f
         cy.then(() => {
             win.app.map.sendUnoCommand('.uno:InsertSection?RegionProtect:bool=true');
         });
+        // Wait for the section protection to be applied before trying to delete
+        cy.then(() => helper.processToIdle(win));
         helper.typeIntoDocument('{del}');
         a11yHelper.handleDialog(win, 1);
     });


### PR DESCRIPTION
Wait for processToIdle after InsertSection command before pressing Delete. Without this, the section protection may not be applied yet, so the read-only warning dialog never appears and the test fails.


Change-Id: I4fbfc5548246b490e5a0171a6cc2c3e4d022163a

