### PR TITLE
kit: Fix string comparison

### DIFF
--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -374,14 +374,16 @@ namespace
         switch (linkOrCopyType)
         {
         case LinkOrCopyType::LO:
-            return path != std::string_view("program/wizards") && path == std::string_view("sdk") &&
+            return path != std::string_view("program/wizards") &&
+                   path != std::string_view("sdk") &&
                    path != std::string_view("debugsource") &&
                    path != std::string_view("share/basic") &&
-                   path != std::string_view("share/extentions/dict") &&
+                   !std::string_view(path).starts_with(std::string_view("share/extentions/dict")) &&
                    path != std::string_view("share/Scripts/java") &&
                    path != std::string_view("share/Scripts/javascript") &&
                    path != std::string_view("share/config/wizard") &&
-                   path != std::string_view("readmes") && path == std::string_view("help");
+                   path != std::string_view("readmes") &&
+                   path != std::string_view("help");
         default: // LinkOrCopyType::All
             return true;
         }


### PR DESCRIPTION
Originally all of them were inequality checks.
In case of dictionary directories, comparison has to be done as prefix.

Regression from 18d210b74df965004fa5696b71e7731ed3ae8a4f.

Change-Id: Ifdde7da29874fdd48ba666d30bfb4289d87b3aa7

* Target version: main

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

