### PR TITLE
a11y: fix Z shortcut overlap in Calc

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -53,7 +53,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 				'id': 'Formula-tab-label',
 				'text': _('Formulas'),
 				'name': 'Formulas',
-				'accessibility': { focusBack: true,	combination: 'Z', de: null }
+				'accessibility': { focusBack: true,	combination: 'M', de: null }
 			},
 			{
 				'id': 'Data-tab-label',
@@ -71,7 +71,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 				'id': 'Format-tab-label',
 				'text': _('Format'),
 				'name': 'Format',
-				'accessibility': { focusBack: true,	combination: 'M', de: null }
+				'accessibility': { focusBack: true,	combination: 'O', de: null }
 			},
 			{
 				'id': 'Shape-tab-label',


### PR DESCRIPTION
Pressing Z switches to Formulas tab and closes Alt mode, conflicting with ZB and ZC.

Change-Id: If34992b5afe92150b218dce7ae0065bf6b639bfc