### PR TITLE
Animate view switcher on formatting shortcuts in view mode

### DIFF
--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -155,6 +155,17 @@ class UIManager extends window.L.Control {
 	}
 
 	/**
+	 * Shows a timed tooltip on the view mode button and optionally plays the attention animation.
+	 */
+	showViewModeAttention(): void {
+		const permissionMode = this.permissionViewMode;
+		const viewModeBtn = permissionMode && (permissionMode.viewModeDropdown || permissionMode.viewModeContainer);
+		if (viewModeBtn) {
+			this.showAttention(viewModeBtn, _('You are currently in View mode'), true, 5000);
+		}
+	}
+
+	/**
 	 * Returns the current UI mode ("notebookbar" or "classic").
 	 */
 	getCurrentMode(): UIMode {

--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -7,7 +7,7 @@
  * at TextInput.
  */
 
-/* global _ app UNOKey TileManager */
+/* global app UNOKey TileManager */
 
 window.L.Map.mergeOptions({
 	keyboard: true,
@@ -671,11 +671,7 @@ window.L.Map.Keyboard = window.L.Handler.extend({
 				map.setZoom(map.getZoom() + (ev.shiftKey ? 3 : 1) * this._zoomKeys[key], null, true /* animate? */);
 			}
 			else if (ev.key && ev.key.length === 1 && !ev.ctrlKey && !ev.altKey && !map.isEditMode()) {
-				let permissionMode = map.uiManager && map.uiManager.permissionViewMode;
-				let viewModeBtn = permissionMode && (permissionMode.viewModeDropdown || permissionMode.viewModeContainer);
-				if (viewModeBtn && map.uiManager && map.uiManager.showAttention) {
-					map.uiManager.showAttention(viewModeBtn, _('You are currently in View mode'), true, 5000);
-				}
+				map.uiManager.showViewModeAttention();
 			}
 		}
 

--- a/browser/src/map/handler/Map.KeyboardShortcuts.ts
+++ b/browser/src/map/handler/Map.KeyboardShortcuts.ts
@@ -240,6 +240,8 @@ class KeyboardShortcuts {
                 shortcut.unoAction !== '.uno:CloseWin' &&
                 shortcut.viewType !== ViewType.ReadOnly) {
                 event.preventDefault();
+                this.map.uiManager.showViewModeAttention();
+
                 return true;
             }
 
@@ -338,6 +340,10 @@ keyboardShortcuts.definitions.set('default', new Array<ShortcutDescriptor>(
         Disable F2 in Writer, formula bar is unsupported, and messes with further input.
         Disable CTRL+SHIFT+N because core side template dialog is not supported on Online.
     */
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 'b', unoAction: '.uno:Bold' }),
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 'i', unoAction: '.uno:Italic' }),
+    new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL, key: 'u', unoAction: '.uno:Underline' }),
+
     new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.CTRL | Mod.SHIFT, key: 'N' }),
     new ShortcutDescriptor({ eventType: 'keydown', key: 'F1', dispatchAction: 'showhelp' }),
     new ShortcutDescriptor({ eventType: 'keydown', modifier: Mod.ALT, key: 'F1', dispatchAction: 'focustonotebookbar' }),


### PR DESCRIPTION
Change-Id: I6b827a51d71f4cc903e60ca38615a6a30e9545d5


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
 - Registers formatting shortcuts like Ctrl+B, Ctrl+I, and Ctrl+U globally so they are always intercepted, even when in viewmode.

 - Prevents the browser’s default actions (like opening sidebars or page source) and, in view mode, triggers the view mode switcher animation instead of silently ignoring the input.

### PREVIEW


https://github.com/user-attachments/assets/084f56d1-d54c-45b1-b39e-184420fe8552



