### PR TITLE
Writer: Convert View Changes split button into radio-style menu btn

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1433,7 +1433,7 @@ img.context-menu-icon {
 	background-color: var(--color-background-hover);
 }
 
-.ui-combobox-entry.selected:not(:hover) span,
+.ui-combobox-entry.selected:not(:hover):not(.checked):not(.notchecked) span,
 .margin-item.selected {
 	background-color: var(--color-background-darker);
 }
@@ -1479,7 +1479,7 @@ img.context-menu-icon {
 	filter: contrast(0.5);
 }
 
-.ui-combobox-entry.selected img:not(:hover) {
+.ui-combobox-entry.selected:not(.checked):not(.notchecked) img:not(:hover) {
 	border: 1px solid var(--color-primary);
 }
 

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -2367,8 +2367,8 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 						'id': 'compare-tracked-change:ViewChangesMenu',
 						'type': 'menubutton',
 						'text': _('View Changes'),
-						'applyCallback': 'comparechanges',
-						'command': 'comparechanges',
+						'icon': 'lc_comparechanges.svg',
+						'command': 'viewchanges',
 						'accessibility': { focusBack: true, combination: 'CC' }
 					},
 					{

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -117,6 +117,24 @@ class UIManager extends window.L.Control {
 		this.map['stateChangeHandler'].setItemValue('toggledarktheme', 'false');
 		this.map['stateChangeHandler'].setItemValue('invertbackground', 'false');
 		this.map['stateChangeHandler'].setItemValue('showannotations', 'true');
+
+		// View Changes menu: default to Hidden, sync with core state.
+		this.map['stateChangeHandler'].setItemValue('viewchanges-hidden', 'true');
+		this.map['stateChangeHandler'].setItemValue('viewchanges-inline', 'false');
+		this.map['stateChangeHandler'].setItemValue('viewchanges-sidebyside', 'false');
+		this.map['stateChangeHandler'].setItemValue('viewchanges', 'false');
+		this.map.on('commandstatechanged', (e: any) => {
+			if (e.commandName === '.uno:ShowTrackedChanges') {
+				const isSideBySide =
+					app.activeDocument?.activeLayout?.type === 'ViewLayoutCompareChanges';
+				if (isSideBySide) return; // side-by-side mode manages its own state
+
+				const isInline = e.state === 'true';
+				this.map['stateChangeHandler'].setItemValue('viewchanges-inline', isInline ? 'true' : 'false');
+				this.map['stateChangeHandler'].setItemValue('viewchanges-hidden', isInline ? 'false' : 'true');
+				this.map['stateChangeHandler'].setItemValue('viewchanges', isInline ? 'true' : 'false');
+			}
+		});
 		window.addEventListener('browsersettingchanged', () => {
 			this.initDarkModeFromSettings();
 		});
@@ -659,7 +677,7 @@ class UIManager extends window.L.Control {
 					if (e.statusType !== 'initializationcomplete') {
 						return;
 					}
-					app.dispatcher.dispatch('comparechanges');
+					app.dispatcher.dispatch('viewchanges-sidebyside');
 					this.map.off('statusindicator', enterCompareChanges);
 				};
 				this.map.on('statusindicator', enterCompareChanges);

--- a/browser/src/control/jsdialog/Definitions.Menu.ts
+++ b/browser/src/control/jsdialog/Definitions.Menu.ts
@@ -1797,16 +1797,24 @@ menuDefinitions.set('PasteMenu', [
 
 menuDefinitions.set('ViewChangesMenu', [
 	{
-		id: 'review-show-tracked-changes',
+		id: 'viewchanges-inline',
 		img: 'showtrackedchanges',
 		text: _('Inline'),
-		uno: '.uno:ShowTrackedChanges',
+		action: 'viewchanges-inline',
+		checked: false,
 	},
 	{
-		id: 'compare-tracked-change',
+		id: 'viewchanges-sidebyside',
 		img: 'comparechanges',
 		text: _('Side by Side'),
-		action: 'comparechanges',
+		action: 'viewchanges-sidebyside',
+		checked: false,
+	},
+	{
+		id: 'viewchanges-hidden',
+		text: _('Hidden'),
+		action: 'viewchanges-hidden',
+		checked: false,
 	},
 ] as Array<MenuDefinition>);
 

--- a/browser/src/control/jsdialog/Util.ButtonType.ts
+++ b/browser/src/control/jsdialog/Util.ButtonType.ts
@@ -70,7 +70,7 @@ function getToggleButtons() {
 		'.uno:TrackChangesInAllViews',
 		'.uno:TrackChangesInThisView',
 		'.uno:Underline',
-		'comparechanges',
+		'viewchanges',
 		'showannotations',
 		'toggledarktheme',
 	];

--- a/browser/src/control/jsdialog/Util.Dropdown.ts
+++ b/browser/src/control/jsdialog/Util.Dropdown.ts
@@ -96,7 +96,8 @@ JSDialog.OpenDropdown = function (
 		const checkedValue =
 			entries[i].checked === undefined
 				? undefined
-				: entries[i].uno && isChecked('.uno' + entries[i].uno);
+				: (entries[i].uno ? isChecked('.uno' + entries[i].uno) : false) ||
+					(entries[i].action ? isChecked(String(entries[i].action)) : false);
 
 		let entry:
 			| WidgetJSON

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -816,6 +816,81 @@ class Dispatcher {
 				}
 			}
 		};
+
+		// View Changes menu: radio-style actions (Inline / Side by Side / Hidden).
+		// Each action activates its mode and deactivates the others.
+
+		const updateViewChangesState = function (mode: string) {
+			const states: Record<string, boolean> = {
+				'viewchanges-inline': mode === 'inline',
+				'viewchanges-sidebyside': mode === 'sidebyside',
+				'viewchanges-hidden': mode === 'hidden',
+				viewchanges: mode !== 'hidden',
+			};
+
+			for (const key in states) {
+				const val = states[key] ? 'true' : 'false';
+				app.map['stateChangeHandler'].setItemValue(key, val);
+				app.map.fire('commandstatechanged', {
+					commandName: key,
+					state: val,
+				});
+			}
+		};
+
+		const switchToWriterLayout = function () {
+			if (
+				app.activeDocument?.activeLayout?.type === 'ViewLayoutCompareChanges'
+			) {
+				app.activeDocument.activeLayout = new ViewLayoutWriter();
+				TileManager.redraw();
+				app.map._docLayer._fitWidthZoom(null, null, true);
+				app.activeDocument.activeLayout.sendClientVisibleArea();
+				app.sectionContainer.requestReDraw();
+			}
+		};
+
+		this.actionsMap['viewchanges-inline'] = function () {
+			if (!app.activeDocument?.activeLayout) return;
+
+			switchToWriterLayout();
+
+			// Ensure inline tracked changes are visible.
+			const showState = app.map['stateChangeHandler'].getItemValue(
+				'.uno:ShowTrackedChanges',
+			);
+			if (showState !== 'true')
+				app.map.sendUnoCommand('.uno:ShowTrackedChanges');
+
+			updateViewChangesState('inline');
+		};
+
+		this.actionsMap['viewchanges-sidebyside'] = function () {
+			if (!app.activeDocument?.activeLayout) return;
+
+			Util.ensureValue(app.activeDocument);
+			app.socket.sendMessage('uno .uno:RedlineRenderMode');
+
+			if (app.activeDocument.activeLayout.type !== 'ViewLayoutCompareChanges')
+				app.activeDocument.activeLayout = new ViewLayoutCompareChanges();
+
+			updateViewChangesState('sidebyside');
+		};
+
+		this.actionsMap['viewchanges-hidden'] = function () {
+			if (!app.activeDocument?.activeLayout) return;
+
+			switchToWriterLayout();
+
+			// Ensure inline tracked changes are hidden.
+			const showState = app.map['stateChangeHandler'].getItemValue(
+				'.uno:ShowTrackedChanges',
+			);
+			if (showState === 'true')
+				app.map.sendUnoCommand('.uno:ShowTrackedChanges');
+
+			updateViewChangesState('hidden');
+		};
 	}
 
 	private addMobileCommands() {

--- a/cypress_test/integration_tests/desktop/writer/compare_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/compare_changes_spec.js
@@ -8,6 +8,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Compare Changes view with 
 	function enterCompareChangesMode() {
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
 		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-entry-1').click();
 		cy.cGet('.compare-changes-labels').should('not.have.css', 'display', 'none');
 	}
 

--- a/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/track_changes_spec.js
@@ -147,6 +147,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.cGet('#AcceptRejectChangesDialog').should('not.exist');
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
 		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-entry-1').click();
 
 		// Then the left label should show the old document name:
 		cy.cGet('#compare-changes-left-title').should(function($el) {
@@ -178,6 +179,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		// If this is visible or not is not interesting, we want to assert the resulting
 		// title.
 		cy.cGet('#compare-tracked-change-button').click({force: true});
+		cy.cGet('#compare-tracked-change-entry-1').click();
 		cy.cGet('#compare-changes-left-title').should(function($el) {
 			expect($el.text()).to.match(/^remote_old\.odt/);
 		});
@@ -194,6 +196,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		// When entering doc compare mode via View Changes:
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
 		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-entry-1').click();
 
 		// Then tiles should exist for both mode=1 (LeftSide) and mode=2 (RightSide)
 		// with content:
@@ -227,6 +230,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.cGet('#Review-tab-label').click();
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
 		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-entry-1').click();
 		cy.cGet('.compare-changes-labels').should('not.have.css', 'display', 'none');
 
 		// When faking a tooltip message for a tracked change on the right side:
@@ -256,6 +260,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.cGet('#Review-tab-label').click();
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
 		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-entry-1').click();
 		cy.cGet('.compare-changes-labels').should('not.have.css', 'display', 'none');
 
 		// When faking a tooltip message with anchor rectangles for a deletion:
@@ -290,6 +295,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.cGet('#Review-tab-label').click();
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
 		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-entry-1').click();
 		cy.cGet('.compare-changes-labels').should('not.have.css', 'display', 'none');
 
 		// When double-clicking at the cursor position on the right side to create a selection:
@@ -313,6 +319,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.cGet('#Review-tab-label').click();
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
 		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-entry-1').click();
 		cy.cGet('.compare-changes-labels').should('not.have.css', 'display', 'none');
 
 		// When zooming out:
@@ -350,6 +357,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Track Changes', function (
 		cy.cGet('#Review-tab-label').click();
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
 		cy.cGet('#compare-tracked-change-button').filter(':visible').click();
+		cy.cGet('#compare-tracked-change-entry-1').click();
 		cy.cGet('.compare-changes-labels').should('not.have.css', 'display', 'none');
 
 		// When scrolling down:


### PR DESCRIPTION
Replace the split button with a regular menu button offering three
mutually exclusive modes: Inline, Side by Side, and Hidden.

The split button was confusing: its toggle state only tracked
side-by-side layout, not inline tracked changes, so the button
appeared off even when changes were visible. The two click zones
(toggle vs dropdown) also hurt discoverability.

Now any click opens the menu with radio-style checkmarks showing
the active mode. The button itself shows pressed/active when
changes are visible (Inline or Side by Side).

Fixes the .selected CSS class by adding a gray background and border
to the currently keyboard-focused menu item.
  - The problem was that this styling also applied inside dropdown
  menus that use checkmarks so, you'd see a gray highlight and a
  checkmark on the same item, which looked broken. The fix makes those
  styles skip entries that already have checkmark indicators.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: Ib9716b80a8ad53a3367ca5e4c42f0ead000162c8
