### PR TITLE
fix(mobile): correct unresponsive function wizard

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -845,12 +845,13 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		if (builder.wizard) {
 			var that = this;
 			var functionName = data.functionName;
-			$(rightDiv).click(() => {
+			$(rightDiv).click(e => {
+				e.stopPropagation();
 				builder.wizard.goLevelDown(mainContainer);
 				if (contentNode.onshow)
 					contentNode.onshow();
 			});
-			$(leftDiv).click(() => {
+			$(sectionTitle).click(() => {
 				if (functionName !== '') {
 					app.socket.sendMessage('completefunction name=' + functionName);
 					that.map.fire('closemobilewizard');


### PR DESCRIPTION
Previously the function wizard only had listeners on the text of the functions, causing us to miss events that would normally be expected to trigger function insertion.

Instead, we can move it to the container so it spans the whole function item. When doing this, we need to make sure that clicking on the question mark to learn more about the function doesn't trigger insertion
- stopPropagation is enough to prevent this


Change-Id: Ic4ec75b027fbef01afba147d864c601c6a6a6964


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

