### PR TITLE
HostUtils: parseAlias: allow hostnames without tld

### DIFF
--- a/test/HostUtilTests.cpp
+++ b/test/HostUtilTests.cpp
@@ -34,17 +34,26 @@ void HostUtilTests::testParseAlias()
     constexpr std::string_view testname = __func__;
 
     LOK_ASSERT_EQUAL_STR("test2\\.local", HostUtil::parseAlias("test2.local"));
+    LOK_ASSERT_EQUAL_STR("test3\\.local", HostUtil::parseAlias("http://test3.local"));
     LOK_ASSERT_EQUAL_STR("test3\\.local", HostUtil::parseAlias("https://test3.local"));
     LOK_ASSERT_EQUAL_STR("test4\\.local", HostUtil::parseAlias("https://test4.local:8080"));
     LOK_ASSERT_EQUAL_STR("test5\\.local", HostUtil::parseAlias("https://test5.local:8080/"));
     LOK_ASSERT_EQUAL_STR("test6\\.local", HostUtil::parseAlias("https://test6.local:8080/path"));
     LOK_ASSERT_EQUAL_STR("test7\\.local", HostUtil::parseAlias("test7.local/path"));
+    LOK_ASSERT_EQUAL_STR("test8", HostUtil::parseAlias("http://test8"));
+    LOK_ASSERT_EQUAL_STR("test9", HostUtil::parseAlias("http://test9:8080"));
+    LOK_ASSERT_EQUAL_STR("test10", HostUtil::parseAlias("http://test10:8080/"));
+    LOK_ASSERT_EQUAL_STR("test11", HostUtil::parseAlias("http://test11:8080/path"));
 
-    LOK_ASSERT_EQUAL_STR("test", HostUtil::parseAlias("test")); // invalid hostname, interpret as regex
-    LOK_ASSERT_EQUAL_STR("test[1-3]", HostUtil::parseAlias("test[1-3]"));
+    LOK_ASSERT_EQUAL_STR("test", HostUtil::parseAlias("test")); // identical result regardless of interpretation
+
+    LOK_ASSERT_EQUAL_STR("test[1-3]", HostUtil::parseAlias("test[1-3]")); // invalid hostname, interpret as regex
     LOK_ASSERT_EQUAL_STR("test[0-9].local", HostUtil::parseAlias("test[0-9].local"));
     LOK_ASSERT_EQUAL_STR("test[0-9]+.local", HostUtil::parseAlias("test[0-9]+.local"));
     LOK_ASSERT_EQUAL_STR("", HostUtil::parseAlias("test[0-9.local")); // invalid regex
+
+    LOK_ASSERT_EQUAL_STR("https://:8080", HostUtil::parseAlias("https://:8080")); // not a valid url, no hostname
+    LOK_ASSERT_EQUAL_STR("/my-path", HostUtil::parseAlias("/my-path")); // not a valid url, no hostname
 
     LOK_ASSERT_EQUAL_STR("https://aliasname[0-9]{1}:443", HostUtil::parseAlias("https://aliasname[0-9]{1}:443"));
 }

--- a/wsd/HostUtil.cpp
+++ b/wsd/HostUtil.cpp
@@ -92,7 +92,7 @@ std::string HostUtil::parseAlias(const std::string& aliasPattern)
     // Must be a full match.
     // Group 2 captures the hostname.
     std::regex re(
-        "^(https?://)?(([a-z0-9\\-]+)(\\.[a-z0-9\\-]+)+)(:[0-9]{1,5})?(/[a-z0-9\\-&?_]*)*$",
+        "^(https?://)?(([a-z0-9\\-]+)(\\.[a-z0-9\\-]+)*)(:[0-9]{1,5})?(/[a-z0-9\\-&?_]*)*$",
         std::regex_constants::icase);
 
     std::smatch matches;


### PR DESCRIPTION
Fixes CollaboraOnline/online/issues/15100


Change-Id: I2bacc4caf1affed090845178c72ecd39bb0cfa91


* Resolves: #15100
* Target version: main

### Summary
Fix HostUtil::parseAlias to accept hostnames with a single segment, e.g. http://test as opposed to http://test.local

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [X] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

