### PR TITLE
Calc Sidebar: Fix layout of keep ratio element group's grid

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -143,7 +143,7 @@ img.sidebar.ui-image {
 	line-height: var(--default-height);
 }
 
-.sidebar.ui-grid.ui-grid-cell > div:not(.ui-treeview) {
+.sidebar.ui-grid.ui-grid-cell > div:not(.ui-treeview):not(.ui-grid) {
 	justify-content: start;
 	display: flex;
 	align-items: center;


### PR DESCRIPTION
Position and Size tab of the calc sidebar has keep ratio. Lock image, connector shapes and checkbox was horizontal instead of in rows and cols

Added :not(.ui-grid) to the flex override rule to prevent nested grids from losing display: grid


Change-Id: I1f7dc48b3b66da27e8f03faeb9688789380e1fcb


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

