### PR TITLE
Fix test's broken assumption about std::source_location::current().file_name()

### DIFF
--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -1023,6 +1023,7 @@ void WhiteBoxTests::testLogCaptureCaller()
     LOK_ASSERT_MESSAGE("Unexpected to find the parent's source location",
                        withoutCaller.find("(from") == std::string::npos);
 
+#line __LINE__ "WhiteBoxTests.cpp"
     const auto logWithCaller = [](LOG_CAPTURE_CALLER_DECLARATION) -> std::string
     {
         std::ostringstream oss;


### PR DESCRIPTION
```
(i.e., __FILE__).  Test was introduced in
d00259dd6c4ddbb1353ca20c7d1d79f16630fae0 "wsd: support logging the caller's
source location" and broke e.g. for my Linux out-of-tree build with

> tst-944160-944160 2026-03-18 22:14:41.075637 [ unittest ] TST  testLogCaptureCaller (+2181ms): With caller: [|(from ../../online/test/WhiteBoxTests.cpp:1033)|online/test/WhiteBoxTests.cpp:1029]|online/test/WhiteBoxTests.cpp:1034
> tst-944160-944160 2026-03-18 22:14:41.075643 [ unittest ] TST  testLogCaptureCaller (+2181ms): ERROR: Assertion failure: Expected to find the parent's source location. Condition: withCaller.find("|(from WhiteBoxTests.cpp:") != std::string::npos|online/test/WhiteBoxTests.cpp:1036

Change-Id: I9b181640f3536c74321ccd3dd93fadbc6ea8ddbb
```

* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

