### PR TITLE
improve the reliability of the initial socket retry test

### DIFF
--- a/cypress_test/integration_tests/desktop/writer/initial_socket_retry_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/initial_socket_retry_spec.js
@@ -31,6 +31,16 @@ describe(['tagdesktop'], 'Initial WebSocket connection retry', function() {
 		// With the fix the first WebSocket closes but the client
 		// retries and the document loads on the second attempt.
 		// Without the fix this times out.
-		helper.documentChecks();
+		//
+		// Only check that the document actually loaded. The full
+		// documentChecks() also waits for notebookbar and sidebar
+		// initialization which can be disrupted by the socket
+		// retry flow (the notebookbar container is replaced during
+		// re-initialization but the initialized flag is not reset).
+		var timeout = Cypress.config('defaultCommandTimeout') * 2.0;
+		cy.cGet('#document-canvas', {timeout: timeout})
+			.should('be.visible');
+		cy.cGet('#map', {timeout: timeout})
+			.should('have.class', 'initialized');
 	});
 });


### PR DESCRIPTION
there's some notebookbar reinit problem here, but that's not what this is trying to test, it want's to test if an initial websocket failure is retried, which is it.


Change-Id: Id9577ecd249530d6d662b8c89059521cb5cdc9a8


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

