### PR TITLE
cool#15195 document compare: fix bad horizontal position of comments

### DIFF
--- a/browser/src/app/ViewLayoutCompareChanges.ts
+++ b/browser/src/app/ViewLayoutCompareChanges.ts
@@ -198,6 +198,15 @@ class ViewLayoutCompareChanges extends ViewLayoutNewBase {
 		return this.viewSize.pX > Math.round(documentAnchor.size[0] * 0.5);
 	}
 
+	public getTotalSideSpace(): number {
+		Util.ensureValue(app.activeDocument);
+
+		const anchorWidth = this.getDocumentAnchorSection().size[0];
+		// Two pages side by side, with a gap in-between.
+		const contentWidth = 2 * app.activeDocument.fileSize.pX + this.viewGap;
+		return anchorWidth - contentWidth;
+	}
+
 	public override scroll(pX: number, pY: number): boolean {
 		const scrolled = super.scroll(pX, pY);
 

--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -355,9 +355,17 @@ export class CommentSection extends CanvasSectionObject {
 		}
 	}
 
+	/// If the current layout has more than one pages in a row, so the comment should be next to
+	/// the document content instead of next to the page.
+	private static isMultiColumnLayout(): boolean {
+		const type = app.activeDocument.activeLayout.type;
+		return type === 'ViewLayoutMultiPage' || type === 'ViewLayoutCompareChanges';
+	}
+
 	public calculateAvailableSpace() {
-		if (app.activeDocument.activeLayout.type === 'ViewLayoutMultiPage') {
-			const availableSpace = (app.activeDocument.activeLayout as ViewLayoutMultiPage).getTotalSideSpace();
+		if (CommentSection.isMultiColumnLayout()) {
+			const layout = app.activeDocument.activeLayout as ViewLayoutMultiPage | ViewLayoutCompareChanges;
+			const availableSpace = layout.getTotalSideSpace();
 			return Math.round(availableSpace * 0.5 / app.dpiScale);
 		}
 		else {
@@ -1416,7 +1424,7 @@ export class CommentSection extends CanvasSectionObject {
 		// This manually shows/hides comments
 		if (!this.sectionProperties.showResolved && app.map._docLayer._docType === 'text') {
 			let hide = annotation.isContainerVisible() && annotation.sectionProperties.data.resolved === 'true';
-			hide = hide || (app.activeDocument.activeLayout.type === 'ViewLayoutMultiPage' && this.calculateAvailableSpace() < this.sectionProperties.collapsedCommentWidth);
+			hide = hide || (CommentSection.isMultiColumnLayout() && this.calculateAvailableSpace() < this.sectionProperties.collapsedCommentWidth);
 
 			if (hide && annotation.isContainerVisible()) {
 				if (this.sectionProperties.selectedComment == annotation) {
@@ -1431,7 +1439,7 @@ export class CommentSection extends CanvasSectionObject {
 			}
 			this.update();
 		}
-		else if (app.activeDocument.activeLayout.type === 'ViewLayoutMultiPage') {
+		else if (CommentSection.isMultiColumnLayout()) {
 			const hide = this.calculateAvailableSpace() < this.sectionProperties.collapsedCommentWidth;
 
 			if (hide && annotation.isContainerVisible()) {
@@ -2198,7 +2206,7 @@ export class CommentSection extends CanvasSectionObject {
 			var selectedIndex = null;
 			var x = isRTL ? 0 : topRight[0];
 
-			if (app.activeDocument.activeLayout.type === 'ViewLayoutMultiPage') {
+			if (CommentSection.isMultiColumnLayout()) {
 				x = topRight[0] - availableSpace;
 			}
 			else if (isRTL)

--- a/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
@@ -368,6 +368,22 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.cGet('#comment-container-1').should(function($el) {
 			expect($el.position().top, 'comment top after scroll').to.be.lessThan(initialTop);
 		});
+
+		// Also verify the comment is to the right of the "new" page (right half),
+		// not between the two pages:
+		cy.getFrameWindow().then(function(win) {
+			// Compute the right edge of the right-side page in view coordinates.
+			var layout = win.app.activeDocument.activeLayout;
+			var rightEdgePoint = new win.cool.SimplePoint(win.app.activeDocument.fileSize.pX, 0);
+			rightEdgePoint.mode = 2; // TileMode.RightSide
+			var rightPageEdge = layout.documentToViewX(rightEdgePoint) / win.app.dpiScale;
+			cy.cGet('#comment-container-1').should(function($el) {
+				// Without the accompanying fix in place, this test would have failed with:
+				// - comment left position: expected 593 to be above 747
+				// i.e. the comment left is 1247.125 with the fix.
+				expect($el.position().left, 'comment left position').to.be.greaterThan(rightPageEdge);
+			});
+		});
 	});
 
 	it.skip('Comment Undo-Redo', function () {


### PR DESCRIPTION
Open the Writer bugdoc which has a comment, switch to doc compare mode,
the comment is between the "old first" and "new first" pages (which are
next to each other horizontally), while the expectation is that the
comment is on the right of the document content, so should be on the
right of the "new first" page.

It seems ViewLayoutMultiPage already has some code for this and
CommentListSection knows how to use that.

Fix this by making that mechanism more general: also implement a
getTotalSideSpace() in ViewLayoutCompareChanges, then improve
CommentListSection to work with "multi-column layouts" (multi-page view,
doc compare view), at a number of locations where previously it only
considered the multi-page view.

Test that comments are now over the right edge of the "new" pages.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I746fe21d952b6d4da849878c7c3c31a672f1f1a0
