### PR TITLE
Show hand cursor when hovering over hyperlinks

### DIFF
--- a/browser/src/app/iface/DocLayer.Interface.ts
+++ b/browser/src/app/iface/DocLayer.Interface.ts
@@ -33,6 +33,7 @@ interface DocLayerInterface {
 	_getViewId(): string;
 	_painter: PainterInterface;
 	_docType: string;
+	_coreMousePointer: string;
 
 	isCalc(): boolean;
 	isWriter(): boolean;

--- a/browser/src/canvas/sections/MouseControl.ts
+++ b/browser/src/canvas/sections/MouseControl.ts
@@ -164,6 +164,11 @@ class MouseControl extends CanvasSectionObject {
 	}
 
 	private setCursorType() {
+		// If the core has set a specific pointer (e.g. 'pointer' for hyperlinks),
+		// let it take precedence over our client-side cursor.
+		const corePointer = app.map._docLayer._coreMousePointer;
+		if (corePointer && corePointer !== 'default') return;
+
 		// If we have blinking cursor visible
 		// we need to change cursor from default style
 		if (app.file.textCursor.visible) this.context.canvas.style.cursor = 'text';

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -1705,9 +1705,10 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 	_onMousePointerMsg: function (textMsg) {
 		textMsg = textMsg.substring(14); // "mousepointer: "
 		textMsg = Cursor.getCustomCursor(textMsg) || textMsg;
-		var mapPane = $('.leaflet-pane.leaflet-map-pane');
-		if (mapPane.css('cursor') !== textMsg) {
-			mapPane.css('cursor', textMsg);
+		this._coreMousePointer = textMsg;
+		const canvas = document.getElementById('document-canvas');
+		if (canvas && canvas.style.cursor !== textMsg) {
+			canvas.style.cursor = textMsg;
 		}
 	},
 
@@ -2698,6 +2699,23 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 				if (link.rectangle.containsPoint([x, y])) {
 					URLPopUpSection.showURLPopUP(link.uri, new cool.SimplePoint(x, y + this.getFiledBasedViewVerticalOffset()), undefined, /*linkIsClientSide:*/true);
 				}
+			}
+		}
+
+		if (type === 'move' && thereArePageLinks) {
+			let overLink = false;
+			for (const link of tempPageLinks) {
+				if (link.rectangle.containsPoint([x, y])) {
+					overLink = true;
+					break;
+				}
+			}
+			const canvas = document.getElementById('document-canvas');
+			if (overLink) {
+				if (canvas && canvas.style.cursor !== 'pointer')
+					canvas.style.cursor = 'pointer';
+			} else if (canvas && canvas.style.cursor === 'pointer') {
+				canvas.style.cursor = '';
 			}
 		}
 


### PR DESCRIPTION
The mouse pointer was not changing to a hand cursor when hovering over hyperlinks, in both editable documents and PDFs.

For documents: the core sends mousepointer: messages but _onMousePointerMsg was setting the cursor on the map pane (parent div), while MouseControl.setCursorType() unconditionally set cursor on the canvas element (child) on every mouse move, overriding the parent. Fix by setting the core cursor on the same canvas element and having setCursorType() respect non-default core cursors.

For PDFs: hyperlinks are page-level metadata (PageLinks), not SdrObjects, so the core never sends mousepointer: for them. Add client-side hit-testing on mouse move to change cursor over PDF links.


Change-Id: If70abf5af7a9306e4faaf571a8dc92d09361c54f

This PR needs these core changes:
- https://gerrit.libreoffice.org/c/core/+/202717
- https://gerrit.libreoffice.org/c/core/+/202718