### PR TITLE
wsd: protect against thread-affinity violation in StreamSocket dtor

### DIFF
--- a/net/Socket.hpp
+++ b/net/Socket.hpp
@@ -1238,7 +1238,21 @@ public:
     {
         LOG_TRC("StreamSocket dtor called with pending write: " << _outBuffer.size()
                                                                 << ", read: " << _inBuffer.size());
-        ensureDisconnected();
+        if (!_doneDisconnect)
+        {
+            // This dtor could be called from a different thread when we are owned by
+            // a weak_ptr elevated to a shared_ptr while the real owning shared_ptr
+            // is destroyed. This can happen when we remove a closed socket from the
+            // poll while in another thread a weak_ptr on it has temporarily lock()'d
+            // and got another valid reference to it.
+            // In that case, the real owner should've called ensureDisconnected()
+            // and we won't need it again here, hence the conditional, and won't get
+            // tripped-up by the ASSERT_CORRECT_SOCKET_THREAD check inside it.
+            // Otherwise, we will invoke it and it's only fair to catch the thread
+            // affinity violation.
+            ensureDisconnected();
+        }
+
         _socketHandler.reset();
 
         if (!_shutdownSignalled)


### PR DESCRIPTION
As the comment explains, there are scenarios
when the socket is closed and removed while
it's held by a temporary shared_ptr acquired
through a weak_ptr in another thread. In such
a scenario, the temp shared_ptr will call the
destructor in its incorrect thread, causing
the thread-affinity assertion to fire inside
of ensureDisconnected().

This isn't helpful for the main reason that
the ensureDisconnected() isn't necessary and
will not do anything but check that there is
nothing to be done! And since avoiding the
destruction in a different thread than the
one we have affinity to is rather complex
and tricky, we avoid the issue by skipping
the ensureDisconnected() call when it's not
needed.

Another fix would've been to reset the thread
affinity, but that seems to be too blunt a
tool and robs us of the opportunity of catching
affinity violations when ensureDisconnected()
isn't invoked on destruction while we are
destroyed from the wrong thread.

Change-Id: I8e41ee56a4203aaba3d21472c9d1a446cb76f9a2
Signed-off-by: Ashod Nakashian <ashod.nakashian@collabora.co.uk>
