### PR TITLE
perf: update scrollable toolbars in task #15091

### DIFF
--- a/browser/src/control/jsdialog/Util.ScrollableBar.ts
+++ b/browser/src/control/jsdialog/Util.ScrollableBar.ts
@@ -14,9 +14,9 @@
  * JSDialog.ScrollableBar - helper for creating toolbars with scrolling left/right
  */
 
-/* global JSDialog $ */
-
 declare var JSDialog: any;
+
+let pendingTask: TaskId | null = null;
 
 function createScrollButtons(parent: Element, scrollable: Element) {
 	window.L.DomUtil.addClass(scrollable, 'ui-scroll-wrapper');
@@ -52,7 +52,9 @@ function setupResizeHandler(container: Element, scrollable: Element) {
 	var isRTL: boolean = document.documentElement.dir === 'rtl';
 	var timer: any; // for shift + mouse wheel up/down
 
-	const handler = function () {
+	const handlerImpl = () => {
+		pendingTask = null;
+
 		const rootContainer = scrollable.querySelector('div');
 		if (!rootContainer) return;
 
@@ -77,7 +79,12 @@ function setupResizeHandler(container: Element, scrollable: Element) {
 			showArrow(left, false);
 			showArrow(right, false);
 		}
-	}.bind(this);
+	};
+
+	const handler = () => {
+		if (pendingTask) app.layoutingService.cancelLayoutingTask(pendingTask);
+		pendingTask = app.layoutingService.appendLayoutingTask(handlerImpl);
+	};
 
 	// handler for toolbar and statusbar
 	// runs if shift + mouse wheel up/down are used


### PR DESCRIPTION
Fixes #15091

- very frequent task
- happens on resize of window, scroll of document, status of commands
- example is scrolling between Writer pages when we need to update page number in statusbar - causing it to happen synchronously and reducing frame rate on that fragments

AFTER:
<img width="868" height="588" alt="Screenshot From 2026-03-20 10-55-50" src="https://github.com/user-attachments/assets/76f3427e-8c7c-4c70-bd3d-50f7c46743b2" />

NOW: more idle frames while scrolling - white bar
PREVIOUSLY: lots of green frames were done, also visible overflowmanager's methods doing layouting