### PR TITLE
Return early when core sends an empty .uno:TableStyles state

### DIFF
--- a/browser/src/app/TableStylesService.ts
+++ b/browser/src/app/TableStylesService.ts
@@ -93,6 +93,8 @@ class TableStylesService {
 
 	public onCommandState(e: any) {
 		if (e.commandName === '.uno:TableStyles') {
+			if (e.state === '') return;
+
 			try {
 				this.styles = JSON.parse(e.state).TableStyles;
 			} catch (e) {


### PR DESCRIPTION
Happens when there's no table context, like when opening the sparkline dialog

Signed-off-by: Samuel Mehrbrodt <samuel.mehrbrodt@collabora.com>
Change-Id: I40e5919bb02aa97ce679ff65878d7fe1edc40899
