### PR TITLE
cypress: improve annotation_spec.js Reply autosave cancel stability

### DIFF
--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -288,6 +288,10 @@ function closeNavigatorSidebar () {
 function insertComment(text = 'some text0', save = true) {
 	cy.log('>> insertComment - start');
 
+	cy.getFrameWindow().then(function(win) {
+		return helper.processToIdle(win);
+	});
+
 	var mode = Cypress.env('USER_INTERFACE');
 	if (mode === 'notebookbar') {
 		cy.cGet('#Insert-tab-label').click();


### PR DESCRIPTION
Failure context for 'Reply autosave cancel':
      cy:command ✔  find	#annotation-modify-textarea-new
      cy:command ✔  type	some text0
      cy:command ✔  cGet	.cool-annotation
      cy:command ✔  find	.cool-annotation-textarea
      cy:command ✘  assert	expected **[ <div#annotation-modify-textarea-1.cool-annotation-textarea>, 1 more... ]** to contain **some text0**
      cy:command ✔  fail:
                    Test failed: integration_tests/desktop/writer/annotation_spec.js / Annotation Autosave Tests / Reply autosave cancel

                    Timed out retrying after 10000ms: expected '[ <div#annotation-modify-textarea-1.cool-annotation-textarea>, 1 more... ]' to contain 'some text0'

                    /home/collabora/jenkins/workspace/github_online_master_debug_vs_co-26.04_cypress_desktop/cypress_test/integration_tests/common/desktop_helper.js:234:88
                      232 |     cy.cGet('.cool-annotation').last({ log: false }).find('#annotation-modify-textarea-new').type(text);
                      233 |     // Check that comment exists
                    > 234 |     cy.cGet('.cool-annotation').last({ log: false }).find('.cool-annotation-textarea').should('contain', text);
                          |                                                                                        ^
                      235 | ...
          cy:log ✱  Finishing test: integration_tests/desktop/writer/annotation_spec.js / Annotation Autosave Tests / Reply autosave cancel
Builds:
  - desktop#986


Change-Id: I450b94901b6e8efc2b8eb488d1e1f20140b10d11


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

