### PR TITLE
refactor: rename window.mode.isMobile() to window.mode.isSmallScreenDevice()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ browser/admin/jsconfig.json
 browser/dist
 browser/compilets
 browser/typescript_js
+*.tsbuildinfo
 browser/src/app/TaskWorker.js
 
 /coolforkit

--- a/browser/js/global.js
+++ b/browser/js/global.js
@@ -167,7 +167,7 @@ class BrowserProperties {
 			},
 			// Here "mobile" means "mobile phone" (at least for now). Has to match small screen size
 			// requirement.
-			isMobile: function() {
+			isSmallScreenDevice: function() {
 				if (global.ThisIsTheWindowsApp || global.ThisIsTheQtApp || global.ThisIsTheMacOSApp)
 					return false;
 
@@ -188,7 +188,7 @@ class BrowserProperties {
 				if (global.mode.isChromebook())
 					return false;
 
-				return global.L.Browser.mobile && !global.mode.isMobile();
+				return global.L.Browser.mobile && !global.mode.isSmallScreenDevice();
 			},
 			isCODesktop: function() {
 				return global.ThisIsTheMacOSApp || global.ThisIsTheQtApp || global.ThisIsTheWindowsApp;
@@ -206,7 +206,7 @@ class BrowserProperties {
 				return !global.L.Browser.mobile;
 			},
 			getDeviceFormFactor: function() {
-				if (global.mode.isMobile())
+				if (global.mode.isSmallScreenDevice())
 					return 'mobile';
 				else if (global.mode.isTablet())
 					return 'tablet';
@@ -352,7 +352,7 @@ class InitializerBase {
 		if(window.useIntegrationTheme && theme_name !== '')
 			theme_prefix = theme_name + '/';
 
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			link.setAttribute("href", this.uriPrefix + 'device-mobile.css');
 			brandingLink.setAttribute("href", this.brandingUriPrefix + theme_prefix + 'branding-mobile.css');
 		} else if (window.mode.isTablet()) {
@@ -1075,7 +1075,7 @@ function showWelcomeSVG() {
 			if (global.ThisIsTheWindowsApp || global.ThisIsTheQtApp || global.ThisIsTheMacOSApp)
 				return false;
 			if (global.keyboard.onscreenKeyboardHint != undefined) return global.keyboard.onscreenKeyboardHint;
-			return (global.ThisIsAMobileApp && !global.ThisIsTheEmscriptenApp) || global.mode.isMobile() || global.mode.isTablet();
+			return (global.ThisIsAMobileApp && !global.ThisIsTheEmscriptenApp) || global.mode.isSmallScreenDevice() || global.mode.isTablet();
 			// It's better to guess that more devices will have an onscreen keyboard than reality,
 			// because calc becomes borderline unusable if you miss a device that pops up an onscreen keyboard which covers
 			// a sizeable portion of the screen

--- a/browser/src/app/ServerConnectionService.ts
+++ b/browser/src/app/ServerConnectionService.ts
@@ -48,7 +48,7 @@ class ServerConnectionService {
 			window.zoteroEnabled &&
 			zoteroAPIKey &&
 			!zoteroPlugin &&
-			!window.mode.isMobile()
+			!window.mode.isSmallScreenDevice()
 		) {
 			app.console.debug('ServerConnectionService: initialize Zotero plugin');
 
@@ -75,7 +75,7 @@ class ServerConnectionService {
 	public onFirstTileReceived() {
 		app.console.debug('ServerConnectionService: onFirstTileReceived');
 
-		if (!window.mode.isMobile()) {
+		if (!window.mode.isSmallScreenDevice()) {
 			// show zotero items if needed
 			const zoteroItems = [
 				'zoteroaddeditbibliography',

--- a/browser/src/app/Socket.ts
+++ b/browser/src/app/Socket.ts
@@ -905,7 +905,7 @@ class Socket {
 			// add the top toolbar and menubar controls to the map.
 			if (window.prefs.useBrowserSetting) {
 				if (
-					!window.mode.isMobile() &&
+					!window.mode.isSmallScreenDevice() &&
 					this._map.uiManager.getCurrentMode() === 'notebookbar'
 				)
 					this._map.uiManager.removeClassicUI();
@@ -953,7 +953,7 @@ class Socket {
 			this._map.uiManager.applyInvert();
 			this._map.uiManager.setCanvasColorAfterModeChange();
 
-			if (!window.mode.isMobile())
+			if (!window.mode.isSmallScreenDevice())
 				this._map.uiManager.initializeNotebookbarInCore();
 
 			// close all the popups otherwise document textArea will not get focus
@@ -1633,7 +1633,7 @@ class Socket {
 				let reloadMessage = _(
 					'Server is now reachable. We have to refresh the page now.',
 				);
-				if (window.mode.isMobile())
+				if (window.mode.isSmallScreenDevice())
 					reloadMessage = _('Server is now reachable...');
 
 				const reloadFunc = function () {

--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -161,7 +161,7 @@ export class CommentSection extends CanvasSectionObject {
 		this.sectionProperties.reLayout = true;
 
 		// This (commentsAreListed) variable means that comments are shown as a list on the right side of the document.
-		this.sectionProperties.commentsAreListed = (app.map._docLayer._docType === 'text' || app.map._docLayer._docType === 'presentation' || app.map._docLayer._docType === 'drawing') && !(<any>window).mode.isMobile();
+		this.sectionProperties.commentsAreListed = (app.map._docLayer._docType === 'text' || app.map._docLayer._docType === 'presentation' || app.map._docLayer._docType === 'drawing') && !(<any>window).mode.isSmallScreenDevice();
 		this.idIndexMap = new Map<any, number>();
 		this.mobileCommentModalId = this.map.uiManager.generateModalId(this.mobileCommentId);
 		this.annotationMinSize = Number(getComputedStyle(document.documentElement).getPropertyValue('--annotation-min-size'));
@@ -196,7 +196,7 @@ export class CommentSection extends CanvasSectionObject {
 		this.backgroundColor = this.containerObject.getClearColor();
 		this.initializeContextMenus();
 
-		if ((<any>window).mode.isMobile()) {
+		if ((<any>window).mode.isSmallScreenDevice()) {
 			this.setShowSection(false);
 			this.size[0] = 0;
 		}
@@ -237,7 +237,7 @@ export class CommentSection extends CanvasSectionObject {
 	}
 
 	private checkCollapseState(): void {
-		if (!(<any>window).mode.isMobile() && app.map._docLayer._docType !== 'spreadsheet') {
+		if (!(<any>window).mode.isSmallScreenDevice() && app.map._docLayer._docType !== 'spreadsheet') {
 			if (this.shouldCollapse()) {
 				this.sectionProperties.deflectionOfSelectedComment = 180;
 				this.setCollapsed();
@@ -286,7 +286,7 @@ export class CommentSection extends CanvasSectionObject {
 
 	private checkSize (): void {
 		// When there is no comment || file is a spreadsheet || view type is mobile, we set this section's size to [0, 0].
-		if (app.map._docLayer._docType === 'spreadsheet' || (<any>window).mode.isMobile() || this.sectionProperties.commentList.length === 0)
+		if (app.map._docLayer._docType === 'spreadsheet' || (<any>window).mode.isSmallScreenDevice() || this.sectionProperties.commentList.length === 0)
 		{
 			if (app.map._docLayer._docType === 'presentation' && this.sectionProperties.scrollAnnotation) {
 				this.map.removeControl(this.sectionProperties.scrollAnnotation);
@@ -370,7 +370,7 @@ export class CommentSection extends CanvasSectionObject {
 	public shouldCollapse (): boolean {
 		if (app.map._docLayer._docType === 'text')
 			return false;
-		if (!this.containerObject.getDocumentAnchorSection() || app.map._docLayer._docType === 'spreadsheet' || (<any>window).mode.isMobile())
+		if (!this.containerObject.getDocumentAnchorSection() || app.map._docLayer._docType === 'spreadsheet' || (<any>window).mode.isSmallScreenDevice())
 			return false;
 		const availableSpace = this.calculateAvailableSpace();
 		/*
@@ -829,7 +829,7 @@ export class CommentSection extends CanvasSectionObject {
 			this.navigateAndFocusComment(cool.Comment.isAnyEdit());
 			return;
 		}
-		if ((<any>window).mode.isMobile()) {
+		if ((<any>window).mode.isSmallScreenDevice()) {
 			var avatar = undefined;
 			var author = this.map.getViewName(app.map._docLayer._viewId);
 			if (author in this.map._viewInfoByUserName) {
@@ -869,7 +869,7 @@ export class CommentSection extends CanvasSectionObject {
 			this.navigateAndFocusComment(cool.Comment.isAnyEdit());
 			return;
 		}
-		if ((<any>window).mode.isMobile()) {
+		if ((<any>window).mode.isSmallScreenDevice()) {
 			this.newAnnotationMobile(annotation, function(annotation: any) {
 				this.save(annotation);
 			}.bind(this), /* isMod */ true);
@@ -1328,13 +1328,13 @@ export class CommentSection extends CanvasSectionObject {
 								this.promote.call(this, options.$trigger[0].annotation);
 							}.bind(this)
 						},
-						showBigger: docLayer._docType !== 'text' || (<any>window).mode.isMobile() ? undefined : {
+						showBigger: docLayer._docType !== 'text' || (<any>window).mode.isSmallScreenDevice() ? undefined : {
 							name: isShownBig ? _('Show on the side') : _('Open in full view'),
 							callback: function (key: any, options: any) {
 								this.toggleShowBigger.call(this, options.$trigger[0].annotation);
 							}.bind(this)
 						},
-						showInNavigator: (docLayer._docType !== 'text' && docLayer._docType !== 'spreadsheet') || (<any>window).mode.isMobile() ? undefined : {
+						showInNavigator: (docLayer._docType !== 'text' && docLayer._docType !== 'spreadsheet') || (<any>window).mode.isSmallScreenDevice() ? undefined : {
 							name: _('Show in navigator'),
 							callback: function (key: any, options: any) {
 								this.showInNavigator.call(this, options.$trigger[0].annotation);
@@ -1685,7 +1685,7 @@ export class CommentSection extends CanvasSectionObject {
 			obj.comment.avatar = this.map._viewInfoByUserName[obj.comment.author].userextrainfo.avatar;
 		}
 
-		if ((<any>window).mode.isMobile()) {
+		if ((<any>window).mode.isSmallScreenDevice()) {
 			var annotation = this.sectionProperties.commentList[this.getRootIndexOf(obj[dataroot].id)];
 			if (!annotation)
 				annotation = this.sectionProperties.commentList[this.getRootIndexOf(obj[dataroot].parent)]; //this is required for reload after reply in writer
@@ -1832,7 +1832,7 @@ export class CommentSection extends CanvasSectionObject {
 				this.showHideComment(comment);
 			}
 		}
-		if ((<any>window).mode.isMobile()) {
+		if ((<any>window).mode.isSmallScreenDevice()) {
 			var shouldOpenWizard = false;
 			var wePerformedAction = obj.comment.author === this.map.getViewName(app.map._docLayer._viewId);
 
@@ -2177,7 +2177,7 @@ export class CommentSection extends CanvasSectionObject {
 	}
 
 	private layout (relayout: boolean = true): void {
-		if ((<any>window).mode.isMobile() || app.map._docLayer._docType === 'spreadsheet') {
+		if ((<any>window).mode.isSmallScreenDevice() || app.map._docLayer._docType === 'spreadsheet') {
 			if (this.sectionProperties.commentList.length > 0)
 				this.orderCommentList();
 			return; // No adjustments for Calc, since only one comment can be shown at a time and that comment is shown at its belonging cell.

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -272,7 +272,7 @@ export class Comment extends CanvasSectionObject {
 
 		this.doPendingInitializationInView();
 
-		if (!(<any>window).mode.isMobile())
+		if (!(<any>window).mode.isSmallScreenDevice())
 			document.getElementById('document-container').appendChild(this.sectionProperties.container);
 	}
 
@@ -282,7 +282,7 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.container.id = 'comment-container-' + this.sectionProperties.data.id;
 		window.L.DomEvent.on(this.sectionProperties.container, 'focusout', this.onLostFocus, this);
 
-		var mobileClass = (<any>window).mode.isMobile() ? ' wizard-comment-box': '';
+		var mobileClass = (<any>window).mode.isSmallScreenDevice() ? ' wizard-comment-box': '';
 
 		if (this.sectionProperties.data.trackchange) {
 			this.sectionProperties.wrapper = window.L.DomUtil.create('div', 'cool-annotation-redline-content-wrapper' + mobileClass, this.sectionProperties.container);
@@ -351,7 +351,7 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	public setContainerPos(forceUpdate: boolean, canvasContainerBounds?: DOMRect, left?: number, top?: number): void {
-		if ((<any>window).mode.isMobile()) {
+		if ((<any>window).mode.isSmallScreenDevice()) {
 			return;
 		}
 
@@ -892,7 +892,7 @@ export class Comment extends CanvasSectionObject {
 		this.cachedIsEdit = false;
 
 		this.positionCalcComment();
-		if (!(<any>window).mode.isMobile()) {
+		if (!(<any>window).mode.isSmallScreenDevice()) {
 			this.sectionProperties.commentListSection.select(this);
 		}
 		this.sectionProperties.container.style.visibility = '';
@@ -904,7 +904,7 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	public positionCalcComment(): void {
-		if (!(<any>window).mode.isMobile()) {
+		if (!(<any>window).mode.isSmallScreenDevice()) {
 			const startX = this.isCalcRTL() ? this.myTopLeft[0] - this.getCommentWidth() : this.myTopLeft[0] + this.calcOptimumSizeForCalc()[0] - 3;
 
 			var pos: Array<number> = [Math.round(startX / app.dpiScale), Math.round(this.myTopLeft[1] / app.dpiScale)];
@@ -950,7 +950,7 @@ export class Comment extends CanvasSectionObject {
 		this.showMarker();
 
 		// On mobile, container shouldn't be 'document-container', but it is 'document-container' on initialization. So we hide the comment until comment wizard is opened.
-		if ((<any>window).mode.isMobile() && this.sectionProperties.container.parentElement === document.getElementById('document-container'))
+		if ((<any>window).mode.isSmallScreenDevice() && this.sectionProperties.container.parentElement === document.getElementById('document-container'))
 			this.sectionProperties.container.style.visibility = 'hidden';
 
 		if (cool.CommentSection.commentWasAutoAdded)
@@ -1072,7 +1072,7 @@ export class Comment extends CanvasSectionObject {
 
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	private onMouseClick (e: any): void {
-		if (((<any>window).mode.isMobile() || (<any>window).mode.isTablet())
+		if (((<any>window).mode.isSmallScreenDevice() || (<any>window).mode.isTablet())
 			&& this.map.getDocType() == 'spreadsheet'
 			&& !this.map.uiManager.mobileWizard.isOpen()) {
 			this.hide();
@@ -1119,7 +1119,7 @@ export class Comment extends CanvasSectionObject {
 	// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 	public onReplyClick (e: any): void {
 		window.L.DomEvent.stopPropagation(e);
-		if ((<any>window).mode.isMobile()) {
+		if ((<any>window).mode.isSmallScreenDevice()) {
 			this.sectionProperties.data.reply = this.sectionProperties.data.text;
 			this.sectionProperties.commentListSection.saveReply(this);
 		} else {
@@ -1597,7 +1597,7 @@ export class Comment extends CanvasSectionObject {
 		// CanvasSectionContainer fires the onClick event. But since Hammer.js is used for map, it disables the onClick for SectionContainer.
 		// We will use this event as click event on touch devices, until we remove Hammer.js (then this code will be removed from here).
 		// Control.ColumnHeader.js file is not affected by this situation, because map element (so Hammer.js) doesn't cover headers.
-		if (!this.containerObject.isDraggingSomething() && (<any>window).mode.isMobile() || (<any>window).mode.isTablet()) {
+		if (!this.containerObject.isDraggingSomething() && (<any>window).mode.isSmallScreenDevice() || (<any>window).mode.isTablet()) {
 			if (app.map._docLayer._docType === 'presentation' || app.map._docLayer._docType === 'drawing')
 				app.map._docLayer._openCommentWizard(this);
 			this.onMouseEnter();
@@ -1934,7 +1934,7 @@ export class Comment extends CanvasSectionObject {
 	}
 
 	private getActiveEditorElement(): HTMLElement | null {
-		if ((<any>window).mode.isMobile()) {
+		if ((<any>window).mode.isSmallScreenDevice()) {
 			const commentSection = app.sectionContainer.getSectionWithName(
 				app.CSections.CommentList.name,
 			);

--- a/browser/src/canvas/sections/ContentControlDropdownSubSection.ts
+++ b/browser/src/canvas/sections/ContentControlDropdownSubSection.ts
@@ -36,7 +36,7 @@ class ContentControlDropdownSubSection extends HTMLObjectSection {
 		builder: any,
 	): void {
 		var fireEvent: string = 'jsdialog';
-		if ((<any>window).mode.isMobile()) {
+		if ((<any>window).mode.isSmallScreenDevice()) {
 			fireEvent = 'mobilewizard';
 		}
 		var closeDropdownJson = {
@@ -152,7 +152,7 @@ class ContentControlDropdownSubSection extends HTMLObjectSection {
 			this.showDatePicker();
 		} else if (this.sectionProperties.json.items) {
 			var fireEvent: string = 'jsdialog';
-			if ((<any>window).mode.isMobile()) {
+			if ((<any>window).mode.isSmallScreenDevice()) {
 				fireEvent = 'mobilewizard';
 			}
 			app.map.fire(fireEvent, {

--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -360,7 +360,7 @@ export class ScrollSection extends CanvasSectionObject {
 			this.calculateCurrentAlpha(elapsedTime);
 
 		if ((this.sectionProperties.drawVerticalScrollBar || this.sectionProperties.alwaysDrawVerticalScrollBar)) {
-			if ((<any>window).mode.isMobile())
+			if ((<any>window).mode.isSmallScreenDevice())
 				this.DrawVerticalScrollBarMobile();
 			else
 				this.drawVerticalScrollBar();

--- a/browser/src/canvas/sections/TableResizeMarkerSection.ts
+++ b/browser/src/canvas/sections/TableResizeMarkerSection.ts
@@ -130,7 +130,10 @@ class TableResizeMarkerSection extends HTMLObjectSection {
 
 	public onMouseDown(point: cool.SimplePoint, e: MouseEvent): void {
 		this.sectionProperties.dragStartPosition = point;
-		if ((<any>window).mode.isMobile() || (<any>window).mode.isTablet()) {
+		if (
+			(<any>window).mode.isSmallScreenDevice() ||
+			(<any>window).mode.isTablet()
+		) {
 			this.calculateLeftMostAndRightMostAvailableX();
 			this.calculateTopMostAndBottomMostAvailableY();
 		}

--- a/browser/src/canvas/sections/TableSelectMarkerSection.ts
+++ b/browser/src/canvas/sections/TableSelectMarkerSection.ts
@@ -57,7 +57,7 @@ class TableSelectMarkerSection extends HTMLObjectSection {
 		// We will use this event as click event on touch devices, until we remove Hammer.js (then this code will be removed from here).
 		if (
 			(!this.containerObject.isDraggingSomething() &&
-				(<any>window).mode.isMobile()) ||
+				(<any>window).mode.isSmallScreenDevice()) ||
 			(<any>window).mode.isTablet()
 		) {
 			this.onClick(point, e);

--- a/browser/src/control/AutoCompletePopup.ts
+++ b/browser/src/control/AutoCompletePopup.ts
@@ -37,7 +37,7 @@ abstract class AutoCompletePopup {
 	protected newPopupData: PopupData;
 	protected data: MessageEvent<any>;
 	protected popupId: string;
-	protected isMobile: boolean;
+	protected isSmallScreenDevice: boolean;
 
 	constructor(popupId: string, map: any) {
 		this.map = map;
@@ -61,7 +61,7 @@ abstract class AutoCompletePopup {
 			persistKeyboard: true,
 		} as PopupData;
 
-		this.isMobile = (<any>window).mode.isMobile();
+		this.isSmallScreenDevice = (<any>window).mode.isSmallScreenDevice();
 		this.onAdd();
 		this.map.on('closepopup', this.closePopup, this);
 	}
@@ -111,7 +111,7 @@ abstract class AutoCompletePopup {
 	}
 
 	sendJSON(data: any): void {
-		const fireEvent = this.isMobile ? 'mobilewizard' : 'jsdialog';
+		const fireEvent = this.isSmallScreenDevice ? 'mobilewizard' : 'jsdialog';
 		this.map.fire(fireEvent, {
 			data: data,
 			callback: this.callback.bind(this),

--- a/browser/src/control/Control.ColumnHeader.ts
+++ b/browser/src/control/Control.ColumnHeader.ts
@@ -100,7 +100,7 @@ export class ColumnHeader extends Header {
 		const isRTL = this.isCalcRTL();
 		// NOTE: From a geometric perspective resizeAreaStart is really "resizeAreaEnd" in RTL case.
 		let resizeAreaStart = isRTL ? Math.min(start + this.borderResizeHandle * app.dpiScale, end) : Math.max(start, end - this.borderResizeHandle * app.dpiScale);
-		if (entryIsCurrent || (window as any).mode.isMobile()) {
+		if (entryIsCurrent || (window as any).mode.isSmallScreenDevice()) {
 			resizeAreaStart = isRTL ? start + this.resizeHandleSize : end - this.resizeHandleSize;
 		}
 		return isRTL ? (position < resizeAreaStart) : (position > resizeAreaStart);

--- a/browser/src/control/Control.Command.js
+++ b/browser/src/control/Control.Command.js
@@ -53,7 +53,7 @@ window.L.Map.include({
 
 			var that = this;
 
-			if (window.mode.isMobile()) {
+			if (window.mode.isSmallScreenDevice()) {
 				var overlay = window.L.DomUtil.create('div', 'locking-overlay', DOMParentElement);
 				var lock = window.L.DomUtil.create('img', 'locking-overlay-lock', overlay);
 				app.LOUtil.setImage(lock, 'lc_lock.svg', this);

--- a/browser/src/control/Control.ContextMenu.js
+++ b/browser/src/control/Control.ContextMenu.js
@@ -108,7 +108,7 @@ window.L.Control.ContextMenu = window.L.Control.extend({
 				break;
 			}
 		}
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			window.contextMenuWizard = true;
 			var menuData = window.L.Control.JSDialogBuilder.getMenuStructureForMobileWizard(contextMenu, true, '');
 			map.fire('mobilewizard', {data: menuData});
@@ -246,7 +246,7 @@ window.L.Control.ContextMenu = window.L.Control.extend({
 				if (item.command && !item.command.startsWith('.uno:')) {
 					itemName = item.text;
 					contextMenu[item.command] = {
-						name: (window.mode.isMobile() ? _(itemName) : app.IconUtil.createMenuItemLink(itemName, item.command)),
+						name: (window.mode.isSmallScreenDevice() ? _(itemName) : app.IconUtil.createMenuItemLink(itemName, item.command)),
 						isHtmlName: true,
 					};
 					isLastItemText = true;
@@ -278,7 +278,7 @@ window.L.Control.ContextMenu = window.L.Control.extend({
 					continue;
 				}
 
-				if (window.mode.isMobile() && this.options.mobileDenylist.indexOf(commandName) !== -1)
+				if (window.mode.isSmallScreenDevice() && this.options.mobileDenylist.indexOf(commandName) !== -1)
 					continue;
 
 				if (commandName == 'None' && !item.text)
@@ -297,7 +297,7 @@ window.L.Control.ContextMenu = window.L.Control.extend({
 
 				contextMenu[item.command] = {
 					// Using 'click' and <a href='#' is vital for copy/paste security context.
-					name: (window.mode.isMobile() ? _(itemName) : app.IconUtil.createMenuItemLink(itemName, commandName)),
+					name: (window.mode.isSmallScreenDevice() ? _(itemName) : app.IconUtil.createMenuItemLink(itemName, commandName)),
 					isHtmlName: true,
 				};
 

--- a/browser/src/control/Control.DocumentNameInput.js
+++ b/browser/src/control/Control.DocumentNameInput.js
@@ -17,7 +17,7 @@ window.L.Control.DocumentNameInput = window.L.Control.extend({
 
 	onAdd: function (map) {
 		this.map = map;
-		if (window.mode.isMobile())
+		if (window.mode.isSmallScreenDevice())
 			this.progressBar = document.getElementById('mobile-progress-bar');
 		else
 			this.progressBar = document.getElementById('document-name-input-progress-bar');

--- a/browser/src/control/Control.DocumentRepair.js
+++ b/browser/src/control/Control.DocumentRepair.js
@@ -98,7 +98,7 @@ window.L.Control.DocumentRepair = window.L.Control.extend({
 		};
 
 
-		this._map.fire(window.mode.isMobile() ? 'mobilewizard' : 'jsdialog', dialogBuildEvent);
+		this._map.fire(window.mode.isSmallScreenDevice() ? 'mobilewizard' : 'jsdialog', dialogBuildEvent);
 
 		return this;
 	},
@@ -162,7 +162,7 @@ window.L.Control.DocumentRepair = window.L.Control.extend({
 				},
 			};
 		}
-		if (window.mode.isMobile()) window.mobileDialogId = dialogUpdateEvent.data.id;
+		if (window.mode.isSmallScreenDevice()) window.mobileDialogId = dialogUpdateEvent.data.id;
 		this._map.fire('jsdialogupdate', dialogUpdateEvent);
 	},
 
@@ -191,7 +191,7 @@ window.L.Control.DocumentRepair = window.L.Control.extend({
 				id: 'DocumentRepairDialog',
 			}
 		};
-		this._map.fire(window.mode.isMobile() ? 'closemobilewizard' : 'jsdialog', closeEvent);
+		this._map.fire(window.mode.isSmallScreenDevice() ? 'closemobilewizard' : 'jsdialog', closeEvent);
 		console.log('Closed after' + element + ' ' + action);
 	},
 

--- a/browser/src/control/Control.FormulaBarJSDialog.js
+++ b/browser/src/control/Control.FormulaBarJSDialog.js
@@ -55,7 +55,7 @@ class FormulaBar {
 	}
 
 	createFormulabar(text) {
-		if (!window.mode.isMobile()) {
+		if (!window.mode.isSmallScreenDevice()) {
 			var data = [
 				{
 					id: 'formulabar-buttons-toolbox',

--- a/browser/src/control/Control.Header.ts
+++ b/browser/src/control/Control.Header.ts
@@ -151,7 +151,7 @@ export class Header extends CanvasSectionObject {
 	}
 
 	onContextMenu(point: cool.SimplePoint, evt: MouseEvent): void {
-		if ((window as any).mode.isMobile() && this._map.isEditMode()) {
+		if ((window as any).mode.isSmallScreenDevice() && this._map.isEditMode()) {
 			(window as any).contextMenuWizard = true;
 			this._map.fire('mobilewizard', {data: this._menuData});
 		}
@@ -531,7 +531,7 @@ export class Header extends CanvasSectionObject {
 	}
 
 	_bindContextMenu(): void {
-		if ((window as any).mode.isMobile()) {
+		if ((window as any).mode.isSmallScreenDevice()) {
 			// On mobile, we use the mobile wizard rather than the context menu
 			return;
 		}

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -582,7 +582,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 	},
 
 	_stressAccessKey: function(element, accessKey) {
-		if (!accessKey || window.mode.isMobile() || window.getAccessibilityState())
+		if (!accessKey || window.mode.isSmallScreenDevice() || window.getAccessibilityState())
 			return;
 
 		var text = element.textContent;

--- a/browser/src/control/Control.LanguageDialog.js
+++ b/browser/src/control/Control.LanguageDialog.js
@@ -133,7 +133,7 @@ window.L.Control.LanguageDialog = window.L.Control.extend({
 			callback: this._onAction.bind(this),
 		};
 
-		this.map.fire(window.mode.isMobile() ? 'mobilewizard' : 'jsdialog', dialogBuildEvent);
+		this.map.fire(window.mode.isSmallScreenDevice() ? 'mobilewizard' : 'jsdialog', dialogBuildEvent);
 	},
 
 	_onAction: function (element, action, data, index) {
@@ -151,7 +151,7 @@ window.L.Control.LanguageDialog = window.L.Control.extend({
 				id: 'LanguageDialog',
 			}
 		};
-		this.map.fire(window.mode.isMobile() ? 'closemobilewizard' : 'jsdialog', closeEvent);
+		this.map.fire(window.mode.isSmallScreenDevice() ? 'closemobilewizard' : 'jsdialog', closeEvent);
 	}
 });
 

--- a/browser/src/control/Control.LokDialog.js
+++ b/browser/src/control/Control.LokDialog.js
@@ -306,7 +306,7 @@ window.L.Control.LokDialog = window.L.Control.extend({
 		}
 
 		if (e.action === 'created') {
-			if ((e.winType === 'dialog' || e.winType === 'dropdown') && !window.mode.isMobile()) {
+			if ((e.winType === 'dialog' || e.winType === 'dropdown') && !window.mode.isSmallScreenDevice()) {
 				// When left/top are invalid, the dialog shows in the center.
 				this._launchDialog(e.id, left, top, width, height, e.title, null, e.unique_id);
 			} else if (e.winType === 'child' || e.winType === 'tooltip') {
@@ -352,7 +352,7 @@ window.L.Control.LokDialog = window.L.Control.extend({
 		}
 
 		// We don't want dialogs on smartphones, only calc input window is allowed
-		if (window.mode.isMobile())
+		if (window.mode.isSmallScreenDevice())
 			return;
 
 		if (e.action === 'invalidate') {
@@ -752,7 +752,7 @@ window.L.Control.LokDialog = window.L.Control.extend({
 		var offsetX = 0;
 		var offsetY = 0;
 
-		if ((window.mode.isMobile() || window.mode.isTablet()) && width > window.screen.width) {
+		if ((window.mode.isSmallScreenDevice() || window.mode.isTablet()) && width > window.screen.width) {
 			ratio = window.screen.width / (width + 40);
 			offsetX = -(width - window.screen.width) / 2;
 			offsetY = -(height - window.screen.height) / 2;
@@ -774,7 +774,7 @@ window.L.Control.LokDialog = window.L.Control.extend({
 
 		// on mobile, force the positioning to the top, so that it is not
 		// covered by the virtual keyboard
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			$(dialogContainer).dialog('option', 'position', { my: 'center top', at: 'center top', of: '#document-container' });
 			transformation.origin = 'center top';
 			transformation.translate.y = 0;

--- a/browser/src/control/Control.Mention.ts
+++ b/browser/src/control/Control.Mention.ts
@@ -110,7 +110,11 @@ class Mention extends AutoCompletePopup {
 
 		const isMobileCommentActive = commentSection?.isMobileCommentActive();
 		const mobileCommentModalId = commentSection?.getMobileCommentModalId();
-		if (entries.length === 0 && this.isMobile && isMobileCommentActive) {
+		if (
+			entries.length === 0 &&
+			this.isSmallScreenDevice &&
+			isMobileCommentActive
+		) {
 			const control = this.getTreeJSON();
 			control.hideIfEmpty = true;
 			const data = this.getPopupJSON(control, { x: 0, y: 0 });
@@ -194,7 +198,7 @@ class Mention extends AutoCompletePopup {
 		if (!mentionPopup) return;
 
 		this.map.jsdialog.focusToLastElement(this.popupId);
-		if (this.isMobile) {
+		if (this.isSmallScreenDevice) {
 			const commentSection = app.sectionContainer.getSectionWithName(
 				app.CSections.CommentList.name,
 			);

--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -1768,7 +1768,7 @@ class Menubar extends window.L.Control {
 			var pageStyles = e.commandValues['HeaderFooter'];
 			for (var iterator in pageStyles) {
 				style = pageStyles[iterator];
-				if (!window.mode.isMobile()) {
+				if (!window.mode.isSmallScreenDevice()) {
 					$menuHeader.append(this._createUnoMenuItem(_(style), constHeader + encodeURIComponent(style) + constArg, style));
 					$menuFooter.append(this._createUnoMenuItem(_(style), constFooter + encodeURIComponent(style) + constArg, style));
 				} else {
@@ -1813,7 +1813,7 @@ class Menubar extends window.L.Control {
 		this._bindEventIfNotBound('#main-menu', 'click', 'smapi', {self: this}, this._onClicked);
 		this._bindEventIfNotBound('#main-menu', 'keydown', '', {self: this}, this._onKeyDown);
 
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			$('#main-menu').parent().css('height', '0');
 			$('#toolbar-wrapper').addClass('mobile');
 		}
@@ -1828,12 +1828,12 @@ class Menubar extends window.L.Control {
 					var $menu = $('#main-menu');
 					var $nav = $menu.parent();
 					if ((event.target as HTMLInputElement).checked) {
-						if (!window.mode.isMobile()) {
+						if (!window.mode.isSmallScreenDevice()) {
 							// Surely this code, if it really is related only to the hamburger menu,
 							// will never be invoked on non-mobile browsers? I might be wrong though.
 							// If you notice this logging, please modify this comment to indicate what is
 							// going on.
-							window.app.console.log('======> Assertion failed!? Not window.mode.isMobile()? Control.Menubar.js #1');
+							window.app.console.log('======> Assertion failed!? Not window.mode.isSmallScreenDevice()? Control.Menubar.js #1');
 							$nav.css({height: 'initial', bottom: '38px'});
 							$menu.hide().slideDown(250, () => { $menu.css('display', ''); });
 						} else {
@@ -1844,9 +1844,9 @@ class Menubar extends window.L.Control {
 							$('#toolbar-mobile-back').css('visibility', 'hidden');
 							$('#formulabar').hide();
 						}
-					} else if (!window.mode.isMobile()) {
+					} else if (!window.mode.isSmallScreenDevice()) {
 						// Ditto.
-						window.app.console.log('======> Assertion failed!? Not window.mode.isMobile()? Control.Menubar.js #2');
+						window.app.console.log('======> Assertion failed!? Not window.mode.isSmallScreenDevice()? Control.Menubar.js #2');
 						$menu.show().slideUp(250, () => { $menu.css('display', ''); });
 						$nav.css({height:'', bottom: ''});
 					} else {
@@ -2470,7 +2470,7 @@ class Menubar extends window.L.Control {
 			this._executeAction(item);
 		}
 
-		if (!window.mode.isMobile() && $(item).data('id') !== 'insertcomment' && self && this._map)
+		if (!window.mode.isSmallScreenDevice() && $(item).data('id') !== 'insertcomment' && self && this._map)
 			this._map.focus();
 	}
 

--- a/browser/src/control/Control.MobileWizard.js
+++ b/browser/src/control/Control.MobileWizard.js
@@ -24,7 +24,7 @@ window.L.Control.MobileWizard = window.L.Control.extend({
 		this.map = map;
 
 		// for the moment, the mobile-wizard is mobile phone only
-		if (!window.mode.isMobile())
+		if (!window.mode.isSmallScreenDevice())
 			return;
 
 		this.contents = [];

--- a/browser/src/control/Control.MobileWizardWindow.js
+++ b/browser/src/control/Control.MobileWizardWindow.js
@@ -63,7 +63,7 @@ window.L.Control.MobileWizardWindow = window.L.Control.extend({
 		this.map = map;
 
 		// for the moment, the mobile-wizard is mobile phone only
-		if (!window.mode.isMobile())
+		if (!window.mode.isSmallScreenDevice())
 			return;
 
 		this.content.replaceChildren();
@@ -461,8 +461,8 @@ window.L.Control.MobileWizardWindow = window.L.Control.extend({
 				return;
 			}
 
-			var isMobileDialog = data.id && !isNaN(data.id) && !isSidebar;
-			if (isMobileDialog) {
+		var isMobileDialog = data.id && !isNaN(data.id) && !isSidebar;
+		if (isMobileDialog) {
 				// id is a number - remember window id for interaction
 				window.mobileDialogId = data.id;
 				//dialogid is string - name of the dialog in json

--- a/browser/src/control/Control.NavigatorPanel.ts
+++ b/browser/src/control/Control.NavigatorPanel.ts
@@ -71,7 +71,7 @@ class NavigatorPanel extends SidebarBase {
 		// for presentation show slide sorter navigation panel by default
 		if (
 			allowedDocTypes.includes(app.map.getDocType()) &&
-			!window.mode.isMobile()
+			!window.mode.isSmallScreenDevice()
 		) {
 			// Navigator panel should be visible and by default we should open slide sorter in case of impress/draw
 			this.showNavigationPanel(false);

--- a/browser/src/control/Control.PresentationBar.js
+++ b/browser/src/control/Control.PresentationBar.js
@@ -147,7 +147,7 @@ class PresentationBar {
 			this.showItem('presentation', true);
 		}
 
-		if (!window.mode.isMobile())
+		if (!window.mode.isSmallScreenDevice())
 			this.show();
 	}
 

--- a/browser/src/control/Control.RowHeader.ts
+++ b/browser/src/control/Control.RowHeader.ts
@@ -100,7 +100,7 @@ export class RowHeader extends cool.Header {
 
 	isMouseOverResizeArea(start: number, end:number, position: number, entryIsCurrent: boolean) : boolean {
 		let resizeAreaStart = Math.max(start, end - this.borderResizeHandle * app.dpiScale);
-		if (entryIsCurrent || (window as any).mode.isMobile()) {
+		if (entryIsCurrent || (window as any).mode.isSmallScreenDevice()) {
 			if (this.resizeHandleSize > (end - start) / 4) {
 				resizeAreaStart = end - ((end - start) / 4);
 			} else {

--- a/browser/src/control/Control.SaveState.ts
+++ b/browser/src/control/Control.SaveState.ts
@@ -38,7 +38,7 @@ class SaveState {
 
 	// Function to show the saving status
 	showSavingStatus(): void {
-		if (window.mode.isMobile()) return;
+		if (window.mode.isSmallScreenDevice()) return;
 
 		if (!this.saveEle) this.initialize();
 
@@ -56,7 +56,7 @@ class SaveState {
 
 	// Function to show the saved status
 	showSavedStatus(): void {
-		if (window.mode.isMobile()) return;
+		if (window.mode.isSmallScreenDevice()) return;
 
 		if (!this.saveEle) this.initialize();
 

--- a/browser/src/control/Control.ServerAuditDialog.ts
+++ b/browser/src/control/Control.ServerAuditDialog.ts
@@ -193,7 +193,7 @@ class ServerAuditDialog {
 		};
 
 		this.map.fire(
-			window.mode.isMobile() ? 'mobilewizard' : 'jsdialog',
+			window.mode.isSmallScreenDevice() ? 'mobilewizard' : 'jsdialog',
 			dialogBuildEvent,
 		);
 	}
@@ -358,7 +358,7 @@ class ServerAuditDialog {
 			},
 		};
 		this.map.fire(
-			window.mode.isMobile() ? 'closemobilewizard' : 'jsdialog',
+			window.mode.isSmallScreenDevice() ? 'closemobilewizard' : 'jsdialog',
 			closeEvent,
 		);
 	}

--- a/browser/src/control/Control.SheetsBar.js
+++ b/browser/src/control/Control.SheetsBar.js
@@ -101,7 +101,7 @@ class SheetsBar {
 	onDocLayerInit() {
 		var docType = this.map.getDocType();
 		if (docType == 'spreadsheet') {
-			if (!window.mode.isMobile()) {
+			if (!window.mode.isSmallScreenDevice()) {
 				this.show();
 			}
 		}

--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -115,7 +115,7 @@ class StatusBar extends JSDialog.Toolbar {
 		if (e.count === 0) {
 			this.enableItem('searchprev', false);
 			this.enableItem('searchnext', false);
-			if (window.mode.isMobile()) {
+			if (window.mode.isSmallScreenDevice()) {
 				this.enableItem('cancelsearch', false);
 			} else {
 				this.showItem('cancelsearch', false);
@@ -300,7 +300,7 @@ class StatusBar extends JSDialog.Toolbar {
 			this.showItem('overview', false);
 			this.showItem('overviewbreak', false);
 
-			if (!window.mode.isMobile()) {
+			if (!window.mode.isSmallScreenDevice()) {
 				this.showItem('statusdocpos-container', true);
 				this.showItem('rowcolselcount-container', true);
 				this.showItem('insertmode-container', true);
@@ -319,7 +319,7 @@ class StatusBar extends JSDialog.Toolbar {
 			this.showItem('overview', false);
 			this.showItem('overviewbreak', false);
 
-			if (!window.mode.isMobile()) {
+			if (!window.mode.isSmallScreenDevice()) {
 				this.showItem('statepagenumber-container', true);
 				this.showItem('statewordcount-container', true);
 				this.showItem('insertmode-container', true);
@@ -337,7 +337,7 @@ class StatusBar extends JSDialog.Toolbar {
 			break;
 
 		case 'presentation':
-			if (!window.mode.isMobile()) {
+			if (!window.mode.isSmallScreenDevice()) {
 				this.showItem('slidestatus-container', true);
 				this.showItem('languagestatus', !app.map.isReadOnlyMode());
 				this.showItem('languagestatusbreak', !app.map.isReadOnlyMode());
@@ -346,7 +346,7 @@ class StatusBar extends JSDialog.Toolbar {
 			}
 			break;
 		case 'drawing':
-			if (!window.mode.isMobile()) {
+			if (!window.mode.isSmallScreenDevice()) {
 				this.showItem('pagestatus-container', true);
 				this.showItem('languagestatus', !app.map.isReadOnlyMode());
 				this.showItem('languagestatusbreak', !app.map.isReadOnlyMode());
@@ -446,7 +446,7 @@ class StatusBar extends JSDialog.Toolbar {
 
 		JSDialog.RefreshScrollables();
 
-		if (!window.mode.isMobile()) {
+		if (!window.mode.isSmallScreenDevice()) {
 			this.showItem('languagestatus', !isReadOnlyMode);
 			this.showItem('languagestatusbreak', !isReadOnlyMode);
 			if (this.map.getDocType() === 'spreadsheet') {

--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -120,7 +120,7 @@ window.L.Control.Tabs = window.L.Control.extend({
 			},
 		};
 
-		if (!window.mode.isMobile() || window.mode.isTablet()) {
+		if (!window.mode.isSmallScreenDevice() || window.mode.isTablet()) {
 			var that = this;
 			window.L.installContextMenu({
 				selector: '.spreadsheet-tab',
@@ -164,7 +164,7 @@ window.L.Control.Tabs = window.L.Control.extend({
 				}
 				var ssTabScroll = window.L.DomUtil.create('div', 'spreadsheet-tab-scroll', this._tabsCont);
 				ssTabScroll.id = 'spreadsheet-tab-scroll';
-				if (!window.mode.isMobile())
+				if (!window.mode.isSmallScreenDevice())
 					ssTabScroll.style.overflowX = 'scroll';
 
 				this._tabsCont.style.display = 'grid';
@@ -200,7 +200,7 @@ window.L.Control.Tabs = window.L.Control.extend({
 					);
 				}
 
-				if (window.mode.isMobile()) {
+				if (window.mode.isSmallScreenDevice()) {
 					var menuData = window.L.Control.JSDialogBuilder.getMenuStructureForMobileWizard(menuItemMobile, true, '');
 				}
 
@@ -218,13 +218,13 @@ window.L.Control.Tabs = window.L.Control.extend({
 					var label = window.L.DomUtil.create('div', '', tab);
 					window.L.DomUtil.create('div', 'lock', tab);
 					window.L.DomUtil.create('div', 'view-indicator', tab);
-					if (window.mode.isMobile() || window.mode.isTablet()) {
+					if (window.mode.isSmallScreenDevice() || window.mode.isTablet()) {
 						(new Hammer(tab, {recognizers: [[Hammer.Press]]}))
 							.on('press', function (j) {
 								return function(e) {
 									this._tabForContextMenu = j;
 									if (!this._map.isReadOnlyMode()) {
-										if (window.mode.isMobile()) {
+										if (window.mode.isSmallScreenDevice()) {
 											window.contextMenuWizard = true;
 											this._map.fire('mobilewizard', {data: menuData});
 										} else {
@@ -239,7 +239,7 @@ window.L.Control.Tabs = window.L.Control.extend({
 						horizScrollPos = tab.offsetLeft;
 					}
 
-					if (!window.mode.isMobile()) {
+					if (!window.mode.isSmallScreenDevice()) {
 						window.L.DomEvent.on(tab, 'dblclick', function(j) {
 							return function() {
 								// window.app.console.err('Double clicked ' + j);

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -866,7 +866,7 @@ function onWopiProps(e) {
 }
 
 function processStateChangedCommand(commandName, state) {
-	var toolbar = window.mode.isMobile() ? app.map.mobileBottomBar : app.map.topToolbar;
+	var toolbar = window.mode.isSmallScreenDevice() ? app.map.mobileBottomBar : app.map.topToolbar;
 	if (!toolbar)
 		return;
 
@@ -1019,7 +1019,7 @@ function onCommandResult(e) {
 }
 
 function onUpdatePermission(e) {
-	var toolbar = window.mode.isMobile() ? app.map.mobileBottomBar : app.map.topToolbar;
+	var toolbar = window.mode.isSmallScreenDevice() ? app.map.mobileBottomBar : app.map.topToolbar;
 	if (toolbar) {
 		// always enabled items
 		var enabledButtons = ['closemobile', 'undo', 'redo', 'fold'];
@@ -1113,7 +1113,7 @@ function setupToolbar(e) {
 
 	map.on('search', function (e) {
 		var searchInput = window.L.DomUtil.get('search-input');
-		var toolbar = window.mode.isMobile() ? app.map.mobileSearchBar: app.map.statusBar;
+		var toolbar = window.mode.isSmallScreenDevice() ? app.map.mobileSearchBar: app.map.statusBar;
 		if (!toolbar) {
 			console.debug('Cannot find search bar');
 			return;
@@ -1121,7 +1121,7 @@ function setupToolbar(e) {
 		if (e.count === 0) {
 			toolbar.enableItem('searchprev', false);
 			toolbar.enableItem('searchnext', false);
-			if (window.mode.isMobile()) {
+			if (window.mode.isSmallScreenDevice()) {
 				toolbar.enableItem('cancelsearch', false);
 			} else {
 				toolbar.showItem('cancelsearch', false);
@@ -1160,7 +1160,7 @@ function setupToolbar(e) {
 	map.on('wopiprops', onWopiProps);
 	map.on('commandresult', onCommandResult);
 
-	if (map.options.wopi && window.L.Params.closeButtonEnabled && !window.mode.isMobile()) {
+	if (map.options.wopi && window.L.Params.closeButtonEnabled && !window.mode.isSmallScreenDevice()) {
 		$('#closebuttonwrapper').css('display', 'flex');
 		var button = window.L.DomUtil.get('closebutton');
 		if (button) {
@@ -1172,7 +1172,7 @@ function setupToolbar(e) {
 	} else if (!window.L.Params.closeButtonEnabled) {
 		$('#closebuttonwrapper').hide();
 		$('#closebuttonwrapperseparator').hide();
-	} else if (window.L.Params.closeButtonEnabled && !window.mode.isMobile()) {
+	} else if (window.L.Params.closeButtonEnabled && !window.mode.isSmallScreenDevice()) {
 		$('#closebuttonwrapper').css('display', 'flex');
 	}
 

--- a/browser/src/control/Control.TopToolbar.js
+++ b/browser/src/control/Control.TopToolbar.js
@@ -25,7 +25,7 @@ class TopToolbar extends JSDialog.Toolbar {
 		map.on('commandstatechanged', this.onCommandStateChanged, this);
 		app.events.on('contextchange', this.onContextChange.bind(this));
 
-		if (!window.mode.isMobile()) {
+		if (!window.mode.isSmallScreenDevice()) {
 			map.on('updatetoolbarcommandvalues', this.updateCommandValues, this);
 		}
 	}
@@ -41,7 +41,7 @@ class TopToolbar extends JSDialog.Toolbar {
 		this.map.off('wopiprops', this.onWopiProps, this);
 		this.map.off('commandstatechanged', this.onCommandStateChanged, this);
 
-		if (!window.mode.isMobile()) {
+		if (!window.mode.isSmallScreenDevice()) {
 			this.map.off('updatetoolbarcommandvalues', this.updateCommandValues, this);
 		}
 	}
@@ -321,7 +321,7 @@ class TopToolbar extends JSDialog.Toolbar {
 		var items = this.getToolItems();
 		this.builder.build(this.parentContainer, items);
 
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			JSDialog.MakeScrollable(this.parentContainer, this.parentContainer.querySelector('div'));
 			JSDialog.RefreshScrollables();
 		}

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -75,7 +75,7 @@ class UIManager extends window.L.Control {
 		map.on('infobar', this.showInfoBar, this);
 		app.events.on('updatepermission', this.onUpdatePermission.bind(this));
 
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			window.addEventListener('popstate', this.onGoBack.bind(this));
 
 			// provide entries in the history we can catch to close the app
@@ -145,7 +145,7 @@ class UIManager extends window.L.Control {
 	 */
 	getCurrentMode(): UIMode {
 		// no notebookbar on mobile
-		if (window.mode.isMobile())
+		if (window.mode.isSmallScreenDevice())
 			return 'classic';
 
 		return this.shouldUseNotebookbarMode() ? 'notebookbar' : 'classic';
@@ -304,7 +304,7 @@ class UIManager extends window.L.Control {
 		}
 		this.applyInvert();
 		this.setCanvasColorAfterModeChange();
-		if (!window.mode.isMobile())
+		if (!window.mode.isSmallScreenDevice())
 			this.refreshAfterThemeChange();
 
 		if (app.map._docLayer._docType === 'spreadsheet') {
@@ -372,14 +372,14 @@ class UIManager extends window.L.Control {
 	 */
 	initializeMenubarAndTopToolbar(): void {
 		const enableNotebookbar = this.shouldUseNotebookbarMode();
-		const isMobile = window.mode.isMobile();
-		if (isMobile || !enableNotebookbar) {
+		const isSmallScreenDevice = window.mode.isSmallScreenDevice();
+		if (isSmallScreenDevice || !enableNotebookbar) {
 			var menubar = new Menubar();
 			this.map.menubar = menubar;
 			this.map.addControl(menubar);
 		}
 
-		if (!isMobile && !enableNotebookbar)
+		if (!isSmallScreenDevice && !enableNotebookbar)
 			this.map.topToolbar = JSDialog.TopToolbar(this.map);
 
 		this.permissionViewMode = new PermissionViewMode(this.map);
@@ -394,13 +394,13 @@ class UIManager extends window.L.Control {
 
 		this.initializeMenubarAndTopToolbar();
 
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			$('#toolbar-mobile-back').on('click', () => {
 				this.enterReadonlyOrClose();
 			});
 		}
 
-		if (!window.mode.isMobile()) {
+		if (!window.mode.isSmallScreenDevice()) {
 			this.map.statusBar = JSDialog.StatusBar(this.map);
 
 			this.map.sidebar = JSDialog.Sidebar(this.map);
@@ -422,7 +422,7 @@ class UIManager extends window.L.Control {
 			this.map.addControl(this.documentNameInput);
 		}
 		this.map.addControl(window.L.control.alertDialog());
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			this.mobileWizard = window.L.control.mobileWizard();
 			this.map.addControl(this.mobileWizard);
 		}
@@ -552,7 +552,7 @@ class UIManager extends window.L.Control {
 		if (hasShare)
 			document.body.setAttribute('data-integratorSidebar', 'true');
 
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			$('#mobile-edit-button').css('display', 'flex');
 			this.map.mobileBottomBar = JSDialog.MobileBottomBar(this.map);
 			this.map.mobileTopBar = JSDialog.MobileTopBar(this.map);
@@ -628,7 +628,7 @@ class UIManager extends window.L.Control {
 			this._map.fire('commandstatechanged', {commandName : 'showannotations', state : initialCommentState});
 			this.map.mention = new Mention(this.map);
 
-			if (!window.mode.isMobile()) {
+			if (!window.mode.isSmallScreenDevice()) {
 				// setup quickfind panel
 				this.map.quickFindPanel = JSDialog.QuickFindPanel(this.map);
 				this.map.addControl(this.map.quickFindPanel);
@@ -966,7 +966,7 @@ class UIManager extends window.L.Control {
 	 * @param uiMode - Object containing the new UI mode and additional flags.
 	 */
 	onChangeUIMode(uiMode: UIModeCommand): void {
-		if (window.mode.isMobile())
+		if (window.mode.isSmallScreenDevice())
 			return;
 
 		var currentMode = this.getCurrentMode();
@@ -1416,7 +1416,7 @@ class UIManager extends window.L.Control {
 
 	initializeNotebookbarInCore(): void {
 		// do it always apart of mobile as we need it for contextual toolbar
-		if (window.mode.isMobile()) return;
+		if (window.mode.isSmallScreenDevice()) return;
 
 		if (!this.notebookbar.impl.initialized) {
 			this.map.sendUnoCommand('.uno:ToolbarMode?Mode:string=Default');
@@ -1580,7 +1580,7 @@ class UIManager extends window.L.Control {
 	 * @param e - The event object containing permission details.
 	 */
 	onUpdatePermission(e: any): void {
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			if (e.detail.perm === 'edit') {
 				history.pushState({context: 'app-started'}, 'edit-mode');
 				$('#toolbar-down').show();
@@ -1592,7 +1592,7 @@ class UIManager extends window.L.Control {
 		}
 
 		var enableNotebookbar = this.shouldUseNotebookbarMode();
-		if (enableNotebookbar && !window.mode.isMobile()) {
+		if (enableNotebookbar && !window.mode.isSmallScreenDevice()) {
 			if (e.detail.perm === 'edit') {
 				this.removeClassicUI();
 				// Avoid re-refreshing the notebookbar if it is already initialized.
@@ -1999,7 +1999,7 @@ class UIManager extends window.L.Control {
 				id: 'info-modal-tile-m',
 				type: 'fixedtext',
 				text: title,
-				hidden: !window.mode.isMobile()
+				hidden: !window.mode.isSmallScreenDevice()
 			},
 			{
 				id: 'info-modal-label1',
@@ -2078,7 +2078,7 @@ class UIManager extends window.L.Control {
 				id: 'info-modal-tile-m',
 				type: 'fixedtext',
 				text: title,
-				hidden: !window.mode.isMobile()
+				hidden: !window.mode.isSmallScreenDevice()
 			},
 			{
 				id: 'info-modal-label1',
@@ -2179,7 +2179,7 @@ class UIManager extends window.L.Control {
 				id: 'info-modal-tile-m',
 				type: 'fixedtext',
 				text: title,
-				hidden: !window.mode.isMobile()
+				hidden: !window.mode.isSmallScreenDevice()
 			},
 			{
 				id: 'info-modal-label1',
@@ -2324,7 +2324,7 @@ class UIManager extends window.L.Control {
 			}
 		}]);
 
-		if (!window.mode.isMobile()) {
+		if (!window.mode.isSmallScreenDevice()) {
 			const dialogElement = document.getElementById(dialogId);
 			if (dialogElement != null) {
 				dialogElement.style.marginRight = '0';
@@ -2353,7 +2353,7 @@ class UIManager extends window.L.Control {
 				id:  dialogId + '-title',
 				type: 'fixedtext',
 				text: title,
-				hidden: !window.mode.isMobile()
+				hidden: !window.mode.isSmallScreenDevice()
 			},
 			{
 				id: dialogId + '-label',

--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -73,7 +73,7 @@ class UserList extends window.L.Control {
 		map.on('removeview', this.onRemoveView, this);
 		map.on('deselectuser', this.deselectUser, this);
 
-		if (window.mode.isMobile() || window.mode.isTablet()) {
+		if (window.mode.isSmallScreenDevice() || window.mode.isTablet()) {
 			this.options.nUsers = '%n';
 			this.options.oneUser = '1';
 			this.options.noUser = '0';
@@ -243,7 +243,7 @@ class UserList extends window.L.Control {
 			(this.map['wopi'].HideUserList !== null &&
 				this.map['wopi'].HideUserList !== undefined &&
 				$.inArray('true', this.map['wopi'].HideUserList) >= 0) ||
-			(window.mode.isMobile() &&
+			(window.mode.isSmallScreenDevice() &&
 				$.inArray('mobile', this.map['wopi'].HideUserList) >= 0) ||
 			(window.mode.isTablet() &&
 				$.inArray('tablet', this.map['wopi'].HideUserList) >= 0) ||
@@ -299,7 +299,7 @@ class UserList extends window.L.Control {
 		const userListElement = document.getElementById('userListSummary');
 
 		if (
-			window.mode.isMobile() ||
+			window.mode.isSmallScreenDevice() ||
 			this.hideUserList() ||
 			this.users.size === 1
 		) {

--- a/browser/src/control/Control.Zotero.js
+++ b/browser/src/control/Control.Zotero.js
@@ -386,7 +386,7 @@ window.L.Control.Zotero = window.L.Control.extend({
 		};
 
 
-		this.map.fire(window.mode.isMobile() ? 'mobilewizard' : 'jsdialog', dialogBuildEvent);
+		this.map.fire(window.mode.isSmallScreenDevice() ? 'mobilewizard' : 'jsdialog', dialogBuildEvent);
 
 		return this;
 	},
@@ -827,7 +827,7 @@ window.L.Control.Zotero = window.L.Control.extend({
 
 				var dialogUpdateEvent = that.updateList([_('Styles')],_('An error occurred while fetching style list'));
 
-				if (window.mode.isMobile()) window.mobileDialogId = dialogUpdateEvent.data.id;
+				if (window.mode.isSmallScreenDevice()) window.mobileDialogId = dialogUpdateEvent.data.id;
 				that.map.fire('jsdialogupdate', dialogUpdateEvent);
 				var styleToBeSelected = (that.settings.style && that.settings.style !== '') ? that.settings : {name: window.prefs.get('Zotero_LastUsedStyle', '')};
 				if (styleToBeSelected !== '')
@@ -1152,7 +1152,7 @@ window.L.Control.Zotero = window.L.Control.extend({
 				that.fillItems(data);
 				var dialogUpdateEvent = that.updateList([_('Title'), _('Creator(s)'), _('Date')], _('Your library is empty'));
 				that.map.fire('jsdialogupdate', dialogUpdateEvent);
-				if (window.mode.isMobile()) window.mobileDialogId = dialogUpdateEvent.data.id;
+				if (window.mode.isSmallScreenDevice()) window.mobileDialogId = dialogUpdateEvent.data.id;
 
 				// mark already existing citations
 				if (checkState) {
@@ -1278,7 +1278,7 @@ window.L.Control.Zotero = window.L.Control.extend({
 				id: 'ZoteroDialog',
 			}
 		};
-		this.map.fire(window.mode.isMobile() ? 'closemobilewizard' : 'jsdialog', closeEvent);
+		this.map.fire(window.mode.isSmallScreenDevice() ? 'closemobilewizard' : 'jsdialog', closeEvent);
 
 		// clear all previous selections
 		delete this.selectedCitationLangCode;
@@ -1339,7 +1339,7 @@ window.L.Control.Zotero = window.L.Control.extend({
 
 		var updateDialog = function () {
 			var dialogUpdateEvent = that.updateList([_('Notes')],_('An error occurred while fetching notes'));
-			if (window.mode.isMobile()) window.mobileDialogId = dialogUpdateEvent.data.id;
+			if (window.mode.isSmallScreenDevice()) window.mobileDialogId = dialogUpdateEvent.data.id;
 			that.map.fire('jsdialogupdate', dialogUpdateEvent);
 		};
 

--- a/browser/src/control/HRuler.ts
+++ b/browser/src/control/HRuler.ts
@@ -1314,7 +1314,7 @@ class HRuler extends Ruler {
 		var pointXTwip = this._map._docLayer._pixelsToTwips({ x: pointX, y: 0 }).x;
 		var tabstop = this._getTabStopHit(tabstopContainer, pointX);
 
-		if (window.mode.isMobile() || window.mode.isTablet()) {
+		if (window.mode.isSmallScreenDevice() || window.mode.isTablet()) {
 			if (tabstop == null) {
 				this.currentPositionInTwips = pointXTwip;
 				this.currentTabStopIndex = null;

--- a/browser/src/control/Permission.js
+++ b/browser/src/control/Permission.js
@@ -35,14 +35,14 @@ window.L.Map.include({
 		// For mobile we need to display the edit button for all the cases except for PDF
 		// we offer save-as to another place where the user can edit the document
 		var isPDF = app.file.fileBasedView && app.file.editComment;
-		if (!isPDF && (window.mode.isMobile() || window.mode.isTablet())) {
+		if (!isPDF && (window.mode.isSmallScreenDevice() || window.mode.isTablet())) {
 			button.css('display', 'flex');
 		} else {
 			button.hide();
 		}
 		var that = this;
 		if (perm === 'edit') {
-			if (this._shouldStartReadOnly() || window.mode.isMobile() || window.mode.isTablet()) {
+			if (this._shouldStartReadOnly() || window.mode.isSmallScreenDevice() || window.mode.isTablet()) {
 				button.on('click', function () {
 					that._switchToEditMode();
 				});
@@ -68,7 +68,7 @@ window.L.Map.include({
 				button.on('click', function () {
 					that._requestFileCopy();
 				});
-			} else if ((!window.ThisIsAMobileApp && !this['wopi'].UserCanWrite) || (!this.options.canTryLock && (window.mode.isMobile() || window.mode.isTablet()))) {
+			} else if ((!window.ThisIsAMobileApp && !this['wopi'].UserCanWrite) || (!this.options.canTryLock && (window.mode.isSmallScreenDevice() || window.mode.isTablet()))) {
 				$('#mobile-edit-button').hide();
 			}
 
@@ -135,7 +135,7 @@ window.L.Map.include({
 		this.options.canTryLock = false; // don't respond to lockfailed anymore
 		$('#mobile-edit-button').hide();
 		this._enterEditMode('edit');
-		if (window.mode.isMobile() || window.mode.isTablet() || window.mode.isCODesktop()) {
+		if (window.mode.isSmallScreenDevice() || window.mode.isTablet() || window.mode.isCODesktop()) {
 			this.fire('editorgotfocus');
 			this.fire('closemobilewizard');
 			// In the iOS/android app, just clicking the mobile-edit-button is
@@ -216,7 +216,7 @@ window.L.Map.include({
 	_enterEditMode: function (perm) {
 		this._permission = perm;
 
-		if ((window.mode.isMobile() || window.mode.isTablet()) && this._textInput && this.getDocType() === 'text') {
+		if ((window.mode.isSmallScreenDevice() || window.mode.isTablet()) && this._textInput && this.getDocType() === 'text') {
 			this._textInput.setSwitchedToEditMode();
 		}
 

--- a/browser/src/control/Signing.js
+++ b/browser/src/control/Signing.js
@@ -63,7 +63,7 @@ window.L.Map.include({
 		}
 
 		if (statusText) {
-			if (!window.mode.isMobile()) {
+			if (!window.mode.isSmallScreenDevice()) {
 				app.map.statusBar.showSigningItem(statusIcon, statusText);
 
 				// If requested, show the signatures, now that the sign status

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -765,18 +765,18 @@ window.L.Map.include({
 	},
 
 	cancelSearch: function() {
-		var toolbar = window.mode.isMobile() ? app.map.mobileSearchBar: app.map.statusBar;
+		var toolbar = window.mode.isSmallScreenDevice() ? app.map.mobileSearchBar: app.map.statusBar;
 		var searchInput = window.L.DomUtil.get('search-input');
 		app.searchService.resetSelection();
 		if (toolbar) {
-			if (!window.mode.isMobile()) {
+			if (!window.mode.isSmallScreenDevice()) {
 				toolbar.showItem('cancelsearch', false);
 			}
 			toolbar.enableItem('searchprev', false);
 			toolbar.enableItem('searchnext', false);
 		}
 		searchInput.value = '';
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			searchInput.focus();
 			toolbar.enableItem('cancelsearch', false);
 		}
@@ -801,7 +801,7 @@ window.L.Map.include({
 	},
 
 	onFormulaBarFocus: function() {
-		if (window.mode.isMobile() === true) {
+		if (window.mode.isSmallScreenDevice() === true) {
 			var mobileTopBar = this.mobileTopBar;
 			mobileTopBar.showItem('undo', false);
 			mobileTopBar.showItem('redo', false);
@@ -819,7 +819,7 @@ window.L.Map.include({
 	onFormulaBarBlur: function() {
 		var map = this;
 
-		if (window.mode.isMobile() && this.isEditMode()) {
+		if (window.mode.isSmallScreenDevice() && this.isEditMode()) {
 			var mobileTopBar = map.mobileTopBar;
 			mobileTopBar.showItem('cancelformula', false);
 			mobileTopBar.showItem('acceptformula', false);

--- a/browser/src/control/jsdialog/Component.Toolbar.ts
+++ b/browser/src/control/jsdialog/Component.Toolbar.ts
@@ -203,7 +203,7 @@ class Toolbar extends JSDialogComponent {
 			) {
 				toHide.push(item.id);
 			} else if (
-				((window.mode.isMobile() && item.mobile === false) ||
+				((window.mode.isSmallScreenDevice() && item.mobile === false) ||
 					(window.mode.isTablet() && item.tablet === false) ||
 					(window.mode.isDesktop() && item.desktop === false) ||
 					(!(window as any).ThisIsAMobileApp &&
@@ -212,7 +212,7 @@ class Toolbar extends JSDialogComponent {
 			) {
 				toHide.push(item.id);
 			} else if (
-				((window.mode.isMobile() && item.mobile === true) ||
+				((window.mode.isSmallScreenDevice() && item.mobile === true) ||
 					(window.mode.isTablet() && item.tablet === true) ||
 					(window.mode.isDesktop() && item.desktop === true) ||
 					((window as any).ThisIsAMobileApp && item.mobilebrowser === true)) &&

--- a/browser/src/control/jsdialog/Util.MessageRouter.ts
+++ b/browser/src/control/jsdialog/Util.MessageRouter.ts
@@ -68,7 +68,7 @@ class JSDialogMessageRouter {
 		if (msgData.jsontype === 'popup') return;
 
 		// re/create component
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			// allow to use desktop's JSDialog component to show dropdowns
 			if (
 				msgData.type === 'dropdown' ||

--- a/browser/src/control/jsdialog/Widget.PushButton.ts
+++ b/browser/src/control/jsdialog/Widget.PushButton.ts
@@ -38,7 +38,7 @@ JSDialog.pushButton = function (
 		data.enabled = false;
 	}
 
-	const wrapperClass = window.mode.isMobile()
+	const wrapperClass = window.mode.isSmallScreenDevice()
 		? ''
 		: 'd-flex justify-content-center';
 

--- a/browser/src/control/jsdialog/Widget.SearchEdit.ts
+++ b/browser/src/control/jsdialog/Widget.SearchEdit.ts
@@ -80,7 +80,7 @@ class SearchEditWidget extends EditWidget {
 	}
 
 	private updateSearchButtons() {
-		var toolbar = (window as any).mode.isMobile()
+		var toolbar = (window as any).mode.isSmallScreenDevice()
 			? app.map.mobileSearchBar
 			: app.map.statusBar;
 		if (!toolbar) {
@@ -92,7 +92,7 @@ class SearchEditWidget extends EditWidget {
 		if (this.edit.input.value === '') {
 			toolbar.enableItem('searchprev', false);
 			toolbar.enableItem('searchnext', false);
-			if (window.mode.isMobile()) {
+			if (window.mode.isSmallScreenDevice()) {
 				toolbar.enableItem('cancelsearch', false);
 			} else {
 				toolbar.showItem('cancelsearch', false);
@@ -100,7 +100,7 @@ class SearchEditWidget extends EditWidget {
 		} else {
 			toolbar.enableItem('searchprev', true);
 			toolbar.enableItem('searchnext', true);
-			if (window.mode.isMobile()) {
+			if (window.mode.isSmallScreenDevice()) {
 				toolbar.enableItem('cancelsearch', true);
 			} else {
 				toolbar.showItem('cancelsearch', true);

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -392,7 +392,7 @@ class Dispatcher {
 
 	private addCalcCommands() {
 		this.actionsMap['acceptformula'] = function () {
-			if (window.mode.isMobile()) {
+			if (window.mode.isSmallScreenDevice()) {
 				app.map.focus();
 				app.map._docLayer.postKeyboardEvent(
 					'input',
@@ -423,7 +423,7 @@ class Dispatcher {
 		};
 
 		this.actionsMap['functiondialog'] = function () {
-			if (window.mode.isMobile() && app.map._functionWizardData) {
+			if (window.mode.isSmallScreenDevice() && app.map._functionWizardData) {
 				app.map._docLayer._closeMobileWizard();
 				app.map._docLayer._openMobileWizard(app.map._functionWizardData);
 				app.map.formulabarSetDirty();
@@ -884,7 +884,7 @@ class Dispatcher {
 			this.addImpressAndDrawCommands();
 		}
 
-		if (window.mode.isMobile()) this.addMobileCommands();
+		if (window.mode.isSmallScreenDevice()) this.addMobileCommands();
 	}
 
 	public dispatch(action: string, data?: any) {

--- a/browser/src/global.d.ts
+++ b/browser/src/global.d.ts
@@ -334,7 +334,7 @@ interface Window {
 		get(name: string): string;
 	};
 	mode: {
-		isMobile(): boolean;
+		isSmallScreenDevice(): boolean;
 		isDesktop(): boolean;
 		isTablet(): boolean;
 		isCODesktop(): boolean;

--- a/browser/src/layer/marker/TextInput.js
+++ b/browser/src/layer/marker/TextInput.js
@@ -754,7 +754,7 @@ window.L.TextInput = window.L.Layer.extend({
 		// And that is caused because after entering the first character
 		// cursor position is never updated by keyboard (I know it is strange)
 		// so here we manually correct the position
-		if (window.mode.isMobile() && content.length === 1 && this._lastContent.length === 0)
+		if (window.mode.isSmallScreenDevice() && content.length === 1 && this._lastContent.length === 0)
 			this._setCursorPosition(1);
 
 		var matchTo = 0;
@@ -1210,7 +1210,7 @@ window.L.TextInput = window.L.Layer.extend({
 		// We want to trigger auto-correction, but not if we may
 		// have to delete a count of characters in the future,
 		// which is specific to crazy mobile keyboard / IMEs:
-		if (!window.mode.isMobile() && !window.mode.isTablet() &&
+		if (!window.mode.isSmallScreenDevice() && !window.mode.isTablet() &&
 			this._autoCorrectChars[text])
 		{
 			let codes;

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -374,7 +374,7 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 		tileSize: window.tileSize,
 		opacity: 1,
 
-		updateWhenIdle: (window.mode.isMobile() || window.mode.isTablet()),
+		updateWhenIdle: (window.mode.isSmallScreenDevice() || window.mode.isTablet()),
 		updateInterval: 200,
 
 		attribution: null,
@@ -492,7 +492,7 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 
 		// For mobile/tablet the hammerjs swipe handler already uses a requestAnimationFrame to fire move/drag events
 		// Using window.L.TileSectionManager's own requestAnimationFrame loop to do the updates in that case does not perform well.
-		if (window.mode.isMobile() || window.mode.isTablet()) {
+		if (window.mode.isSmallScreenDevice() || window.mode.isTablet()) {
 			this._map.on('move', this._painter.update, this._painter);
 			this._map.on('moveend', function () {
 				setTimeout(this.update.bind(this), 200);
@@ -1450,7 +1450,7 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 		} else {
 			var funcData = JSON.parse(textMsg);
 
-			if (window.mode.isMobile()) {
+			if (window.mode.isSmallScreenDevice()) {
 				this._closeMobileWizard();
 
 				var data = {
@@ -3640,7 +3640,7 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 	},
 
 	_mobileChecksAfterResizeEvent: function(heightIncreased) {
-		if (!window.mode.isMobile()) return;
+		if (!window.mode.isSmallScreenDevice()) return;
 
 		const hasMobileWizardOpened = this._map.uiManager.mobileWizard ? this._map.uiManager.mobileWizard.isOpen() : false;
 		const hasIframeModalOpened = $('.iframe-dialog-modal').is(':visible');
@@ -3657,7 +3657,7 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 
 	_nonDesktopChecksAfterResizeEvent: function(heightIncreased) {
 		// We want to keep cursor visible when we show the keyboard on mobile device or tablet
-		if (!window.mode.isMobile() && !window.mode.isTablet()) return;
+		if (!window.mode.isSmallScreenDevice() && !window.mode.isTablet()) return;
 
 		const hasVisibleCursor = app.file.textCursor.visible
 			&& this._map._docLayer._cursorMarker && this._map._docLayer._cursorMarker.isDomAttached();

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -19,13 +19,13 @@ window.L.ImpressTileLayer = window.L.CanvasTileLayer.extend({
 	initialize: function (options) {
 		window.L.CanvasTileLayer.prototype.initialize.call(this, options);
 		// If this is mobile view, we we'll change the layout position of 'presentation-controls-wrapper'.
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			this._putPCWOutsideFlex();
 		}
 
 		this._preview = window.L.control.partsPreview();
 
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			this._addButton = window.L.control.mobileSlide();
 			window.L.DomUtil.addClass(window.L.DomUtil.get('mobile-edit-button'), 'impress');
 		}
@@ -154,7 +154,7 @@ window.L.ImpressTileLayer = window.L.CanvasTileLayer.extend({
 
 		var mobileEditButton = document.getElementById('mobile-edit-button');
 
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			if (window.L.DomUtil.isPortrait()) {
 				this._putPCWOutsideFlex();
 				if (mobileEditButton)
@@ -192,7 +192,7 @@ window.L.ImpressTileLayer = window.L.CanvasTileLayer.extend({
 	},
 
 	onUpdatePermission: function (e) {
-		if (window.mode.isMobile()) {
+		if (window.mode.isSmallScreenDevice()) {
 			if (e.detail.perm === 'edit') {
 				this._addButton.addTo(this._map);
 			} else {

--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -1478,7 +1478,7 @@ window.L.Clipboard = window.L.Class.extend({
 		var innerDiv = window.L.DomUtil.create('div', '', null);
 		box.insertBefore(innerDiv, box.firstChild);
 
-		if (window.mode.isMobile() || window.mode.isTablet()) {
+		if (window.mode.isSmallScreenDevice() || window.mode.isTablet()) {
 			const p = document.createElement('p');
 			p.textContent = _('Your browser has very limited access to the clipboard, so please use the paste buttons on your on-screen keyboard instead.');
 			innerDiv.appendChild(p);

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -177,7 +177,7 @@ window.L.Map = window.L.Evented.extend({
 				this._fireInitComplete('doclayerinit');
 			}
 
-			if (window.mode.isMobile())
+			if (window.mode.isSmallScreenDevice())
 			{
 				document.getElementById('document-container').classList.add('mobile');
 				this._size = new cool.Point(0,0);
@@ -291,7 +291,7 @@ window.L.Map = window.L.Evented.extend({
 					commentSection.clearList();
 			}
 
-			if (!window.mode.isMobile())
+			if (!window.mode.isSmallScreenDevice())
 				this.initializeModificationIndicator();
 
 			// We have loaded.

--- a/browser/src/map/handler/Map.Feedback.js
+++ b/browser/src/map/handler/Map.Feedback.js
@@ -104,7 +104,7 @@ window.L.Map.Feedback = window.L.Handler.extend({
 		var proxyPrefixEnabled = window.socketProxy ? "True" : "False";
 
 		var cssVar = getComputedStyle(document.documentElement).getPropertyValue('--co-primary-element');
-		var params = [{ mobile : window.mode.isMobile() },
+		var params = [{ mobile : window.mode.isSmallScreenDevice() },
 			      { cssvar : cssVar},
 			      { wsdhash : window.app.socket.WSDServer.Hash },
 			      { 'version_number' : window.app.socket.WSDServer.Version },

--- a/browser/src/map/handler/Map.Settings.ts
+++ b/browser/src/map/handler/Map.Settings.ts
@@ -61,7 +61,7 @@ window.L.Map.Settings = window.L.Handler.extend({
 		const params: Array<Record<string, any>> = [
 			{ ui_theme: theme },
 			{ lang: window.langParam },
-			{ mobile: window.mode.isMobile() },
+			{ mobile: window.mode.isSmallScreenDevice() },
 			{ access_token: window.accessToken },
 			{ access_token_ttl: window.accessTokenTTL },
 			{ wopi_setting_base_url: window.wopiSettingBaseUrl },
@@ -73,7 +73,7 @@ window.L.Map.Settings = window.L.Handler.extend({
 					JSON.stringify({
 						ui_theme: theme,
 						lang: window.langParam,
-						mobile: window.mode.isMobile(),
+						mobile: window.mode.isSmallScreenDevice(),
 					}),
 			);
 


### PR DESCRIPTION
* **Resolves:** #14140
* **Target version:** main

### Summary
This PR renames the internal identifier `window.mode.isMobile()` to `window.mode.isSmallScreenDevice()` across the JavaScript and TypeScript layers. 

**Motivation:**
The term "mobile" is increasingly ambiguous. Renaming this to `isSmallScreenDevice` clarifies that the logic is checking for **available screen real estate** (responsive breakpoints) rather than the specific **hardware type**. This improves developer experience and semantic clarity.

**Technical Details:**
- Updated 54 files, including core definitions in `global.js` and `global.d.ts`.
- **Note on CSS:** I have intentionally kept the `.mobile` CSS class toggles (`addClass('mobile')`) intact to avoid high-risk visual regressions in the stylesheet library, while still achieving the goal of clarifying the underlying JS/TS logic.

### TODO
- [x] Rename `isMobile` function definition.
- [x] Refactor all `~120` occurrences of function calls and properties.
- [x] Verify TypeScript compilation via `npx tsc`.

### Checklist
- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check` (Verified via `npx tsc` for browser/src)
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required
