### PR TITLE
test: disable WhiteBoxTests::testLogCaptureCaller() with older clang

### DIFF
--- a/test/WhiteBoxTests.cpp
+++ b/test/WhiteBoxTests.cpp
@@ -1011,6 +1011,11 @@ void WhiteBoxTests::testLogCaptureCaller()
 {
     constexpr std::string_view testname = __func__;
 
+#if defined(__clang__) && __clang_major__ < 19
+    // std::source_location is broken in older clang versions.
+    return;
+#endif
+
     const auto logWithoutCaller = []() -> std::string
     {
         std::ostringstream oss;


### PR DESCRIPTION
The fuzzer build is done with clang-15 at the moment, which fails on
this test.

We'll need to update to a newer toolchain there (currently running on
openSUSE Leap 15.6; 16.0 would be fine e.g.) but in the meantime to just
skip this test to keep the rest working.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I76ac9418058b3080fead1beda3a02ed04c3436ec
