### PR TITLE
Writer: Ruler overlaps with section drawings.

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -346,6 +346,7 @@ COOL_JS_LST =\
 	src/canvas/CanvasSectionContainer.ts \
 	src/canvas/CanvasSectionObject.ts \
 	src/canvas/sections/HTMLObjectSection.ts \
+	src/canvas/sections/RulerSpacerSection.ts \
 	src/canvas/sections/CompareChangesLabelSection.ts \
 	src/canvas/sections/CommentMarkerSubSection.ts \
 	src/canvas/sections/CommentSection.ts \

--- a/browser/src/app/DocumentBase.ts
+++ b/browser/src/app/DocumentBase.ts
@@ -71,6 +71,10 @@ class DocumentBase {
 	private addSections() {
 		this.mouseControl = new MouseControl(app.CSections.MouseControl.name);
 		app.sectionContainer.addSection(this.mouseControl);
+
+		if (app.map._docLayer._docType === 'text') {
+			app.sectionContainer.addSection(new cool.RulerSpacerSection());
+		}
 	}
 
 	public get fileSize(): cool.SimplePoint {

--- a/browser/src/app/ViewLayoutCompareChanges.ts
+++ b/browser/src/app/ViewLayoutCompareChanges.ts
@@ -148,11 +148,20 @@ class ViewLayoutCompareChanges extends ViewLayoutNewBase {
 		// Default to right side.
 		if (point.mode === -1) point.mode = TileMode.RightSide;
 
-		return point.pX + this.getDeflectionX(point.mode);
+		return (
+			point.pX +
+			this.getDeflectionX(point.mode) +
+			this._documentAnchorPosition[0]
+		);
 	}
 
 	public override documentToViewY(point: cool.SimplePoint): number {
-		return point.pY + this.yStart - this.scrollProperties.viewY;
+		return (
+			point.pY +
+			this.yStart -
+			this.scrollProperties.viewY +
+			this._documentAnchorPosition[1]
+		);
 	}
 
 	public override canvasToDocumentPoint(
@@ -166,8 +175,12 @@ class ViewLayoutCompareChanges extends ViewLayoutNewBase {
 		// Remember which tile mode was used last.
 		this.lastTileMode = point.mode;
 
-		result.pX -= this.getDeflectionX(point.mode);
-		result.pY += this.scrollProperties.viewY - this.yStart;
+		result.pX -=
+			this.getDeflectionX(point.mode) + this._documentAnchorPosition[0];
+		result.pY +=
+			this.scrollProperties.viewY -
+			this.yStart -
+			this._documentAnchorPosition[1];
 
 		return result;
 	}

--- a/browser/src/app/ViewLayoutMultiPage.ts
+++ b/browser/src/app/ViewLayoutMultiPage.ts
@@ -276,10 +276,12 @@ class ViewLayoutMultiPage extends ViewLayoutNewBase {
 
 		result.pX =
 			this.documentRectangles[index].pX1 +
-			(point.pX - this.viewRectangles[index].pX1);
+			(point.pX - this.viewRectangles[index].pX1) -
+			this._documentAnchorPosition[0];
 		result.pY =
 			this.documentRectangles[index].pY1 +
-			(point.pY - this.viewRectangles[index].pY1);
+			(point.pY - this.viewRectangles[index].pY1) -
+			this._documentAnchorPosition[1];
 
 		return result;
 	}

--- a/browser/src/canvas/CanvasSectionProps.js
+++ b/browser/src/canvas/CanvasSectionProps.js
@@ -30,6 +30,7 @@ app.CSections.Debug = {}; // For keeping things simple.
 // First definitions. Other properties will be written according to their orders.
 app.CSections.MouseControl =        { name: "mouse-control"     , zIndex: 5 }; // Handles the event if no section prevented it.
 app.CSections.CommentList =			{ name: 'comment list'		, zIndex: 5	};
+app.CSections.RulerSpacer =			{ name: 'ruler spacer'		, zIndex: 5 };
 app.CSections.Tiles = 				{ name: 'tiles'				, zIndex: 5 };
 app.CSections.CompareChangesLabel =	{ name: 'compare changes label', zIndex: 5 };
 app.CSections.Overlays =				{ name: 'overlay'			, zIndex: 5 };
@@ -84,6 +85,7 @@ app.CSections.ColumnGroup.processingOrder =			29; // Calc.
 app.CSections.CornerHeader.processingOrder =			30; // Calc.
 app.CSections.RowHeader.processingOrder =				40; // Calc.
 app.CSections.ColumnHeader.processingOrder =			50; // Calc.
+app.CSections.RulerSpacer.processingOrder =			55; // Writer. Before tiles so it is located first.
 app.CSections.Tiles.processingOrder = 				60; // Writer & Impress & Calc.
 app.CSections.CompareChangesLabel.processingOrder =	61; // Writer.
 app.CSections.FocusCell.processingOrder =     		61; // Calc.
@@ -104,6 +106,7 @@ app.CSections.ShapeHandlesSection.processingOrder =	75;
 app.CSections.Splitter.processingOrder = 			    80; // Calc.
 
 app.CSections.CalcGrid.drawingOrder = 				40; // Calc.
+app.CSections.RulerSpacer.drawingOrder =				49; // Writer. Before tiles.
 app.CSections.Tiles.drawingOrder = 					50; // Writer & Impress & Calc.
 app.CSections.CompareChangesLabel.drawingOrder =	51; // Writer.
 app.CSections.MouseControl.drawingOrder =           51; // After tiles section.

--- a/browser/src/canvas/sections/RulerSpacerSection.ts
+++ b/browser/src/canvas/sections/RulerSpacerSection.ts
@@ -1,0 +1,72 @@
+/* -*- js-indent-level: 8; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * RulerSpacerSection - Reserves vertical space for the horizontal ruler
+ * in the canvas section layout.
+ *
+ * This section acts as a layout spacer so that the TilesSection (and any
+ * sections anchored to it, such as CompareChangesLabelSection) are
+ * positioned below the ruler when it is visible.
+ *
+ * NOTE: The ruler itself is currently rendered as a Leaflet control
+ * (see HRuler.ts / VRuler.ts) using legacy DOM placement via
+ * map._controlCorners. In the future, ruler rendering should be moved
+ * into this section, eliminating the Leaflet control dependency entirely.
+ */
+
+namespace cool {
+	export class RulerSpacerSection extends CanvasSectionObject {
+		anchor: string[] = ['top', 'left'];
+		expand: string[] = ['right'];
+		processingOrder: number = app.CSections.RulerSpacer.processingOrder;
+		drawingOrder: number = app.CSections.RulerSpacer.drawingOrder;
+		zIndex: number = app.CSections.RulerSpacer.zIndex;
+		interactable: boolean = false;
+
+		constructor() {
+			super(app.CSections.RulerSpacer.name);
+			this.size = [0, 0];
+		}
+
+		onInitialize(): void {
+			const map = (<any>window).L.Map.THIS;
+			map.on('rulerchanged', this.onRulerChanged, this);
+			this.updateSize();
+		}
+
+		onRemove(): void {
+			const map = (<any>window).L.Map.THIS;
+			map.off('rulerchanged', this.onRulerChanged, this);
+		}
+
+		private onRulerChanged(): void {
+			this.updateSize();
+			if (this.containerObject) this.containerObject.reNewAllSections();
+		}
+
+		private updateSize(): void {
+			const rulerEl = document.querySelector(
+				'.cool-ruler:not(.vruler)',
+			) as HTMLElement;
+			const visible = rulerEl && rulerEl.style.display !== 'none';
+
+			if (visible) {
+				const height = Math.round(
+					rulerEl.getBoundingClientRect().height * app.dpiScale,
+				);
+				this.size = [0, height];
+			} else {
+				this.size = [0, 0];
+			}
+		}
+	}
+} // namespace cool

--- a/browser/src/canvas/sections/TilesSection.ts
+++ b/browser/src/canvas/sections/TilesSection.ts
@@ -18,8 +18,7 @@ namespace cool {
 
 export class TilesSection extends CanvasSectionObject {
 
-	// Below anchor list may be expanded. For example, Writer may have ruler section. Then ruler section should also be added here.
-	anchor: any = [[app.CSections.ColumnHeader.name, 'bottom', 'top'], [app.CSections.RowHeader.name, 'right', 'left']];
+	anchor: any = [[app.CSections.RulerSpacer.name, 'bottom', app.CSections.ColumnHeader.name, 'bottom', 'top'], [app.CSections.RowHeader.name, 'right', 'left']];
 	expand: any = ['top', 'left', 'bottom', 'right'];
 	processingOrder: number = app.CSections.Tiles.processingOrder;
 	drawingOrder: number = app.CSections.Tiles.drawingOrder;
@@ -182,7 +181,7 @@ export class TilesSection extends CanvasSectionObject {
 			tilePos.pY = tile.coords.part * partHeightPixels + tile.coords.y;
 		}
 
-		this.drawTileToCanvas(tile, this.context, tilePos.vX, tilePos.vY, TileManager.tileSize, TileManager.tileSize);
+		this.drawTileToCanvas(tile, this.context, tilePos.vX - this.myTopLeft[0], tilePos.vY - this.myTopLeft[1], TileManager.tileSize, TileManager.tileSize);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -391,12 +390,16 @@ export class TilesSection extends CanvasSectionObject {
 		var ctx = this.sectionProperties.tsManager._paintContext();
 
 		if (app.activeDocument && app.activeDocument.activeLayout.type === 'ViewLayoutMultiPage') {
+			this.context.translate(-this.myTopLeft[0], -this.myTopLeft[1]);
 			this.drawPageBackgrounds(ctx);
 			this.drawForViewLayoutMultiPage();
+			this.context.translate(this.myTopLeft[0], this.myTopLeft[1]);
 			return;
 		}
 		else if (app.activeDocument.activeLayout.type === 'ViewLayoutCompareChanges') {
+			this.context.translate(-this.myTopLeft[0], -this.myTopLeft[1]);
 			this.drawForViewLayoutCompareChanges();
+			this.context.translate(this.myTopLeft[0], this.myTopLeft[1]);
 			return;
 		}
 


### PR DESCRIPTION
Issue:
* Open a text file.
* Activate compare-changes view.
* Activate ruler.
* Notice that compare changes view headers and ruler overlap.

Reason: Ruler is not a canvas section and they (ruler+view headers) are independently positioned and drawen.

Fix: Add a spacer section for ruler.


Change-Id: I54be89b245046d40e2ad7e0dc8726096f051a9a8


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

