### PR TITLE
HostUtils: parseAlias: allow hostnames without tld

### DIFF
--- a/test/HostUtilTests.cpp
+++ b/test/HostUtilTests.cpp
@@ -39,8 +39,9 @@ void HostUtilTests::testParseAlias()
     LOK_ASSERT_EQUAL_STR("test5\\.local", HostUtil::parseAlias("https://test5.local:8080/"));
     LOK_ASSERT_EQUAL_STR("test6\\.local", HostUtil::parseAlias("https://test6.local:8080/path"));
     LOK_ASSERT_EQUAL_STR("test7\\.local", HostUtil::parseAlias("test7.local/path"));
+    LOK_ASSERT_EQUAL_STR("test8-local", HostUtil::parseAlias("http://test8-local:8080"));
 
-    LOK_ASSERT_EQUAL_STR("test", HostUtil::parseAlias("test")); // invalid hostname, interpret as regex
+    LOK_ASSERT_EQUAL_STR("test", HostUtil::parseAlias("test"));
     LOK_ASSERT_EQUAL_STR("test[1-3]", HostUtil::parseAlias("test[1-3]"));
     LOK_ASSERT_EQUAL_STR("test[0-9].local", HostUtil::parseAlias("test[0-9].local"));
     LOK_ASSERT_EQUAL_STR("test[0-9]+.local", HostUtil::parseAlias("test[0-9]+.local"));

--- a/wsd/HostUtil.cpp
+++ b/wsd/HostUtil.cpp
@@ -92,7 +92,7 @@ std::string HostUtil::parseAlias(const std::string& aliasPattern)
     // Must be a full match.
     // Group 2 captures the hostname.
     std::regex re(
-        "^(https?://)?(([a-z0-9\\-]+)(\\.[a-z0-9\\-]+)+)(:[0-9]{1,5})?(/[a-z0-9\\-&?_]*)*$",
+        "^(https?://)?(([a-z0-9\\-]+)(\\.[a-z0-9\\-]+)*)(:[0-9]{1,5})?(/[a-z0-9\\-&?_]*)*$",
         std::regex_constants::icase);
 
     std::smatch matches;


### PR DESCRIPTION
Change-Id: Ie2d2ca6765b3ccfa38d4d08551bcb9ad57f83d41


* Resolves: #15100 
* Target version: main

### Summary

https://github.com/CollaboraOnline/online/pull/13869#issuecomment-4077672533

### TODO

- [ ] ...

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

