### PR TITLE
expander has no id, so focus cannot be restored to it

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -865,6 +865,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 				var headingLevel = Math.min(builder._expanderDepth + 2, 6);
 				var heading = window.L.DomUtil.create('h' + headingLevel, 'ui-expander-heading ' + builder.options.cssClass, expander);
 				var expanderBtn = window.L.DomUtil.create('button', 'ui-expander-btn ' + builder.options.cssClass, heading);
+				expanderBtn.id = prefix + '-button';
 				expanderBtn.tabIndex = '0';
 				expanderBtn.setAttribute('aria-controls', prefix + '-children');
 


### PR DESCRIPTION
The expander button in _expanderHandler had no id attribute. When the expander is toggled, core triggers _updateWidgetImpl.

That method saves document.activeElement.id, rebuilds the widget, then tries to restore focus by finding an element with that the old id. Since the button had no id the fallback of sending focus to the document body happens.


Change-Id: Idb4370930a13d0a5351f3119964ff3031cf9e35d


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

