### PR TITLE
Show document name by default: Labels or instructions

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -42,10 +42,20 @@
 .document-title {
 	white-space: nowrap;
 	display: flex;
-	align-items: flex-start;
+	align-items: baseline;
 	justify-content: center;
-	flex-direction: column;
+	flex-direction: row;
 	flex: 1 1 auto;
+	gap: 4px;
+}
+
+.document-title:focus-within > label[for='document-name-input'] {
+	clip: unset;
+	height: auto;
+	overflow: visible;
+	position: static;
+	width: auto;
+	color: var(--color-text-lighter);
 }
 
 .readonly .document-title {

--- a/browser/html/cool.html.m4
+++ b/browser/html/cool.html.m4
@@ -120,8 +120,7 @@ m4_ifelse(MOBILEAPP,[true],
         <ul id="main-menu" class="sm sm-simple lo-menu readonly"></ul>
         <div id="document-titlebar">
           <div class="document-title">
-            <!-- visuallyhidden: hide it visually but keep it available to screen reader and other assistive technology -->
-            <label class="visuallyhidden" for="document-name-input" aria-hidden="false">Document name</label>
+            <label class="visuallyhidden" for="document-name-input">Document name</label>
             <input id="document-name-input" type="text" spellcheck="false" disabled="true" />
             <div class="loading-bar-container">
               <div id="document-name-input-loading-bar"></div>

--- a/browser/src/control/Control.DocumentNameInput.js
+++ b/browser/src/control/Control.DocumentNameInput.js
@@ -22,6 +22,10 @@ window.L.Control.DocumentNameInput = window.L.Control.extend({
 		else
 			this.progressBar = document.getElementById('document-name-input-progress-bar');
 
+		var label = document.querySelector('label[for="document-name-input"]');
+		if (label)
+			label.textContent = _('Document name');
+
 		map.on('doclayerinit', this.onDocLayerInit, this);
 		map.on('wopiprops', this.onWopiProps, this);
 	},


### PR DESCRIPTION
At the top of the Writer, within the menu area, the document name is displayed. When **focused** using the keyboard or clicked with the mouse, an input field appears that allows the user to change the document name. This input field does not have a visible label.

Also make the label translatable.


Change-Id: Id414af5df16e1a170a1d07bbe3080182c93b6987


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

