### PR TITLE
clipboard: use latest copied slides across tab/docs

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -273,15 +273,7 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 						callback: function(key, options) {
 								if (nPos === undefined)
 									nPos = that._findClickedPart(options.$trigger[0]);
-								if (that.copiedSlide) {
-									// Same-tab paste: use duplicate allows insertion at a position
-									that._setPart(that.copiedSlide);
-									that._map.duplicatePage(nPos);
-								} else {
-									// Cross-tab/browser paste: use system clipboard
-									that._map.setPart(nPos - 1); // new slide is inserted after set slide
-									that._map._clip.filterExecCopyPaste('.uno:Paste');
-								}
+								that._pasteSlide(nPos);
 						},
 						visible: function() {
 							// Show paste if we have a local copied slide OR
@@ -335,7 +327,7 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 						name: app.IconUtil.createMenuItemLink(_('Paste'), 'Paste'),
 						isHtmlName: true,
 						callback: function() {
-							that._map._clip.filterExecCopyPaste('.uno:Paste');
+							that._pasteSlide();
 						},
 					},
 					newslide: {
@@ -472,6 +464,59 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 		var currentScrollX = app.activeDocument.activeLayout.viewedRectangle.cX1;
 
 		app.sectionContainer.getSectionWithName(app.CSections.Scroll.name).onScrollBy({x: currentScrollX, y: buttonType === 'prev' ? -scrollBySize : scrollBySize});
+	},
+
+	// Paste a slide, preferring the system clipboard for cross-tab pastes.
+	// nPos: insertion position for the frame context menu (may be undefined for img context menu).
+	_pasteSlide: async function(nPos) {
+		// Guard against concurrent invocations (e.g. rapid double-click).
+		if (this._pastePending)
+			return;
+		this._pastePending = true;
+		try {
+			if (this.copiedSlide) {
+				// Check if the system clipboard has been updated by a different
+				// tab/session since our last copy. If so, prefer the system clipboard.
+				let useInternalCopy = true;
+				if (window.L.Browser.clipboardApiAvailable) {
+					try {
+						const items = await navigator.clipboard.read();
+						if (items.length > 0 && items[0].types.includes('text/html')) {
+							const blob = await items[0].getType('text/html');
+							const html = await blob.text();
+							const clip = this._map._clip;
+							const meta = clip.getMetaOrigin(html);
+							const id = clip.getMetaPath(0);
+							const idOld = clip.getMetaPath(1);
+							// If meta origin does not match this tab's clipboard, use system clipboard
+							if (meta !== '' && (id === '' || meta.indexOf(id) < 0) && (idOld === '' || meta.indexOf(idOld) < 0)) {
+								useInternalCopy = false;
+							}
+						}
+					} catch (e) {
+						// clipboard read failed or permission denied - keep using internal copy
+					}
+				}
+				if (useInternalCopy) {
+					// Same-tab paste: use duplicate which allows insertion at a position
+					this._setPart(this.copiedSlide);
+					this._map.duplicatePage(nPos);
+				} else {
+					// System clipboard is from a different tab - use it
+					this.copiedSlide = null;
+					if (nPos !== undefined)
+						this._map.setPart(Math.max(0, nPos - 1));
+					this._map._clip.filterExecCopyPaste('.uno:Paste');
+				}
+			} else {
+				// Cross-tab/browser paste: use system clipboard
+				if (nPos !== undefined)
+					this._map.setPart(Math.max(0, nPos - 1)); // new slide is inserted after set slide
+				this._map._clip.filterExecCopyPaste('.uno:Paste');
+			}
+		} finally {
+			this._pastePending = false;
+		}
 	},
 
 	_isSelected: function (e) {

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -209,6 +209,10 @@ window.L.Clipboard = window.L.Class.extend({
 		));
 	},
 
+	getMetaOrigin: function (html) {
+		return this._getMetaOrigin(html, '<div id="meta-origin" data-coolorigin="');
+	},
+
 	_getMetaOrigin: function (html, prefix) {
 		var start = html.indexOf(prefix);
 		if (start < 0) {
@@ -992,6 +996,26 @@ window.L.Clipboard = window.L.Class.extend({
 				// When document is not focused, writing to clipboard is not allowed. But this error shouldn't stop the usage of clipboard API.
 				if (!document.hasFocus()) {
 					window.app.console.warn('navigator.clipboard.write() failed: ' + error.message);
+					// The user switched to another tab before the async clipboard write completed.
+					// Schedule a one-shot retry when this window regains focus so the system
+					// clipboard is updated with the latest copied content, enabling correct
+					// cross-tab paste behaviour.
+					// Remove any previous pending retry - only the latest copy matters.
+					if (this._pendingClipboardRetryHandler) {
+						window.removeEventListener('focus', this._pendingClipboardRetryHandler);
+					}
+					var retryClipboardItem = clipboardItem;
+					var retryClipboard = clipboard;
+					var self = this;
+					var retryHandler = function() {
+						window.removeEventListener('focus', retryHandler);
+						self._pendingClipboardRetryHandler = null;
+						retryClipboard.write([retryClipboardItem]).catch(function(retryError) {
+							window.app.console.warn('navigator.clipboard.write() retry failed: ' + retryError.message);
+						});
+					};
+					this._pendingClipboardRetryHandler = retryHandler;
+					window.addEventListener('focus', retryHandler);
 					return;
 				}
 


### PR DESCRIPTION
problem:
when slide was copied using context menu,
we just remembered the slide numbers and duplicated them is pasted again in the same slide.
This method was completely unaware of the actual clipboard. when copied from different doc/tab and tried to paste, pages were duplicated from the older copies and ignored the updated clipboard


Change-Id: I2cfa8417696724b0127694178f08f337314b85ee


* Target version: main


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

