### PR TITLE
Tabbed view: Fix Menubutton, stop pretending to be a split button

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1897,6 +1897,12 @@ img.context-menu-icon {
 	background-color: var(--color-background-darker);
 }
 
+.menubutton:not(.splitbutton) .arrowbackground,
+.menubutton:not(.splitbutton) .arrowbackground:hover {
+	border-left-color: transparent;
+	background-color: transparent;
+}
+
 .unoarrow:not([disabled]):hover, .arrowbackground:not([disabled]):hover .unoarrow {
 	border-top-color: var(--color-text-darker);
 }


### PR DESCRIPTION
Before this commit menubuttons such as Data > Statistics or any other
menu button was appearing to be a split button (the right part of the
button - arrow - was getting independent background change on hover).

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I3c51b4e5a28bdd1833c6fc7e8f088e25fc163f2c
