### PR TITLE
multipageview flicker: while scrolling, some tile drawings can flicker.

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -223,10 +223,24 @@ class TileManager {
 			window.app.console.assert(!this.tileBitmapList.find((i) => i == tile));
 
 		// free the last tile if we need to
-		if (this.tileBitmapList.length > highNumBitmaps)
-			this.reclaimTileBitmapMemory(
-				this.tileBitmapList[this.tileBitmapList.length - 1],
-			);
+		if (this.tileBitmapList.length > highNumBitmaps) {
+			let chosenTile = null;
+			let i = this.tileBitmapList.length - 1;
+
+			while (i >= 0) {
+				if (this.tileBitmapList[i].distanceFromView > 0) {
+					chosenTile = this.tileBitmapList[i];
+					break;
+				}
+				i--;
+			}
+
+			if (chosenTile) this.reclaimTileBitmapMemory(chosenTile);
+			else
+				window.app.console.warn(
+					'There are more visible tiles than the allowed cached tile count.',
+				);
+		}
 
 		// current tiles are first:
 		if (tile.distanceFromView === 0) this.tileBitmapList.unshift(tile);


### PR DESCRIPTION
Issue: Open a writer document on a high definition - 4k - screen. switch to multi page view (which is already tile hungry view). then scroll. according to the report, one tile may flicker. this fix targets that one-tile-flicker issue.


Change-Id: I8eb6b12dc2228c54cbf27df2d544ebb1f19b17e7


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

