### PR TITLE
Dialogue Tabs Layout follow Navigation tab layout #14358

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -489,33 +489,41 @@ algned to the bottom */
 	line-height: normal !important;
 	color: dimgray !important;
 	color: var(--color-text-dark) !important;
-	height: 24px !important;
+	height: var(--header-height) !important;
 	display: flex !important;
 	align-items: center !important;
 	justify-content: center;
 	padding: 0px 1em !important;
 	border: solid 1px transparent !important;
 	border-radius: var(--border-radius) !important;
-	background-color: var(--color-main-background) !important;
 	margin-inline-end: 12px !important;
-	margin-bottom: 6px;
+	background-color: transparent !important;
+	margin-block: 0 4px;
 }
 
 .ui-tab.hidden.jsdialog {
 	visibility: hidden !important;
 }
 
+[data-theme='dark'] .ui-tab.selected.jsdialog {
+	color: var(--color-main-text) !important;
+}
+
 .ui-toggle.checked button,
 .ui-tab.selected.jsdialog {
 	background-color: var(--color-background-lighter) !important;
-	color: var(--color-text-darker) !important;
-	box-shadow: 0 0 2px 1px var(--color-box-shadow-dark) !important;
+	color: rgba(var(--doc-type), 1) !important;
+	text-decoration: underline 2px solid rgba(var(--doc-type), 1);
+	text-underline-offset: 6px;
+}
+
+body button:not(.ui-corner-all):not(.button-primary):not(.unobutton):not(.form-field-button):not(.notebookbar.ui-tab):not(.ui-expander-btn):not(.arrowbackground):not(.ui-combobox-button):not(.inserttable-grid .col):not(.spinfieldbutton-up):not(.spinfieldbutton-down):hover {
+	color: rgba(var(--doc-type), 1) !important;
+	background-color: var(--color-background-darker) !important;
 }
 
 .ui-tab.jsdialog:not(.selected):hover {
 	cursor: pointer !important;
-	background-color: var(--color-background-darker) !important;
-	color: var(--color-text-darker) !important;
 }
 
 /* Sub Tabs: example Format Cells: Font */


### PR DESCRIPTION
Change-Id: I26c7245e7f16e8c1453432bfbf5913d7e28954c5

* Resolves: #14358 
* Target version: main

### Proposal

The dialog tab's follow the navigation tab layout (and the notebookbar tab layout, unbranded)

### New Tab Layout

<img width="971" height="869" alt="Screenshot_20260320_232909" src="https://github.com/user-attachments/assets/30d21bad-e7a6-417a-89a7-d3fee6df66fe" />

### New Tab Layout (dark)

<img width="985" height="869" alt="Screenshot_20260320_233111" src="https://github.com/user-attachments/assets/e1e39fb0-770d-4f97-a35b-a4e7231e2f7c" />