### PR TITLE
[backport] A11y: Enable dropdown select to focus using keyboard

### DIFF
--- a/browser/src/dom/NotebookbarAccessibility.js
+++ b/browser/src/dom/NotebookbarAccessibility.js
@@ -192,10 +192,15 @@ var NotebookbarAccessibility = function() {
 				else if (this.state === 1) {
 					itemWasClicked = true;
 					this.setTabItemDescription(element);
-					var clickTarget = element.querySelector('button.unobutton') || element;
-					clickTarget.click();
-					if (this.filteredItem && this.filteredItem.focusBack === true) {
-						this.focusToMap();
+					var selectTarget = element.tagName === 'SELECT' ? element : element.querySelector('select');
+					if (selectTarget) {
+						selectTarget.focus();
+						selectTarget.showPicker();
+					} else {
+						var clickTarget = element.querySelector('button.unobutton') || element;
+						clickTarget.click();
+						if (this.filteredItem && this.filteredItem.focusBack === true)
+							this.focusToMap();
 					}
 				}
 			}


### PR DESCRIPTION
Earlier on Home tab, number format dropdown was not triggered via keyboard shortcut as it's a select element however we still tried to use the click event. Current fix uses focus with showPicker for select elements. showPicker might not work on older browsers however focus still puts cursor focus on that element and pressing ENTER would work.


Change-Id: Ia742c1a726fbc37c9b1d3b72666305de89d22545


* Resolves: # <!-- related github issue -->
* Target version: distro/collabora/co-25.04

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

