### PR TITLE
Fixed movement in notebookbar

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1257,7 +1257,15 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 								let visibleContainer = Array.from(container[0].children).find(child =>
 									!child.classList.contains('hidden') && child.offsetParent !== null
 								);
-								let focusables = visibleContainer ? Array.from(visibleContainer.querySelectorAll('[tabindex="-1"]:not([disabled])')) : [];
+								
+								var allFocusables = visibleContainer ? Array.from(visibleContainer.querySelectorAll('*'))
+									.filter(function(el) { return el.checkVisibility() && JSDialog.IsFocusable(el); }) : [];
+
+								// Only leaf-level focusable elements are candidates.
+								var focusables = allFocusables.filter(function(el) {
+									return !allFocusables.some(function(other) { return other !== el && el.contains(other); });
+								});
+
 								if (focusables.length) {
 									let first = focusables[0];
 									let last = focusables[focusables.length - 1];


### PR DESCRIPTION
Change-Id: I5c2e4955bf9fb1c6fd13b6801f1f063411e7ba9b


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
Pressing down when on the lowest row of the notebookbar now properly selects first focusable element.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

