### PR TITLE
Don't copy color-palette.css into browser/dist if it is already in bundle.css

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -902,7 +902,7 @@ build-cool: \
 	$(DIST_FOLDER)/device-desktop.css \
 	$(DIST_FOLDER)/progressbar.css \
 	$(DIST_FOLDER)/settings.css \
-	$(DIST_FOLDER)/color-palette.css \
+	$(if $(IS_SEPARATE),$(DIST_FOLDER)/color-palette.css) \
 	$(DIST_FOLDER)/color-palette-dark.css \
 	$(DIST_FOLDER)/bundle.js \
 	$(DIST_FOLDER)/cool.html \


### PR DESCRIPTION
Change-Id: I65393b254efa6450b67de9935f5d92697381605a


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

