### PR TITLE
Added aria tags and keyboard navigation to page size dialog in calc

### DIFF
--- a/browser/src/control/jsdialog/Widget.PageSizeEntry.ts
+++ b/browser/src/control/jsdialog/Widget.PageSizeEntry.ts
@@ -28,9 +28,12 @@ function createPageSizeEntryWidget(data: any, builder: any): HTMLElement {
 	const sizes: PageSizeOption[] = data.options || [];
 	const container = document.createElement('div');
 	container.className = 'jsdialog ui-grid';
+	container.setAttribute('tabindex', '-1');
 
 	const list = document.createElement('div');
 	list.className = 'jsdialog pagesize-list';
+	list.setAttribute('role', 'listbox');
+	list.setAttribute('tabindex', '-1');
 	container.appendChild(list);
 
 	const map = builder.map;
@@ -39,10 +42,19 @@ function createPageSizeEntryWidget(data: any, builder: any): HTMLElement {
 		const item = document.createElement('div');
 		item.className = 'ui-combobox-entry jsdialog ui-grid-cell';
 		item.id = opt.id;
+		item.setAttribute('role', 'option');
+		item.setAttribute('aria-selected', 'false');
+		item.tabIndex = 0;
 
 		item.addEventListener('click', (evt: MouseEvent) => {
 			map.sendUnoCommand(opt.uno);
 			builder.callback('dialog', 'close', { id: data.id }, null);
+		});
+
+		item.addEventListener('keydown', (evt: KeyboardEvent) => {
+			if (evt.key === 'Enter') {
+				item.click();
+			}
 		});
 
 		const text = document.createElement('span');
@@ -54,15 +66,25 @@ function createPageSizeEntryWidget(data: any, builder: any): HTMLElement {
 
 	const hr = document.createElement('hr');
 	hr.className = 'jsdialog ui-separator horizontal';
+	hr.setAttribute('tabindex', '-1');
 	container.appendChild(hr);
 
 	const moreSizeContainer = document.createElement('div');
 	moreSizeContainer.className = 'ui-combobox-entry jsdialog ui-grid-cell';
 	moreSizeContainer.id = 'page-size-more';
+	moreSizeContainer.setAttribute('aria-haspopup', 'dialog');
+	moreSizeContainer.setAttribute('role', 'button');
+	moreSizeContainer.tabIndex = 0;
 
 	moreSizeContainer.addEventListener('click', (evt: MouseEvent) => {
 		map.sendUnoCommand('.uno:PageFormatDialog');
 		builder.callback('dialog', 'close', { id: data.id }, null);
+	});
+
+	moreSizeContainer.addEventListener('keydown', (evt: KeyboardEvent) => {
+		if (evt.key === 'Enter') {
+			moreSizeContainer.click();
+		}
 	});
 
 	const text = document.createElement('span');
@@ -80,5 +102,16 @@ JSDialog.pageSizeEntry = function (
 ): boolean {
 	const element = createPageSizeEntryWidget(data, builder);
 	parentContainer.appendChild(element);
+
+	// Focus first item
+	const firstEntry = element.querySelector('.ui-combobox-entry') as HTMLElement;
+	if (firstEntry) {
+		firstEntry.focus();
+		firstEntry.classList.add('selected');
+		firstEntry.setAttribute('aria-selected', 'true');
+
+		data.initialSelectedId = firstEntry.id;
+	}
+
 	return false;
 };


### PR DESCRIPTION
Change-Id: I319ecbe4b01cd369c7cdfb0861b0ae34a737890b

* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
Page size dropdown was not focused on open. When investigating, I realised it lacked keyboard navigation and aria tags entirely, so I added those as well


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

