### PR TITLE
Adapt poco-1.12.4-emscripten.patch to emsdk 5.0.4

### DIFF
--- a/wasm/poco-1.12.4-emscripten.patch
+++ b/wasm/poco-1.12.4-emscripten.patch
@@ -1,3 +1,23 @@
+--- poco-1.12.4-all/Foundation/include/Poco/Platform.h
++++ poco-1.12.4-all/Foundation/include/Poco/Platform.h
+@@ -61,7 +61,7 @@
+ #elif defined(__NACL__)
+ 	#define POCO_OS_FAMILY_UNIX 1
+ 	#define POCO_OS POCO_OS_NACL
+-#elif defined(linux) || defined(__linux) || defined(__linux__) || defined(__TOS_LINUX__) || defined(EMSCRIPTEN)
++#elif defined(linux) || defined(__linux) || defined(__linux__) || defined(__TOS_LINUX__) || defined(__EMSCRIPTEN__)
+ 	#define POCO_OS_FAMILY_UNIX 1
+ 	#if defined(__ANDROID__)
+ 		#define POCO_OS POCO_OS_ANDROID
+@@ -142,7 +142,7 @@
+ #if defined(__ALPHA) || defined(__alpha) || defined(__alpha__) || defined(_M_ALPHA)
+ 	#define POCO_ARCH POCO_ARCH_ALPHA
+ 	#define POCO_ARCH_LITTLE_ENDIAN 1
+-#elif defined(i386) || defined(__i386) || defined(__i386__) || defined(_M_IX86) || defined(EMSCRIPTEN)
++#elif defined(i386) || defined(__i386) || defined(__i386__) || defined(_M_IX86) || defined(__EMSCRIPTEN__)
+ 	#define POCO_ARCH POCO_ARCH_IA32
+ 	#define POCO_ARCH_LITTLE_ENDIAN 1
+ #elif defined(_IA64) || defined(__IA64__) || defined(__ia64__) || defined(__ia64) || defined(_M_IA64)
 --- poco-1.12.4-all/Foundation/src/Thread_POSIX.cpp	2022-10-31 18:44:32.000000000 +0100
 +++ poco-1.12.4-all/Foundation/src/Thread_POSIX.cpp	2022-11-09 18:20:41.701346868 +0100
 @@ -67,7 +67,7 @@


### PR DESCRIPTION
...which dropped the predefined EMSCRIPTEN macro, see <https://github.com/emscripten-core/emscripten/commit/39f17c3960c32c13503f8e39cc2bdd88e7eb6a86> "Remove command line definition of legacy EMSCRIPTEN macro (#26417)", so building Poco 1.12.4 as per wasm/README.no-container.md started to fail with

> In file included from src/ArchiveStrategy.cpp:15:
> In file included from include/Poco/ArchiveStrategy.h:21:
> In file included from include/Poco/Foundation.h:98:
> include/Poco/Platform.h:286:3: error: "Unknown Hardware Architecture."
>   286 |         #error "Unknown Hardware Architecture."
>       |          ^


Change-Id: If19962b90a121beb3ed74cae73eb7ca6a8489e92


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

