### PR TITLE
give up on remaining cypress specs on first failure

### DIFF
--- a/cypress_test/plugins/index.js
+++ b/cypress_test/plugins/index.js
@@ -22,6 +22,14 @@ function plugin(on, config) {
 		config.video = true;
 	}
 
+	// Abort the run after the first spec failure so CI does not waste
+	// time running remaining specs when the build is already doomed.
+	on('after:spec', (spec, results) => {
+		if (results && results.stats.failures > 0) {
+			process.exit(1);
+		}
+	});
+
 	on('before:browser:launch', function(browser, launchOptions) {
 
 		if (process.env.ENABLE_CONSOLE_LOG) {


### PR DESCRIPTION
commit 74dd40135bbec3480d3321d13f53f4c3e56f70e8
Date:   Sat Dec 20 21:20:44 2025 +0000

    try to make cypress stop on first failure

only helps to skip the remainder of the current .spec, it doesn't abort the entire run


Change-Id: Ief17611cb91553f94af438d35d8cdb28887ade14


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

