### PR TITLE
browser: a11y: increase jsdialog tab selected contrast ratio

### DIFF
--- a/browser/css/color-palette.css
+++ b/browser/css/color-palette.css
@@ -54,6 +54,7 @@
 
 	--color-box-shadow-light: rgba(77, 77, 77, 0.1);
 	--color-box-shadow: rgba(77, 77, 77, 0.5);
+	--color-box-shadow-dark: rgba(77, 77, 77, 0.85);
 	--color-hyperlink: #000080;
 
 	--color-calc-grid: #c0c0c0;

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -509,7 +509,7 @@ algned to the bottom */
 .ui-tab.selected.jsdialog {
 	background-color: var(--color-background-lighter) !important;
 	color: var(--color-text-darker) !important;
-	box-shadow: 0 0 2px 1px var(--color-box-shadow) !important;
+	box-shadow: 0 0 2px 1px var(--color-box-shadow-dark) !important;
 }
 
 .ui-tab.jsdialog:not(.selected):hover {


### PR DESCRIPTION
The selected tab box-shadow had a contrast ratio of only 1.9:1
against the background, below the required minimum of 3:1

Added darker box-shadow color, achieving a contrast ratio of 3.4:1

Change-Id: I718415a65da48860bb7a79ba53bcdd34f8932165

* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

