### PR TITLE
LOK_ALLOWED_EXTREF_PATHS env. var. was renamed in core

### DIFF
--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -2360,7 +2360,7 @@ void COOLWSD::setLokitEnvironmentVariables(const Poco::Util::LayeredConfiguratio
     }
 
 #if !MOBILEAPP
-    setenv("LOK_ALLOWED_EXTREF_PATHS", "", true);
+    setenv("KIT_ALLOWED_EXTREF_PATHS", "", true);
 #endif
 }
 


### PR DESCRIPTION
LOK_ALLOWED_EXTREF_PATHS was renamed to KIT_ALLOWED_EXTREF_PATHS in core
