### PR TITLE
WIP: honor halign, hexpand, and expand layout properties from core

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2687,6 +2687,8 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		this._expanderDepth = savedExpanderDepth;
 		var backupGridColSpan = control.style.gridColumn;
 		var backupGridRowSpan = control.style.gridRow;
+		var backupJustifySelf = control.style.justifySelf;
+		var backupWidth = control.style.width;
 
 		control.replaceWith(temporaryParent.firstChild)
 
@@ -2695,6 +2697,8 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			newControl.scrollTop = scrollTop;
 			newControl.style.gridColumn = backupGridColSpan;
 			newControl.style.gridRow = backupGridRowSpan;
+			newControl.style.justifySelf = backupJustifySelf;
+			newControl.style.width = backupWidth;
 
 			// todo: is that needed? should be in widget impl?
 			if (data.has_default === true && (data.type === 'pushbutton' || data.type === 'okbutton')) {
@@ -2882,12 +2886,20 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 					var cols = this._getGridColumns(childData.children);
 
 					if (rows > 1 && cols > 1) {
-						var gridRowColStyle = 'grid-template-rows: repeat(' + rows  + '); \
-							grid-template-columns: repeat(' + cols  + ');';
+						var gridRowColStyle = 'grid-template-rows: repeat(' + rows  + ', auto); \
+							grid-template-columns: repeat(' + cols  + ', auto); \
+							justify-content: start;';
 
 						table.style = gridRowColStyle;
 					} else {
 						$(table).css('grid-auto-flow', 'column');
+						var hasExpand = childData.children.some(function (c) { return c.expand; });
+						var colDefs = childData.children.map(function (c) {
+							return c.expand ? '1fr' : 'auto';
+						});
+						$(table).css('grid-template-columns', colDefs.join(' '));
+						if (!hasExpand)
+							$(table).css('justify-content', 'start');
 					}
 
 					$(table).css('display', 'grid');

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -26,6 +26,10 @@ interface WidgetJSON {
 	top?: string; // placement in the grid - row
 	left?: string; // placement in the grid - column
 	width?: string; // inside grid - width in number of columns
+	halign?: string; // horizontal alignment in grid cell: start, center, end
+	hexpand?: boolean; // whether widget expands horizontally in grid
+	expand?: boolean; // box packing: whether child gets extra space
+	fill?: boolean; // box packing: whether child fills its allocation
 	labelledBy?: string;
 	allyRole?: string;
 	aria?: AriaLabelAttributes; // ARIA Label attributes

--- a/browser/src/control/jsdialog/Widget.Containers.ts
+++ b/browser/src/control/jsdialog/Widget.Containers.ts
@@ -78,13 +78,27 @@ JSDialog.grid = function (
 	if (data.tabIndex !== undefined)
 		table.setAttribute('tabindex', data.tabIndex);
 
+	const expandCols: boolean[] = new Array(cols).fill(false);
+	if (data.children) {
+		for (const child of data.children) {
+			if (child.hexpand && child.left !== undefined) {
+				expandCols[parseInt(child.left)] = true;
+			}
+		}
+	}
+
+	const hasExpand = expandCols.some((v: boolean) => v);
+	const colDefs = [];
+	for (let c = 0; c < cols; c++) colDefs.push(expandCols[c] ? '1fr' : 'auto');
+
 	const gridRowColStyle =
 		'grid-template-rows: repeat(' +
 		rows +
 		', auto); \
-		grid-template-columns: repeat(' +
-		cols +
-		', auto);';
+		grid-template-columns: ' +
+		colDefs.join(' ') +
+		';' +
+		(hasExpand ? '' : ' justify-content: start;');
 
 	table.style = gridRowColStyle;
 
@@ -106,9 +120,13 @@ JSDialog.grid = function (
 				const sandbox = window.L.DomUtil.create('div');
 				builder.build(sandbox, [child], false);
 
-				const control = sandbox.firstChild;
+				const control = sandbox.firstChild as HTMLElement;
 				if (control) {
 					window.L.DomUtil.addClass(control, 'ui-grid-cell');
+					if (child.halign) {
+						control.style.justifySelf = child.halign;
+						control.style.width = 'auto';
+					}
 					table.appendChild(control);
 				}
 


### PR DESCRIPTION
Core now sends halign, hexpand, expand, and fill properties in the jsdialog JSON. Use them to make CSS Grid layout match GTK behavior:

- halign maps to justify-self on grid cells, so widgets with halign=start no longer stretch to fill their column.
- hexpand marks grid columns as 1fr instead of auto, so they absorb extra space.
- expand (box packing) controls whether children of horizontal containers get 1fr or auto columns.
- Grids with no expanding columns get justify-content:start to prevent auto columns from absorbing leftover space, matching GTK's behavior where columns only take their content width.
- The widget update mechanism preserves justify-self and width inline styles across element rebuilds, following the existing pattern for gridColumn and gridRow.

font page looks a bit funky though, on the other hand there is a glaring preexisting bug there, so lets get that fixed before debugging the additional weirdness


Change-Id: I9b72d13e4aa57e87833ffb4381f20ade169ca079


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

