### PR TITLE
allow save as in view only mode

### DIFF
--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -294,7 +294,7 @@ window.L.Map.include({
 		}
 
 		var isAllowedInReadOnly = false;
-		var allowedCommands = ['.uno:Save', '.uno:WordCountDialog',
+		var allowedCommands = ['.uno:Save', '.uno:SaveAs', '.uno:WordCountDialog',
 			'.uno:Signature', '.uno:PrepareSignature', '.uno:DownloadSignature', '.uno:InsertSignatureLine',
 			'.uno:ShowResolvedAnnotations', '.uno:Open', '.uno:CloseWin',
 			'.uno:ToolbarMode?Mode:string=notebookbar_online.ui', '.uno:ToolbarMode?Mode:string=Default',


### PR DESCRIPTION
* Target version: main

### Summary

on Linux, Collabora Office (qt app) in the view only mode File -> Save As did
nothing. This adds .uno:SaveAs to the read only allow list, enabling Save As.

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

<!-- Message of single commit: -->

fix(browser): allow Save As in readonly mode

File -> Save As does nothing in the Desktop Linux app when in readonly
mode. The .uno:SaveAs command is blocked by the sendUnoCommand() readonly
gate in Toolbar.js. Add it to the allowed commands list.

Signed-off-by: Sarper Akdemir <sarper.akdemir@collabora.com>
Change-Id: Ib1ab416dd7d34b9c84c4889258bd06073b6791aa