### PR TITLE
jsdialog: apply ARIA role to focusable drawing area images

### DIFF
--- a/browser/src/control/jsdialog/Widget.DrawingArea.js
+++ b/browser/src/control/jsdialog/Widget.DrawingArea.js
@@ -50,6 +50,9 @@ function _drawingAreaControl (parentContainer, data, builder) {
 	if (isFocusableImg) {
 		image.tabIndex = 0;
 		JSDialog.AddAltAttrOnFocusableImg(image, data, builder);
+		if (data.aria && data.aria.role) {
+			image.setAttribute('role', data.aria.role);
+		}
 	} else {
 		image.alt = '';
 		image.classList.add('ui-decorative-image');


### PR DESCRIPTION
jsdialog: apply ARIA role to focusable drawing area images

To reproduce:
Open Writer in Online, type misspelled text, then Review > Spelling (F7). The errorsentence <img> should now have role=textbox instead of no role.


Change-Id: I75fea9282c0f56901c10f4f6bded0404adb47355


* Resolves: # <!-- related github issue -->
* Target version: main

