### PR TITLE
browser: a11y: add column-spacing support to grid types

### DIFF
--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -316,6 +316,7 @@ interface TextWidget extends WidgetJSON {
 	style?: string;
 	hidden?: boolean;
 	renderAsStatic?: boolean;
+	xalign: string;
 }
 
 // type: 'pushbutton'

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -268,6 +268,7 @@ interface GridWidgetJSON extends ContainerWidgetJSON {
 	rows: number; // numer of grid rows
 	tabIndex?: number;
 	initialSelectedId?: string; // id of the first selected element
+	columnSpacing?: number;
 }
 
 interface ToolboxWidgetJSON extends WidgetJSON {

--- a/browser/src/control/jsdialog/Widget.Containers.ts
+++ b/browser/src/control/jsdialog/Widget.Containers.ts
@@ -92,7 +92,8 @@ JSDialog.grid = function (
 		', auto); \
 		grid-template-columns: repeat(' +
 		cols +
-		', auto);';
+		', 1fr);' +
+		(data.columnSpacing > 0 ? ' column-gap:' + data.columnSpacing + 'px;' : '');
 
 	table.style = gridRowColStyle;
 

--- a/browser/src/control/jsdialog/Widget.FixedTextControl.ts
+++ b/browser/src/control/jsdialog/Widget.FixedTextControl.ts
@@ -39,6 +39,10 @@ JSDialog.fixedtextControl = function (
 	if (data.text) fixedtext.textContent = builder._cleanText(data.text);
 	else if (data.html) fixedtext.innerHTML = data.html;
 
+	if (data.xalign) {
+		fixedtext.style.cssText = 'text-align:' + data.xalign + ';';
+	}
+
 	const accKey = builder._getAccessKeyFromText(data.text);
 	builder._stressAccessKey(fixedtext, accKey);
 

--- a/browser/src/control/jsdialog/Widget.SpinField.ts
+++ b/browser/src/control/jsdialog/Widget.SpinField.ts
@@ -416,6 +416,19 @@ const _createBaseSpinField = function (
 		);
 	}
 
+	let style = '';
+	if (data.widthChars && data.widthChars > 0) {
+		style = 'width: ' + data.widthChars + 'ch;';
+	}
+
+	if (data.halign) {
+		style += 'justify-self: ' + data.halign + ';';
+	}
+
+	if (style) {
+		controls.container.style.cssText = style;
+	}
+
 	listenNumericChanges(data, builder, controls, customCallback);
 
 	const value = parseFloat(data.value);


### PR DESCRIPTION
The Columns dialog requires that the Spacing
input labels adjust with the column-spacing
property to visually center the columns and
avoid misinterpretation by users with accessibility
needs.

Change-Id: I4ae383073a5f422e975eeb03f8ec7e044e7bbb55
Signed-off-by: Henry Castro <hcastro@collabora.com>
