### PR TITLE
Fix document mode label color (Edit/view mode)

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -449,6 +449,7 @@ label.notebookbar.ui-checkbox-label {
 .has-label.has-dropdown:not(.inline) .unolabel {
 	display: inline-block;
 	clear: both;
+	color: var(--color-main-text);
 }
 
 /* adding focus to tab in notebookbar */


### PR DESCRIPTION
Backport of: https://github.com/CollaboraOnline/online/pull/14928

* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

