### PR TITLE
fix(app:linux): align flatpak manifest with flathub

### DIFF
--- a/qt/flatpak/com.collaboraoffice.Office.json
+++ b/qt/flatpak/com.collaboraoffice.Office.json
@@ -17,10 +17,8 @@
     "--socket=wayland",
     "--socket=pulseaudio",
     "--socket=cups",
-    "--filesystem=xdg-config/gtk-3.0",
-    "--filesystem=xdg-config/fontconfig:ro",
     "--filesystem=xdg-run/gvfsd",
-    "--filesystem=host",
+    "--filesystem=xdg-documents",
     "--env=LIBO_FLATPAK=1",
     "--talk-name=org.gtk.vfs.*",
     "--device=dri"
@@ -32,10 +30,7 @@
     "/share/man"
   ],
   "build-options": {
-    "append-path": "/usr/lib/sdk/node20/bin:/usr/lib/libexec",
-    "env": {
-      "NINJA_STATUS": "[%p | %f/%t] "
-    }
+    "append-path": "/usr/lib/sdk/node20/bin:/usr/lib/libexec"
   },
   "modules": [
     {


### PR DESCRIPTION
we need to use --filesystem=xdg-documents in the manifest (similar to the
flathub manifest) so our daily snapshots, have the the same sandbox permissions
as our releases on flathub.

---

fix(app:linux): align flatpak manifest with flathub

Drop NINJA_STATUS from build-options and match finish-args
to the flathub manifest. Having the same --filesystem access
is necessary for catching access related bugs early on.

Signed-off-by: Sarper Akdemir <sarper.akdemir@collabora.com>
Change-Id: Ie94472713371304a7ca3132564a10dbc33c6edee