### PR TITLE
Separators marked as hidden for compact view

### DIFF
--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -2694,6 +2694,9 @@ class Menubar extends window.L.Control {
 
 			var liItem = window.L.DomUtil.create('li', '');
 			liItem.setAttribute('role', 'menuitem');
+			if (menu[i].type === 'separator') {
+				liItem.setAttribute('aria-hidden', 'true');
+			}
 			if (menu[i].id) {
 				liItem.id = 'menu-' + menu[i].id;
 				if (menu[i].id === 'closedocument' && isReadOnly) {


### PR DESCRIPTION
Change-Id: I074dbdfa463df84c8afee9ffc926b8a91bfcedfd


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

In compact view, the separators would be read out as menuitem menuitem. This solves the issue.

# TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

