### PR TITLE
Active-state tooltip for Clone Formatting toolitem

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2001,6 +2001,17 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 							builder.map,
 						);
 					}
+
+					// Swap tooltip text when activeTooltip is set
+					if (data.activeTooltip) {
+						if (isOn) {
+							div._wasActiveTooltip = true;
+							div.setAttribute('data-cooltip', data.activeTooltip);
+						} else if (div._wasActiveTooltip) {
+							div._wasActiveTooltip = false;
+							div.setAttribute('data-cooltip', enabledTooltip);
+						}
+					}
 				};
 
 				updateFunction();

--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -445,6 +445,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 									'type': 'toolitem',
 									'text': _UNO('.uno:FormatPaintbrush'),
 									'tooltip': _('Clone Formatting (double click to keep active)'),
+									'activeTooltip': _('Clone Formatting is active (click again or press Esc to exit)'),
 									'command': '.uno:FormatPaintbrush',
 									'doubleClickCommand': '.uno:FormatPaintbrush',
 									'doubleClickCommandArgs': { PersistentCopy: { type: 'boolean', value: true } },

--- a/browser/src/control/Control.NotebookbarDraw.js
+++ b/browser/src/control/Control.NotebookbarDraw.js
@@ -638,6 +638,7 @@ window.L.Control.NotebookbarDraw = window.L.Control.NotebookbarImpress.extend({
 										'type': 'toolitem',
 										'text': _UNO('.uno:FormatPaintbrush'),
 										'tooltip': _('Clone Formatting (double click to keep active)'),
+										'activeTooltip': _('Clone Formatting is active (click again or press Esc to exit)'),
 										'command': '.uno:FormatPaintbrush',
 										'doubleClickCommand': '.uno:FormatPaintbrush',
 										'doubleClickCommandArgs': { PersistentCopy: { type: 'boolean', value: true } },

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -777,6 +777,7 @@ window.L.Control.NotebookbarImpress = window.L.Control.NotebookbarWriter.extend(
 										'type': 'toolitem',
 										'text': _UNO('.uno:FormatPaintbrush'),
 										'tooltip': _('Clone Formatting (double click to keep active)'),
+										'activeTooltip': _('Clone Formatting is active (click again or press Esc to exit)'),
 										'command': '.uno:FormatPaintbrush',
 										'doubleClickCommand': '.uno:FormatPaintbrush',
 										'doubleClickCommandArgs': { PersistentCopy: { type: 'boolean', value: true } },

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -637,6 +637,7 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 									'type': 'toolitem',
 									'text': _UNO('.uno:FormatPaintbrush'),
 									'tooltip': _('Clone Formatting (double click to keep active)'),
+									'activeTooltip': _('Clone Formatting is active (click again or press Esc to exit)'),
 									'command': '.uno:FormatPaintbrush',
 									'doubleClickCommand': '.uno:FormatPaintbrush',
 									'doubleClickCommandArgs': { PersistentCopy: { type: 'boolean', value: true } },

--- a/browser/src/control/Control.TopToolbar.js
+++ b/browser/src/control/Control.TopToolbar.js
@@ -145,7 +145,7 @@ class TopToolbar extends JSDialog.Toolbar {
 			{type: 'toolitem',  id: 'redo', text: _UNO('.uno:Redo'), command: '.uno:Redo', mobile: false, icon: 'compact_redo.svg'}
 		];
 		var fontGroup = [
-			{type: 'toolitem',  id: 'formatpaintbrush', text: _UNO('.uno:FormatPaintbrush'), tooltip: _('Clone Formatting (double click to keep active)'), command: '.uno:FormatPaintbrush', doubleClickCommand: '.uno:FormatPaintbrush', doubleClickCommandArgs: { PersistentCopy: { type: 'boolean', value: true } }, mobile: false, icon: 'compact_formatpaintbrush.svg'},
+			{type: 'toolitem',  id: 'formatpaintbrush', text: _UNO('.uno:FormatPaintbrush'), tooltip: _('Clone Formatting (double click to keep active)'), activeTooltip: _('Clone Formatting is active (click again or press Esc to exit)'), command: '.uno:FormatPaintbrush', doubleClickCommand: '.uno:FormatPaintbrush', doubleClickCommandArgs: { PersistentCopy: { type: 'boolean', value: true } }, mobile: false, icon: 'compact_formatpaintbrush.svg'},
 			{type: 'toolitem',  id: 'reset', text: _UNO('.uno:ResetAttributes', 'text'), visible: false, command: '.uno:ResetAttributes', mobile: false, icon: 'compact_setdefault.svg'},
 			{type: 'toolitem',  id: 'resetimpress', class: 'unoResetAttributes', text: _UNO('.uno:SetDefault', 'presentation', 'true'), visible: false, command: '.uno:SetDefault', mobile: false, icon: 'compact_setdefault.svg'},
 			{type: 'separator', orientation: 'vertical', id: 'breakreset', invisible: true, mobile: false, tablet: false,},

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -141,6 +141,20 @@ class UIManager extends window.L.Control {
 	}
 
 	/**
+	 * Shows a timed tooltip on an element and optionally plays the attention animation.
+	 */
+	showAttention(element: HTMLElement, text: string, animate: boolean, timeMs: number = 3000): void {
+		this.showTimedTooltip(element, text, timeMs);
+
+		if (animate && !element.classList.contains('attention')) {
+			element.classList.add('attention');
+			element.addEventListener('animationend', function () {
+				element.classList.remove('attention');
+			}, { once: true });
+		}
+	}
+
+	/**
 	 * Returns the current UI mode ("notebookbar" or "classic").
 	 */
 	getCurrentMode(): UIMode {

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -673,14 +673,8 @@ window.L.Map.Keyboard = window.L.Handler.extend({
 			else if (ev.key && ev.key.length === 1 && !ev.ctrlKey && !ev.altKey && !map.isEditMode()) {
 				let permissionMode = map.uiManager && map.uiManager.permissionViewMode;
 				let viewModeBtn = permissionMode && (permissionMode.viewModeDropdown || permissionMode.viewModeContainer);
-				if (viewModeBtn && map.uiManager && map.uiManager.showTimedTooltip) {
-					map.uiManager.showTimedTooltip(viewModeBtn, _('You are currently in View mode'), 5000);
-					if (!viewModeBtn.classList.contains('attention')) {
-						viewModeBtn.classList.add('attention');
-						viewModeBtn.addEventListener('animationend', function() {
-							viewModeBtn.classList.remove('attention');
-						}, { once: true });
-					}
+				if (viewModeBtn && map.uiManager && map.uiManager.showAttention) {
+					map.uiManager.showAttention(viewModeBtn, _('You are currently in View mode'), true, 5000);
 				}
 			}
 		}


### PR DESCRIPTION
Toolitem definitions can now declare `activeTooltip` and `activeDoubleClickTooltip` properties to show context-sensitive tooltips when their command state changes. On double-click activation, the button also plays a shake animation to draw the user's attention.

The tooltip and animation logic lives in `UIManager.showAttention()`, replacing the inline implementation that was previously duplicated in `Map.Keyboard.js` for the view-mode dropdown.

In `JSDialogBuilder._toolitemHandler`, the existing `updateFunction` now tracks activation via `_wasActiveTooltip` and `_activatedByDoubleClick` on the DOM element, so tooltips only appear on real user interactions and not during initial document load.

Applied to Clone Formatting as the first consumer:

- single click: "Clone Formatting is active (click again or press Escape to exit)"
- double click: "Clone Formatting is active (press Escape to exit)" with attention animation
- deactivation: reverts to the original tooltip

[Screencast from 2026-03-23 23-28-43.webm](https://github.com/user-attachments/assets/0ef1c2e2-99c6-4acb-8082-989bed81d515)

Change-Id: I30dea9dfd59594f1ea81477afdffa031b15103a5


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

