### PR TITLE
limit the dimensions of tunnelled dialogs

### DIFF
--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -2736,7 +2736,14 @@ bool ChildSession::renderWindow(const StringVector& tokens)
             dpiScale = 1.0;
     }
 
-    const size_t pixmapDataSize = 4 * bufferWidth * bufferHeight;
+    constexpr int maxDimension = 4096;
+    if (bufferWidth <= 0 || bufferHeight <= 0 || bufferWidth > maxDimension || bufferHeight > maxDimension)
+    {
+        LOG_WRN("paintwindow: rejecting invalid dimensions " << bufferWidth << 'x' << bufferHeight);
+        return true;
+    }
+
+    const size_t pixmapDataSize = static_cast<size_t>(4) * bufferWidth * bufferHeight;
     std::vector<unsigned char> pixmap(pixmapDataSize);
     const int width = bufferWidth;
     const int height = bufferHeight;


### PR DESCRIPTION
Change-Id: I0c7eb216be52c7e070fd4fd66e176440bacbb380


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

