### PR TITLE
cypress: fix impress undo_redo_spec assertions and typing reliability

### DIFF
--- a/cypress_test/integration_tests/desktop/impress/undo_redo_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/undo_redo_spec.js
@@ -7,31 +7,8 @@ var repairHelper = require('../../common/repair_document_helper');
 
 describe(['tagdesktop'], 'Editing Operations', function() {
 
-	function expectInitialText() {
-		impressHelper.triggerNewSVGForShapeInTheCenter();
-		impressHelper.dblclickOnSelectedShape();
-		helper.typeIntoDocument('{ctrl+a}');
-		helper.copy();
-		helper.clipboardTextShouldBeDifferentThan('Hello World');
-	}
-
-	function expectTypedText() {
-		cy.log('expectTypedText - START');
-
-		impressHelper.triggerNewSVGForShapeInTheCenter();
-		impressHelper.dblclickOnSelectedShape();
-		helper.typeIntoDocument('{ctrl+a}');
-		helper.copy();
-
-		impressHelper.dblclickOnSelectedShape();
-		helper.expectTextForClipboard('Hello World');
-
-		cy.log('expectTypedText - END');
-	}
-
 	beforeEach(function() {
 		helper.setupAndLoadDocument('impress/undo_redo.odp');
-		// close the default slide-sorter navigation sidebar
 		desktopHelper.closeNavigatorSidebar();
 		desktopHelper.selectZoomLevel('30', false);
 
@@ -49,40 +26,62 @@ describe(['tagdesktop'], 'Editing Operations', function() {
 		impressHelper.dblclickOnSelectedShape();
 	});
 
+	// Type text one character at a time with processToIdle
+	// between each keystroke.  This avoids text corruption
+	// caused by accessibility echo-back racing with rapid
+	// typing under load.
+	function typeTextSafely(win, text) {
+		for (var i = 0; i < text.length; i++) {
+			helper.typeIntoDocument(text[i]);
+			helper.processToIdle(win);
+		}
+	}
+
+	// Exit text editing to commit the change, refresh the
+	// shape SVG and verify it contains the expected text.
+	function expectShapeText(text) {
+		impressHelper.triggerNewSVGForShapeInTheCenter();
+		cy.cGet('#document-container svg g.Page g')
+			.should('contain.text', text);
+	}
+
+	// Refresh the shape SVG and verify it does not contain
+	// the given text (the shape initially has an empty paragraph).
+	function expectShapeTextAbsent(text) {
+		impressHelper.triggerNewSVGForShapeInTheCenter();
+		cy.cGet('#document-container svg g.Page g').invoke('text')
+			.should('not.include', text);
+	}
+
 	function undo(win) {
 		helper.processToIdle(win);
-		helper.typeIntoDocument('Hello World');
-		helper.processToIdle(win);
-		expectTypedText();
+		typeTextSafely(win, 'Hello World');
+		expectShapeText('Hello World');
 		helper.typeIntoDocument('{ctrl+z}');
 		helper.processToIdle(win);
-		expectInitialText();
+		expectShapeTextAbsent('Hello World');
 	}
 
 	it('Undo', function() {
-		helper.setDummyClipboardForCopy();
 		undo(this.win);
 	});
 
 	it('Redo', function() {
-		helper.setDummyClipboardForCopy();
 		undo(this.win);
 		helper.typeIntoDocument('{ctrl+y}');
 		helper.processToIdle(this.win);
-		expectTypedText();
+		expectShapeText('Hello World');
 	});
 
 	it('Repair Document', function() {
-		helper.setDummyClipboardForCopy();
-		helper.typeIntoDocument('Hello World');
 		helper.processToIdle(this.win);
+		typeTextSafely(this.win, 'Hello World');
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 		impressHelper.dblclickOnSelectedShape();
-		helper.typeIntoDocument('Overwrite Text');
 		helper.processToIdle(this.win);
+		typeTextSafely(this.win, 'Overwrite Text');
 		impressHelper.triggerNewSVGForShapeInTheCenter();
 		repairHelper.rollbackPastChange('Undo', false, true);
-		impressHelper.triggerNewSVGForShapeInTheCenter();
-		expectTypedText();
+		expectShapeText('Hello World');
 	});
 });


### PR DESCRIPTION
The undo/redo assertions were not actually verifying anything. expectInitialText() used copy() followed by a negative clipboard assertion (clipboardTextShouldBeDifferentThan). However, triggerNewSVGForShapeInTheCenter() clears the copy-paste container during shape deselection, and copy() repopulates it asynchronously via _dummyClipboard.write(). The negative assertion ran against the still-empty container and passed instantly regardless of document content. Commenting out ctrl+z or ctrl+y did not cause any test failure.

Replace the clipboard-based verification with direct SVG text checks. triggerNewSVGForShapeInTheCenter() forces core to emit a fresh SVG snapshot that is inserted into the DOM atomically, so checking its text content has no async race.

Also type text one character at a time with processToIdle between keystrokes. Under CPU load, rapid typing races with the a11y echo-back from core (a11yfocuschanged messages that overwrite _textArea.innerHTML), corrupting the typed text.

Change-Id: I719013740f8b0ad061f12636d59ef7cbbb6b531b


* Resolves: # <!-- related github issue -->
* Target version: main
