### PR TITLE
Fix viewModeDropdown redering in iOS. Fixes issue 1 in #15144

### DIFF
--- a/browser/css/btns.css
+++ b/browser/css/btns.css
@@ -56,6 +56,7 @@
 	border: none;
 	padding: 4px 8px;
 	height: var(--btn-size-s);
+	width: fit-content;
 }
 
 #viewModeDropdown .arrowbackground {


### PR DESCRIPTION
Change-Id: I5199d9e2dea7fee905bb09a5e0cef47370ff192b

Fix text in viewModeDropdown overflowing in iOS

* Resolves issue 1 in: #15144
* Target version: main

- Fix tested manually by inspection on iPad Pro.
- No regressions seen in Ubuntu 25.10, Firefox 148.0 (64-bit)

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

