### PR TITLE
Compare changes view: Fix flickering of section labels.

### DIFF
--- a/browser/src/canvas/sections/CompareChangesLabelSection.ts
+++ b/browser/src/canvas/sections/CompareChangesLabelSection.ts
@@ -121,26 +121,37 @@ class CompareChangesLabelSection extends HTMLObjectSection {
 		);
 	}
 
-	override onDraw(): void {
-		const container = this.getHTMLObject();
+	private checkSettings() {
+		if (app.activeDocument) {
+			this.size = app.activeDocument.fileSize.pToArray();
 
-		if (
-			!app.activeDocument ||
-			app.activeDocument.activeLayout.type !== 'ViewLayoutCompareChanges'
-		) {
-			container.style.display = 'none';
-			return;
-		}
+			const layoutCheck =
+				app.activeDocument.activeLayout.type === 'ViewLayoutCompareChanges';
+
+			if (!layoutCheck) {
+				if (this.isSectionShown()) this.setShowSection(false);
+				return false;
+			} else {
+				if (!this.isSectionShown()) this.setShowSection(true);
+				return true;
+			}
+		} else return false;
+	}
+
+	public onNewDocumentTopLeft(): void {
+		this.checkSettings();
+	}
+
+	override onDraw(): void {
+		if (!this.checkSettings() || !app.activeDocument) return;
 
 		this.adjustHTMLObjectPosition();
-		container.style.display = '';
 
 		const layout = app.activeDocument.activeLayout as ViewLayoutCompareChanges;
 
 		// Use page rectangle to get actual page position and width (in twips).
 		const pageRects = app.file.writer.pageRectangleList;
 		if (!pageRects || pageRects.length === 0) {
-			container.style.display = 'none';
 			return;
 		}
 		const firstPage = pageRects[0];
@@ -186,8 +197,6 @@ class CompareChangesLabelSection extends HTMLObjectSection {
 			);
 			this.updateSubtitle(this.leftSubtitle, props.metadata.otherDocument);
 			this.updateSubtitle(this.rightSubtitle, props.metadata.thisDocument);
-			this.leftSubtitle.style.display = '';
-			this.rightSubtitle.style.display = '';
 		} else {
 			CompareChangesLabelSection.setTextContent(
 				this.leftTitle,
@@ -197,8 +206,6 @@ class CompareChangesLabelSection extends HTMLObjectSection {
 				this.rightTitle,
 				_('Current Version'),
 			);
-			this.leftSubtitle.style.display = 'none';
-			this.rightSubtitle.style.display = 'none';
 		}
 
 		// We only have a subtitle right after comparing; so if we don't have a subtitle,
@@ -207,16 +214,12 @@ class CompareChangesLabelSection extends HTMLObjectSection {
 		this.leftTitle.style.lineHeight = titleHeight + 'px';
 		this.rightTitle.style.lineHeight = titleHeight + 'px';
 
-		this.leftLabel.style.display = '';
 		this.leftLabel.style.left = leftX + 'px';
 		this.leftLabel.style.top = topY + 'px';
 		this.leftLabel.style.width = pageWidth + 'px';
 
-		this.rightLabel.style.display = '';
 		this.rightLabel.style.left = rightX + 'px';
 		this.rightLabel.style.top = topY + 'px';
 		this.rightLabel.style.width = pageWidth + 'px';
 	}
 }
-
-app.definitions.compareChangesLabelSection = CompareChangesLabelSection;

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -3,7 +3,7 @@
  * window.L.CanvasTileLayer is a layer with canvas based rendering.
  */
 
-/* global app JSDialog CanvasSectionContainer GraphicSelection CanvasOverlay CursorHeaderSection $ _ CPolyUtil CPolygon Cursor UNOKey cool OtherViewCellCursorSection TileManager SplitSection TextSelections CellSelectionMarkers URLPopUpSection CalcValidityDropDown DocumentBase CellCursorSection FormFieldButton TextCursorSection CStyleData CSelections CReferences OtherViewGraphicSelectionSection */
+/* global app JSDialog CanvasSectionContainer GraphicSelection CanvasOverlay CursorHeaderSection $ _ CPolyUtil CPolygon Cursor UNOKey cool OtherViewCellCursorSection TileManager SplitSection TextSelections CellSelectionMarkers URLPopUpSection CalcValidityDropDown DocumentBase CellCursorSection FormFieldButton TextCursorSection CStyleData CSelections CReferences OtherViewGraphicSelectionSection CompareChangesLabelSection */
 
 function clamp(num, min, max)
 {
@@ -481,7 +481,7 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 		app.sectionContainer.setDocumentAnchorSection(app.CSections.Tiles.name);
 
 		if (this._docType === 'text')
-			app.sectionContainer.addSection(new app.definitions.compareChangesLabelSection());
+			app.sectionContainer.addSection(new CompareChangesLabelSection());
 
 		app.sectionContainer.getSectionWithName('tiles').onResize();
 


### PR DESCRIPTION
Issue: Labels are shown and then hidden and then show again while scrolling.

Root cause: The section size is not set. Visibility checks are not healthy.

Fix:
* Set section's size.
* Remove manuel setting of HTML elements' visibility and rely on "setShowSection" function. Visibility is automatically handled by the base section (HTMLObjectSection).


Change-Id: I898c77b2c024c3e9d1a39f3d56cf88f095a652f6


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

