### PR TITLE
Implement hexpand for jsdialog

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2705,6 +2705,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		this._expanderDepth = savedExpanderDepth;
 		var backupGridColSpan = control.style.gridColumn;
 		var backupGridRowSpan = control.style.gridRow;
+		var backupWidth = control.style.width;
 
 		control.replaceWith(temporaryParent.firstChild)
 
@@ -2713,6 +2714,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			newControl.scrollTop = scrollTop;
 			newControl.style.gridColumn = backupGridColSpan;
 			newControl.style.gridRow = backupGridRowSpan;
+			newControl.style.width = backupWidth;
 
 			// todo: is that needed? should be in widget impl?
 			if (data.has_default === true && (data.type === 'pushbutton' || data.type === 'okbutton')) {
@@ -2763,6 +2765,10 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		let gridRow = this._composeGridStyle(data.top, data.height);
 		if (gridRow) {
 			control.style.gridRow = gridRow;
+		}
+
+		if (data.hexpand) {
+			control.style.width = '100%';
 		}
 	},
 

--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -26,6 +26,7 @@ interface WidgetJSON {
 	top?: string; // placement in the grid - row
 	left?: string; // placement in the grid - column
 	width?: string; // inside grid - width in number of columns
+	hexpand?: boolean; // horizontal expand in grid column
 	labelledBy?: string;
 	allyRole?: string;
 	accessibility?: NotebookbarAccessibilityDescriptor;

--- a/browser/src/control/jsdialog/Widget.Containers.ts
+++ b/browser/src/control/jsdialog/Widget.Containers.ts
@@ -78,13 +78,22 @@ JSDialog.grid = function (
 	if (data.tabIndex !== undefined)
 		table.setAttribute('tabindex', data.tabIndex);
 
+	const expandCols = new Set<number>();
+	for (const child of data.children || []) {
+		if (child.hexpand && child.left !== undefined)
+			expandCols.add(parseInt(child.left));
+	}
+
+	let colTemplate = '';
+	for (let c = 0; c < cols; c++)
+		colTemplate += (c > 0 ? ' ' : '') + (expandCols.has(c) ? '1fr' : 'auto');
+
 	const gridRowColStyle =
 		'grid-template-rows: repeat(' +
 		rows +
-		', auto); \
-		grid-template-columns: repeat(' +
-		cols +
-		', auto);';
+		', auto); grid-template-columns: ' +
+		colTemplate +
+		';';
 
 	table.style = gridRowColStyle;
 


### PR DESCRIPTION
To allow widgets consume all horizontal space in the grid
as needed in the sparkline dialog

Signed-off-by: Samuel Mehrbrodt <samuel.mehrbrodt@collabora.com>
Change-Id: I8275120f1657078f2a2d7b9f86c3ba4975c2dcba
