### PR TITLE
Fixed ghost tabs issue

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -30,6 +30,8 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 
 	additionalShortcutButtons: [],
 
+	_isMasterVisible: false,
+
 	setBuilder: function(builder, model) {
 		this.builder = builder;
 		this.model = model;
@@ -458,6 +460,17 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 		let alreadySelected = null;
 		// Currently selected tab name, part of the element's ID.
 		let currentlySelectedTabName = null;
+
+		var anotherPageContext = requestedContext.endsWith('Page') && requestedContext !== 'MasterPage';
+
+		if (!this._isMasterVisible && requestedContext === 'MasterPage') {
+			this._isMasterVisible = true;
+		} else if (this._isMasterVisible && anotherPageContext) {
+			this._isMasterVisible = false;
+		}
+
+		// TODO nu mai pierde clasa hidden cand e selectat tabu shape
+
 		for (var tab in tabs) {
 			var tabElement = $('#' + tabs[tab].name + '-tab-label');
 			if (tabElement.hasClass('selected')) {
@@ -478,10 +491,17 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 							contextTab = tabElement;
 						else
 							alreadySelected = tabElement;
+						break;
 					} else if (contexts[context] === 'default') {
 						tabElement.show();
 						if (!tabElement.hasClass('selected'))
 							defaultTab = tabElement;
+					} else if (tabs[tab].name !== 'Home') {
+						if (this._isMasterVisible && contexts[context] === 'MasterPage') {
+							tabElement.show();
+						} else {
+							tabElement.addClass('hidden');
+						}
 					}
 				}
 			} else if (!this.map.uiManager.isTabVisible(tabs[tab].name)) {


### PR DESCRIPTION
Change-Id: Iecdb07c3708127d4d3eb134508cfd2a02db4c6b9


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

Context-dependent tabs (such as Master in Impress, Table, Shape) lose the hidden class when selected but did not gain it back when deselected, which made them accessible with arrow key navigation even if they didn't appear in the tab list on top of the screen. The fix makes sure they properly get the hidden class when their context is not met anymore.


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

