### PR TITLE
Windows: fix About dialog Copy button via TEXTCLIPBOARD bridge message

### DIFF
--- a/browser/src/control/Control.AboutDialog.ts
+++ b/browser/src/control/Control.AboutDialog.ts
@@ -371,7 +371,7 @@ class AboutDialog {
 		}
 
 		const addLine = (label: string, value: string) => {
-			if (value.trim()) {
+			if (value && value.trim()) {
 				text += `${label}: ${value.trim()}\n`;
 			}
 		};
@@ -390,7 +390,7 @@ class AboutDialog {
 
 		text = text.replace(/\u00A0/g, ' ');
 
-		if ((window as any).ThisIsTheQtApp || (window as any).ThisIsTheMacOSApp) {
+		if (window.mode.isCODesktop()) {
 			(window as any).postMobileMessage('TEXTCLIPBOARD ' + text);
 			this.contentHasBeenCopiedShowSnackbar();
 		} else if (navigator.clipboard && window.isSecureContext) {

--- a/windows/coda/CODA/CODA.cpp
+++ b/windows/coda/CODA/CODA.cpp
@@ -1773,6 +1773,22 @@ static void processMessage(WindowData& data, wil::unique_cotaskmem_string& messa
         {
             do_paste_or_read(ClipboardOp::READ, data);
         }
+        else if (s.starts_with(L"TEXTCLIPBOARD "))
+        {
+            std::wstring text = s.substr(14);
+            if (OpenClipboard(NULL))
+            {
+                EmptyClipboard();
+                HGLOBAL hMem = GlobalAlloc(GMEM_MOVEABLE, (text.size() + 1) * sizeof(wchar_t));
+                if (hMem)
+                {
+                    memcpy(GlobalLock(hMem), text.c_str(), (text.size() + 1) * sizeof(wchar_t));
+                    GlobalUnlock(hMem);
+                    SetClipboardData(CF_UNICODETEXT, hMem);
+                }
+                CloseClipboard();
+            }
+        }
         else if (s.starts_with(L"CLIPBOARDSET "))
         {
             do_clipboard_set(data.appDocId, Util::wide_string_to_string(s.substr(13)).c_str());


### PR DESCRIPTION
Same issue as Qt and macOS: the embedded WebView2 doesn't expose navigator.clipboard. Handle the TEXTCLIPBOARD message in the Windows message handler and set the system clipboard via the Win32 API.

Also use window.mode.isCODesktop() instead of enumerating individual platform flags in the JS condition, covering all three desktop apps.

Change-Id: I7f3a2c8b5e9d4a1f6c0e8b3d7a2f5e9c1b4d8a6f

Surprisingly we need this, it used to work on Windows, but it does not work now.