### PR TITLE
unit-perf: increase timeout with sanitizers

### DIFF
--- a/test/UnitPerf.cpp
+++ b/test/UnitPerf.cpp
@@ -117,7 +117,11 @@ UnitPerf::UnitPerf()
     , _done(false)
 {
     // Double of the default.
+#if ENABLE_RUNTIME_OPTIMIZATIONS
     constexpr std::chrono::minutes timeout_minutes(1);
+#else
+    constexpr std::chrono::minutes timeout_minutes(2);
+#endif
     setTimeout(timeout_minutes);
 }
 


### PR DESCRIPTION
This works fine, but needs a bit more time than the default 1m timeout;
increase that to 2 minutes in the "disable runtime optimizations" case
(which is effectively any -fsanitize= compiler option).

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Ifb98dbf8f14fbc019aefedcbbf064cb423f0875a
