### PR TITLE
sidebar: avoid flicker and canvas redraw

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -357,6 +357,11 @@ body {
 	height: 100%;
 }
 
+/* setup it statuc so we don't flicker to resize canvas */
+#sidebar-dock-wrapper {
+	width: 329px;
+}
+
 #sidebar-dock-wrapper.visible {
 	display: block;
 	/* synchronize time with Sidebar.ts setting focus */


### PR DESCRIPTION
- changing sidebar deck to one with different width will redraw canvas with visible flicker
- be sure we do not change width dynamically but prefer static width