### PR TITLE
fix: pass instantJump and parseInt for Action_FollowUser PostMessage …

### DIFF
--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -761,7 +761,7 @@ window.L.Map.WOPI = window.L.Handler.extend({
 		}
 		else if (msg.MessageId === 'Action_FollowUser') {
 			if (msg.Values) {
-				this._map._setFollowing(msg.Values.Follow, msg.Values.ViewId);
+				this._map._setFollowing(msg.Values.Follow, parseInt(msg.Values.ViewId, 10), true);
 			}
 			else {
 				this._map._setFollowing(true, null);


### PR DESCRIPTION
Resolves: #15069
Target version: main

### Summary
The `Action_FollowUser` PostMessage API was not working correctly —
User2's view was not following User1's cursor movements visually.

Two issues found in `browser/src/map/handler/Map.WOPI.js`:
1. `instantJump` was not passed to `_setFollowing`, so `_goToViewId`
   was never called and User2's viewport never jumped to User1's position
   to initiate visual following.
2. `ViewId` was passed without `parseInt`, causing a type mismatch when
   compared later, resulting in `FollowUser_Changed` returning the wrong
   `FollowedViewId` (own viewId instead of target viewId).

### Fix
- Pass `true` for the `instantJump` argument in `_setFollowing`
- Wrap `msg.Values.ViewId` with `parseInt(..., 10)` to ensure it is always a number

### TODO

### Checklist
- [ ] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required