### PR TITLE
Keep more recent files and limit the number returned from serialise()…

### DIFF
--- a/common/RecentFiles.cpp
+++ b/common/RecentFiles.cpp
@@ -40,7 +40,7 @@ void RecentFiles::load(const std::string& fileName, int maxFiles)
     if (stream.is_open())
     {
         int n = 0;
-        while (!stream.eof() && !stream.bad() && n++ < maxFiles)
+        while (!stream.eof() && !stream.bad() && n++ < _maxFiles * 2)
         {
             Entry entry;
             std::getline(stream, entry.uri);
@@ -124,6 +124,8 @@ std::string RecentFiles::serialiseFiltered(std::set<std::string> dropTheseURIs)
             "\"timestamp\": \"" + std::format("{:%FT%TZ}", _mostRecentlyUsed[i].timestamp) + "\""
             " }";
         n++;
+        if (n == _maxFiles)
+            break;
     }
     result += " ]";
 

--- a/common/RecentFiles.hpp
+++ b/common/RecentFiles.hpp
@@ -24,8 +24,14 @@ public:
 
     // Loads the list of recent files and timestamps. The fileName parameter is the file where the
     // list is stored. If it doesn't exist, start with an empty list, but remember the pathname as
-    // the list will be saved there whenever a file is added. The maxFiles parameter indicates how
-    // many entries will be kept. Only after calling this can you call the other member functions.
+    // the list will be saved there whenever a file is added.
+    //
+    // The maxFiles parameter indicates the maximum number of entries that will be returned from
+    // the serialise() member function. At most twice that number of entries are stored in the file,
+    // to have a buffer in case some of the files are subsequently removed or temporarily
+    // inaccessible when running the app the next time.
+    //
+    // Only after calling this can you call the other member functions.
     void load(const std::string& fileName, int maxFiles);
 
     // Add a document URI to the list. It will be placed first in the list. Its timestamp will be


### PR DESCRIPTION
… instead

Thus we will be more likely to be able to return the requested number of recent files, even if some of them have been removed, renamed, or are inacessible.


Change-Id: I60040f1215ba131cfc57784145c262067e6e2e9b


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

