### PR TITLE
a11y: update accessibility combination for format cells and dialogs to avoid conflict with Paragraph Dialog

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -2709,14 +2709,14 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 				'type': 'overflowgroup',
 				'id': 'format-cells',
 				'name':_('Format Cells'),
-				'accessibility': { focusBack: true,	combination: 'PD', de: null },
+				'accessibility': { focusBack: true,	combination: 'PF', de: null },
 				'children' : [
 					{
 						'id': 'format-page-format-dialog',
 						'type': 'bigtoolitem',
 						'text': _UNO('.uno:PageFormatDialog', 'spreadsheet', true),
 						'command': '.uno:PageFormatDialog',
-						'accessibility': { focusBack: true,	combination: 'PD', de: null }
+						'accessibility': { focusBack: true,	combination: 'PF', de: null }
 					},
 					{
 						'id': 'format-format-cell-dialog',


### PR DESCRIPTION
Change-Id: Ic51019a0b80b388287e4fd61fb4cd2a3b4a52975

Changes:
1. update accessibility combination for format cells and dialogs to avoid conflict with Paragraph Dialog


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

