### PR TITLE
Fix welcome workflow triggering for returning contributors.

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -9,17 +9,19 @@ permissions:
 
 jobs:
   welcome:
-    if: >-
-      github.event.action == 'opened' &&
-      (github.event.pull_request.author_association == 'NONE' ||
-       github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
-       github.event.pull_request.author_association == 'FIRST_TIMER')
+    if: github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
       - name: Post welcome comment
         uses: actions/github-script@v7
         with:
           script: |
+            const author = context.payload.pull_request.user.login;
+            const { data: prs } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} type:pr author:${author}`,
+            });
+            if (prs.total_count > 1) return;
+
             const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
The welcome message was posted on every PR from non-members because the author_association check treated NONE (no repo role) as a new contributor. Replace it with a PR count search so only genuinely first-time contributors see the welcome message.


Change-Id: I444ea6c1cdf6b41ddcd7669e1ee8803c8d2e1560


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

