### PR TITLE
fix: Show error alert for unauthorized WOPI host in UI

### DIFF
--- a/browser/src/app/Socket.ts
+++ b/browser/src/app/Socket.ts
@@ -2050,6 +2050,9 @@ class Socket {
 					msgId: 'Action_Load_Resp',
 					args: postMessageObj,
 				});
+				this._map.fire('error', {
+					msg: _('Unauthorized WOPI host. Please try again later and report to your administrator if the issue persists.')
+				});
 			}
 
 			if (this._map._docLayer) {

--- a/browser/src/app/Socket.ts
+++ b/browser/src/app/Socket.ts
@@ -2051,7 +2051,9 @@ class Socket {
 					args: postMessageObj,
 				});
 				this._map.fire('error', {
-					msg: _('Unauthorized WOPI host. Please try again later and report to your administrator if the issue persists.')
+					msg: _(
+						'Unauthorized WOPI host. Please try again later and report to your administrator if the issue persists.',
+					),
 				});
 			}
 


### PR DESCRIPTION
Change-Id: I45ec3e5c66be6a51937efe2cb0d9160fa0df60af


* Resolves: #14546 

* Target version: main

### Summary

When an unauthorized WOPI host error occurs, no error message was shown 
in the UI , the document just appeared empty. Added a `this._map.fire('error', ...)`
call in the `unauthorized` case of `_onErrorMsg` in `Socket.ts` so the 
error alert is now displayed to the user.

### Screenshots
Before: Empty page with no error message in the UI

After: Error alert displayed correctly

<img width="1568" height="751" alt="image" src="https://github.com/user-attachments/assets/1e022e19-4033-4e26-8c40-07d746da01f7" />

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

