### PR TITLE
Remove checks for EditStyle command

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -277,8 +277,7 @@ window.L.Map.include({
 
 		if ((command.startsWith('.uno:Sidebar') && !command.startsWith('.uno:SidebarShow')) ||
 			command.startsWith('.uno:CustomAnimation') || command.startsWith('.uno:ModifyPage') ||
-			command.startsWith('.uno:MasterSlidesPanel') || command.startsWith('.uno:SidebarDeck') ||
-			(command.startsWith('.uno:EditStyle') && command.indexOf('Family:short=') == -1)) {
+			command.startsWith('.uno:MasterSlidesPanel') || command.startsWith('.uno:SidebarDeck')) {
 
 			// sidebar control is present only in desktop/tablet case
 			if (this.sidebar) {


### PR DESCRIPTION
This was redirected to open the styles sidebar - no longer needed
since this is now properly fixed in core with https://gerrit.libreoffice.org/c/core/+/202715

Signed-off-by: Samuel Mehrbrodt <samuel.mehrbrodt@collabora.com>
Change-Id: I0e8a3bb00e811dd498eb467af53657e5adf2ba97
