### PR TITLE
cypress desktop: increase tolerance in calc/chart_dialog_spec.js

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/chart_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/chart_dialog_spec.js
@@ -53,7 +53,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Chart dialog tests', funct
 	 * tests if the width of the 'chart wizard' is larger than a "reasonable"
 	 * width and if it's larger that means something is obviously wrong, probably
 	 * some css property.
-	 * `reasonableWidth` = width at the time of writing this test + 15px ;)
+	 * `reasonableWidth` = width at the time of writing this test +- 15px ;)
 	 */
 	it('Chart Wizard width', function() {
 		cy.cGet('#Insert-tab-label').click();
@@ -62,6 +62,6 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Chart dialog tests', funct
 		cy.cGet('#CHART2_HID_SCH_WIZARD_ROADMAP')
 			.should('be.visible')
 			.invoke('width')
-			.should('be.greaterThan', 400).and('be.lessThan',415);
+			.should('be.greaterThan', 385).and('be.lessThan',415);
 	});
 });


### PR DESCRIPTION
Chart wizard width was required to be inside 400...415 pixels, but this
failed locally with:

> Timed out retrying after 10000ms
> + expected - actual
> -397.609375
> +400

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ib62e16cbda1b32243a6b2ef67f1b40365bfeb3e6
