### PR TITLE
qt: implement Save Image from context menu

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -842,6 +842,9 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 		else if (textMsg.startsWith('downloadas:')) {
 			this._onDownloadAsMsg(textMsg);
 		}
+		else if (textMsg.startsWith('exportfile:')) {
+			this._onExportFileMsg(textMsg);
+		}
 		else if (textMsg.startsWith('error:')) {
 			this._onErrorMsg(textMsg);
 		}
@@ -1588,6 +1591,14 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 				this._map._fileDownloader.src = url;
 			else
 				this._map._fileDownloader.setAttribute('data-src', url);
+		}
+	},
+
+	_onExportFileMsg: function (textMsg) {
+		this._map.hideBusy();
+		var command = app.socket.parseServerCmd(textMsg);
+		if (command.url) {
+			window.postMobileMessage('exportfile url=' + command.url);
 		}
 	},
 

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -4024,6 +4024,10 @@ void ChildSession::loKitCallback(const int type, const std::string& payload)
         // continue editing the saved and differently named copy, the PDF and EPUB cases that
         // continue to be more like "Export" need to be put into a separate "Export" menu. Or
         // something.
+#elif defined(QTAPP)
+        // Send the exported file URL to JS, which forwards it to the Qt Bridge
+        // for presenting a native save dialog to the user.
+        sendTextFrame("exportfile: url=" + payload);
 #else
         // Register download id -> URL mapping in the DocumentBroker
         auto url = std::string("../../") + payload.substr(payload.find_last_of('/'));

--- a/qt/Bridge.cpp
+++ b/qt/Bridge.cpp
@@ -37,6 +37,7 @@
 #include <QClipboard>
 #include <QDesktopServices>
 #include <QDir>
+#include <QFile>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QMainWindow>
@@ -739,6 +740,50 @@ QVariant Bridge::cool(const QString& messageStr)
             }
 
             LOG_INF("downloadas: exported to " << destPath.toStdString());
+        });
+
+        dialog->open();
+    }
+    else if (tokens.equals(0, "exportfile"))
+    {
+        std::string fileUrl;
+        if (!COOLProtocol::getTokenString(tokens, "url", fileUrl))
+        {
+            LOG_ERR("exportfile: no url= specified");
+            return {};
+        }
+
+        const QUrl srcUrl(QString::fromStdString(fileUrl));
+        const QString srcPath = srcUrl.toLocalFile();
+        if (srcPath.isEmpty() || !QFileInfo::exists(srcPath))
+        {
+            LOG_ERR("exportfile: source file not found: " << fileUrl);
+            return {};
+        }
+
+        const QString ext = QFileInfo(srcPath).suffix();
+        const QString suggestedName =
+            QStringLiteral("image.") + (ext.isEmpty() ? QStringLiteral("png") : ext);
+
+        QFileDialog* dialog = new QFileDialog(
+            _webView,
+            QObject::tr("Save Image"),
+            QDir::home().filePath(suggestedName),
+            QObject::tr("All Files (*)"));
+
+        dialog->setAcceptMode(QFileDialog::AcceptSave);
+        dialog->setAttribute(Qt::WA_DeleteOnClose);
+
+        QObject::connect(dialog, &QFileDialog::fileSelected,
+                        [srcPath](const QString& destPath) {
+            if (QFile::exists(destPath))
+                QFile::remove(destPath);
+            if (!QFile::copy(srcPath, destPath))
+            {
+                LOG_ERR("exportfile: failed to copy to '" << destPath.toStdString() << "'");
+                return;
+            }
+            LOG_INF("exportfile: saved image to " << destPath.toStdString());
         });
 
         dialog->open();


### PR DESCRIPTION
On Qt/Linux, .uno:SaveGraphic fires LOK_CALLBACK_EXPORT_FILE but the generic #else branch tried to construct an HTTP download URL, which does not work with the FakeSocket architecture.

Add a new exportfile: message that carries the file:// URL of the already-exported image back to JS, which forwards it to the Qt Bridge. The Bridge presents a native QFileDialog and copies the file to the user-selected destination.


Change-Id: I6a978bf5038e887881953d68a40de90fa831cf55

