### PR TITLE
cypress: add a11y test for kerning spinfield label in spacing popover

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/spinfield_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/spinfield_spec.js
@@ -1,6 +1,7 @@
 /* global describe it cy require beforeEach expect */
 
 var helper = require('../../common/helper');
+var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'Spinfield unit and button tests', function () {
 	var win;
@@ -212,6 +213,33 @@ describe(['tagdesktop'], 'Spinfield unit and button tests', function () {
 			var num = parseFloat($el.val());
 			expect(num).to.equal(max);
 		});
+	});
+
+	it('Kerning spinfield is labelled by Custom Value label', function () {
+		desktopHelper.switchUIToNotebookbar();
+		cy.cGet('#sidebar-dock-wrapper').should('be.visible');
+
+		// Click the dropdown arrow on the Spacing toolbar button
+		// in the sidebar to open the TextCharacterSpacingControl popover
+		cy.cGet('#sidebar-dock-wrapper .unoSpacing .arrowbackground').click();
+
+		cy.cGet('.jsdialog-window.modalpopup').should('exist');
+		cy.then(function () {
+			return helper.processToIdle(win);
+		});
+
+		// The kerning spinfield should be labeled by a <label> element
+		// with text "Custom Value", not have a stale aria-label
+		// containing the current numeric value.
+		cy.cGet('label[for="kerning-input"]').should('exist')
+			.should('contain.text', 'Custom Value');
+		cy.cGet('#kerning-input').should('not.have.attr', 'aria-label');
+
+		// Change the value and verify the label still says "Custom Value"
+		// and no aria-label with the old value reappears.
+		cy.cGet('#kerning-input').clear().type('1.5');
+		cy.cGet('#kerning-input').should('not.have.attr', 'aria-label');
+		cy.cGet('label[for="kerning-input"]').should('contain.text', 'Custom Value');
 	});
 
 	it('Buttons enabled after re-enabling spinfield in columns dialog', function () {


### PR DESCRIPTION
The "Custom Value" label in the sidebar character spacing popover was not programmatically associated with the kerning spinfield input. The input had a stale aria-label containing the numeric value instead of being labeled by a proper <label> element.


Change-Id: Ie25bd2959c93c8ae71a25570997fd3263f054bf6


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

