### PR TITLE
fix: unselect selected comment on scroll

### DIFF
--- a/browser/src/app/ViewLayout.ts
+++ b/browser/src/app/ViewLayout.ts
@@ -368,6 +368,11 @@ class ViewLayoutBase {
 		return false;
 	}
 
+	// virtual function implemented by the children
+	public unselectCommentOnScroll() {
+		return;
+	}
+
 	private addToMoveBy(pX: number, pY: number) {
 		if (this.scrollProperties.moveBy !== null) {
 			// Add offset to the pending move event.
@@ -489,6 +494,7 @@ class ViewLayoutBase {
 			this.scrollVertical(pY);
 
 		this.refreshCurrentCoordList();
+		this.unselectCommentOnScroll();
 		app.sectionContainer.requestReDraw();
 	}
 

--- a/browser/src/app/ViewLayoutWriter.ts
+++ b/browser/src/app/ViewLayoutWriter.ts
@@ -31,6 +31,16 @@ class ViewLayoutWriter extends ViewLayoutBase {
 		);
 	}
 
+	public unselectCommentOnScroll() {
+		const commentSection = app.sectionContainer.getSectionWithName(
+			app.CSections.CommentList.name,
+		) as cool.CommentSection;
+
+		if (commentSection && commentSection.sectionProperties.selectedComment) {
+			commentSection.unselect();
+		}
+	}
+
 	private getCommentAndDocumentSpacingInfo(): DocumentSpacingInfo {
 		const commentSection = app.sectionContainer.getSectionWithName(
 			app.CSections.CommentList.name,

--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -1009,7 +1009,7 @@ export class CommentSection extends CanvasSectionObject {
 			}
 
 			if (app.map._docLayer._docType !== 'spreadsheet') {
-				this.sectionProperties.selectedComment.setContainerPos(true, this.sectionProperties.canvasContainerBounds);
+				this.sectionProperties.selectedComment?.setContainerPos(true, this.sectionProperties.canvasContainerBounds);
 			}
 
 			this.update();

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -818,4 +818,14 @@ describe(['tagdesktop'], 'Annotation with @mention', function() {
 		cy.cGet('#mentionPopup').should('not.exist');
 		cy.cGet('#annotation-modify-textarea-new').should('have.focus');
 	});
+
+	it('Unselect comment on scroll', function() {
+		desktopHelper.insertComment('test comment');
+		cy.cGet('#comment-container-1').should('exist');
+		cy.cGet('#comment-container-1').should('exist').should('not.have.class', 'annotation-active');
+		cy.cGet('#comment-container-1').click();
+		cy.cGet('#comment-container-1').should('exist').should('have.class', 'annotation-active');
+		cy.getFrameWindow().then(function(win) { win.app.sectionContainer.getSectionWithName('scroll').scrollVerticalWithOffset(10); });
+		cy.cGet('#comment-container-1').should('exist').should('not.have.class', 'annotation-active');
+	})
 });


### PR DESCRIPTION
Change-Id: I617603782260d4c3c19e8bdeafc794e3b7457d1d


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
#### buggy comments
- click on a comment in writer
- start scrolling
- the comment gets stuck and doesn't go off the screen


https://github.com/user-attachments/assets/979d7dcc-fec3-438c-9adb-f9bd6e78c060

#### fix
- comment is automatically unselected when scrolling



https://github.com/user-attachments/assets/aa3687d8-bfa4-403f-9ab0-40f82beda119

