### PR TITLE
fix(a11y): add modelid fallback for access key lookup

### DIFF
--- a/browser/src/dom/NotebookbarAccessibilityDefinitions.js
+++ b/browser/src/dom/NotebookbarAccessibilityDefinitions.js
@@ -29,6 +29,19 @@ var NotebookbarAccessibilityDefinitions = function() {
 					var arrow = document.querySelector('#' + id + ' .arrowbackground');
 					var element = document.getElementById(id + '-button');
 
+					// If standard lookups failed and item has a UNO command, try
+					// finding by modelid. This handles WeldedToolbar items where
+					// core assigns command-based ids (e.g. NumberFormatCurrency)
+					// instead of the JS definition ids (e.g. home-number-format-currency).
+					if (!overflow && !arrow && !element && rawList[i].command) {
+						var commandId = rawList[i].command.replace('.uno:', '');
+						var byModelId = document.querySelector('[modelid="' + commandId + '"]');
+						if (byModelId) {
+							id = commandId;
+							arrow = byModelId.querySelector('.arrowbackground');
+						}
+					}
+
 					if (overflow) {
 						// overflow button
 						if (typeof overflow.isCollapsed === 'function' && overflow.isCollapsed()) {


### PR DESCRIPTION
fix(a11y): add modelid fallback for access key lookup

The number currency format in Calc was not accessible via the access key when the currency was applied (selected state). This is because the WeldedToolbar currency button gets its DOM id from core (e.g., NumberFormatCurrency677) instead of the JS definition id (home-number-format-currency), so exact id selectors never match and the P access key is never assigned.

This fix ensures that lookup via modelid is used as a fallback, so in case the state changes and the element gets a new id, it still works correctly.


Change-Id: Ide8573c54cca21ca69c12f8aba6e49b58310b253


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

