### PR TITLE
Close visible snackbar on permission mode switch

### DIFF
--- a/browser/src/control/PermissionMode.ts
+++ b/browser/src/control/PermissionMode.ts
@@ -184,6 +184,8 @@ class PermissionViewMode extends JSDialogComponent {
 			return;
 		}
 
+		this.map.uiManager.closeSnackbar();
+
 		if (mode === 'edit') {
 			if (typeof this.map._switchToEditMode === 'function')
 				this.map._switchToEditMode();


### PR DESCRIPTION
  - When switching between Viewing and Editing mode via the dropdown, any visible snackbar could remain on screen and overlap with the new mode's UI.
  - Close it in handleModeSelection before the mode transition begins.


Change-Id: I33d3c6c8b20b4aa9db2df1d62f4aa59a9fdf0e08

* Resolves: #15420 
* Target version: main


[Screencast from 2026-04-10 20-17-07.webm](https://github.com/user-attachments/assets/a571c576-38a4-4e61-a5b0-bd406faadad4)

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

