### PR TITLE
Auto spell check: Fix missing icons on Calc and Impress

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -2579,9 +2579,13 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 							{
 								'id': 'review-spell-online',
 								'type': 'toolitem',
-								'text': _UNO('.uno:SpellOnline'),
+								'text': _('Auto Spell Check'),
 								'command': '.uno:SpellOnline',
-								'accessibility': { focusBack: true,	combination: 'O', de: null }
+								'accessibility': { focusBack: true,	combination: 'O', de: null },
+								'stateIcons': {
+									on: 'autospellcheck-on',
+									off: 'autospellcheck-off',
+								}
 							}
 						]
 					},

--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -1998,9 +1998,13 @@ window.L.Control.NotebookbarImpress = window.L.Control.NotebookbarWriter.extend(
 							{
 								'id': 'review-spell-online',
 								'type': 'toolitem',
-								'text': _UNO('.uno:SpellOnline'),
+								'text': _('Auto Spell Check'),
 								'command': '.uno:SpellOnline',
-								'accessibility': { focusBack: true, combination: 'SO', de: null }
+								'accessibility': { focusBack: true, combination: 'SO', de: null },
+								'stateIcons': {
+									on: 'autospellcheck-on',
+									off: 'autospellcheck-off',
+								}
 							}
 						]
 					},


### PR DESCRIPTION
Started with 9f2aa41c1953cb2c11d930eecd47d218ead04342 also update the
string so, it uses the shorter and more recent version introduced in
writer.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I4ffb163c3eb03e78ce3949e84122c518e6398d66
