### PR TITLE
feat(helm): make probe paths configurable

### DIFF
--- a/kubernetes/helm/collabora-online/templates/deployment.yaml
+++ b/kubernetes/helm/collabora-online/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
           {{- if .Values.probes.startup.enabled }}
           startupProbe:
             httpGet:
-              path: /
+              path: {{ .Values.probes.startup.path }}
               port: {{ .Values.deployment.containerPort }}
               scheme: HTTP
             failureThreshold: {{ .Values.probes.startup.failureThreshold }}
@@ -78,7 +78,7 @@ spec:
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.probes.liveness.path }}
               port: {{ .Values.deployment.containerPort }}
               scheme: HTTP
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
@@ -90,7 +90,7 @@ spec:
           {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
             httpGet:
-              path: /
+              path: {{ .Values.probes.readiness.path }}
               port: {{ .Values.deployment.containerPort }}
               scheme: HTTP
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -201,7 +201,7 @@ probes:
     enabled: true
     failureThreshold: 30
     periodSeconds: 3
-
+    path: /
   readiness:
     enabled: true
     initialDelaySeconds: 0
@@ -209,6 +209,7 @@ probes:
     timeoutSeconds: 30
     successThreshold: 1
     failureThreshold: 2
+    path: /
   liveness:
     enabled: true
     initialDelaySeconds: 0
@@ -216,6 +217,7 @@ probes:
     timeoutSeconds: 30
     successThreshold: 1
     failureThreshold: 4
+    path: /
 
 route:
   # -- enable an HTTPRoute resource for collabora.


### PR DESCRIPTION
* Resolves: https://github.com/CollaboraOnline/online/issues/7499
* Target version: main

### Summary

This PR makes the HTTP probe path configurable in the Helm chart.

When service_root is set via extra_params (e.g. `--o:net.service_root=/collabora`), Collabora is no longer served on `/`. Kubernetes probes (startup, readiness, liveness) still default to `/`, which causes them to fail even though the service itself is healthy.

This change introduces a configurable path parameter for probes and wires it into deployment.yaml, allowing probes to correctly target the configured service root.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

