### PR TITLE
A11y: fix Share button keyboard accessibility

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -640,7 +640,6 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 				'command': 'shareas',
 				'inlineLabel': true,
 				'accessibility': { focusBack: false, combination: 'ZS', de: null },
-				'tabIndex': 0,
 			});
 		}
 


### PR DESCRIPTION
Change-Id: Ie0ab3a94049955fc3a4bd2ad9f8cc6a23b791cdb


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

A11y: fix Share button keyboard accessibility

The commit b1cce37 (https://github.com/CollaboraOnline/online/pull/13736/changes/b1cce372446630520a41c1ee3b94d5b09eae430b) made the Share button's container div focusable (tabIndex=0) instead of the button itself. This caused the builder to set tabIndex=-1 on the inner button, making it unreachable via keyboard. Pressing Enter/Space on the focused div had no effect since click handlers are on the button, not the container.

Remove the explicit tabIndex=0 from the Share button definition so the button element remains naturally focusable and activatable.

