### PR TITLE
context toolbar: show is nearer to the cursor

### DIFF
--- a/browser/src/control/Control.ContextToolbar.ts
+++ b/browser/src/control/Control.ContextToolbar.ts
@@ -111,8 +111,8 @@ class ContextToolbar extends JSDialogComponent {
 		}
 
 		URLPopUpSection.closeURLPopUp();
-		let statRect;
-		if (!TextSelections || !(statRect = TextSelections.getStartRectangle()))
+		const statRect = app.file.textCursor.rectangle;
+		if (!TextSelections || !TextSelections.getStartRectangle() || !statRect)
 			return;
 
 		Util.ensureValue(app.activeDocument);


### PR DESCRIPTION
problem:
when large paragraph is selected from top to bottom context toolbar appeared at the top of the selection which is very far from the mouse cursor and text cursor.

This will always show toolbar near to the cursor.

i.e: if the selection is in the forward direction
toolbar appears at the end of the selection. If the selection is in the reverse direction toolbar will appear at the top near cursor.

fixed #15297


Change-Id: I19cfafc9d03efcdc1c759150988fd195d3b726c2


* Resolves: # <!-- related github issue -->
* Target version: main



### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

