### PR TITLE
calc: center minus/plus symbols and level numbers in group boxes

### DIFF
--- a/browser/src/control/Control.ColumnGroup.ts
+++ b/browser/src/control/Control.ColumnGroup.ts
@@ -84,38 +84,13 @@ export class ColumnGroup extends GroupBase {
 	drawGroupControl (group: GroupEntry): void {
 		let startX = this.getRelativeX(group.startPos);
 		let startY = this._levelSpacing + (this._groupHeadSize + this._levelSpacing) * group.level;
+		startX = Math.round(startX);
+		startY = Math.round(startY);
 		const strokeColor = this.getColors().strokeColor;
 		const endX = this.getEndPosition(group.endPos);
 
 		if (this.isGroupHeaderVisible(startX, group.startPos)) {
-			// draw head
-			this.context.beginPath();
-			this.context.fillStyle = this.backgroundColor;
-			this.context.fillRect(this.transformRectX(startX, this._groupHeadSize), startY, this._groupHeadSize, this._groupHeadSize);
-			this.context.strokeStyle = strokeColor;
-			this.context.lineWidth = 1.0;
-			this.context.strokeRect(this.transformRectX(startX + 0.5, this._groupHeadSize), startY + 0.5, this._groupHeadSize, this._groupHeadSize);
-
-			if (!group.hidden) {
-				// draw '-'
-				this.context.beginPath();
-				this.context.moveTo(this.transformX(startX + this._groupHeadSize * 0.25), startY + this._groupHeadSize * 0.5 + 0.5);
-				this.context.lineTo(this.transformX(startX + this._groupHeadSize * 0.75 + app.roundedDpiScale), startY + this._groupHeadSize * 0.5 + 0.5);
-				this.context.stroke();
-			}
-			else {
-				// draw '+'
-				this.context.beginPath();
-				this.context.moveTo(this.transformX(startX + this._groupHeadSize * 0.25), startY + this._groupHeadSize * 0.5 + 0.5);
-				this.context.lineTo(this.transformX(startX + this._groupHeadSize * 0.75 + app.roundedDpiScale), startY + this._groupHeadSize * 0.5 + 0.5);
-
-				this.context.stroke();
-
-				this.context.moveTo(this.transformX(startX + this._groupHeadSize * 0.50 + 0.5), startY + this._groupHeadSize * 0.25);
-				this.context.lineTo(this.transformX(startX + this._groupHeadSize * 0.50 + 0.5), startY + this._groupHeadSize * 0.75 + app.roundedDpiScale);
-
-				this.context.stroke();
-			}
+			this.drawGroupBoxes(startX, startY, group.hidden);
 		}
 
 		if (!group.hidden && endX > this._cornerHeaderWidth + this._groupHeadSize && endX > startX) {
@@ -127,9 +102,9 @@ export class ColumnGroup extends GroupBase {
 			startX = Math.round(startX) + 1;
 			startY = Math.round(startY);
 			this.context.strokeStyle = strokeColor;
-			this.context.lineWidth = 2.0;
-			this.context.moveTo(this.transformX(startX), startY);
-			this.context.lineTo(this.transformX(endX - app.roundedDpiScale), startY);
+			this.context.lineWidth = 1.0;
+			this.context.moveTo(this.transformX(startX) + 0.5, startY + 0.5);
+			this.context.lineTo(this.transformX(endX - app.roundedDpiScale) + 0.5, startY + 0.5);
 			this.context.stroke();
 		}
 	}
@@ -151,7 +126,7 @@ export class ColumnGroup extends GroupBase {
 		ctx.font = this._getFont();
 		ctx.textAlign = 'center';
 		ctx.textBaseline = 'middle';
-		ctx.fillText((level + 1).toString(), this.transformX(startX + (ctrlHeadSize / 2)), startY + (ctrlHeadSize / 2) + 2 * app.dpiScale);
+		ctx.fillText((level + 1).toString(), this.transformX(startX + (ctrlHeadSize / 2)), startY + (ctrlHeadSize / 1.9));
 	}
 
 	// Handle user interaction.

--- a/browser/src/control/Control.GroupBase.ts
+++ b/browser/src/control/Control.GroupBase.ts
@@ -80,9 +80,8 @@ export abstract class GroupBase extends CanvasSectionObject {
 		const elem = window.L.DomUtil.create('div', 'spreadsheet-header-row', baseElem);
 
 		const fontFamily = window.L.DomUtil.getStyle(elem, 'font-family');
-		const fontSize = parseInt(window.L.DomUtil.getStyle(elem, 'font-size'));
-		this._getFont = function() {
-			return Math.round(fontSize * app.dpiScale) + 'px ' + fontFamily;
+		this._getFont = () => {
+			return Math.round(this._groupHeadSize * 0.8) + 'px ' + fontFamily;
 		};
 		window.L.DomUtil.remove(elem);
 	}
@@ -253,6 +252,42 @@ export abstract class GroupBase extends CanvasSectionObject {
 					return this._isParentGroupVisible(parentGroup);
 				}
 			}
+		}
+	}
+
+	drawGroupBoxes(startX: number, startY: number, hidden: boolean): void {
+		// By forcing _groupHeadSize to be an even number, we guarantee that (_groupHeadSize / 2) is a solid integer.
+		// This prevents the canvas from anti-aliasing (blurring) the line across two distinct pixels.
+		if (this._groupHeadSize % 2 !== 0) {
+			this._groupHeadSize++;
+		}
+
+		// draw head
+		this.context.beginPath();
+		this.context.fillStyle = this.backgroundColor;
+		this.context.fillRect(this.transformRectX(startX, this._groupHeadSize), startY, this._groupHeadSize, this._groupHeadSize);
+		this.context.strokeStyle = this.getColors().strokeColor;
+		this.context.lineWidth = 1.0;
+		this.context.strokeRect(this.transformRectX(startX + 0.5, this._groupHeadSize), startY + 0.5, this._groupHeadSize, this._groupHeadSize);
+
+		if (!hidden) {
+			// draw '-'
+			this.context.beginPath();
+			this.context.moveTo(startX + 0.5 + this._groupHeadSize * 0.25, startY + 0.5 + this._groupHeadSize / 2);
+			this.context.lineTo(startX + 0.5 + this._groupHeadSize * 0.75, startY + 0.5 + this._groupHeadSize / 2);
+			this.context.stroke();
+		}
+		else {
+			// draw '+'
+			this.context.beginPath();
+			// horizontal
+			this.context.moveTo(startX + 0.5 + this._groupHeadSize * 0.25, startY + 0.5 + this._groupHeadSize / 2);
+			this.context.lineTo(startX + 0.5 + this._groupHeadSize * 0.75, startY + 0.5 + this._groupHeadSize / 2);
+			this.context.stroke();
+			// vertical
+			this.context.moveTo(startX + 0.5 + this._groupHeadSize / 2, startY + 0.5 + this._groupHeadSize * 0.25);
+			this.context.lineTo(startX + 0.5 + this._groupHeadSize / 2, startY + 0.5 + this._groupHeadSize * 0.75);
+			this.context.stroke();
 		}
 	}
 

--- a/browser/src/control/Control.RowGroup.ts
+++ b/browser/src/control/Control.RowGroup.ts
@@ -83,38 +83,13 @@ export class RowGroup extends GroupBase {
 	drawGroupControl (group: GroupEntry): void {
 		let startX = this._levelSpacing + (this._groupHeadSize + this._levelSpacing) * group.level;
 		let startY = this.getRelativeY(group.startPos);
+		startX = Math.round(startX);
+		startY = Math.round(startY);
 		const endY = this.getEndPosition(group.endPos);
 		const strokeColor = this.getColors().strokeColor;
 
 		if (this.isGroupHeaderVisible(startY, group.startPos)) {
-			// draw head
-			this.context.beginPath();
-			this.context.fillStyle = this.backgroundColor;
-			this.context.fillRect(this.transformRectX(startX, this._groupHeadSize), startY, this._groupHeadSize, this._groupHeadSize);
-			this.context.strokeStyle = strokeColor;
-			this.context.lineWidth = 1.0;
-			this.context.strokeRect(this.transformRectX(startX + 0.5, this._groupHeadSize), startY + 0.5, this._groupHeadSize, this._groupHeadSize);
-
-			if (!group.hidden) {
-				// draw '-'
-				this.context.beginPath();
-				this.context.moveTo(this.transformX(startX + this._groupHeadSize * 0.25), startY + this._groupHeadSize / 2 + 0.5);
-				this.context.lineTo(this.transformX(startX + this._groupHeadSize * 0.75 + app.roundedDpiScale), startY + this._groupHeadSize / 2 + 0.5);
-				this.context.stroke();
-			}
-			else {
-				// draw '+'
-				this.context.beginPath();
-				this.context.moveTo(this.transformX(startX + this._groupHeadSize * 0.25), startY + this._groupHeadSize / 2 + 0.5);
-				this.context.lineTo(this.transformX(startX + this._groupHeadSize * 0.75 + app.roundedDpiScale), startY + this._groupHeadSize / 2 + 0.5);
-
-				this.context.stroke();
-
-				this.context.moveTo(this.transformX(startX + this._groupHeadSize * 0.50 + 0.5), startY + this._groupHeadSize * 0.25);
-				this.context.lineTo(this.transformX(startX + this._groupHeadSize * 0.50 + 0.5), startY + this._groupHeadSize * 0.75 + app.roundedDpiScale);
-
-				this.context.stroke();
-			}
+			this.drawGroupBoxes(startX, startY, group.hidden);
 		}
 
 		if (!group.hidden && endY > this._cornerHeaderHeight + this._groupHeadSize && endY > startY) {
@@ -126,11 +101,11 @@ export class RowGroup extends GroupBase {
 			startX = Math.round(startX);
 			startY = Math.round(startY) + 1;
 			this.context.strokeStyle = strokeColor;
-			this.context.lineWidth = 2.0;
-			this.context.moveTo(this.transformX(startX), startY);
-			this.context.lineTo(this.transformX(startX), endY - app.roundedDpiScale);
+			this.context.lineWidth = 1.0;
+			this.context.moveTo(this.transformX(startX) + 0.5, Math.round(startY) + 0.5);
+			this.context.lineTo(this.transformX(startX) + 0.5, Math.round(endY - app.roundedDpiScale) + 0.5);
 			this.context.stroke();
-			this.context.lineTo(Math.round(this.transformX(startX + this._groupHeadSize / 2)), endY - app.roundedDpiScale);
+			this.context.lineTo(Math.round(this.transformX(startX + this._groupHeadSize / 2)) + 0.5, Math.round(endY - app.roundedDpiScale) + 0.5);
 			this.context.stroke();
 		}
 	}
@@ -152,7 +127,7 @@ export class RowGroup extends GroupBase {
 		ctx.font = this._getFont();
 		ctx.textAlign = 'center';
 		ctx.textBaseline = 'middle';
-		ctx.fillText((level + 1).toString(), this.transformX(startX + (ctrlHeadSize / 2)), startY + (ctrlHeadSize / 2) + 2 * app.dpiScale);
+		ctx.fillText((level + 1).toString(), this.transformX(startX + (ctrlHeadSize / 2)), startY + (ctrlHeadSize / 1.9));
 	}
 
 	// Handle user interaction.


### PR DESCRIPTION
Change-Id: I752f6a0a5eed762d83e680c2da1ab06b3fabde3c


* Resolves: https://github.com/CollaboraOnline/online/pull/8022#issuecomment-4073960830
* Target version: main

### Summary
- The plus and minus symbols inside the row and column group boxes were not visually centered because their line endpoints were uneven. The drawing logic used 25% and 75% of the box size, but the end coordinate had an extra app.roundedDpiScale, which pushed the line too far on one side. Removing that extra offset makes the padding even on both sides and centers the symbols properly.

- The level numbers in the header boxes also appeared slightly off vertically. Although the text is drawn with textBaseline = 'middle', the previous offset of + 2 * app.dpiScale pushed the numbers too far from the visual center. Reducing it to + app.dpiScale reuslting in better alignment without over adjusting.


### PREVIEW

<img width="585" height="700" alt="2026-03-24_04-19" src="https://github.com/user-attachments/assets/b7c4b900-18fe-460c-9443-0d1d25772241" />


