### PR TITLE
Calc: Adapt the frozen area better to big scale.

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -181,7 +181,9 @@ window.L.CalcTileLayer = window.L.CanvasTileLayer.extend({
 				TileManager.tileSize);
 		}
 		this._restrictDocumentSize();
+		this.dontSendSplitPosToCore = true;
 		this.setSplitPosFromCell();
+		this.dontSendSplitPosToCore = false;
 		this._map.fire('zoomchanged');
 		this.refreshViewData();
 		this._replayPrintTwipsMsgs(false);


### PR DESCRIPTION
Issue:
* Set split panes to somewhere.
* Zoom in.
* Frozen area has to get smaller or you can't move the screen anymore, because all the area you see will be frozen.
* So the smaller area gets smaller, we have this already.
* But while we shrink the frozen area of the document, we also send the new frozen zone to the core side.
* This saves the shrunk area to the document.
* That last step is a bit unwanted.

Fix:
* Don't send the adjusted frozen area to the core side. If user does it themselves, they can, but we won't do after a zoom level change.

Fix uses an already used variable.


Change-Id: I71bba8d1249b99817495fc9d703635fb0480f502


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

