### PR TITLE
Add comment_avatar coolwsd.xml setting to override comment avatars

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -667,7 +667,10 @@ export class CommentSection extends CanvasSectionObject {
 			const tdAuthor = window.L.DomUtil.create(tagTd, 'cool-annotation-author', tr);
 			const imgAuthor = window.L.DomUtil.create('img', 'avatar-img', tdImg);
 			const user = this.map.getViewId(commentData.author);
-			app.LOUtil.setUserImage(imgAuthor, this.map, user);
+			if (this.map['wopi'] && this.map['wopi'].CommentAvatarUrl)
+				imgAuthor.setAttribute('src', this.map['wopi'].CommentAvatarUrl);
+			else
+				app.LOUtil.setUserImage(imgAuthor, this.map, user);
 			imgAuthor.setAttribute('width', 32);
 			imgAuthor.setAttribute('height', 32);
 			const authorAvatarImg = imgAuthor;
@@ -675,7 +678,8 @@ export class CommentSection extends CanvasSectionObject {
 			const contentDate = window.L.DomUtil.create(tagDiv, 'cool-annotation-date', tdAuthor);
 
 			$(contentAuthor).text(commentData.author);
-			$(authorAvatarImg).attr('src', commentData.avatar);
+			if (!this.map['wopi'] || !this.map['wopi'].CommentAvatarUrl)
+				$(authorAvatarImg).attr('src', commentData.avatar);
 			if (user >= 0) {
 				const color = app.LOUtil.rgbToHex(this.map.getViewColor(user));
 				$(authorAvatarImg).css('border-color', color);

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -310,7 +310,10 @@ export class Comment extends CanvasSectionObject {
 		var imgAuthor = window.L.DomUtil.create('img', 'avatar-img', tdImg);
 		imgAuthor.setAttribute('alt', this.sectionProperties.data.author);
 		var viewId = this.map.getViewId(this.sectionProperties.data.author);
-		app.LOUtil.setUserImage(imgAuthor, this.map, viewId);
+		if (this.map['wopi'] && this.map['wopi'].CommentAvatarUrl)
+			imgAuthor.setAttribute('src', this.map['wopi'].CommentAvatarUrl);
+		else
+			app.LOUtil.setUserImage(imgAuthor, this.map, viewId);
 		imgAuthor.setAttribute('width', this.sectionProperties.imgSize[0]);
 		imgAuthor.setAttribute('height', this.sectionProperties.imgSize[1]);
 
@@ -595,7 +598,10 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.contentAuthor.innerText = this.sectionProperties.data.author;
 
 		this.updateResolvedField(this.sectionProperties.data.resolved);
-		if (this.sectionProperties.data.avatar) {
+		if (this.map['wopi'] && this.map['wopi'].CommentAvatarUrl) {
+			this.sectionProperties.authorAvatarImg.setAttribute('src', this.map['wopi'].CommentAvatarUrl);
+		}
+		else if (this.sectionProperties.data.avatar) {
 			this.sectionProperties.authorAvatarImg.setAttribute('src', this.sectionProperties.data.avatar);
 		}
 		else {

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -165,6 +165,7 @@ window.L.Map.WOPI = window.L.Handler.extend({
 		this.UserCanWrite = !!wopiInfo['UserCanWrite'];
 		this.DisablePresentation = wopiInfo['DisablePresentation'];
 		this.PresentationLeader = wopiInfo['PresentationLeader'];
+		this.CommentAvatarUrl = wopiInfo['CommentAvatarUrl'];
 
 		if (this.UserCanWrite && !app.isReadOnly()) // There are 2 places that set the file permissions, WOPI and URI. Don't change permission if URI doesn't allow.
 			app.setPermission('edit');

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -260,6 +260,8 @@
       <text desc="Watermark text to be displayed on the document if entered" type="string"></text>
     </watermark>
 
+    <comment_avatar desc="URL of an image to use as the avatar for all comments, overriding per-user avatars. When empty (default), normal user avatars are shown" type="string" default=""></comment_avatar>
+
     @WELCOME_CONFIG_FRAGMENT@
 
     <user_interface>

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -1509,6 +1509,10 @@ DocumentBroker::updateSessionWithWopiInfo(const std::shared_ptr<ClientSession>& 
     disablePresentation = disablePresentation || (!ConfigUtil::getBool("canvas_slideshow_enabled", true) && !watermarkText.empty());
     wopiInfo->set("DisablePresentation", disablePresentation);
 
+    const std::string commentAvatarUrl = ConfigUtil::getString("comment_avatar", "");
+    if (!commentAvatarUrl.empty())
+        wopiInfo->set("CommentAvatarUrl", commentAvatarUrl);
+
     std::ostringstream ossWopiInfo;
     wopiInfo->stringify(ossWopiInfo);
     const std::string wopiInfoString = ossWopiInfo.str();


### PR DESCRIPTION
New "comment_avatar" config option: when set to an image URL, all
comments display that image instead of per-user avatars. The URL is
read from coolwsd.xml, forwarded to the browser via the wopi info
message, and applied in both CommentSection and CommentListSection.

When empty (default), existing per-user avatar behavior is unchanged.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I6cf44b3adfd327b1dd1625657377161018817916
