### PR TITLE
browser: a11y: add text-align to fixedtext type

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1547,6 +1547,10 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		else if (data.html)
 			fixedtext.innerHTML = data.html;
 
+		if (data.xalign) {
+			fixedtext.style = 'text-align:' + data.xalign + ';';
+		}
+
 		var accKey = builder._getAccessKeyFromText(data.text);
 		builder._stressAccessKey(fixedtext, accKey);
 


### PR DESCRIPTION
Some columns in the grid widget require centering
the static text for accessibility.

Change-Id: I439688e17b500c472d893fe97b4a5b8452e0a872
Signed-off-by: Henry Castro <henry.castro@collabora.com>
