### PR TITLE
browser: a11y: fix dialog size at 400% zoom

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -42,6 +42,14 @@
 	min-width: 400px;
 }
 
+@media (max-width: 480px) {
+
+	.jsdialog-window:not(.modalpopup) .jsdialog-container:not(.snackbar) {
+		min-width: unset;
+		width: 460px;
+	}
+}
+
 .jsdialog-container:not(.snackbar) td[role='gridcell'] {
 	padding-left: 5px;
 	padding-right: 5px;
@@ -205,9 +213,25 @@ div#autoFillPreviewTooltip .lokdialog.ui-dialog-content.ui-widget-content {
 	overflow: hidden; /* don't inherit scrollbar from parent */
 }
 
+@media (max-width: 480px) {
+
+	.jsdialog-container .ui-dialog-content > div:not(.ui-scrollwindow) {
+		overflow: unset;
+	}
+}
+
+
 .jsdialog-container .lokdialog.ui-dialog-content.ui-widget-content {
 	overflow: hidden;
 }
+
+@media (max-width: 480px) {
+
+	.jsdialog-container .lokdialog.ui-dialog-content.ui-widget-content {
+		overflow-x: unset;
+	}
+}
+
 
 .jsdialog.vertical label, .ui-frame-label, #ui-color-picker-recent-label {
 	margin: auto 4px;


### PR DESCRIPTION
When zooming to 400%, the dialog size should remain fixed.
Otherwise, the horizontal scrollbar will not be visible.

Change-Id: I755841dc9ab7c8876193bc85a250bf8b853326ed
Signed-off-by: Henry Castro <hcastro@collabora.com>
