### PR TITLE
Add Action_GoToComment WOPI postMessage, and resp. response

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -133,6 +133,7 @@ export class CommentSection extends CanvasSectionObject {
 		this.sectionProperties.docLayer = this.map._docLayer;
 		this.sectionProperties.calcLastTab = -1;
 		this.sectionProperties.calcMasterList = [];
+		this.sectionProperties.doNotHideCommentTimer = null; // For _goToCalcComment, where comment needs to show, despite async events trying to hide it
 		this.sectionProperties.commentList = new Array(0);
 		this.sectionProperties.selectedComment = null;
 		this.sectionProperties.arrow = null;
@@ -386,7 +387,9 @@ export class CommentSection extends CanvasSectionObject {
 
 	public hideAllComments (): void {
 		for (var i: number = 0; i < this.sectionProperties.commentList.length; i++) {
-			this.sectionProperties.commentList[i].hide();
+			if (!this.sectionProperties.doNotHideCommentTimer
+				|| this.sectionProperties.commentList[i] !== this.sectionProperties.selectedComment)
+				this.sectionProperties.commentList[i].hide();
 			var part = app.map._docLayer._selectedPart;
 			if (app.map._docLayer._docType === 'spreadsheet') {
 				// Change drawing order so they don't prevent each other from being shown.
@@ -733,6 +736,11 @@ export class CommentSection extends CanvasSectionObject {
 				this.updateIdIndexMap();
 				break;
 			}
+		}
+		// Synchronize calcMasterList
+		var masterElementIndex = this.sectionProperties.calcMasterList.findIndex(el => el.id == id);
+		if (masterElementIndex >= 0) {
+			this.sectionProperties.calcMasterList.splice(masterElementIndex, 1);
 		}
 		this.checkSize();
 		app.map.fire('deleteannotation');
@@ -1374,7 +1382,7 @@ export class CommentSection extends CanvasSectionObject {
 
 	public onNewDocumentTopLeft (): void {
 		if (app.map._docLayer._docType === 'spreadsheet') {
-			if (this.sectionProperties.selectedComment)
+			if (this.sectionProperties.selectedComment && !this.sectionProperties.doNotHideCommentTimer)
 				this.sectionProperties.selectedComment.hide();
 		}
 
@@ -1677,6 +1685,10 @@ export class CommentSection extends CanvasSectionObject {
 					}
 					return;
 				}
+
+				// Synchronize calcMasterList
+				if (app.map._docLayer._docType === 'spreadsheet' && obj.comment.id !== 'new')
+					this.sectionProperties.calcMasterList.push(structuredClone(obj.comment));
 
 				this.adjustComment(obj.comment);
 				annotation = this.add(obj.comment);

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -1459,8 +1459,10 @@ export class Comment extends CanvasSectionObject {
 			if (this.sectionProperties.data.rectangles[0].containsPoint(app.calc.cellCursorRectangle.center))
 				this.sectionProperties.commentListSection.sectionProperties.calcCurrentComment = this;
 			else if (this.isSelected()) {
-				this.hide();
-				this.sectionProperties.commentListSection.sectionProperties.calcCurrentComment = null;
+				if (!this.sectionProperties.commentListSection.sectionProperties.doNotHideCommentTimer) {
+					this.hide();
+					this.sectionProperties.commentListSection.sectionProperties.calcCurrentComment = null;
+				}
 			}
 			else if (this.sectionProperties.commentListSection.sectionProperties.calcCurrentComment == this)
 				this.sectionProperties.commentListSection.sectionProperties.calcCurrentComment = null;

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -799,6 +799,22 @@ window.L.Map.WOPI = window.L.Handler.extend({
 				}
 			}
 		}
+		else if (msg.MessageId === 'Action_GoToComment') {
+			if (msg.Values) {
+				var commentSection = app.sectionContainer.getSectionWithName(app.CSections.CommentList.name);
+				if (!commentSection) {
+					this._sendGoToCommentResp(msg.Values.Id, false, 'Comment section not available');
+					return;
+				}
+				var docType = this._map._docLayer._docType;
+				if (docType === 'spreadsheet')
+					this._goToCalcComment(commentSection, msg.Values.Id);
+				else if (docType === 'text')
+					this._goToComment(commentSection, msg.Values.Id);
+				else
+					this._sendGoToCommentResp(msg.Values.Id, false, 'Unsupported document type'); // TODO: support Draw/Impress
+			}
+		}
 		else if (msg.sender === 'EIDEASY_SINGLE_METHOD_SIGNATURE') {
 			// This is produced by the esign popup.
 			const eSignature = this._map.eSignature;
@@ -806,6 +822,122 @@ window.L.Map.WOPI = window.L.Handler.extend({
 				eSignature.handleSigned(msg);
 			}
 		}
+	},
+
+	_goToComment: function(commentSection, commentId) {
+		// Writer and Calc use different types for Id: string vs. integer?
+		var comment = commentSection.getComment(commentId);
+		if (!comment)
+			comment = commentSection.getComment(parseInt(commentId));
+		if (!comment) {
+			this._sendGoToCommentResp(commentId, false, 'Comment not found');
+			return;
+		}
+
+		this._map.showComments(true);
+		if (comment.sectionProperties.data.resolved === 'true')
+			this._map.showResolvedComments(true);
+
+		// Move the cursor to the comment's anchor
+		var clickX, clickY;
+		var cellRange = comment.sectionProperties.data.cellRange;
+		if (this._map._docLayer._docType === 'spreadsheet' && cellRange) {
+			var cellRect = this._map._docLayer._cellRangeToTwipRect(cellRange).toRectangle();
+			clickX = Math.round(cellRect[0] + cellRect[2] / 2);
+			clickY = Math.round(cellRect[1] + cellRect[3] / 2);
+		} else {
+			var anchorPos = comment.sectionProperties.data.anchorPos;
+			clickX = anchorPos[0];
+			clickY = anchorPos[1];
+		}
+		if (clickX && clickY) {
+			this._map._docLayer._postMouseEvent('buttondown', clickX, clickY, 1, 1, 0);
+			this._map._docLayer._postMouseEvent('buttonup', clickX, clickY, 1, 1, 0);
+		}
+
+		commentSection.navigateAndFocusComment(comment);
+
+		if (this._map._docLayer._docType === 'spreadsheet') {
+			// The sheet switch and mouse click (which sets cursor to anchor) trigger
+			// async events (_onSetPartMsg, onNewDocumentTopLeft, onCellAddressChanged)
+			// that would normally hide the comment. Set a guard to prevent that, show
+			// the comment, then clear the guard after a timeout to let events settle.
+			// 2 s timeout is an arbitrary value, hoped to cover typical cases, and at
+			// the same time, not block expected responsiveness, when user expects it
+			// to hide.
+			var props = commentSection.sectionProperties;
+			if (props.doNotHideCommentTimer)
+				clearTimeout(props.doNotHideCommentTimer);
+			props.doNotHideCommentTimer = setTimeout(function() {
+				props.doNotHideCommentTimer = null;
+			}, 2000);
+
+			// Finally, an additional operation specific to Calc (maybe also Draw?):
+			// it actually shows the comment on mouse hover
+			comment.onMouseEnter();
+		}
+
+		this._sendGoToCommentResp(commentId, true);
+	},
+
+	_goToCalcComment: function(commentSection, commentId) {
+		var map = this._map;
+		var props = commentSection.sectionProperties;
+
+		// Try to find the comment in the current calcMasterList.
+		var entry = props.calcMasterList.find(el => el.id == commentId);
+		if (!entry) {
+			this._sendGoToCommentResp(commentId, false, 'Comment not found');
+			return;
+		}
+
+		// If timeout from previous command is still active, stop it; and hide any shown comment,
+		// to avoid a case when doNotHideCommentTimer would prevent another comment from hiding.
+		if (props.doNotHideCommentTimer)
+			clearTimeout(props.doNotHideCommentTimer);
+		props.doNotHideCommentTimer = null;
+		commentSection.hideAllComments();
+
+		var targetTab = parseInt(entry.tab);
+		if (map._docLayer._selectedPart == targetTab) {
+			// Already on the right sheet - navigate immediately.
+			this._goToComment(commentSection, commentId);
+			return;
+		}
+
+		// The comment is on a different sheet. Switch to it and wait for
+		// sheetgeometrychanged so the geometry is ready for positioning.
+
+		var safetyTimer = null;
+		var self = this;
+
+		function cleanup() {
+			clearTimeout(safetyTimer);
+			map.off('sheetgeometrychanged', onGeometry);
+		}
+
+		function onGeometry() {
+			cleanup();
+			self._goToComment(commentSection, commentId);
+		}
+
+		safetyTimer = setTimeout(function() {
+			cleanup();
+			self._sendGoToCommentResp(commentId, false, 'Timed out waiting for server');
+		}, 10000);
+
+		map.once('sheetgeometrychanged', onGeometry);
+		map.setPart(targetTab);
+	},
+
+	_sendGoToCommentResp: function(commentId, success, errorMsg) {
+		var args = { Id: String(commentId), success: success };
+		if (errorMsg)
+			args.errorMsg = errorMsg;
+		this._map.fire('postMessage', {
+			msgId: 'Action_GoToComment_Resp',
+			args: args
+		});
 	},
 
 	_postMessage: function(e) {

--- a/cypress_test/integration_tests/desktop/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/annotation_spec.js
@@ -200,6 +200,59 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 		desktopHelper.assertScrollbarPosition('vertical', 249, 252);
 	});
 
+	it('Action_GoToComment postMessage navigates to a comment across sheets', function() {
+		// Put text and a comment in cell B2 on Sheet 1.
+		helper.typeIntoInputField(helper.addressInputSelector, 'B2');
+		helper.typeIntoDocument('COMMENT_CELL{enter}');
+		helper.typeIntoInputField(helper.addressInputSelector, 'B2');
+		desktopHelper.insertComment();
+		cy.cGet('#comment-container-1').should('exist');
+
+		// Move to a faraway cell, to check that GoToComment will scroll back
+		helper.typeIntoInputField(helper.addressInputSelector, 'Z1000');
+		helper.typeIntoDocument('FAR_AWAY_CELL{enter}');
+
+		// Create a new sheet and put text there.
+		cy.cGet('#spreadsheet-toolbar #insertsheet').click();
+		calcHelper.assertNumberofSheets(2);
+		helper.typeIntoInputField(helper.addressInputSelector, 'A1');
+		helper.typeIntoDocument('SHEET2_CELL{enter}');
+
+		// We are now on Sheet 2; the comment is on Sheet 1.
+
+		// Stub postMessage to capture the response.
+		cy.getFrameWindow().then(win => {
+			cy.stub(win.parent, 'postMessage').as('postMessage');
+		});
+
+		// Send Action_GoToComment postMessage with the comment's Id.
+		cy.getFrameWindow().then(win => {
+			var message = {
+				'MessageId': 'Action_GoToComment',
+				'Values': { 'Id': '1' }
+			};
+			win.postMessage(JSON.stringify(message), '*');
+		});
+
+		// Verify the response postMessage was sent with success and no error.
+		cy.get('@postMessage').should(stub => {
+			var calls = stub.getCalls().filter(call => {
+				try {
+					var msg = typeof call.args[0] === 'string' ? JSON.parse(call.args[0]) : call.args[0];
+					return msg.MessageId === 'Action_GoToComment_Resp';
+				} catch (e) { return false; }
+			});
+			expect(calls.length, 'Action_GoToComment_Resp was not posted').to.be.greaterThan(0);
+			var resp = typeof calls[0].args[0] === 'string' ? JSON.parse(calls[0].args[0]) : calls[0].args[0];
+			expect(resp.Values.success, 'Action_GoToComment_Resp reported error: ' + resp.Values.errorMsg).to.be.true;
+			expect(resp.Values.Id).to.equal('1');
+		});
+
+		// The comment should be visible and the anchor cell (B2) selected.
+		cy.cGet('#comment-container-1').should('be.visible');
+		cy.cGet(helper.addressInputSelector).should('have.prop', 'value', 'B2');
+	});
+
 });
 
 describe(['tagdesktop'], 'Annotation Autosave Tests', function() {

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -297,6 +297,91 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 		cy.get('@windowOpen').should('be.called');
 	});
 
+	it('Action_GoToComment postMessage navigates to a comment', function() {
+		// Type identifiable text on the first line where the comment will be.
+		helper.typeIntoDocument('COMMENT_ANCHOR_LINE');
+
+		desktopHelper.insertComment();
+
+		cy.cGet('.cool-annotation-content-wrapper').should('be.visible');
+		cy.cGet('#annotation-content-area-1').should('contain', 'some text0');
+
+		// Type lots of paragraph breaks so the document scrolls well past the comment.
+		helper.typeIntoDocument('{ctrl}{end}');
+		helper.typeIntoDocument('{enter}'.repeat(80) + 'BOTTOM_OF_DOCUMENT');
+
+		// The comment should now be scrolled out of view.
+		cy.cGet('#comment-container-1').should('not.be.visible');
+
+		// Stub postMessage to capture the response.
+		cy.getFrameWindow().then(win => {
+			cy.stub(win.parent, 'postMessage').as('postMessage');
+		});
+
+		// Send Action_GoToComment postMessage with the comment's Id.
+		cy.getFrameWindow().then(win => {
+			var message = {
+				'MessageId': 'Action_GoToComment',
+				'Values': { 'Id': '1' }
+			};
+			win.postMessage(JSON.stringify(message), '*');
+		});
+
+		// Verify the response postMessage was sent with success and no error.
+		cy.get('@postMessage').should(stub => {
+			var calls = stub.getCalls().filter(call => {
+				try {
+					var msg = typeof call.args[0] === 'string' ? JSON.parse(call.args[0]) : call.args[0];
+					return msg.MessageId === 'Action_GoToComment_Resp';
+				} catch (e) { return false; }
+			});
+			expect(calls.length, 'Action_GoToComment_Resp was not posted').to.be.greaterThan(0);
+			var resp = typeof calls[0].args[0] === 'string' ? JSON.parse(calls[0].args[0]) : calls[0].args[0];
+			expect(resp.Values.success, 'Action_GoToComment_Resp reported error: ' + resp.Values.errorMsg).to.be.true;
+			expect(resp.Values.Id).to.equal('1');
+		});
+
+		// After GoToComment, the comment should be scrolled back into view.
+		cy.cGet('#comment-container-1').should('be.visible');
+		// The cursor should be at the end of the first paragraph (the comment anchor).
+		// #clipboard-area has a copy of current cursor's node text (including anchor character):
+		cy.cGet('#clipboard-area').should('have.prop', 'textContent', 'COMMENT_ANCHOR_LINE\uFFFC');
+		cy.getFrameWindow().then(win => {
+			var textInput = win.app.map._textInput;
+			expect(textInput._lastSelectionStart).to.equal(20);
+			expect(textInput._lastSelectionEnd).to.equal(20);
+		});
+	});
+
+	it('Action_GoToComment postMessage returns error for invalid comment', function() {
+		// Stub postMessage to capture the response.
+		cy.getFrameWindow().then(win => {
+			cy.stub(win.parent, 'postMessage').as('postMessage');
+		});
+
+		// Send Action_GoToComment with a non-existent comment Id.
+		cy.getFrameWindow().then(win => {
+			var message = {
+				'MessageId': 'Action_GoToComment',
+				'Values': { 'Id': '999' }
+			};
+			win.postMessage(JSON.stringify(message), '*');
+		});
+
+		// Verify error response was sent.
+		cy.get('@postMessage').should(stub => {
+			var found = stub.getCalls().some(call => {
+				try {
+					var msg = typeof call.args[0] === 'string' ? JSON.parse(call.args[0]) : call.args[0];
+					return msg.MessageId === 'Action_GoToComment_Resp'
+						&& msg.Values && msg.Values.success === false
+						&& msg.Values.Id === '999';
+				} catch (e) { return false; }
+			});
+			expect(found, 'Action_GoToComment_Resp with failure was not posted').to.be.true;
+		});
+	});
+
 });
 
 describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {


### PR DESCRIPTION
Navigate to a comment by ID via postMessage from the host.
Supports Writer (scroll + focus) and Calc (cross-sheet navigation
with a guard timer to prevent async events from hiding the comment).
Synchronizes calcMasterList on comment add/remove.
Includes cypress tests for Writer and Calc.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: Ib6175ce047ea9acf8f1a9e1022a6d08644c07093
