### PR TITLE
remove unused renderfont support

### DIFF
--- a/browser/src/app/Socket.ts
+++ b/browser/src/app/Socket.ts
@@ -1211,7 +1211,6 @@ class Socket {
 		} else if (
 			!textMsg.startsWith('tile:') &&
 			!textMsg.startsWith('delta:') &&
-			!textMsg.startsWith('renderfont:') &&
 			!textMsg.startsWith('slidelayer:') &&
 			!textMsg.startsWith('zstdslidelayer:') &&
 			!textMsg.startsWith('windowpaint:')
@@ -1305,7 +1304,6 @@ class Socket {
 				e.data.startsWith('tile:') ||
 				e.data.startsWith('tilecombine:') ||
 				e.data.startsWith('delta:') ||
-				e.data.startsWith('renderfont:') ||
 				e.data.startsWith('rendersearchlist:') ||
 				e.data.startsWith('slidelayer:') ||
 				e.data.startsWith('zstdslidelayer:') ||
@@ -1338,7 +1336,6 @@ class Socket {
 		if (
 			!isTile &&
 			!isDelta &&
-			!e.textMsg.startsWith('renderfont:') &&
 			!e.textMsg.startsWith('slidelayer:') &&
 			!e.textMsg.startsWith('windowpaint:')
 		)

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -885,9 +885,6 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 		else if (textMsg.startsWith('mousepointer:')) {
 			this._onMousePointerMsg(textMsg);
 		}
-		else if (textMsg.startsWith('renderfont:')) {
-			this._onRenderFontMsg(textMsg, img);
-		}
 		else if (textMsg.startsWith('searchnotfound:')) {
 			this._onSearchNotFoundMsg(textMsg);
 		}
@@ -2094,15 +2091,6 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 		// Sending postMessage about View_Added / View_Removed is
 		// deprecated, going forward we prefer sending the entire information.
 		this._map.fire('updateviewslist');
-	},
-
-	_onRenderFontMsg: function (textMsg, img) {
-		var command = app.socket.parseServerCmd(textMsg);
-		this._map.fire('renderfont', {
-			font: command.font,
-			char: command.char,
-			img: img
-		});
 	},
 
 	_onSearchNotFoundMsg: function (textMsg) {

--- a/common/Protocol.hpp
+++ b/common/Protocol.hpp
@@ -37,7 +37,6 @@ namespace COOLProtocol
         "tile:",
         "tilecombine:",
         "delta:",
-        "renderfont:",
         "rendersearchresult:",
         "slidelayer:",
         "zstdslidelayer:",

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -502,10 +502,6 @@ bool ChildSession::_handleInput(const char *buffer, int length)
         sendTextFrameAndLogError("error: cmd=" + tokens[0] + " kind=nodocloaded");
         return false;
     }
-    else if (tokens.equals(0, "renderfont"))
-    {
-        sendFontRendering(tokens);
-    }
     else if (tokens.equals(0, "setclientpart"))
     {
         return setClientPart(tokens);
@@ -1096,69 +1092,6 @@ bool ChildSession::saveDocumentBackground([[maybe_unused]] const StringVector& t
     }
 
     return false;
-}
-
-bool ChildSession::sendFontRendering(const StringVector& tokens)
-{
-    std::string font, text, decodedFont, decodedChar;
-    bool success;
-
-    if (tokens.size() < 3 ||
-        !getTokenString(tokens[1], "font", font))
-    {
-        sendTextFrameAndLogError("error: cmd=renderfont kind=syntax");
-        return false;
-    }
-
-    getTokenString(tokens[2], "char", text);
-
-    try
-    {
-        URI::decode(font, decodedFont);
-        URI::decode(text, decodedChar);
-    }
-    catch (Poco::SyntaxException& exc)
-    {
-        LOG_ERR(exc.message());
-        sendTextFrameAndLogError("error: cmd=renderfont kind=syntax");
-        return false;
-    }
-
-    const std::string response = "renderfont: " + tokens.cat(' ', 1) + '\n';
-
-    std::vector<char> output;
-    output.resize(response.size());
-    std::memcpy(output.data(), response.data(), response.size());
-
-    const auto start = std::chrono::steady_clock::now();
-    // renderFont use a default font size (25) when width and height are 0
-    int width = 0, height = 0;
-
-    getLOKitDocument()->setView(_viewId);
-
-    ScopedBytes ptrFont(getLOKitDocument()->renderFont(decodedFont.c_str(), decodedChar.c_str(), &width, &height));
-
-    const auto duration = std::chrono::steady_clock::now() - start;
-    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(duration);
-    LOG_TRC("renderFont [" << font << "] rendered in " << elapsed);
-
-    if (!ptrFont)
-    {
-        return sendTextFrame(output.data(), output.size());
-    }
-
-    const auto mode = static_cast<COKitTileMode>(getLOKitDocument()->getTileMode());
-
-    if (Png::encodeBufferToPNG(ptrFont.get(), width, height, output, mode))
-    {
-        success = sendTextFrame(output.data(), output.size());
-    }
-    else
-    {
-        success = sendTextFrameAndLogError("error: cmd=renderfont kind=failure");
-    }
-
-    return success;
 }
 
 bool ChildSession::getStatus()

--- a/kit/ChildSession.hpp
+++ b/kit/ChildSession.hpp
@@ -177,7 +177,6 @@ private:
     bool loadDocument(const StringVector& tokens);
     bool saveDocumentBackground(const StringVector &tokens);
 
-    bool sendFontRendering(const StringVector& tokens);
     bool getCommandValues(const StringVector& tokens);
 
     bool clientZoom(const StringVector& tokens);

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1462,10 +1462,6 @@ bool ClientSession::_handleInput(const char *buffer, int length)
         sendTextFrame("pong rendercount=" + count);
         return true;
     }
-    else if (tokens.equals(0, "renderfont"))
-    {
-        return sendFontRendering(buffer, length, tokens, docBroker);
-    }
     else if (tokens.equals(0, "status") || tokens.equals(0, "statusupdate"))
     {
         assert(firstLine.size() == static_cast<std::size_t>(length));
@@ -2551,31 +2547,6 @@ bool ClientSession::getCommandValues(const char *buffer, int length, const Strin
     return forwardToChild(std::string(buffer, length), docBroker);
 }
 
-bool ClientSession::sendFontRendering(const char *buffer, int length, const StringVector& tokens,
-                                      const std::shared_ptr<DocumentBroker>& docBroker)
-{
-    std::string font, text;
-    if (tokens.size() < 2 ||
-        !getTokenString(tokens[1], "font", font))
-    {
-        return sendTextFrameAndLogError("error: cmd=renderfont kind=syntax");
-    }
-
-    getTokenString(tokens[2], "char", text);
-
-    if (docBroker->hasTileCache())
-    {
-        Blob cachedStream = docBroker->tileCache().lookupCachedStream(TileCache::StreamType::Font, font+text);
-        if (cachedStream)
-        {
-            const std::string response = "renderfont: " + tokens.cat(' ', 1) + '\n';
-            return sendBlob(response, cachedStream);
-        }
-    }
-
-    return forwardToChild(std::string(buffer, length), docBroker);
-}
-
 bool ClientSession::sendTile(const char * /*buffer*/, int /*length*/, const StringVector& tokens,
                              const std::shared_ptr<DocumentBroker>& docBroker)
 {
@@ -3607,22 +3578,6 @@ ClientSession::handleOpenDocKitToClientMessage(const std::shared_ptr<Message>& p
         return status;
     }
 #endif
-    else if (tokens.equals(0, "renderfont:"))
-    {
-        std::string font, text;
-        if (tokens.size() < 3 || !getTokenString(tokens[1], "font", font))
-        {
-            LOG_ERR("Bad syntax for: " << firstLine);
-            return false;
-        }
-
-        getTokenString(tokens[2], "char", text);
-        assert(firstLine.size() < payload->size() && "Missing multiline data in renderfont");
-        docBroker->tileCache().saveStream(TileCache::StreamType::Font, font + text,
-                                          payload->data().data() + firstLine.size() + 1,
-                                          payload->data().size() - firstLine.size() - 1);
-        return forwardToClient(payload);
-    }
     else if (tokens.equals(0, "extractedlinktargets:"))
     {
         LOG_TRC("Sending extracted link targets response.");

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -375,8 +375,6 @@ private:
     bool sendCombinedTiles(const char* buffer, int length, const StringVector& tokens,
                            const std::shared_ptr<DocumentBroker>& docBroker);
 
-    bool sendFontRendering(const char* buffer, int length, const StringVector& tokens,
-                           const std::shared_ptr<DocumentBroker>& docBroker);
     bool handleGetSlideRequest(const StringVector& tokens,
                                const std::shared_ptr<DocumentBroker>& docBroker);
 

--- a/wsd/TileCache.hpp
+++ b/wsd/TileCache.hpp
@@ -258,7 +258,6 @@ public:
 
     enum StreamType : std::uint8_t
     {
-        Font,
         Style,
         CmdValues,
         Last

--- a/wsd/protocol.txt
+++ b/wsd/protocol.txt
@@ -193,11 +193,6 @@ ping
 
     requests a 'pong' server message.
 
-renderfont font=<font> char=<characters>
-
-    requests the rendering of the given font.
-    The font parameter is URL encoded
-    The char parameter is URL encoded
 
 resetselection
 


### PR DESCRIPTION
unused since:

commit 5a65eefe3a03e9855ab7909a7d877df56e2bbb2f
Date:   Mon Dec 21 21:57:21 2020 +0100

    Remove unused functions.


Change-Id: I0cf0940cf86ec81e6cfd2bff412e66eb2eb6b6b4


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

