### PR TITLE
nginx: simplify proxy config, fix WebSocket with encoded URLs

### DIFF
--- a/etc/apache2/coolwsd.conf
+++ b/etc/apache2/coolwsd.conf
@@ -30,7 +30,7 @@
   # Admin Console websocket
   ProxyPass   /cool/adminws ws://127.0.0.1:9980/cool/adminws
 
-  # Download as, Fullscreen presentation and Image upload operations
+  # Download as, presentation (legacy svg) and image upload operations
   ProxyPass           /cool http://127.0.0.1:9980/cool
   ProxyPassReverse    /cool http://127.0.0.1:9980/cool
   # Compatibility with integrations that use the /lool/convert-to endpoint

--- a/etc/nginx/coolwsd.conf
+++ b/etc/nginx/coolwsd.conf
@@ -16,27 +16,19 @@
         proxy_set_header Host $host;
     }
 
-    # main websocket
-    location ~ ^/cool/(.*)/ws$ {
+    # main websocket, download, presentation (legacy svg) and image upload
+    location ^~ /cool/ {
         proxy_pass http://localhost:9980;
+        proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
         proxy_set_header Host $host;
         proxy_read_timeout 36000s;
     }
 
-    # download, presentation and image upload
-    # we accept 'lool' to be backward compatible
-    location ~ ^/(c|l)ool {
+    # backward compatibility for integrations that use the /lool/ POST API
+    location ^~ /lool/ {
         proxy_pass http://localhost:9980;
         proxy_set_header Host $host;
     }
 
-    # Admin Console websocket
-    location ^~ /cool/adminws {
-        proxy_pass http://localhost:9980;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "Upgrade";
-        proxy_set_header Host $host;
-        proxy_read_timeout 36000s;
-    }


### PR DESCRIPTION
The regex location `~ ^/cool/(.*)/ws$` can fail to match when nginx percent-decodes the URI for matching: `%3F` decodes to `?`, truncating the path so it no longer ends with `/ws`. The request then falls through to the catch-all location which lacks WebSocket support.

Fix by replacing the separate websocket/download/admin regex locations with a single `^~ /cool/` prefix location that handles everything. Prefix locations preserve the original URI encoding and avoid the regex matching issue entirely. Add `proxy_http_version 1.1;` which is required for proper WebSocket Upgrade support.

Also update the Apache config comment: the old "Fullscreen presentation" SVG download is now legacy, replaced by the client-side canvas slideshow engine.


Change-Id: I5412895e3d299200cdbcad4440378f6a38b56c50

