### PR TITLE
a11y: fix shortcut overlap in Calc Data tab

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -2542,7 +2542,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 				'type': 'menubutton',
 				'text': _UNO('.uno:StatisticsMenu', 'spreadsheet'),
 				'enabled': 'true',
-				'accessibility': { focusBack: true,	combination: 'DS', de: null }
+				'accessibility': { focusBack: true,	combination: 'ST', de: null }
 			},
 		];
 


### PR DESCRIPTION
"Show Details" and "Statistics" both use the DS shortcut in the Calc Data tab
Change "Statistics" to use "ST" instead

Change-Id: I8056f7d01f022b7c50eb4f709a03795dfa155b7f

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

