### PR TITLE
Replace Welcome behavior bot with GitHub Actions welcome workflow

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,61 @@
+name: Welcome New Contributors
+
+on:
+  pull_request_target:
+    types: [opened, closed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  welcome:
+    if: >-
+      github.event.action == 'opened' &&
+      (github.event.pull_request.author_association == 'NONE' ||
+       github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
+       github.event.pull_request.author_association == 'FIRST_TIMER')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post welcome comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            const botComment = comments.data.find(c =>
+              c.user.type === 'Bot' && c.body.includes('Thanks for opening this pull request!')
+            );
+            if (botComment) return;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `Thanks for opening this pull request!\n\nThings that will help get your PR across the finish line:\n\n- Check out our [contributing guidelines](https://github.com/CollaboraOnline/online/blob/main/CONTRIBUTING.md).\n- Connect with us through one of [our communication channels](https://collaboraonline.github.io/post/communicate/).\n- Click on the details link next to the failing CI checks, if any, to see an explanation on how to fix it.\n- Feel free to ping @Darshan-upadhyay1110 or the mentor of the easyHack you are solving if you need help. CC: @pedropintosilva\n- Explore more Easy Hacks to dive deeper into Collabora Online and start contributing: https://github.com/CollaboraOnline/online/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22Easy%20Hack%22`
+            });
+
+  first-merge:
+    if: >-
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if first contribution and post congrats
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const { data: prs } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} type:pr is:merged author:${author}`,
+            });
+            if (prs.total_count > 1) return;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: `Thanks a lot for your contribution, and congrats on your first pull request merged! Welcome aboard! 🎉🎉🎉\n\nIf you haven't decided on your next task yet, take a look at our [easy-hacks](https://github.com/CollaboraOnline/online/issues?q=is%3Aissue+is%3Aopen+easy+label%3A%22Easy+Hack%22). We're looking forward to your next pull request! :)`
+            });


### PR DESCRIPTION
- The external behaviorbot app stopped posting welcome comments for new contributors.
-  Replace it with a self-hosted GitHub Actions workflow that posts a welcome comment on first-time contributor PRs and a congrats comment when their first PR is merged.


Change-Id: I46809302ffb283f806ccdfbb9eeb131aad59208e


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

