### PR TITLE
Allow listboxes smaller than 100px

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1226,7 +1226,7 @@ input[type='number']:hover::-webkit-outer-spin-button {
 .jsdialog-window .ui-combobox,
 .jsdialog-window .ui-timefield {
 	height: 32px;/* Use the same height as in .jsdialog.ui-edit */
-	min-width: 100px;
+	min-width: 50px;
 	width: 100%;
 }
 

--- a/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/jsdialog_spec.js
@@ -143,6 +143,29 @@ describe(['tagdesktop'], 'JSDialog unit test', function() {
 		cy.cGet('#data-input').should('not.be.disabled');
 	});
 
+	it('Sparkline dialog listboxes allow narrow width', function() {
+		cy.getFrameWindow().then(function(win) {
+			win.app.map.sendUnoCommand('.uno:InsertSparkline');
+		});
+		cy.cGet('.ui-dialog[role="dialog"]').should('have.length', 1);
+		cy.getFrameWindow().then(function(win) {
+			return helper.processToIdle(win);
+		});
+
+		cy.cGet('#cbType').should('be.visible');
+		cy.cGet('#cbEmptyCells').should('be.visible');
+
+		cy.getFrameWindow().then(function(win) {
+			var typeEl = win.document.getElementById('cbType');
+			var emptyEl = win.document.getElementById('cbEmptyCells');
+			expect(typeEl.getBoundingClientRect().width).to.be.equal(75);
+			expect(emptyEl.getBoundingClientRect().width).to.be.equal(75);
+		});
+
+		cy.cGet('.ui-dialog-titlebar-close').click();
+		cy.cGet('.ui-dialog[role="dialog"]').should('not.exist');
+	});
+
 	it('QuerySelector Syntax error', function(){
 
 		cy.getFrameWindow().then(function(win) {


### PR DESCRIPTION
This causes listboxes to overlap with labels in the column right to it in the sparkline dialog.

50px looks like a better minimum width for list boxes.
