### PR TITLE
jsdialog: don't show search field for small listboxes

### DIFF
--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -1827,7 +1827,9 @@ class TreeViewControl {
 		return (
 			!data.noSearchField &&
 			!TreeViewControl.isMenu(data) &&
-			TreeViewControl.isListbox(data)
+			TreeViewControl.isListbox(data) &&
+			data.entries &&
+			data.entries.length > 25
 		);
 	}
 


### PR DESCRIPTION
Listboxes with 25 or fewer entries (like the Level list in the TOC Entries tab) don't need a search/filter field.


Change-Id: Iecbd4dccd129cf16a87448c3259539011f2a9a95


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

