### PR TITLE
browser: a11y: fix Tab key navigation in multiline edit

### DIFF
--- a/browser/src/control/jsdialog/Widget.MultilineEdit.js
+++ b/browser/src/control/jsdialog/Widget.MultilineEdit.js
@@ -86,12 +86,16 @@ function _multiLineEditControl(parentContainer, data, builder, callback) {
 		edit.readOnly = true;
 	}
 
-	function _keyupChangeHandler() {
+	function _keyupChangeHandler(e) {
+		const nav_keys = ['Tab', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
+
 		if (callback)
 			callback(this.value);
 
 		builder.callback('edit', 'change', edit, this.value, builder);
-		setTimeout(function () { _sendSimpleSelection(edit, builder); }, 0);
+		if (!nav_keys.includes(e.code)) {
+			setTimeout(function () { _sendSimpleSelection(edit, builder); }, 0);
+		}
 	}
 
 	edit.addEventListener('keyup', _keyupChangeHandler);


### PR DESCRIPTION
The multiline edit widget is supposed to send the 'selection' command
to the server if and only if there is an actual text selection.

Currently, every navigation key (even those only changing focus)
triggers the command, causing the server to react and hide elements in
dialogs (e.g., in the Formula Wizard Dialog).

Change-Id: I6049ec4bc4ed794b7f0672586f5c31757c2e005a
Signed-off-by: Henry Castro <hcastro@collabora.com>
