### PR TITLE
browser: a11y: fix Alt+UP shortcut

### DIFF
--- a/browser/css/toolbar.css
+++ b/browser/css/toolbar.css
@@ -1568,7 +1568,7 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 
 #followingChipBackground {
 	transform: translateX(calc(2.5px /* border widths */ + 2.5px /* background paddings */ + var(--btn-img-size) - 0.6px /* browser rendering fudge */));
-	/* We'd like this to flow over the first item of the userListSummary. I've added a fudge because browser rendering seems to have subpixel errors here and it's far better to
+	/* We'd like this to flow over the first item of the userListSummaryButton. I've added a fudge because browser rendering seems to have subpixel errors here and it's far better to
 	 * render the border marginally too far left than leave a gap. */
 }
 
@@ -1577,12 +1577,12 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 }
 
 #followingChipBackground:hover:has(#followingChip:hover),
-#userListSummaryBackground:hover:has(#userListSummary:hover) {
+#userListSummaryBackground:hover:has(#userListSummaryButton:hover) {
 	background-color: var(--color-background-darker);
 }
 
 #followingChipBackground > #followingChip,
-#userListSummaryBackground > #userListSummary {
+#userListSummaryBackground > #userListSummaryButton {
 	cursor: pointer;
 
 	margin: 0; /* everything is in the respective #fooBackground selectors */
@@ -1608,7 +1608,7 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	box-sizing: border-box;
 }
 
-#userListSummaryBackground > #userListSummary {
+#userListSummaryBackground > #userListSummaryButton {
 	background: transparent !important; /* we want to override some classes that are added to buttons by default */
 
 	height: fit-content !important;
@@ -1623,20 +1623,20 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 	border: none !important; /* we want to override some classes that are added to buttons by default */
 }
 
-#userListSummary .avatar-img:first-child {
+#userListSummaryButton .avatar-img:first-child {
 	margin-left: 0;
 }
 
-#userListSummary .avatar-img:last-child {
+#userListSummaryButton .avatar-img:last-child {
 	margin-right: 0 !important;
 }
 
-#userListSummary .avatar-img {
+#userListSummaryButton .avatar-img {
 	background-clip: padding-box;
 	margin-left: -10px;
 }
 
-#userListSummary:not(:hover) .avatar-img.following {
+#userListSummaryButton:not(:hover) .avatar-img.following {
 	border-color: transparent !important;
 }
 
@@ -1755,7 +1755,7 @@ menu-entry-with-icon.padding-left + menu-entry-icon.width */
 #picture-transparency-entry-6 img { filter: opacity(0.05) }
 
 @media only screen and (max-width: 600px) {
-	#userListSummary,
+	#userListSummaryButton,
 	#userListHeader {
 		display: none;
 	}

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -148,7 +148,7 @@ m4_ifelse(MOBILEAPP,[true],
           <div id="followingChipBackground">
             <div id="followingChip"></div>
           </div>
-          <div id="userListSummaryBackground"><button id="userListSummary"></button></div>
+          <div id="userListSummaryBackground"><button id="userListSummaryButton"></button></div>
         </div>
         <div id="viewMode">
         </div>

--- a/browser/src/control/Control.UserList.ts
+++ b/browser/src/control/Control.UserList.ts
@@ -83,7 +83,7 @@ class UserList extends window.L.Control {
 			this.options.noUser = _('0 users');
 		}
 
-		const userListElement = document.getElementById('userListSummary');
+		const userListElement = document.getElementById('userListSummaryButton');
 		userListElement.setAttribute('aria-label', _('User List Summary'));
 
 		this.registerHeaderAvatarEvents();
@@ -221,14 +221,14 @@ class UserList extends window.L.Control {
 		if (canShowDropdown) {
 			JSDialog.OpenDropdown(
 				'userlist',
-				document.getElementById('userListSummary'),
+				document.getElementById('userListSummaryButton'),
 				JSDialog.MenuDefinitions.get('UsersListMenu'),
 			);
 		}
 	}
 
 	registerHeaderAvatarEvents() {
-		document.getElementById('userListSummary').addEventListener(
+		document.getElementById('userListSummaryButton').addEventListener(
 			'click',
 			function (e: MouseEvent) {
 				e.stopPropagation();
@@ -296,7 +296,7 @@ class UserList extends window.L.Control {
 		const userListElementBackground = document.getElementById(
 			'userListSummaryBackground',
 		);
-		const userListElement = document.getElementById('userListSummary');
+		const userListElement = document.getElementById('userListSummaryButton');
 
 		if (
 			window.mode.isSmallScreenDevice() ||


### PR DESCRIPTION
The querySelector matched userListSummaryBackground div before the button
because both ids start with "userListSummary" and the div appears first in the DOM. 
This caused the accesskey to be assigned to the div, and the browser activated the div instead of the button on Alt+UP.

Renamed button id from userListSummary to userListSummaryButton so the querySelector matches only the button.


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

