### PR TITLE
fix: replace CloseDropdown with CloseAllDropdowns in Util.Dropdown

### DIFF
--- a/browser/src/control/jsdialog/Util.Dropdown.ts
+++ b/browser/src/control/jsdialog/Util.Dropdown.ts
@@ -241,7 +241,7 @@ JSDialog.OpenDropdown = function (
 					const uno =
 						entry.uno.indexOf('.uno:') === 0 ? entry.uno : '.uno:' + entry.uno;
 					window.L.Map.THIS.sendUnoCommand(uno);
-					JSDialog.CloseDropdown(id);
+					JSDialog.CloseAllDropdowns();
 					return;
 				} else {
 					app.console.debug(
@@ -262,7 +262,7 @@ JSDialog.OpenDropdown = function (
 			)
 				return;
 
-			if (eventType === 'selected') JSDialog.CloseDropdown(id);
+			if (eventType === 'selected') JSDialog.CloseAllDropdowns();
 
 			// we want to send render request to the default callback -> no warn
 			if (eventType === 'render_entry') return;


### PR DESCRIPTION
issue:
 - when nested dropdown is opened and an entry is selected it closes the child dropdown but do not close the parent dropdown
 - i.e. "Conditional" > "Highlight cells with" > "More highlights" will close "Highlight cells with" dropdown but will not close "Conditional" dropdown, instead it opens the relevant dialog underneath.

 solution:
 - close all dropdowns when event is of type 'selected' as user action is performed and there is no need to keep open any dropdowns.


Change-Id: If937af169283ae96ccd479d7b56bf8e2c2490d19

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

