### PR TITLE
Make Control-W work in CODA also in viewing mode

### DIFF
--- a/browser/src/map/handler/Map.KeyboardShortcuts.ts
+++ b/browser/src/map/handler/Map.KeyboardShortcuts.ts
@@ -232,7 +232,12 @@ class KeyboardShortcuts {
         if (shortcut) {
             // In read-only mode, block shortcuts that send uno commands
             // to core unless they are explicitly meant for read-only use.
+
+            // FIXME: For some reason we need to check for .uno:CloseWin separately here. That is
+            // supposed to work both in viewing mode (called ViewType.ReadOnly) and editing mode.
+
             if (!this.map.isEditMode() && shortcut.unoAction &&
+                shortcut.unoAction !== '.uno:CloseWin' &&
                 shortcut.viewType !== ViewType.ReadOnly) {
                 event.preventDefault();
                 return true;
@@ -315,6 +320,12 @@ const keyboardShortcuts = new KeyboardShortcuts();
 
 // Default shortcuts.
 keyboardShortcuts.definitions.set('default', new Array<ShortcutDescriptor>(
+
+    // FIXME: Should we mark shortcuts that are supposed to work *only* in editing mode with
+    // viewType: ViewType.Edit? Having viewType as null means the shortcut is supposed to work in
+    // either viewing or editing mode, and having it as ViewType.ReadOnly means it is supposed to
+    // work only in viewing mode. At least if you believe the comment for viewType in the
+    // ShortcutDescriptor constructor.
 
     // All document types.
     new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 'o', platform: Platform.CODAWINDOWS | Platform.CODAMAC | Platform.CODAQT, unoAction: '.uno:Open' }),


### PR DESCRIPTION
The logic for shortcut handling is hairy. I didn't have the courage to try to clean it up. Instead I just added a special case check for what Control-W does, i.e. .uno:CloseWin. I also added two FIXMEs.


Change-Id: I255dfe8fecb8ca773207348188bca0a26a0940bf


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

