### PR TITLE
Added aria label to collabora icon

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -112,6 +112,7 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 			docLogo.setAttribute('id', 'document-logo');
 			docLogo.setAttribute('type', 'action');
 			docLogo.setAttribute('target', '_blank');
+			docLogo.setAttribute('aria-label', _('file type icon'));
 			docLogo.setAttribute('tabIndex', 0);
 
 			if (iconTooltip) {


### PR DESCRIPTION
Change-Id: Ifc70c13d58d8d318945a690767cfde72931e4f6a


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

Link to collaboraonline.com in upper left area of editor lacked any kind of alt text


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

