### PR TITLE
MultiPageView: Fix missing tiles issue.

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -1368,6 +1368,11 @@ class TileManager {
 				app.activeDocument.activeLayout.type,
 			)
 		) {
+			for (const tile of this.tiles.values()) {
+				this.updateTileDistance(tile, zoom);
+			}
+			this.sortTileBitmapList();
+
 			this.beginTransaction();
 			const queue = this.checkRequestTiles(
 				app.activeDocument.activeLayout.getCurrentCoordList(),

--- a/browser/src/app/ViewLayout.ts
+++ b/browser/src/app/ViewLayout.ts
@@ -330,7 +330,7 @@ class ViewLayoutBase {
 
 	protected refreshCurrentCoordList() {
 		this.currentCoordList.length = 0;
-		const zoom = app.map.getZoom();
+		const zoom = Math.round(app.map.getZoom());
 
 		const columnCount = Math.ceil(
 			this._viewedRectangle.pWidth / TileManager.tileSize,

--- a/browser/src/app/ViewLayoutMultiPage.ts
+++ b/browser/src/app/ViewLayoutMultiPage.ts
@@ -224,6 +224,71 @@ class ViewLayoutMultiPage extends ViewLayoutNewBase {
 		}
 	}
 
+	protected override refreshCurrentCoordList() {
+		this.currentCoordList.length = 0;
+		const zoom = Math.round(app.map.getZoom());
+		const tileSize = TileManager.tileSize;
+
+		const documentAnchor = this.getDocumentAnchorSection();
+		const view = cool.SimpleRectangle.fromCorePixels([
+			this.scrollProperties.viewX,
+			this.scrollProperties.viewY,
+			documentAnchor.size[0],
+			documentAnchor.size[1],
+		]);
+
+		const added: Set<string> = new Set();
+
+		for (let i = 0; i < this.documentRectangles.length; i++) {
+			const viewRect = this.viewRectangles[i];
+
+			if (!view.intersectsRectangle(viewRect.toArray())) continue;
+
+			const docRect = this.documentRectangles[i];
+
+			// Compute the visible portion of this page in view coordinates.
+			const visibleVX1 = Math.max(view.pX1, viewRect.pX1);
+			const visibleVY1 = Math.max(view.pY1, viewRect.pY1);
+			const visibleVX2 = Math.min(
+				view.pX1 + view.pWidth,
+				viewRect.pX1 + viewRect.pWidth,
+			);
+			const visibleVY2 = Math.min(
+				view.pY1 + view.pHeight,
+				viewRect.pY1 + viewRect.pHeight,
+			);
+
+			// Map the visible view portion back to document coordinates.
+			const docVisX1 = docRect.pX1 + (visibleVX1 - viewRect.pX1);
+			const docVisY1 = docRect.pY1 + (visibleVY1 - viewRect.pY1);
+			const docVisX2 = docRect.pX1 + (visibleVX2 - viewRect.pX1);
+			const docVisY2 = docRect.pY1 + (visibleVY2 - viewRect.pY1);
+
+			const startX = Math.floor(docVisX1 / tileSize) * tileSize;
+			const startY = Math.floor(docVisY1 / tileSize) * tileSize;
+			const columnCount = Math.ceil((docVisX2 - startX) / tileSize);
+			const rowCount = Math.ceil((docVisY2 - startY) / tileSize);
+
+			for (let c = 0; c <= columnCount; c++) {
+				for (let r = 0; r <= rowCount; r++) {
+					const coords = new TileCoordData(
+						startX + c * tileSize,
+						startY + r * tileSize,
+						zoom,
+						0,
+					);
+
+					const key = coords.key();
+					if (added.has(key)) continue;
+					added.add(key);
+
+					if (TileManager.isValidTile(coords))
+						this.currentCoordList.push(coords);
+				}
+			}
+		}
+	}
+
 	protected updateViewData() {
 		if (!app.file.writer.pageRectangleList.length) return;
 


### PR DESCRIPTION
Issue: On 4k screen or high dpiScale+zoomed in document, some tiles are not rendered / randomly. It's easy to reproduce, zoom the browser (high dpiScale) and zoom into the document, then scroll the document.

Root Cause:
MultiPage view has to set the viewedRectangle to a large area, because it renders the pages side by side. Side by side rendering can contain 2 different zones of the document, like the top sections of 2 pages, without their bottom sections. Since viewedrectangle is a continues 1 piece rectangle, multipage view has to send a viewed rectangle of the 2 pages entirely (not only the top sections of pages). When the dpiScale is high and and the document is zoomed in, that viewed rectangles corresponds to too many tiles. That causes to hit the tile count upper limit and some tiles are deleted. And that causes empty tiles.

Fix:
* Fine-tune visible coordinate list for multi page view (other views are fine).
* Also, order the tiles in getMissingTiles function - or switching the tabs and getting back to document will again not render some tiles (random deletion of extra tiles).


Change-Id: I620c72190a8389dc464da9572aa2eb7b4ac995b4


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

