### PR TITLE
fix(calc): Make dropdows work with different zooms

### DIFF
--- a/browser/src/canvas/sections/CalcValidityDropDownSection.ts
+++ b/browser/src/canvas/sections/CalcValidityDropDownSection.ts
@@ -33,11 +33,9 @@ class CalcValidityDropDown extends HTMLObjectSection {
 		e.preventDefault();
 		this.stopPropagating();
 
-		// Calculate the center position of the section. We will send this to core side.
-		point.pX = this.position[0] + this.size[0] / 2;
-		point.pY = this.position[1] + this.size[1] / 2;
-
-		app.map._docLayer._postMouseEvent('buttondown', point.x, point.y, 1, 1, 0);
-		app.map._docLayer._postMouseEvent('buttonup', point.x, point.y, 1, 1, 0);
+		const _validatedCellAddress = (app.map._docLayer as { _validatedCellAddress?: null | cool.SimplePoint })._validatedCellAddress;
+		if (_validatedCellAddress && app.calc.cellCursorVisible && _validatedCellAddress.equals(app.calc.cellAddress?.toArray() ?? [])) {
+			app.map.sendUnoCommand('.uno:DataSelect');
+		}
 	}
 }


### PR DESCRIPTION
In I4cab2546f6828ab3c76ba8a4e06601904a06502e, DropDownSection was moved into its own file. During this move, some stuff was broken so the dropdown was only active on part of the dropdown arrow.

In I6a5b26b42e4cf77a070452042d5f7a242e874bc0, we then stopped using the uno command to send the dropdown to core, and instead relied on the core position of the dropdown arrow.

Finally, Ib48f7266f7b0d147761eaccd647caf39df0d6550 made it so we would click in the center of the dropdown arrow.

Unfortunately, Ib48f7266f7b0d147761eaccd647caf39df0d6550 made the problem worse on certain zooms/high DPI screens. The dropdown would then either be activeateable across the whole arrow or not be activateable at all.

I think the problems caused by I4cab2546f6828ab3c76ba8a4e06601904a06502e are not still around today, however they did mask problems caused by  I6a5b26b42e4cf77a070452042d5f7a242e874bc0 which made the dropdown break when the core position didn't line up.

To fix this, we can revert to using the original uno-command-based approach to handling dropdowns. I've chatted to Gokay and he has OKed this as an approach...


Change-Id: I8973fa6d2caa5558dd4c9d6c52c4cd126a6a6964


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

