### PR TITLE
[Backport] A11y: fix Share button keyboard accessibility

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -651,7 +651,6 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 				'command': 'shareas',
 				'inlineLabel': true,
 				'accessibility': { focusBack: false, combination: 'ZS', de: null },
-				'tabIndex': 0,
 			});
 		}
 


### PR DESCRIPTION
The commit b1cce37 made the Share button's container div focusable (tabIndex=0) instead of the button itself. This caused the builder to set tabIndex=-1 on the inner button, making it unreachable via keyboard. Pressing Enter/Space on the focused div had no effect since click handlers are on the button, not the container.

Remove the explicit tabIndex=0 from the Share button definition so the button element remains naturally focusable and activatable.


Change-Id: Ie0ab3a94049955fc3a4bd2ad9f8cc6a23b791cdb


* Resolves: # <!-- related github issue -->
* Target version: distro/collabora/co-25.04

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

