### PR TITLE
Spin button: Add missing space before

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -348,8 +348,10 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		var str = '' + value;
 		if (this._decimal !== '.')
 			str = str.replace('.', this._decimal);
-		if (unit)
-			return str + unit;
+		if (unit) {
+			var noSpace = (unit === '°' || unit === '"' || unit === '\u2033' || unit === '%');
+			return noSpace ? str + unit : str + ' ' + unit;
+		}
 		return str;
 	},
 

--- a/cypress_test/integration_tests/desktop/writer/spinfield_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/spinfield_spec.js
@@ -82,6 +82,26 @@ describe(['tagdesktop'], 'Spinfield unit and button tests', function () {
 		testUnitPersistence('.', '\u2033');
 	});
 
+	it('Space before unit in displayed value', function () {
+		helper.setupAndLoadDocument('writer/help_dialog.odt', false, false, 'de-DE');
+		cy.getFrameWindow().then(function (w) {
+			win = w;
+		});
+
+		openDialogAndSwitchToBorder();
+
+		// cm unit should have a space before it
+		cy.cGet('#leftmf-input').invoke('val').then(function (val) {
+			expect(val).to.match(/\d\scm$/);
+		});
+
+		// After incrementing, the space should persist
+		cy.cGet('#leftmf .spinfieldbutton-up').click();
+		cy.cGet('#leftmf-input').invoke('val').then(function (val) {
+			expect(val).to.match(/\d\scm$/);
+		});
+	});
+
 	it('Unit persists with German locale', function () {
 		helper.setupAndLoadDocument('writer/help_dialog.odt', false, false, 'de-DE');
 		cy.getFrameWindow().then(function (w) {


### PR DESCRIPTION
Insert a space before the unit, except when the unit is °, ", or %

Sources
- https://www.unicode.org/reports/tr35/tr35-general.html
-
https://www.nist.gov/pml/special-publication-811/nist-guide-si-chapter-7-rules-and-style-conventions-expressing-values

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I514159a621db61b7976f90105b671d4af56ec1f2
