### PR TITLE
fix Exception TypeError due to NaN

### DIFF
--- a/browser/src/slideshow/engine/tools.ts
+++ b/browser/src/slideshow/engine/tools.ts
@@ -44,7 +44,9 @@ function clampN(nValue: number, nMinimum: number, nMaximum: number) {
 }
 
 function hasValue(x: any): boolean {
-	return x !== undefined && x !== null;
+	if (x === undefined || x === null) return false;
+	if (typeof x === 'number' && Number.isNaN(x)) return false;
+	return true;
 }
 
 function booleanParser(sValue: string) {


### PR DESCRIPTION
Exception TypeError: Failed to execute 'fromMatrix' on 'DOMMatrix': The is2D member is set to true but the input matrix is a 3d matrix. emitting event slideshowfollow dispatcheffect TypeError: The is2D member is set to true but the input matrix is a 3d matrix.
    at AnimatedElement.saveState (AnimatedElement.ts:934:24)
    at AnimationBaseNode.saveStateOfAnimatedElement (AnimationBaseNode.ts:179:29)
    at AnimationBaseNode.activate_st (AnimationBaseNode.ts:120:9)
    at BaseNode.activate (BaseNode.ts:487:9)
    at DelayEvent.fire (Event.ts:53:8)
    at TimerEventQueue.process_ (TimerEventQueue.ts:57:35)
    at TimerEventQueue.process (TimerEventQueue.ts:43:8)
    at SlideShowHandler.update (SlideShowHandler.ts:973:25)
    at SlideShowHandler.nextEffect (SlideShowHandler.ts:549:8)
    at SlideShowNavigator.dispatchEffect (SlideShowNavigator.ts:123:38)


Change-Id: Ieeb5432640752364b5c9531632bafade2e5df910


* Target version: main

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

