### PR TITLE
A11y: Enable dropdown select to focus using keyboard

### DIFF
--- a/browser/src/dom/NotebookbarAccessibility.js
+++ b/browser/src/dom/NotebookbarAccessibility.js
@@ -192,10 +192,15 @@ var NotebookbarAccessibility = function() {
 				else if (this.state === 1) {
 					itemWasClicked = true;
 					this.setTabItemDescription(element);
-					var clickTarget = element.querySelector('button.unobutton') || element;
-					clickTarget.click();
-					if (this.filteredItem && this.filteredItem.focusBack === true) {
-						this.focusToMap();
+					var selectTarget = element.tagName === 'SELECT' ? element : element.querySelector('select');
+					if (selectTarget) {
+						selectTarget.focus();
+						selectTarget.showPicker();
+					} else {
+						var clickTarget = element.querySelector('button.unobutton') || element;
+						clickTarget.click();
+						if (this.filteredItem && this.filteredItem.focusBack === true)
+							this.focusToMap();
 					}
 				}
 			}


### PR DESCRIPTION
A11y: Enable dropdown select to focus using keyboard

Earlier on Home tab, number format dropdown was not triggered via keyboard shortcut as it's a select element however we still tried to use the click event. Current fix uses focus with showPicker for select elements. showPicker might not work on older browsers however focus still puts cursor focus on that element and pressing ENTER would work.


Change-Id: Ia742c1a726fbc37c9b1d3b72666305de89d22545


* Resolves: # <!-- related github issue -->
* Target version: main
