### PR TITLE
Fix Windows build after Util namespace refactoring

### DIFF
--- a/common/ProcUtil.cpp
+++ b/common/ProcUtil.cpp
@@ -160,7 +160,7 @@ void setThreadName(const std::string& s)
 #elif defined __EMSCRIPTEN__
     emscripten_console_logf("COOL thread name: \"%s\"", s.c_str());
 #elif defined _WIN32
-    SetThreadDescription(GetCurrentThread(), string_to_wide_string(s).c_str());
+    SetThreadDescription(GetCurrentThread(), Util::string_to_wide_string(s).c_str());
     LOG_INF("Thread " << getThreadId() << " is now called [" << s << ']');
 #endif
 
@@ -186,7 +186,7 @@ const char* getThreadName()
 #elif defined _WIN32
         PWSTR description;
         if (SUCCEEDED(GetThreadDescription(GetCurrentThread(), &description)))
-            strncpy(ThreadName, wide_string_to_string(description).c_str(), sizeof(ThreadName) - 1);
+            strncpy(ThreadName, Util::wide_string_to_string(description).c_str(), sizeof(ThreadName) - 1);
         LocalFree(description);
 #endif
         ThreadName[sizeof(ThreadName) - 1] = '\0';


### PR DESCRIPTION
Change-Id: Ie63dc766ca60c04a1ab509211b4be8e2bacf922c


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

