### PR TITLE
Cypress test for tracked changes dialog honoring restricted_commands

### DIFF
--- a/common/CommandControl.cpp
+++ b/common/CommandControl.cpp
@@ -168,37 +168,36 @@ std::string RestrictionManager::RestrictedCommandListString;
 
 RestrictionManager::RestrictionManager() {}
 
-void RestrictionManager::generateRestrictedCommandList()
+void RestrictionManager::setRestrictedCommandList(const std::string& commandListString)
 {
-#ifdef ENABLE_FEATURE_RESTRICTION
-    RestrictedCommandListString = ConfigUtil::getString("restricted_commands", "");
-    Util::trim(RestrictedCommandListString);
-    StringVector commandList = StringVector::tokenize(RestrictedCommandListString);
-
-    std::string command;
-    for (std::size_t i = 0; i < commandList.size(); i++)
-    {
-        command = commandList[i];
-        if (!command.empty())
-        {
-            RestrictedCommandList.emplace(command);
-        }
-    }
+#if defined(ENABLE_FEATURE_RESTRICTION) || ENABLE_DEBUG
+    RestrictedCommandListString = Util::trimmed(commandListString);
+    RestrictedCommandList.clear();
 #endif
 }
 
 const std::unordered_set<std::string>& RestrictionManager::getRestrictedCommandList()
 {
-    if (RestrictedCommandList.empty())
-        generateRestrictedCommandList();
+    if (RestrictedCommandList.empty() && !RestrictedCommandListString.empty())
+    {
+        StringVector commandList = StringVector::tokenize(RestrictedCommandListString);
+        for (std::size_t i = 0; i < commandList.size(); i++)
+        {
+            std::string command = commandList[i];
+            if (!command.empty())
+            RestrictedCommandList.emplace(command);
+        }
+    }
 
     return RestrictedCommandList;
 }
 
 const std::string RestrictionManager::getRestrictedCommandListString()
 {
+#ifdef ENABLE_FEATURE_RESTRICTION
     if (RestrictedCommandListString.empty())
-        generateRestrictedCommandList();
+        setRestrictedCommandList(ConfigUtil::getString("restricted_commands", ""));
+#endif
 
     return RestrictedCommandListString;
 }

--- a/common/CommandControl.hpp
+++ b/common/CommandControl.hpp
@@ -137,10 +137,9 @@ class RestrictionManager
     static bool _isRestrictedUser;
     static std::string RestrictedCommandListString;
 
-    static void generateRestrictedCommandList();
-
 public:
     RestrictionManager();
+    static void setRestrictedCommandList(const std::string& commandListString);
     static const std::unordered_set<std::string>& getRestrictedCommandList();
     static const std::string getRestrictedCommandListString();
 

--- a/cypress_test/data/desktop/writer/manage_tracking_changes.odt.wopi.json
+++ b/cypress_test/data/desktop/writer/manage_tracking_changes.odt.wopi.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "this .wopi.json is only used in tests, when setupAndLoadDocument is called with copyCertificates equal to true",
+  "IsUserRestricted": true,
+  "Test_RestrictedCommandList": ".uno:AcceptAllTrackedChanges .uno:AcceptTrackedChange .uno:RejectAllTrackedChanges .uno:RejectTrackedChange"
+}

--- a/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
@@ -393,3 +393,41 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 
 	});
 });
+
+describe(['tagdesktop'], 'Restricted user tracked changes dialog button state', function() {
+	function openManageChangesDialog() {
+		desktopHelper.switchUIToNotebookbar();
+		cy.viewport(1920, 1080);
+		cy.cGet('.notebookbar #Review-tab-label').click();
+		desktopHelper.getNbIcon('AcceptTrackedChanges', 'Review').click();
+		cy.cGet('#AcceptRejectChangesDialog').should('be.visible');
+		cy.cGet('#writerchanges .ui-treeview-entry').first().click();
+	}
+
+	it('Accept and reject buttons are disabled for restricted user', function() {
+		helper.setupAndLoadDocument('writer/manage_tracking_changes.odt',
+			/* isMultiUser */ false, /* copyCertificates copies .wopi.json */ true);
+		openManageChangesDialog();
+
+		// When loading writer/manage_tracking_changes.odt.wopi.json, which
+		// has IsUserRestricted=true and Test_RestrictedCommandList containing
+		// the accept/reject UNO commands, all four buttons must be disabled
+		cy.cGet('#accept-button').should('have.attr', 'disabled');
+		cy.cGet('#reject-button').should('have.attr', 'disabled');
+		cy.cGet('#acceptall-button').should('have.attr', 'disabled');
+		cy.cGet('#rejectall-button').should('have.attr', 'disabled');
+	});
+
+	it('Accept and reject buttons are enabled for unrestricted user', function() {
+		helper.setupAndLoadDocument('writer/manage_tracking_changes.odt',
+			/* isMultiUser */ false, /* copyCertificates copies .wopi.json */ false);
+		openManageChangesDialog();
+
+		// Without the .wopi.json the user is not restricted,
+		// so all four buttons must be enabled
+		cy.cGet('#accept-button').should('not.have.attr', 'disabled');
+		cy.cGet('#reject-button').should('not.have.attr', 'disabled');
+		cy.cGet('#acceptall-button').should('not.have.attr', 'disabled');
+		cy.cGet('#rejectall-button').should('not.have.attr', 'disabled');
+	});
+});

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -545,7 +545,7 @@ bool ChildSession::_handleInput(const char *buffer, int length)
     }
     else if (tokens.equals(0, "blockingcommandstatus"))
     {
-#if ENABLE_FEATURE_LOCK || ENABLE_FEATURE_RESTRICTION
+#if (ENABLE_FEATURE_LOCK || ENABLE_FEATURE_RESTRICTION || ENABLE_DEBUG) && !MOBILEAPP
         return updateBlockingCommandStatus(tokens);
 #endif
     }
@@ -3465,7 +3465,7 @@ int ChildSession::getSpeed()
     return _cursorInvalidatedEvent.size();
 }
 
-#if ENABLE_FEATURE_LOCK || ENABLE_FEATURE_RESTRICTION
+#if (ENABLE_FEATURE_LOCK || ENABLE_FEATURE_RESTRICTION || ENABLE_DEBUG) && !MOBILEAPP
 bool ChildSession::updateBlockingCommandStatus(const StringVector& tokens)
 {
     std::string lockStatus, restrictedStatus;
@@ -3481,7 +3481,20 @@ bool ChildSession::updateBlockingCommandStatus(const StringVector& tokens)
     }
     std::string blockedCommands;
     if (restrictedStatus == "true")
+    {
         blockedCommands += CommandControl::RestrictionManager::getRestrictedCommandListString();
+#if ENABLE_DEBUG
+        // Extract restricted commands passed from the wsd process.
+        // Format: blockingcommandstatus isRestrictedUser=true isLockedUser=... test_restrictedCommands=cmd1 cmd2 ...
+        std::string firstCmd;
+        if (tokens.size() > 3 && getTokenString(tokens[3], "test_restrictedCommands", firstCmd))
+        {
+            blockedCommands += firstCmd;
+            for (std::size_t i = 4; i < tokens.size(); ++i)
+                blockedCommands += " " + tokens[i];
+        }
+#endif
+    }
     if (lockStatus == "true")
         blockedCommands += blockedCommands.empty()
                                ? CommandControl::LockManager::getLockedCommandListString()

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -218,7 +218,7 @@ private:
     bool askSignatureStatus(const char* buffer, int length, const StringVector& tokens);
     bool renderShapeSelection(const StringVector& tokens);
     bool removeTextContext(const StringVector& tokens);
-#if ENABLE_FEATURE_LOCK || ENABLE_FEATURE_RESTRICTION
+#if ENABLE_FEATURE_LOCK || ENABLE_FEATURE_RESTRICTION || ENABLE_DEBUG
     bool updateBlockingCommandStatus(const StringVector& tokens);
     std::string getBlockedCommandType(const std::string& command);
 #endif

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -2755,7 +2755,7 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
             _canonicalViewId = CanonicalViewId(canonicalId);
         }
     }
-#if ENABLE_FEATURE_LOCK || ENABLE_FEATURE_RESTRICTION
+#if (ENABLE_FEATURE_LOCK || ENABLE_FEATURE_RESTRICTION || ENABLE_DEBUG) && !MOBILEAPP
     else if (tokens.equals(0, "status:") && !isViewLoaded())
     {
         std::ostringstream blockingCommandStatus;
@@ -2764,6 +2764,13 @@ bool ClientSession::handleKitToClientMessage(const std::shared_ptr<Message>& pay
                                                                                          : "false")
                               << " isLockedUser="
                               << (CommandControl::LockManager::isLockedUser() ? "true" : "false");
+#if ENABLE_DEBUG
+        // Enable testing feature restriction
+        const std::string restrictedCmds =
+            CommandControl::RestrictionManager::getRestrictedCommandListString();
+        if (!restrictedCmds.empty())
+            blockingCommandStatus << " test_restrictedCommands=" << restrictedCmds;
+#endif
         docBroker->forwardToChild(client_from_this(), blockingCommandStatus.str());
     }
 #endif

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -306,6 +306,13 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo, Poco::JSON::Ob
     JsonUtil::findJSONValue(object, "IsUserRestricted", booleanFlag);
     CommandControl::RestrictionManager::setRestrictedUser(booleanFlag);
 
+#if ENABLE_DEBUG
+    // Enable testing feature restriction; always reset to avoid stale state from prior loads
+    std::string restrictedCommandList;
+    JsonUtil::findJSONValue(object, "Test_RestrictedCommandList", restrictedCommandList);
+    CommandControl::RestrictionManager::setRestrictedCommandList(restrictedCommandList);
+#endif
+
     if (JsonUtil::findJSONValue(object, "DisableChangeTrackingRecord", booleanFlag))
         _disableChangeTrackingRecord =
             (booleanFlag ? WOPIFileInfo::TriState::True : WOPIFileInfo::TriState::False);


### PR DESCRIPTION
Corresponding core commit fa9a5b4960ffaee791635c204e7afd0c6b386db9
(lok: Make SwRedlineAcceptDlg take blocked commands into account,
2026-03-19).

Command restriction requires --enable-feature-restriction config
option, and restricted_commands in coolwsd.xml. To enable testing
in the existing infrastructure, where the config flag is not used
in build, and the same coolwsd.xml is used for all tests, a test-
only WOPI value was introduced, "Test_RestrictedCommandList". It
is only available in ENABLE_DEBUG builds.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I82cff25b8d0e07685a00c314340c25c09ea7cbdf
