### PR TITLE
jsdialog: visually disable menu entries with enabled=false

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -712,9 +712,11 @@ algned to the bottom */
 }
 
 .ui-treeview.disabled,
-.ui-treeview-entry div.disabled {
+.ui-treeview-entry div.disabled,
+.ui-treeview-entry.disabled {
 	background-color: var(--color-background-dark) !important;
 	color: var(--color-text-lighter) !important;
+	pointer-events: none;
 }
 
 #custom_animation_label_parent {


### PR DESCRIPTION
The core now sends "enabled": false for disabled menu items in Menu::DumpAsPropertyTree. The TreeView widget already adds the 'disabled' CSS class to the tr element and blocks clicks in JS, but there was no CSS rule matching .ui-treeview-entry.disabled (the existing rule only matched div.disabled inside an entry).

Add the missing selector so disabled entries appear grayed out, and add pointer-events: none as extra safety.


Change-Id: I25ac8bdc70e4c007d952af935a21ad4d454623de

The corresponding core change: https://gerrit.libreoffice.org/c/core/+/202314

And this needs a backport to co-25.04
