### PR TITLE
make mobile/impress/annotation_spec.js more reliable

### DIFF
--- a/cypress_test/integration_tests/common/mobile_helper.js
+++ b/cypress_test/integration_tests/common/mobile_helper.js
@@ -312,10 +312,14 @@ function insertComment(skipCommentCheck = false) {
 	cy.cGet('.cool-annotation-table').should('exist');
 	cy.cGet('#input-modal-input').type('some text');
 	cy.cGet('#response-ok').click();
-	cy.wait(2000); // FIXME: skip DocModified message
+
+	// Wait for core to process the comment insertion
+	cy.getFrameWindow().then((win) => {
+		helper.processToIdle(win);
+	});
 
 	if (!skipCommentCheck) {
-		cy.cGet('[id^=comment-container-]').should('exist').wait(300);
+		cy.cGet('[id^=comment-container-]').should('exist');
 		cy.cGet('[id^=annotation-content-area-]').should('be.visible');
 		cy.cGet('[id^=annotation-content-area-]').should('have.text', 'some text');
 	}

--- a/cypress_test/integration_tests/mobile/impress/annotation_spec.js
+++ b/cypress_test/integration_tests/mobile/impress/annotation_spec.js
@@ -10,12 +10,19 @@ describe(['tagmobile'], 'Annotation tests.', function() {
 		newFilePath = helper.setupAndLoadDocument('impress/annotation.odp');
 
 		mobileHelper.enableEditingMobile();
+
+		cy.getFrameWindow().then(function(win) {
+			this.win = win;
+		});
 	});
 
 	it('Saving comment.', function() {
 		mobileHelper.insertComment();
 
 		mobileHelper.selectHamburgerMenuItem(['File', 'Save']);
+
+		// Wait for save to complete before reloading
+		helper.processToIdle(this.win);
 
 		helper.reloadDocument(newFilePath);
 
@@ -37,6 +44,9 @@ describe(['tagmobile'], 'Annotation tests.', function() {
 		cy.cGet('#input-modal-input').type('{end}');
 		cy.cGet('#input-modal-input').type('modified');
 		cy.cGet('#response-ok').click();
+
+		helper.processToIdle(this.win);
+
 		cy.cGet('#toolbar-up #comment_wizard').click();
 		cy.cGet('[id^=annotation-content-area-]').should('exist');
 		cy.cGet('[id^=annotation-content-area-]').should('have.text', 'some textmodified');
@@ -49,6 +59,8 @@ describe(['tagmobile'], 'Annotation tests.', function() {
 		cy.cGet('#mobile-wizard .wizard-comment-box .cool-annotation-content').should('have.text', 'some text');
 
 		mobileHelper.selectAnnotationMenuItem('Remove');
+
+		helper.processToIdle(this.win);
 
 		cy.cGet('#mobile-wizard .wizard-comment-box .cool-annotation-content').should('not.exist');
 		cy.cGet('.annotation-marker').should('not.exist');


### PR DESCRIPTION
Change-Id: Icbb045961d8f998e8a70e77c2b5c67271f903a21


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

