### PR TITLE
clipboard container: move it to the document-container html element.

### DIFF
--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -666,7 +666,7 @@ div.leaflet-cursor-container:hover > .leaflet-cursor-header {
 }
 
 .clipboard-container {
-	position: absolute;
+	position: fixed;
 	left: 0px;
 	top: 0px;
 	width: 0px;

--- a/browser/src/app/iface/Map.Interface.ts
+++ b/browser/src/app/iface/Map.Interface.ts
@@ -24,7 +24,11 @@ interface LatLngLike {
 interface MapInterface extends Evented {
 	_docLayer: DocLayerInterface;
 	uiManager: UIManager;
-	_textInput: { debug(value: boolean): void };
+	_textInput: {
+		debug(value: boolean): void;
+		_isDebugOn: boolean;
+		update(): void;
+	};
 	addressInputField: AddressInputField;
 
 	removeLayer(layer: any): void;

--- a/browser/src/canvas/sections/TilesSection.ts
+++ b/browser/src/canvas/sections/TilesSection.ts
@@ -896,6 +896,11 @@ export class TilesSection extends CanvasSectionObject {
 			corePxBounds.max.multiplyBy(convScale)
 		);
 	}
+
+	onNewDocumentTopLeft(): void {
+		if (app.map._textInput && app.map._textInput._isDebugOn)
+			app.map._textInput.update();
+	}
 }
 
 }

--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -17,7 +17,7 @@
  * text area itself.
  */
 
-/* global app _ CursorHandler */
+/* global app _ CursorHandler cool */
 
 window.L.TextInput = window.L.Layer.extend({
 	initialize: function() {
@@ -122,7 +122,9 @@ window.L.TextInput = window.L.Layer.extend({
 
 	onAdd: function() {
 		if (this._container) {
-			this.getPane().appendChild(this._container);
+			var docContainer = document.getElementById('document-container');
+			if (docContainer)
+				docContainer.appendChild(this._container);
 			this.update();
 		}
 
@@ -163,8 +165,8 @@ window.L.TextInput = window.L.Layer.extend({
 		window.MagicKeyDownHandler = null;
 		window.MagicKeyUpHandler = null;
 
-		if (this._container) {
-			this.getPane().removeChild(this._container);
+		if (this._container && this._container.parentNode) {
+			this._container.parentNode.removeChild(this._container);
 		}
 
 		if (!this.hasAccessibilitySupport()) {
@@ -400,9 +402,13 @@ window.L.TextInput = window.L.Layer.extend({
 	},
 
 	update: function() {
-		if (this._container && this._map && this._latlng) {
-			var position = this._map.latLngToLayerPoint(this._latlng).round();
-			this._setPos(position);
+		if (this._container && this._map && app.file.textCursor.rectangle && app.activeDocument) {
+			var rect = app.file.textCursor.rectangle;
+			var pos = new cool.Point(
+				Math.round(rect.v1X / app.dpiScale),
+				Math.round(rect.v1Y / app.dpiScale)
+			);
+			this._setPos(pos);
 		}
 	},
 
@@ -526,10 +532,7 @@ window.L.TextInput = window.L.Layer.extend({
 			this._cursorHandler.setShowSection(false);
 		}
 
-		// Fetch top and bottom coords of caret
-		var top = this._map._docLayer._twipsToLatLng({ x: app.file.textCursor.rectangle.x1, y: app.file.textCursor.rectangle.y1 });
 		// Move the hidden text area with the cursor
-		this._latlng = window.L.latLng(top);
 		this.update();
 		// shape handlers hidden (if selected)
 		this._map.fire('handlerstatus', {hidden: true});
@@ -567,7 +570,7 @@ window.L.TextInput = window.L.Layer.extend({
 		else {
 			pos.y += this._isDebugOn ? 50 : 200;
 		}
-		window.L.DomUtil.setPosition(this._container, pos);
+		this._container.style.transform = 'translate(' + pos.x + 'px, ' + pos.y + 'px)';
 	},
 
 	// Generic handle attached to most text area events, just for debugging purposes.

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3107,6 +3107,9 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 				this._map.focus(false);
 		}
 
+		if (app.map._textInput && app.activeDocument)
+			app.map._textInput.update();
+
 		// when first time we updated the cursor - document is loaded
 		// let's move cursor to the target
 		if (this._map.options.docTarget !== '') {

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -311,13 +311,14 @@ window.L.Map.Keyboard = window.L.Handler.extend({
 			container.tabIndex = '0';
 		}
 
-		window.L.DomEvent.on(this._map.getContainer(), 'keydown keyup keypress', this._onKeyDown, this);
+		this._keyEventContainer = document.getElementById('document-container');
+		window.L.DomEvent.on(this._keyEventContainer, 'keydown keyup keypress', this._onKeyDown, this);
 		window.L.DomEvent.on(window.document, 'keydown', this._globalKeyEvent, this);
 		window.document.addEventListener('keyup', this._globalKeyUp.bind(this), true);
 	},
 
 	removeHooks: function () {
-		window.L.DomEvent.off(this._map.getContainer(), 'keydown keyup keypress', this._onKeyDown, this);
+		window.L.DomEvent.off(this._keyEventContainer, 'keydown keyup keypress', this._onKeyDown, this);
 		window.L.DomEvent.off(window.document, 'keydown', this._globalKeyEvent, this);
 		window.document.removeEventListener('keyup', this._globalKeyUp.bind(this));
 	},

--- a/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_cursor_spec.js
@@ -169,7 +169,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test Cell Selections', fun
 		calcHelper.clickOnACell(1, 1, 2, 3);
 
 		// Press CTRL and hold.
-		cy.cGet('div.clipboard').type('{ctrl}', { release: false });
+		cy.cGet('div.clipboard').type('{ctrl}', { force: true, release: false });
 
 		cy.wait(500);
 		calcHelper.clickOnACell(2, 3, 4, 3);
@@ -178,7 +178,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test Cell Selections', fun
 		calcHelper.clickOnACell(4, 3, 2, 6);
 
 		// Press SHIFT and hold.
-		cy.cGet('div.clipboard').type('{shift}', { release: false });
+		cy.cGet('div.clipboard').type('{shift}', { force: true, release: false });
 
 		cy.wait(500);
 		calcHelper.clickOnACell(2, 6, 2, 10);


### PR DESCRIPTION
this commit is to first solve the invisible debugging container but it also moves the container to under document-container element. bacause we are moving away from leaflet and there may occur other issues in the future.


Change-Id: I7bc41bac5ad83d314be9c6273d74b9b151994a74


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

