### PR TITLE
Group button missing shortcut

### DIFF
--- a/browser/src/app/A11yValidator.ts
+++ b/browser/src/app/A11yValidator.ts
@@ -368,6 +368,7 @@ class A11yValidator {
 
 		let errorCount = this.validateContainer(notebookbar.container);
 		errorCount += this.checkTabContainerConsistency(notebookbar);
+		errorCount += this.checkOverflowGroupChildIds(notebookbar);
 
 		if (errorCount === 0) {
 			console.error('A11yValidator: notebookbar passed all checks');
@@ -412,6 +413,77 @@ class A11yValidator {
 		}
 
 		return errorCount;
+	}
+
+	private checkOverflowGroupChildIds(notebookbar: any): number {
+		const selectedTab = document.querySelector(
+			'.ui-tab.notebookbar.selected',
+		) as HTMLElement;
+		if (!selectedTab || !selectedTab.id) return 0;
+
+		const tabName = selectedTab.id.split('-')[0];
+		const containerId = tabName + '-container';
+
+		const fullJSON = notebookbar.getFullJSON();
+		const tabJSON = this.findJSONNodeById(fullJSON, containerId);
+		if (!tabJSON) return 0;
+
+		let errorCount = 0;
+
+		const walk = (node: any): void => {
+			if (!node || !node.children || !Array.isArray(node.children)) return;
+
+			for (const child of node.children) {
+				if (child.type === 'overflowgroup' && child.id) {
+					this.findDuplicateIdInChildren(
+						child.id,
+						child.children,
+						(dupId: string) => {
+							console.error(
+								new A11yValidatorException(
+									`Overflow group '${dupId}' contains a child with the same id. This breaks accessibility shortcut resolution because querySelector matches the parent instead of the child.`,
+								),
+							);
+							errorCount++;
+						},
+					);
+				}
+				walk(child);
+			}
+		};
+
+		walk(tabJSON);
+		return errorCount;
+	}
+
+	private findJSONNodeById(node: any, id: string): any {
+		if (!node) return null;
+		if (node.id === id) return node;
+		if (node.children && Array.isArray(node.children)) {
+			for (const child of node.children) {
+				const found = this.findJSONNodeById(child, id);
+				if (found) return found;
+			}
+		}
+		return null;
+	}
+
+	private findDuplicateIdInChildren(
+		parentId: string,
+		children: any[],
+		onDuplicate: (id: string) => void,
+	): void {
+		if (!children || !Array.isArray(children)) return;
+
+		for (const child of children) {
+			if (child.id === parentId) {
+				onDuplicate(parentId);
+				return;
+			}
+			if (child.children) {
+				this.findDuplicateIdInChildren(parentId, child.children, onDuplicate);
+			}
+		}
 	}
 }
 

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -2419,7 +2419,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 				'accessibility': { focusBack: true,	combination: 'GA', de: null },
 				'children' : [
 					{
-						'id': 'data-group',
+						'id': 'data-data-group',
 						'type': 'bigtoolitem',
 						'text': _UNO('.uno:Group'),
 						'command': '.uno:Group',

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -1669,7 +1669,7 @@ window.L.Control.NotebookbarDraw = window.L.Control.NotebookbarImpress.extend({
 				'accessibility': { focusBack: true, combination: 'TI', de: null },
 				'children' : [
 					{
-						'id': 'insert-text',
+						'id': 'insert-insert-text',
 						'type': 'bigtoolitem',
 						'text': _UNO('.uno:Text'),
 						'command': '.uno:Text',

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1716,7 +1716,7 @@ window.L.Control.NotebookbarImpress = window.L.Control.NotebookbarWriter.extend(
 				'accessibility': { focusBack: true, combination: 'IX', de: null },
 				'children' : [
 					{
-						'id': 'insert-text',
+						'id': 'insert-insert-text',
 						'type': 'bigtoolitem',
 						'text': _UNO('.uno:Text'),
 						'command': '.uno:Text',


### PR DESCRIPTION
In the calc Data notebookbar tab, there is no shortcut for Group.

probably since:

commit 7e83016cd859d96e92e06081c2696785a2f50e60
Date:   Wed Aug 6 15:24:33 2025 +0530

    feat: Implement group labels and overflow management in Calc notebookbar

The overflow group data-group and its bigtoolitem child shared the same id. When the accessibility code processes the bigtoolitem, querySelector('#data-group.ui-overflow-group') matches the parent overflow group instead of finding the button, so the Group button's shortcut is never registered.

Add a test for this and fix the other cases found in the other apps that were not yet audited.


Change-Id: Iec07a2722de4e0bde24881389df7aa47af1ec06b


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

