### PR TITLE
Solves shortcut overlap in Calc > Page Layout

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1129,7 +1129,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 						'type': 'menubutton',
 						'text': _UNO('.uno:PrintRangesMenu', 'spreadsheet'),
 						'enabled': 'true',
-						'accessibility': { focusBack: true,	combination: 'R', de: 'H' }
+						'accessibility': { focusBack: true,	combination: 'PR', de: 'H' }
 					},
 				]
 			},


### PR DESCRIPTION
Change-Id: Ieab04d0093a619dad415aafbdcdfb71fcb955ce0


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
Changed Print Range shortcut to avoid overlap

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

