### PR TITLE
Preserve a passed-in DEBUG environment variable for Cypress tests

### DIFF
--- a/cypress_test/Makefile.am
+++ b/cypress_test/Makefile.am
@@ -88,7 +88,7 @@ A11Y_TAG:=$(if $(findstring true,$(A11Y_ENABLE)),taga11yenabled,taga11ydisabled)
 
 if ENABLE_DEBUG
 FILTER_DEBUG=cypress:electron,cypress:launcher
-export DEBUG=$(if $(ENABLE_LOGGING),$(FILTER_DEBUG),)
+export DEBUG:=$(or $(DEBUG),$(if $(ENABLE_LOGGING),$(FILTER_DEBUG)))
 endif
 
 if HAVE_LO_PATH


### PR DESCRIPTION
Change-Id: Ia1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

