### PR TITLE
fix export-as PDF producing 0 bytes for filenames with apostrophes

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -3996,10 +3996,11 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
 
         if (exportWasRequested)
         {
-            std::string encodedURL;
-            Poco::URI::encode(payload, "", encodedURL);
-
-            sendTextFrame("exportas: url=" + encodedURL + " filename=" + _exportAsWopiUrl);
+            // The payload from LOKit is already a properly encoded file:// URL
+            // (e.g., spaces as %20). Pass it through as-is — do NOT re-encode
+            // with Poco::URI::encode(), which would double-encode percent signs
+            // (%20 -> %2520) producing a path that doesn't match the file on disk.
+            sendTextFrame("exportas: url=" + payload + " filename=" + _exportAsWopiUrl);
 
             _exportAsWopiUrl.clear();
             return;


### PR DESCRIPTION
The LOK_CALLBACK_EXPORT_FILE handler used Poco::URI::encode() on the payload URL from LOKit. Since LOKit already returns a properly encoded file:// URL (spaces as %20), and '%' is in Poco's ILLEGAL set, Poco::URI::encode() double-encoded: %20 -> %2520, %27 -> %2527.

When WSD later parsed this double-encoded URL, getPath() returned literal "%20" instead of spaces, so the path didn't match the actual file on disk. Poco::File(path).exists() returned false, resultURL was
cleared, and the client received 0 bytes.

Fix by passing the LOKit payload URL through as-is, like the download/registerdownload branch already does. The URL is already properly encoded by LOKit, so no re-encoding is needed.

Reproducer: open "What's New March 2026.odp" from Nextcloud, export as PDF. The apostrophe triggers Poco's ILLEGAL encoding, and spaces in the filename cause the double-encoding mismatch.

An integration test for the LOK_CALLBACK_EXPORT_FILE code path is not feasible: the callback is only reached via the "Export as PDF" flow (exportas protocol command -> .uno:ExportToPDF), which requires interactive PDF options dialog completion. ExportDirectToPDF bypasses the dialog but takes the download/registerdownload branch in the callback handler, not the exportas: response branch where this fix lives. _exportAsWopiUrl (which selects the branch) is only set by the exportas protocol command that calls ExportToPDF with dialog.

Signed-off-by: Andras Timar <andras.timar@collabora.com>
Change-Id: I2521a6e1279900b7c9c5accb61cccf16d8ee826c
