### PR TITLE
Revert "Use LO branding colors for loading progress bar"

### DIFF
--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -752,14 +752,14 @@ input.clipboard {
 	margin: 0 -1px;
 	height: 100%;
 	text-align: right;
-	background: #18A303;
+	background: #5c3dcc;
 	border: 1px solid;
-	border-color: #106802;
+	border-color: #4422bf #5435c4;
 	border-radius: 10px;
-	background-image: -webkit-linear-gradient(top, #92E285, #43C330 70%, #18A303);
-	background-image: -moz-linear-gradient(top, #92E285, #43C330 70%, #18A303);
-	background-image: -o-linear-gradient(top, #92E285, #43C330 70%, #18A303);
-	background-image: linear-gradient(to bottom, #92E285, #43C330 70%, #18A303);
+	background-image: -webkit-linear-gradient(top, #745dc6, #6549cc 70%, #5c3dcc);
+	background-image: -moz-linear-gradient(top, #745dc6, #6549cc 70%, #5c3dcc);
+	background-image: -o-linear-gradient(top, #745dc6, #6549cc 70%, #5c3dcc);
+	background-image: linear-gradient(to bottom, #745dc6, #6549cc 70%, #5c3dcc);
 	-webkit-box-shadow: inset 0 1px rgba(255, 255, 255, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
 	box-shadow: inset 0 1px rgba(255, 255, 255, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
 }


### PR DESCRIPTION
This reverts commit 43f09f284ca9be50913a3799c0c98137a1fdf42c.

Instead of using green colored progress bar:
<img width="318" height="304" alt="image" src="https://github.com/user-attachments/assets/f8582c9c-8973-4c17-a859-95e3bbbe56b6" />

Now purple colored again:
<img width="318" height="304" alt="image" src="https://github.com/user-attachments/assets/0fb975d5-e60b-4b8e-a597-fd0dfb5c0b78" />
