### PR TITLE
Fix Emscripten build after the recent core android removal

### DIFF
--- a/wasm/README.no-container.md
+++ b/wasm/README.no-container.md
@@ -100,4 +100,4 @@ Once the build is done, you can serve the browser/dist tree from a web server (e
 file_path=/some/exisiting/document query paramter, where /some/exisiting/document is the absolute
 path of an exisiting document in the Emscripten file system (cf. online's
 --with-wasm-additional-files configure option; e.g., some
-<http://localhost:6931/cool.html?file_path=/android/default-document/example.odt> for the emrun example).
+<http://localhost:6931/cool.html?file_path=/TODO/example.odt> for the emrun example).


### PR DESCRIPTION
...which sadly leaves us with no example document in the Emscripten file system, so at least for now stub out any mentions of it in the documentation with "TODO" (see
<https://gerrit.collaboraoffice.com/plugins/gitiles/core/+/56e620e68a247968d91e4d044ff6fda27cbc886f%5E%21/> "Fix Emscripten build after the recent android removal")


Change-Id: I06b2a5155c0e41162a1a77cf2ae5c94d4d739681


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

