### PR TITLE
Allow listboxes smaller than 100px

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1273,7 +1273,7 @@ img.context-menu-icon {
 .jsdialog-window .ui-combobox,
 .jsdialog-window .ui-timefield {
 	height: 32px;/* Use the same height as in .jsdialog.ui-edit */
-	min-width: 100px;
+	min-width: 50px;
 	width: 100%;
 }
 

--- a/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
@@ -143,6 +143,29 @@ describe(['tagdesktop'], 'JSDialog unit test', function() {
 		cy.cGet('#data-input').should('not.be.disabled');
 	});
 
+	it('Sparkline dialog listboxes allow narrow width', function() {
+		cy.getFrameWindow().then(function(win) {
+			win.app.map.sendUnoCommand('.uno:InsertSparkline');
+		});
+		cy.cGet('.ui-dialog[role="dialog"]').should('have.length', 1);
+		cy.getFrameWindow().then(function(win) {
+			return helper.processToIdle(win);
+		});
+
+		cy.cGet('#cbType').should('be.visible');
+		cy.cGet('#cbEmptyCells').should('be.visible');
+
+		cy.getFrameWindow().then(function(win) {
+			var typeEl = win.document.getElementById('cbType');
+			var emptyEl = win.document.getElementById('cbEmptyCells');
+			expect(typeEl.getBoundingClientRect().width).to.be.equal(75);
+			expect(emptyEl.getBoundingClientRect().width).to.be.equal(75);
+		});
+
+		cy.cGet('.ui-dialog-titlebar-close').click();
+		cy.cGet('.ui-dialog[role="dialog"]').should('not.exist');
+	});
+
 	it('QuerySelector Syntax error', function(){
 
 		cy.getFrameWindow().then(function(win) {


### PR DESCRIPTION
This fixes listbox widths in the sparkline edit dialog (which are supposed to be smaller than 100px):

Before:
<img width="450" height="633" alt="grafik" src="https://github.com/user-attachments/assets/c53b8e02-0edb-4349-9df8-5611e5c8a5b0" />

After:
<img width="449" height="724" alt="grafik" src="https://github.com/user-attachments/assets/5c7854f0-120a-4140-a03f-a2884bc67e10" />
