### PR TITLE
cypress: make Chart (LinePropertyPanel) more stable

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/a11y_sidebar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_sidebar_spec.js
@@ -63,46 +63,48 @@ describe(['tagdesktop'], 'Accessibility Writer Sidebar Tests', { testIsolation: 
 		});
 
 		cy.cGet('#test-div-shapeHandlesSection').should('exist');
+		helper.processToIdle(win);
 
 		// Enter chart edit mode
-		cy.realPress('Enter');
+		pressKey('Enter');
 		helper.processToIdle(win);
 
 		// Default chart deck panels
 		runA11yValidation(win);
 
 		// Enter the chart's inner object hierarchy
-		cy.realPress('Enter');
+		pressKey('Enter');
 		helper.processToIdle(win);
 
 		// Select the first sub-object
-		cy.realPress('Tab');
+		pressKey('Tab');
 		helper.processToIdle(win);
 		runA11yValidation(win);
 
 		// Go a level down the hierarchy, Data Series: Column 1
-		cy.realPress('Enter');
+		pressKey('Enter');
 		helper.processToIdle(win);
 		runA11yValidation(win);
 
 		// Go a level down the hierarchy, Data point 1 in data series 1
-		cy.realPress('Enter');
+		pressKey('Enter');
 		helper.processToIdle(win);
 		runA11yValidation(win);
 
 		// Back up to Data Series: Column 1
-		cy.realPress('Escape');
+		pressKey('Escape');
 		helper.processToIdle(win);
 		runA11yValidation(win);
 
 		// Data Series: Column 2
-		cy.realPress('Tab');
+		pressKey('Tab');
 		helper.processToIdle(win);
 		runA11yValidation(win);
 
 		// X Axis
-		cy.realPress('Tab');
-		cy.realPress('Tab');
+		pressKey('Tab');
+		helper.processToIdle(win);
+		pressKey('Tab');
 		helper.processToIdle(win);
 		runA11yValidation(win);
 
@@ -246,8 +248,18 @@ describe(['tagdesktop'], 'Accessibility Writer Sidebar Tests', { testIsolation: 
 		a11yHelper.runA11yValidation(win, 'validatesidebara11y');
 	}
 
+	// Ensure focus is on the document before pressing a key.
+	// After processToIdle or runA11yValidation, focus can move to
+	// sidebar elements. cy.realPress sends events to the focused
+	// element, so we must restore document focus first.
+	function pressKey(key) {
+		cy.cGet('div.clipboard').focus();
+		cy.realPress(key);
+	}
+
 	function escLevel(win, count) {
 		for (var i = 0; i < count; i++) {
+			cy.cGet('div.clipboard').focus();
 			helper.typeIntoDocument('{esc}');
 			helper.processToIdle(win);
 		}


### PR DESCRIPTION
in writer/a11y_sidebar_spec.js.

after processToIdle or runA11yValidation, focus sometimes drifts to sidebar elements like Panel-button or zoom-entry-5. When that happens, cy.realPress('Enter') sends the Enter key to the sidebar button instead of the document. The keyboard handler on the map container never sees it, so the key event never reaches the server.

Focusing div.clipboard before each cy.realPress ensures the document's keyboard input element is targeted.


Change-Id: Ic9409b99a9fda8529f2daaaeda5f008eccd7f1f6

* Target version: main


