### PR TITLE
Don't return files that aren't readable from RecentFiles::serialise()

### DIFF
--- a/common/RecentFiles.cpp
+++ b/common/RecentFiles.cpp
@@ -89,19 +89,32 @@ std::string RecentFiles::serialise()
     std::string result;
 
     result = "[ ";
+    int n = 0;
     for (int i = 0; i < _mostRecentlyUsed.size(); i++)
     {
         Poco::URI uri(_mostRecentlyUsed[i].uri);
         std::vector<std::string> segments;
         uri.getPathSegments(segments);
 
+        // Verify that the file still exists
+        std::string path = uri.getPath();
+#ifdef _WIN32
+        if (path.length() > 4 && path[0] == '/' && path[2] == ':' && path[3] == '/')
+            path = path.substr(1);
+#endif
+        std::ifstream stream;
+        FileUtil::openFileToIFStream(path, stream);
+        if (!stream.is_open())
+            continue;
+
+        if (n > 0)
+            result += ", ";
         result += "{ "
             "\"uri\": \"" + _mostRecentlyUsed[i].uri + "\", "
             "\"name\": \"" + JsonUtil::escapeJSONValue(segments.empty() ? uri.getPathEtc() : segments.back()) + "\", "
             "\"timestamp\": \"" + std::format("{:%FT%TZ}", _mostRecentlyUsed[i].timestamp) + "\""
             " }";
-        if (i < _mostRecentlyUsed.size() - 1)
-            result += ", ";
+        n++;
     }
     result += " ]";
 


### PR DESCRIPTION
Might be files on removable drives that aren't connected any more, or files that have been deleted, renamed, or moved.

A further improvement could be to do keep more entries in the file than the maxFiles parameter passed to RecentFiles::load(), but in RecentFiles::serialise(), only return at most maxFiles entries. Then we would return the requested number of entries even if some of the recent files have been deleted in the meantime.


Change-Id: I72bb093519e0a3a402b0596ee04d3b740804d58a


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

