### PR TITLE
fix: improve accessibility for online help search button

### DIFF
--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -1,7 +1,7 @@
 <div class="search-container">
     <input size="20" id="online-help-search-input" type="search" aria-label="search" spellcheck="false" />
     <button id="online-help-search-button" type="button" aria-label="Search">
-      <img src="images/lc_recsearch.svg" alt="Search" />
+      <img src="images/lc_recsearch.svg" alt="" />
     </button>
 </div>
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -539,6 +539,7 @@ window.L.Map.include({
 		});
 
 		const searchButton = document.getElementById('online-help-search-button');
+		searchButton.setAttribute('aria-label', _('Search'));
 		searchButton.addEventListener('click', performSearch);
 		searchButton.addEventListener('keydown', function (e) {
 			if (e.key === 'Enter') {


### PR DESCRIPTION
Changes (follow-up #15008):
- make alt text empty as its parent button has aria-label attribute (avoid providing duplicate accessible name)
- for newly added button in fc02f81639f1a146bfb1c8f08b4a1559cfaa77b4 set aria-label explicitly in code for translation

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

