### PR TITLE
notebookbar: allow a11y shortcuts in iconviewlist

### DIFF
--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -951,6 +951,7 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 					{
 						'id': 'stylesview-iconview-list',
 						'type': 'iconviewlist',
+						'accessibility': { focusBack: false, combination: 'SD' },
 						'children': [
 							{
 								'id': 'stylesview',

--- a/browser/src/dom/NotebookbarAccessibilityDefinitions.js
+++ b/browser/src/dom/NotebookbarAccessibilityDefinitions.js
@@ -50,6 +50,9 @@ var NotebookbarAccessibilityDefinitions = function() {
 					} else if (document.getElementById(id + '-input')) {
 						// checkbox
 						list.push({ id: id + '-input', focusBack: rawList[i].accessibility.focusBack, combination: combination });
+					} else if (rawList[i].type === 'iconviewlist') {
+						// iconviewlist
+						list.push({ id: id + '-expand-button', focusBack:  rawList[i].accessibility.focusBack, combination: combination });
 					} else {
 						// other
 						list.push({ id: id, focusBack: rawList[i].accessibility.focusBack, combination: combination });


### PR DESCRIPTION
- so we can find expand button
- in the dropdown all entries are accessible

Writer -> Home -> Styles

we need to repeat it for all other places