### PR TITLE
Hide duplicated separator when toggledarktheme is hidden

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -1636,7 +1636,7 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 				'text': _('Invert Background'),
 				'accessibility': { focusBack: true, combination: 'BG', de: null }
 			},
-			{ type: 'separator', id: 'layout-invertbackground-break', orientation: 'vertical' },
+			{ type: 'separator', id: 'view-invertbackground-break', orientation: 'vertical' },
 			{
 				'id': 'view-sidebardeck',
 				'type': 'bigtoolitem',

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1182,6 +1182,11 @@ class UIManager extends window.L.Control {
 
 		if (!found)
 			window.app.console.error('UIManager: Button with id "' + buttonId + '" not found.');
+
+		// When toggledarktheme is hidden, also hide the adjacent separator
+		// to prevent two separators from being displayed in a row.
+		if (buttonId === 'toggledarktheme')
+			this.showButton('view-invertbackground-break', show);
 	}
 
 	/**


### PR DESCRIPTION
Note, I have renamed the id in calc so we have the same id in all
apps.

Before this commit when an integrator would hide the toggle via
postmessage:

postMessageToCollabora('Hide_Button', { id: 'toggledarktheme' })

we would get duplicated separator

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I738e0fffbdac10adab5c31c467f7ed2efad672f2
