### PR TITLE
writer: jump to previous position on reconnection

### DIFF
--- a/browser/src/layer/tile/WriterTileLayer.js
+++ b/browser/src/layer/tile/WriterTileLayer.js
@@ -108,8 +108,10 @@ window.L.WriterTileLayer = window.L.CanvasTileLayer.extend({
 			// of the first paragraph of the document so we want to ignore that
 			// to eliminate document jumping while reconnecting
 			this.persistCursorPositionInWriter = true;
-			this._postMouseEvent('buttondown', this.lastCursorPos.center[0], this.lastCursorPos.center[1], 1, 1, 0);
-			this._postMouseEvent('buttonup', this.lastCursorPos.center[0], this.lastCursorPos.center[1], 1, 1, 0);
+			if (this.lastCursorPos) {
+				// Save position to restore when we have the full layout of the document back
+				this._savedCursorPos = this.lastCursorPos.clone();
+			}
 		}
 		if (!statusJSON.width || !statusJSON.height || this._documentInfo === textMsg)
 			return;
@@ -163,5 +165,11 @@ window.L.WriterTileLayer = window.L.CanvasTileLayer.extend({
 			docType: this._docType
 		});
 		TileManager.resetPreFetching(true);
+
+		if (this._savedCursorPos && this._savedCursorPos.center[0] <= app.activeDocument.fileSize.x && this._savedCursorPos.center[1] <= app.activeDocument.fileSize.y) {
+			this._postMouseEvent('buttondown', this._savedCursorPos.center[0], this._savedCursorPos.center[1], 1, 1, 0);
+			this._postMouseEvent('buttonup', this._savedCursorPos.center[0], this._savedCursorPos.center[1], 1, 1, 0);
+			this._savedCursorPos = null;
+		}
 	},
 });

--- a/cypress_test/data/desktop/writer/writer-edit.fodt
+++ b/cypress_test/data/desktop/writer/writer-edit.fodt
@@ -1,0 +1,4262 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<office:document xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:officeooo="http://openoffice.org/2009/office" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.text">
+ <office:meta><meta:creation-date>2024-05-06T12:44:59.834336364</meta:creation-date><dc:date>2025-02-13T12:59:10.105509918</dc:date><meta:editing-duration>PT20H13M53S</meta:editing-duration><meta:editing-cycles>86</meta:editing-cycles><meta:generator>CollaboraOfficeDev/24.04.12.3$Linux_X86_64 LibreOffice_project/7e5075fea733d68c8167ac33e5ce34d89b50a6a9</meta:generator><meta:document-statistic meta:table-count="4" meta:image-count="4" meta:object-count="1" meta:page-count="12" meta:paragraph-count="166" meta:word-count="2011" meta:character-count="13349" meta:non-whitespace-character-count="11515"/></office:meta>
+ <office:settings>
+  <config:config-item-set config:name="ooo:view-settings">
+   <config:config-item config:name="ViewAreaTop" config:type="long">0</config:config-item>
+   <config:config-item config:name="ViewAreaLeft" config:type="long">0</config:config-item>
+   <config:config-item config:name="ViewAreaWidth" config:type="long">28007</config:config-item>
+   <config:config-item config:name="ViewAreaHeight" config:type="long">17424</config:config-item>
+   <config:config-item config:name="ShowRedlineChanges" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="InBrowseMode" config:type="boolean">false</config:config-item>
+   <config:config-item-map-indexed config:name="Views">
+    <config:config-item-map-entry>
+     <config:config-item config:name="ViewId" config:type="string">view2</config:config-item>
+     <config:config-item config:name="ViewLeft" config:type="long">6332</config:config-item>
+     <config:config-item config:name="ViewTop" config:type="long">3911</config:config-item>
+     <config:config-item config:name="VisibleLeft" config:type="long">0</config:config-item>
+     <config:config-item config:name="VisibleTop" config:type="long">0</config:config-item>
+     <config:config-item config:name="VisibleRight" config:type="long">28005</config:config-item>
+     <config:config-item config:name="VisibleBottom" config:type="long">17422</config:config-item>
+     <config:config-item config:name="ZoomType" config:type="short">0</config:config-item>
+     <config:config-item config:name="ViewLayoutColumns" config:type="short">1</config:config-item>
+     <config:config-item config:name="ViewLayoutBookMode" config:type="boolean">false</config:config-item>
+     <config:config-item config:name="ZoomFactor" config:type="short">130</config:config-item>
+     <config:config-item config:name="IsSelectedFrame" config:type="boolean">false</config:config-item>
+     <config:config-item config:name="KeepRatio" config:type="boolean">true</config:config-item>
+     <config:config-item config:name="AnchoredTextOverflowLegacy" config:type="boolean">false</config:config-item>
+     <config:config-item config:name="LegacySingleLineFontwork" config:type="boolean">true</config:config-item>
+     <config:config-item config:name="ConnectorUseSnapRect" config:type="boolean">false</config:config-item>
+     <config:config-item config:name="IgnoreBreakAfterMultilineField" config:type="boolean">false</config:config-item>
+    </config:config-item-map-entry>
+   </config:config-item-map-indexed>
+  </config:config-item-set>
+  <config:config-item-set config:name="ooo:configuration-settings">
+   <config:config-item config:name="PrintProspectRTL" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintPageBackground" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintDrawings" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintFaxName" config:type="string"/>
+   <config:config-item config:name="PrintReversed" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintAnnotationMode" config:type="short">0</config:config-item>
+   <config:config-item config:name="PrintHiddenText" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintEmptyPages" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintGraphics" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="NoNumberingShowFollowBy" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="HyphenateURLs" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="ImagePreferredDPI" config:type="int">0</config:config-item>
+   <config:config-item config:name="FootnoteInColumnToPageEnd" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="GutterAtTop" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ContinuousEndnotes" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="FrameAutowidthWithMorePara" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="SubtractFlysAnchoredAtFlys" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="SurroundTextWrapSmall" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintControls" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="TreatSingleColumnBreakAsPageBreak" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="TabOverSpacing" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="AutoFirstLineIndentDisregardLineSpace" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="TabOverMargin" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="EmbedComplexScriptFonts" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="EmbedAsianScriptFonts" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintTextPlaceholder" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ApplyTextAttrToEmptyLineAtEndOfParagraph" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="EmbedSystemFonts" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="EmbedFonts" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="DisableOffPagePositioning" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="BackgroundParaOverDrawings" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="TabOverflow" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="AllowPrintJobCancel" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="AddVerticalFrameOffsets" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ProtectBookmarks" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="AddFrameOffsets" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintBlackFonts" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="TableRowKeep" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ApplyParagraphMarkFormatToNumbering" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrinterIndependentLayout" config:type="string">high-resolution</config:config-item>
+   <config:config-item config:name="JustifyLinesWithShrinking" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="RsidRoot" config:type="int">24120</config:config-item>
+   <config:config-item config:name="PrintProspect" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="CollapseEmptyCellPara" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintPaperFromSetup" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="CurrentDatabaseCommand" config:type="string"/>
+   <config:config-item config:name="CurrentDatabaseDataSource" config:type="string"/>
+   <config:config-item config:name="SaveThumbnail" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="EmbeddedDatabaseName" config:type="string"/>
+   <config:config-item config:name="UnbreakableNumberings" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="SaveGlobalDocumentLinks" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="MsWordCompTrailingBlanks" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintTables" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrintLeftPages" config:type="boolean">true</config:config-item>
+   <config:config-item-map-indexed config:name="ForbiddenCharacters">
+    <config:config-item-map-entry>
+     <config:config-item config:name="Language" config:type="string">fr</config:config-item>
+     <config:config-item config:name="Country" config:type="string">FR</config:config-item>
+     <config:config-item config:name="Variant" config:type="string"/>
+     <config:config-item config:name="BeginLine" config:type="string"/>
+     <config:config-item config:name="EndLine" config:type="string"/>
+    </config:config-item-map-entry>
+    <config:config-item-map-entry>
+     <config:config-item config:name="Language" config:type="string">en</config:config-item>
+     <config:config-item config:name="Country" config:type="string">GB</config:config-item>
+     <config:config-item config:name="Variant" config:type="string"/>
+     <config:config-item config:name="BeginLine" config:type="string"/>
+     <config:config-item config:name="EndLine" config:type="string"/>
+    </config:config-item-map-entry>
+    <config:config-item-map-entry>
+     <config:config-item config:name="Language" config:type="string">en</config:config-item>
+     <config:config-item config:name="Country" config:type="string">NG</config:config-item>
+     <config:config-item config:name="Variant" config:type="string"/>
+     <config:config-item config:name="BeginLine" config:type="string"/>
+     <config:config-item config:name="EndLine" config:type="string"/>
+    </config:config-item-map-entry>
+   </config:config-item-map-indexed>
+   <config:config-item config:name="AddParaTableSpacing" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrinterPaperFromSetup" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="CurrentDatabaseCommandType" config:type="int">0</config:config-item>
+   <config:config-item config:name="ChartAutoUpdate" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="OutlineLevelYieldsNumbering" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UseOldNumbering" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="AddParaSpacingToTableCells" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="FieldAutoUpdate" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PropLineSpacingShrinksFirstLine" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="TabAtLeftIndentForParagraphsInList" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintRightPages" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="DoNotCaptureDrawObjsOnPage" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="LoadReadonly" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="HeaderSpacingBelowLastPara" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="SaveVersionOnClose" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ClippedPictures" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="MathBaselineAlignment" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="AlignTabStopPosition" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="UseFormerLineSpacing" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrintSingleJobs" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="PrinterName" config:type="string"/>
+   <config:config-item config:name="AddParaLineSpacingToTableCells" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="IsKernAsianPunctuation" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="DoNotJustifyLinesWithManualBreak" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="CharacterCompressionType" config:type="short">0</config:config-item>
+   <config:config-item config:name="IsLabelDocument" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="EmbedLatinScriptFonts" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="PrinterSetup" config:type="base64Binary"/>
+   <config:config-item config:name="UseVariableWidthNBSP" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="EmbedOnlyUsedFonts" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ApplyUserData" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="AddParaTableSpacingAtStart" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="InvertBorderSpacing" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ProtectFields" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="AddExternalLeading" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="LinkUpdateMode" config:type="short">1</config:config-item>
+   <config:config-item config:name="UseFormerObjectPositioning" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UnxForceZeroExtLeading" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UseFormerTextWrapping" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ConsiderTextWrapOnObjPos" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="StylesNoDefault" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="IgnoreFirstLineIndentInNumbering" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="NoGapAfterNoteNumber" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="EmptyDbFieldHidesPara" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="DoNotResetParaAttrsForNumFont" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="IgnoreTabsAndBlanksForLineCalculation" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="ClipAsCharacterAnchoredWriterFlyFrames" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="DropCapPunctuation" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="UseOldPrinterMetrics" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="RedlineProtectionKey" config:type="base64Binary"/>
+   <config:config-item config:name="TabsRelativeToIndent" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="Rsid" config:type="int">7766687</config:config-item>
+   <config:config-item config:name="UpdateFromTemplate" config:type="boolean">true</config:config-item>
+   <config:config-item config:name="ProtectForm" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="MsWordCompMinLineHeightByFly" config:type="boolean">false</config:config-item>
+   <config:config-item config:name="SmallCapsPercentage66" config:type="boolean">false</config:config-item>
+  </config:config-item-set>
+ </office:settings>
+ <office:scripts>
+  <office:script script:language="ooo:Basic">
+   <ooo:libraries xmlns:ooo="http://openoffice.org/2004/office" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <ooo:library-embedded ooo:name="Standard"/>
+   </ooo:libraries>
+  </office:script>
+ </office:scripts>
+ <office:font-face-decls>
+  <style:font-face style:name="Carlito" svg:font-family="Carlito" style:font-adornments="Regular" style:font-family-generic="swiss" style:font-pitch="variable"/>
+  <style:font-face style:name="Liberation Mono" svg:font-family="&apos;Liberation Mono&apos;" style:font-family-generic="modern" style:font-pitch="fixed"/>
+  <style:font-face style:name="Liberation Sans" svg:font-family="&apos;Liberation Sans&apos;" style:font-family-generic="swiss" style:font-pitch="variable"/>
+  <style:font-face style:name="Liberation Serif" svg:font-family="&apos;Liberation Serif&apos;" style:font-family-generic="roman" style:font-pitch="variable"/>
+  <style:font-face style:name="Lohit Devanagari" svg:font-family="&apos;Lohit Devanagari&apos;"/>
+  <style:font-face style:name="Lohit Devanagari1" svg:font-family="&apos;Lohit Devanagari&apos;" style:font-family-generic="system" style:font-pitch="variable"/>
+  <style:font-face style:name="Noto Sans CJK SC" svg:font-family="&apos;Noto Sans CJK SC&apos;" style:font-family-generic="system" style:font-pitch="variable"/>
+  <style:font-face style:name="Noto Sans Mono CJK SC" svg:font-family="&apos;Noto Sans Mono CJK SC&apos;" style:font-family-generic="modern" style:font-pitch="fixed"/>
+  <style:font-face style:name="Noto Serif CJK SC" svg:font-family="&apos;Noto Serif CJK SC&apos;" style:font-family-generic="system" style:font-pitch="variable"/>
+  <style:font-face style:name="OpenSymbol" svg:font-family="OpenSymbol" style:font-charset="x-symbol"/>
+ </office:font-face-decls>
+ <office:styles>
+  <style:default-style style:family="graphic">
+   <style:graphic-properties svg:stroke-color="#3465a4" draw:fill-color="#729fcf" fo:wrap-option="no-wrap" draw:shadow-offset-x="0.1181in" draw:shadow-offset-y="0.1181in" draw:start-line-spacing-horizontal="0.1114in" draw:start-line-spacing-vertical="0.1114in" draw:end-line-spacing-horizontal="0.1114in" draw:end-line-spacing-vertical="0.1114in" style:writing-mode="lr-tb" style:flow-with-text="false"/>
+   <style:paragraph-properties style:text-autospace="ideograph-alpha" style:line-break="strict" loext:tab-stop-distance="0in" style:writing-mode="lr-tb" style:font-independent-line-spacing="false">
+    <style:tab-stops/>
+   </style:paragraph-properties>
+   <style:text-properties style:use-window-font-color="true" loext:opacity="0%" style:font-name="Liberation Serif" fo:font-size="12pt" fo:language="en" fo:country="GB" style:letter-kerning="true" style:font-name-asian="Noto Serif CJK SC" style:font-size-asian="10.5pt" style:language-asian="zh" style:country-asian="CN" style:font-name-complex="Lohit Devanagari1" style:font-size-complex="12pt" style:language-complex="hi" style:country-complex="IN"/>
+  </style:default-style>
+  <style:default-style style:family="paragraph">
+   <style:paragraph-properties fo:orphans="2" fo:widows="2" fo:hyphenation-ladder-count="no-limit" style:text-autospace="ideograph-alpha" style:punctuation-wrap="hanging" style:line-break="strict" style:tab-stop-distance="0.4925in" style:writing-mode="page"/>
+   <style:text-properties style:use-window-font-color="true" loext:opacity="0%" style:font-name="Liberation Serif" fo:font-size="12pt" fo:language="en" fo:country="GB" style:letter-kerning="true" style:font-name-asian="Noto Serif CJK SC" style:font-size-asian="10.5pt" style:language-asian="zh" style:country-asian="CN" style:font-name-complex="Lohit Devanagari1" style:font-size-complex="12pt" style:language-complex="hi" style:country-complex="IN" fo:hyphenate="false" fo:hyphenation-remain-char-count="2" fo:hyphenation-push-char-count="2" loext:hyphenation-no-caps="false" loext:hyphenation-no-last-word="false" loext:hyphenation-word-char-count="no-limit" loext:hyphenation-zone="no-limit"/>
+  </style:default-style>
+  <style:default-style style:family="table">
+   <style:table-properties table:border-model="collapsing"/>
+  </style:default-style>
+  <style:default-style style:family="table-row">
+   <style:table-row-properties fo:keep-together="auto"/>
+  </style:default-style>
+  <style:style style:name="Standard" style:family="paragraph" style:class="text"/>
+  <style:style style:name="Heading" style:family="paragraph" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="text">
+   <style:paragraph-properties fo:margin-top="0.1665in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" fo:keep-with-next="always"/>
+   <style:text-properties style:font-name="Liberation Sans" fo:font-family="&apos;Liberation Sans&apos;" style:font-family-generic="swiss" style:font-pitch="variable" fo:font-size="14pt" style:font-name-asian="Noto Sans CJK SC" style:font-family-asian="&apos;Noto Sans CJK SC&apos;" style:font-family-generic-asian="system" style:font-pitch-asian="variable" style:font-size-asian="14pt" style:font-name-complex="Lohit Devanagari1" style:font-family-complex="&apos;Lohit Devanagari&apos;" style:font-family-generic-complex="system" style:font-pitch-complex="variable" style:font-size-complex="14pt"/>
+  </style:style>
+  <style:style style:name="Text_20_body" style:display-name="Text body" style:family="paragraph" style:parent-style-name="Standard" style:class="text">
+   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0.0972in" style:contextual-spacing="false" fo:line-height="115%"/>
+   <style:text-properties style:font-name="Carlito" fo:font-family="Carlito" style:font-style-name="Regular" style:font-family-generic="swiss" style:font-pitch="variable"/>
+  </style:style>
+  <style:style style:name="List" style:family="paragraph" style:parent-style-name="Text_20_body" style:class="list">
+   <style:text-properties style:font-size-asian="12pt" style:font-name-complex="Lohit Devanagari" style:font-family-complex="&apos;Lohit Devanagari&apos;"/>
+  </style:style>
+  <style:style style:name="Caption" style:family="paragraph" style:parent-style-name="Standard" style:class="extra">
+   <style:paragraph-properties fo:margin-top="0.0835in" fo:margin-bottom="0.0835in" style:contextual-spacing="false" text:number-lines="false" text:line-number="0"/>
+   <style:text-properties fo:font-size="12pt" fo:font-style="italic" style:font-size-asian="12pt" style:font-style-asian="italic" style:font-name-complex="Lohit Devanagari" style:font-family-complex="&apos;Lohit Devanagari&apos;" style:font-size-complex="12pt" style:font-style-complex="italic"/>
+  </style:style>
+  <style:style style:name="Index" style:family="paragraph" style:parent-style-name="Standard" style:class="index">
+   <style:paragraph-properties text:number-lines="false" text:line-number="0"/>
+   <style:text-properties style:font-size-asian="12pt" style:font-name-complex="Lohit Devanagari" style:font-family-complex="&apos;Lohit Devanagari&apos;"/>
+  </style:style>
+  <style:style style:name="Horizontal_20_Line" style:display-name="Horizontal Line" style:family="paragraph" style:parent-style-name="Standard" style:next-style-name="Text_20_body" style:class="html">
+   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0.1965in" style:contextual-spacing="false" style:border-line-width-bottom="0.0008in 0.0016in 0.0008in" fo:padding="0in" fo:border-left="none" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.2pt double #808080" text:number-lines="false" text:line-number="0" style:join-border="false"/>
+   <style:text-properties fo:font-size="6pt" style:font-size-asian="6pt" style:font-size-complex="6pt"/>
+  </style:style>
+  <style:style style:name="Footnote" style:family="paragraph" style:parent-style-name="Standard" style:class="extra">
+   <style:paragraph-properties fo:margin-left="0.2362in" fo:margin-right="0in" fo:text-indent="-0.2362in" style:auto-text-indent="false" text:number-lines="false" text:line-number="0"/>
+   <style:text-properties fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
+  </style:style>
+  <style:style style:name="Endnote" style:family="paragraph" style:parent-style-name="Standard" style:class="extra">
+   <style:paragraph-properties fo:margin-left="0.2362in" fo:margin-right="0in" fo:text-indent="-0.2362in" style:auto-text-indent="false" text:number-lines="false" text:line-number="0"/>
+   <style:text-properties fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
+  </style:style>
+  <style:style style:name="Index_20_Heading" style:display-name="Index Heading" style:family="paragraph" style:parent-style-name="Heading" style:class="index">
+   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" text:number-lines="false" text:line-number="0"/>
+   <style:text-properties fo:font-size="16pt" fo:font-weight="bold" style:font-size-asian="16pt" style:font-weight-asian="bold" style:font-size-complex="16pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="Contents_20_Heading" style:display-name="Contents Heading" style:family="paragraph" style:parent-style-name="Index_20_Heading" style:class="index">
+   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false" text:number-lines="false" text:line-number="0"/>
+   <style:text-properties fo:font-size="16pt" fo:font-weight="bold" style:font-size-asian="16pt" style:font-weight-asian="bold" style:font-size-complex="16pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="Heading_20_1" style:display-name="Heading 1" style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="1" style:class="text">
+   <style:paragraph-properties fo:margin-top="0.1665in" fo:margin-bottom="0.0835in" style:contextual-spacing="false"/>
+   <style:text-properties fo:font-size="18pt" fo:font-weight="bold" style:font-size-asian="18pt" style:font-weight-asian="bold" style:font-size-complex="18pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="Heading_20_2" style:display-name="Heading 2" style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="2" style:class="text">
+   <style:paragraph-properties fo:margin-top="0.139in" fo:margin-bottom="0.0835in" style:contextual-spacing="false"/>
+   <style:text-properties fo:font-size="16pt" fo:font-weight="bold" style:font-size-asian="16pt" style:font-weight-asian="bold" style:font-size-complex="16pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="Heading_20_3" style:display-name="Heading 3" style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="3" style:class="text">
+   <style:paragraph-properties fo:margin-top="0.0972in" fo:margin-bottom="0.0835in" style:contextual-spacing="false"/>
+   <style:text-properties fo:font-size="14pt" fo:font-weight="bold" style:font-size-asian="14pt" style:font-weight-asian="bold" style:font-size-complex="14pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="Contents_20_1" style:display-name="Contents 1" style:family="paragraph" style:parent-style-name="Index" style:class="index">
+   <style:paragraph-properties fo:margin-left="0in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="6.6929in" style:type="right" style:leader-style="dotted" style:leader-text="."/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="Contents_20_2" style:display-name="Contents 2" style:family="paragraph" style:parent-style-name="Index" style:class="index">
+   <style:paragraph-properties fo:margin-left="0.1965in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="6.4965in" style:type="right" style:leader-style="dotted" style:leader-text="."/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="Contents_20_3" style:display-name="Contents 3" style:family="paragraph" style:parent-style-name="Index" style:class="index">
+   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="6.2992in" style:type="right" style:leader-style="dotted" style:leader-text="."/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="Heading_20_4" style:display-name="Heading 4" style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="4" style:class="text">
+   <style:paragraph-properties fo:margin-top="0.0835in" fo:margin-bottom="0.0835in" style:contextual-spacing="false"/>
+   <style:text-properties fo:font-size="13pt" fo:font-style="italic" fo:font-weight="bold" style:font-size-asian="13pt" style:font-style-asian="italic" style:font-weight-asian="bold" style:font-size-complex="13pt" style:font-style-complex="italic" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="Contents_20_4" style:display-name="Contents 4" style:family="paragraph" style:parent-style-name="Index" style:class="index">
+   <style:paragraph-properties fo:margin-left="0.5902in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="6.1028in" style:type="right" style:leader-style="dotted" style:leader-text="."/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="Table_20_Contents" style:display-name="Table Contents" style:family="paragraph" style:parent-style-name="Standard" style:class="extra">
+   <style:paragraph-properties fo:orphans="0" fo:widows="0" text:number-lines="false" text:line-number="0"/>
+  </style:style>
+  <style:style style:name="Header_20_and_20_Footer" style:display-name="Header and Footer" style:family="paragraph" style:parent-style-name="Standard" style:class="extra">
+   <style:paragraph-properties text:number-lines="false" text:line-number="0">
+    <style:tab-stops>
+     <style:tab-stop style:position="3.3465in" style:type="center"/>
+     <style:tab-stop style:position="6.6929in" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="Header" style:family="paragraph" style:parent-style-name="Header_20_and_20_Footer" style:class="extra">
+   <style:paragraph-properties text:number-lines="false" text:line-number="0">
+    <style:tab-stops>
+     <style:tab-stop style:position="3.3465in" style:type="center"/>
+     <style:tab-stop style:position="6.6929in" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="Footer" style:family="paragraph" style:parent-style-name="Header_20_and_20_Footer" style:class="extra">
+   <style:paragraph-properties text:number-lines="false" text:line-number="0">
+    <style:tab-stops>
+     <style:tab-stop style:position="3.3465in" style:type="center"/>
+     <style:tab-stop style:position="6.6929in" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="Table_20_Heading" style:display-name="Table Heading" style:family="paragraph" style:parent-style-name="Table_20_Contents" style:class="extra">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false" text:number-lines="false" text:line-number="0"/>
+   <style:text-properties fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="List_20_Contents" style:display-name="List Contents" style:family="paragraph" style:parent-style-name="Standard" style:class="html">
+   <style:paragraph-properties fo:margin-left="0.3937in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false"/>
+  </style:style>
+  <style:style style:name="Preformatted_20_Text" style:display-name="Preformatted Text" style:family="paragraph" style:parent-style-name="Standard" style:class="html">
+   <style:paragraph-properties fo:margin-top="0in" fo:margin-bottom="0in" style:contextual-spacing="false"/>
+   <style:text-properties style:font-name="Liberation Mono" fo:font-family="&apos;Liberation Mono&apos;" style:font-family-generic="modern" style:font-pitch="fixed" fo:font-size="10pt" style:font-name-asian="Noto Sans Mono CJK SC" style:font-family-asian="&apos;Noto Sans Mono CJK SC&apos;" style:font-family-generic-asian="modern" style:font-pitch-asian="fixed" style:font-size-asian="10pt" style:font-name-complex="Liberation Mono" style:font-family-complex="&apos;Liberation Mono&apos;" style:font-family-generic-complex="modern" style:font-pitch-complex="fixed" style:font-size-complex="10pt"/>
+  </style:style>
+  <style:style style:name="Figure" style:family="paragraph" style:parent-style-name="Caption" style:class="extra"/>
+  <style:style style:name="Comment" style:family="paragraph" style:parent-style-name="Standard" style:class="extra">
+   <style:text-properties fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
+  </style:style>
+  <style:style style:name="Frame_20_contents" style:display-name="Frame contents" style:family="paragraph" style:parent-style-name="Standard" style:class="extra"/>
+  <style:style style:name="Heading_20_5" style:display-name="Heading 5" style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="5" style:class="text">
+   <style:paragraph-properties fo:margin-top="0.0835in" fo:margin-bottom="0.0417in" style:contextual-spacing="false"/>
+   <style:text-properties fo:font-size="12pt" fo:font-weight="bold" style:font-size-asian="12pt" style:font-weight-asian="bold" style:font-size-complex="12pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="Heading_20_6" style:display-name="Heading 6" style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="6" style:class="text">
+   <style:paragraph-properties fo:margin-top="0.0417in" fo:margin-bottom="0.0417in" style:contextual-spacing="false"/>
+   <style:text-properties fo:font-size="12pt" fo:font-style="italic" fo:font-weight="bold" style:font-size-asian="12pt" style:font-style-asian="italic" style:font-weight-asian="bold" style:font-size-complex="12pt" style:font-style-complex="italic" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="Heading_20_7" style:display-name="Heading 7" style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="7" style:class="text">
+   <style:paragraph-properties fo:margin-top="0.0417in" fo:margin-bottom="0.0417in" style:contextual-spacing="false"/>
+   <style:text-properties fo:font-size="10pt" fo:font-weight="bold" style:font-size-asian="10pt" style:font-weight-asian="bold" style:font-size-complex="10pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="Contents_20_5" style:display-name="Contents 5" style:family="paragraph" style:parent-style-name="Index" style:class="index">
+   <style:paragraph-properties fo:margin-left="0.7874in" fo:margin-right="0in" fo:text-indent="0in" style:auto-text-indent="false">
+    <style:tab-stops>
+     <style:tab-stop style:position="5.9055in" style:type="right" style:leader-style="dotted" style:leader-text="."/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="Heading_20_8" style:display-name="Heading 8" style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="8" style:class="text">
+   <style:paragraph-properties fo:margin-top="0.0417in" fo:margin-bottom="0.0417in" style:contextual-spacing="false"/>
+   <style:text-properties fo:font-size="10pt" fo:font-style="italic" fo:font-weight="bold" style:font-size-asian="10pt" style:font-style-asian="italic" style:font-weight-asian="bold" style:font-size-complex="10pt" style:font-style-complex="italic" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="Heading_20_9" style:display-name="Heading 9" style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:default-outline-level="9" style:class="text">
+   <style:paragraph-properties fo:margin-top="0.0417in" fo:margin-bottom="0.0417in" style:contextual-spacing="false"/>
+   <style:text-properties fo:font-size="9pt" fo:font-weight="bold" style:font-size-asian="9pt" style:font-weight-asian="bold" style:font-size-complex="9pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="Title" style:family="paragraph" style:parent-style-name="Heading" style:next-style-name="Text_20_body" style:class="chapter">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties fo:font-size="28pt" fo:font-weight="bold" style:font-size-asian="28pt" style:font-weight-asian="bold" style:font-size-complex="28pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="Strong_20_Emphasis" style:display-name="Strong Emphasis" style:family="text">
+   <style:text-properties fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="Numbering_20_Symbols" style:display-name="Numbering Symbols" style:family="text"/>
+  <style:style style:name="Emphasis" style:family="text">
+   <style:text-properties fo:font-style="italic" style:font-style-asian="italic" style:font-style-complex="italic"/>
+  </style:style>
+  <style:style style:name="Footnote_20_Symbol" style:display-name="Footnote Symbol" style:family="text"/>
+  <style:style style:name="Footnote_20_anchor" style:display-name="Footnote anchor" style:family="text">
+   <style:text-properties style:text-position="super 58%"/>
+  </style:style>
+  <style:style style:name="Endnote_20_Symbol" style:display-name="Endnote Symbol" style:family="text"/>
+  <style:style style:name="Endnote_20_anchor" style:display-name="Endnote anchor" style:family="text">
+   <style:text-properties style:text-position="super 58%"/>
+  </style:style>
+  <style:style style:name="Internet_20_link" style:display-name="Internet link" style:family="text">
+   <style:text-properties fo:color="#000080" loext:opacity="100%" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color"/>
+  </style:style>
+  <style:style style:name="Index_20_Link" style:display-name="Index Link" style:family="text"/>
+  <style:style style:name="Bullet_20_Symbols" style:display-name="Bullet Symbols" style:family="text">
+   <style:text-properties style:font-name="OpenSymbol" fo:font-family="OpenSymbol" style:font-charset="x-symbol" style:font-name-asian="OpenSymbol" style:font-family-asian="OpenSymbol" style:font-charset-asian="x-symbol" style:font-name-complex="OpenSymbol" style:font-family-complex="OpenSymbol" style:font-charset-complex="x-symbol"/>
+  </style:style>
+  <style:style style:name="Visited_20_Internet_20_Link" style:display-name="Visited Internet Link" style:family="text">
+   <style:text-properties fo:color="#800000" loext:opacity="100%" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color"/>
+  </style:style>
+  <style:style style:name="Line_20_numbering" style:display-name="Line numbering" style:family="text"/>
+  <style:style style:name="Frame" style:family="graphic">
+   <style:graphic-properties text:anchor-type="as-char" svg:y="0in" style:wrap="none" style:vertical-pos="middle" style:vertical-rel="line" fo:background-color="transparent" draw:fill="none" draw:fill-color="#729fcf"/>
+  </style:style>
+  <style:style style:name="Graphics" style:family="graphic">
+   <style:graphic-properties text:anchor-type="paragraph" svg:x="0in" svg:y="0in" style:wrap="dynamic" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" fo:background-color="transparent" draw:fill="none" draw:fill-color="#729fcf"/>
+  </style:style>
+  <style:style style:name="OLE" style:family="graphic">
+   <style:graphic-properties text:anchor-type="paragraph" svg:x="0in" svg:y="0in" style:wrap="dynamic" style:number-wrapped-paragraphs="no-limit" style:wrap-contour="false" style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" fo:background-color="transparent" draw:fill="none" draw:fill-color="#729fcf"/>
+  </style:style>
+  <text:outline-style style:name="Outline">
+   <text:outline-level-style text:level="1" loext:num-list-format="%1%" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="2" loext:num-list-format="%2%" style:num-format="1">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="3" loext:num-list-format="%3%" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="4" loext:num-list-format="%4%" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="5" loext:num-list-format="%5%" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="6" loext:num-list-format="%6%" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="7" loext:num-list-format="%7%" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="8" loext:num-list-format="%8%" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="9" loext:num-list-format="%9%" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+   <text:outline-level-style text:level="10" loext:num-list-format="%10%" style:num-format="">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab"/>
+    </style:list-level-properties>
+   </text:outline-level-style>
+  </text:outline-style>
+  <text:notes-configuration text:note-class="footnote" text:default-style-name="Footnote" text:citation-style-name="Footnote_20_Symbol" text:citation-body-style-name="Footnote_20_anchor" text:master-page-name="Footnote" style:num-format="1" text:start-value="0" text:footnotes-position="page" text:start-numbering-at="document">
+   <text:footnote-continuation-notice-forward>This is the end of footnote</text:footnote-continuation-notice-forward>
+   <text:footnote-continuation-notice-backward>This is the start of Footnote</text:footnote-continuation-notice-backward>
+  </text:notes-configuration>
+  <text:notes-configuration text:note-class="endnote" text:default-style-name="Endnote" text:citation-style-name="Endnote_20_Symbol" text:citation-body-style-name="Endnote_20_anchor" text:master-page-name="Endnote" style:num-format="i" text:start-value="0"/>
+  <text:bibliography-configuration text:prefix="[" text:suffix="]" fo:language="en" fo:country="US"/>
+  <text:linenumbering-configuration text:style-name="Line_20_numbering" text:number-lines="false" text:offset="0.1965in" style:num-format="1" text:number-position="left" text:increment="5"/>
+  <style:style style:name="Default_20_Style.1" style:display-name="Default Style.1" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-top="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.2" style:display-name="Default Style.2" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.3" style:display-name="Default Style.3" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.4" style:display-name="Default Style.4" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-right="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.5" style:display-name="Default Style.5" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.6" style:display-name="Default Style.6" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.7" style:display-name="Default Style.7" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.8" style:display-name="Default Style.8" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.9" style:display-name="Default Style.9" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.10" style:display-name="Default Style.10" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-right="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.11" style:display-name="Default Style.11" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-top="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.12" style:display-name="Default Style.12" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-right="0.51pt solid #000000" fo:border-top="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.13" style:display-name="Default Style.13" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.14" style:display-name="Default Style.14" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-right="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.15" style:display-name="Default Style.15" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-top="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <style:style style:name="Default_20_Style.16" style:display-name="Default Style.16" style:family="table-cell">
+   <style:table-cell-properties fo:border-left="0.51pt solid #000000" fo:border-bottom="0.51pt solid #000000"/>
+   <style:text-properties/>
+  </style:style>
+  <table:table-template table:name="Default Style" table:first-row-end-column="row" table:first-row-start-column="row" table:last-row-end-column="row" table:last-row-start-column="row">
+   <table:first-row table:style-name="Default_20_Style.1"/>
+   <table:last-row table:style-name="Default_20_Style.2"/>
+   <table:first-column table:style-name="Default_20_Style.3"/>
+   <table:last-column table:style-name="Default_20_Style.4"/>
+   <table:body table:style-name="Default_20_Style.9"/>
+   <table:even-rows table:style-name="Default_20_Style.5"/>
+   <table:odd-rows table:style-name="Default_20_Style.6"/>
+   <table:even-columns table:style-name="Default_20_Style.7"/>
+   <table:odd-columns table:style-name="Default_20_Style.8"/>
+   <table:background table:style-name="Default_20_Style.10"/>
+   <loext:first-row-even-column table:style-name="Default_20_Style.15"/>
+   <loext:last-row-even-column table:style-name="Default_20_Style.16"/>
+   <loext:first-row-end-column table:style-name="Default_20_Style.12"/>
+   <loext:first-row-start-column table:style-name="Default_20_Style.11"/>
+   <loext:last-row-end-column table:style-name="Default_20_Style.14"/>
+   <loext:last-row-start-column table:style-name="Default_20_Style.13"/>
+  </table:table-template>
+  <loext:theme loext:name="Office">
+   <loext:theme-colors loext:name="LibreOffice">
+    <loext:color loext:name="dark1" loext:color="#000000"/>
+    <loext:color loext:name="light1" loext:color="#ffffff"/>
+    <loext:color loext:name="dark2" loext:color="#000000"/>
+    <loext:color loext:name="light2" loext:color="#ffffff"/>
+    <loext:color loext:name="accent1" loext:color="#18a303"/>
+    <loext:color loext:name="accent2" loext:color="#0369a3"/>
+    <loext:color loext:name="accent3" loext:color="#a33e03"/>
+    <loext:color loext:name="accent4" loext:color="#8e03a3"/>
+    <loext:color loext:name="accent5" loext:color="#c99c00"/>
+    <loext:color loext:name="accent6" loext:color="#c9211e"/>
+    <loext:color loext:name="hyperlink" loext:color="#0000ee"/>
+    <loext:color loext:name="followed-hyperlink" loext:color="#551a8b"/>
+   </loext:theme-colors>
+  </loext:theme>
+ </office:styles>
+ <office:automatic-styles>
+  <style:style style:name="Table2" style:family="table">
+   <style:table-properties style:width="6.6979in" fo:margin-left="0in" table:align="left" style:may-break-between-rows="true" table:border-model="collapsing"/>
+  </style:style>
+  <style:style style:name="Table2.A" style:family="table-column">
+   <style:table-column-properties style:column-width="0.7083in"/>
+  </style:style>
+  <style:style style:name="Table2.B" style:family="table-column">
+   <style:table-column-properties style:column-width="2.3903in"/>
+  </style:style>
+  <style:style style:name="Table2.C" style:family="table-column">
+   <style:table-column-properties style:column-width="1.9229in"/>
+  </style:style>
+  <style:style style:name="Table2.D" style:family="table-column">
+   <style:table-column-properties style:column-width="1.6764in"/>
+  </style:style>
+  <style:style style:name="Table2.1" style:family="table-row">
+   <style:table-row-properties fo:keep-together="auto"/>
+  </style:style>
+  <style:style style:name="Table2.A1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="0.5pt solid #000000" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table2.D1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table2.A2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table2.D2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="0.5pt solid #000000" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table1" style:family="table">
+   <style:table-properties style:width="1.8465in" table:align="margins" style:may-break-between-rows="true" table:border-model="collapsing"/>
+  </style:style>
+  <style:style style:name="Table1.A" style:family="table-column">
+   <style:table-column-properties style:column-width="0.9229in" style:rel-column-width="32767*"/>
+  </style:style>
+  <style:style style:name="Table1.B" style:family="table-column">
+   <style:table-column-properties style:column-width="0.9236in" style:rel-column-width="32768*"/>
+  </style:style>
+  <style:style style:name="Table1.A1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="0.5pt solid #000000" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table1.B1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table1.2" style:family="table-row">
+   <style:table-row-properties fo:keep-together="auto"/>
+  </style:style>
+  <style:style style:name="Table1.A2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table1.B2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="0.5pt solid #000000" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table3" style:family="table">
+   <style:table-properties style:width="1.8465in" table:align="margins"/>
+  </style:style>
+  <style:style style:name="Table3.A" style:family="table-column">
+   <style:table-column-properties style:column-width="0.9229in" style:rel-column-width="32767*"/>
+  </style:style>
+  <style:style style:name="Table3.B" style:family="table-column">
+   <style:table-column-properties style:column-width="0.9236in" style:rel-column-width="32768*"/>
+  </style:style>
+  <style:style style:name="Table3.A1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="0.5pt solid #000000" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table3.B1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table3.A2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table3.B2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="0.5pt solid #000000" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table4" style:family="table">
+   <style:table-properties style:width="1.8465in" table:align="margins"/>
+  </style:style>
+  <style:style style:name="Table4.A" style:family="table-column">
+   <style:table-column-properties style:column-width="0.9229in" style:rel-column-width="32767*"/>
+  </style:style>
+  <style:style style:name="Table4.B" style:family="table-column">
+   <style:table-column-properties style:column-width="0.9236in" style:rel-column-width="32768*"/>
+  </style:style>
+  <style:style style:name="Table4.A1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="0.5pt solid #000000" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table4.B1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table4.A2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table4.B2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="0.5pt solid #000000" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table1" style:family="table">
+   <style:table-properties style:width="1.8465in" table:align="margins" style:may-break-between-rows="true" table:border-model="collapsing"/>
+  </style:style>
+  <style:style style:name="Table1.A" style:family="table-column">
+   <style:table-column-properties style:column-width="0.9229in" style:rel-column-width="32767*"/>
+  </style:style>
+  <style:style style:name="Table1.B" style:family="table-column">
+   <style:table-column-properties style:column-width="0.9236in" style:rel-column-width="32768*"/>
+  </style:style>
+  <style:style style:name="Table1.A1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="0.5pt solid #000000" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table1.B1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table1.2" style:family="table-row">
+   <style:table-row-properties fo:keep-together="auto"/>
+  </style:style>
+  <style:style style:name="Table1.A2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table1.B2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="0.5pt solid #000000" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table3" style:family="table">
+   <style:table-properties style:width="1.8465in" table:align="margins"/>
+  </style:style>
+  <style:style style:name="Table3.A" style:family="table-column">
+   <style:table-column-properties style:column-width="0.9229in" style:rel-column-width="32767*"/>
+  </style:style>
+  <style:style style:name="Table3.B" style:family="table-column">
+   <style:table-column-properties style:column-width="0.9236in" style:rel-column-width="32768*"/>
+  </style:style>
+  <style:style style:name="Table3.A1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="0.5pt solid #000000" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table3.B1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table3.A2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table3.B2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="0.5pt solid #000000" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table4" style:family="table">
+   <style:table-properties style:width="1.8465in" table:align="margins"/>
+  </style:style>
+  <style:style style:name="Table4.A" style:family="table-column">
+   <style:table-column-properties style:column-width="0.9229in" style:rel-column-width="32767*"/>
+  </style:style>
+  <style:style style:name="Table4.B" style:family="table-column">
+   <style:table-column-properties style:column-width="0.9236in" style:rel-column-width="32768*"/>
+  </style:style>
+  <style:style style:name="Table4.A1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="0.5pt solid #000000" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table4.B1" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table4.A2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="none" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="Table4.B2" style:family="table-cell">
+   <style:table-cell-properties fo:background-color="transparent" fo:padding="0.0382in" fo:border-left="0.5pt solid #000000" fo:border-right="0.5pt solid #000000" fo:border-top="none" fo:border-bottom="0.5pt solid #000000" style:writing-mode="page">
+    <style:background-image/>
+   </style:table-cell-properties>
+  </style:style>
+  <style:style style:name="P1" style:family="paragraph" style:parent-style-name="Header">
+   <style:text-properties fo:language="en" fo:country="GB" fo:font-style="italic" officeooo:rsid="0005e07e" officeooo:paragraph-rsid="0005e07e" style:font-style-asian="italic" style:font-style-complex="italic"/>
+  </style:style>
+  <style:style style:name="P2" style:family="paragraph" style:parent-style-name="Footnote">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:rsid="00014a3c" officeooo:paragraph-rsid="0006bc8e"/>
+  </style:style>
+  <style:style style:name="P3" style:family="paragraph" style:parent-style-name="Footnote">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="7.2437in" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties officeooo:rsid="00014a3c" officeooo:paragraph-rsid="0006bc8e"/>
+  </style:style>
+  <style:style style:name="P4" style:family="paragraph" style:parent-style-name="Header">
+   <style:text-properties fo:language="en" fo:country="GB"/>
+  </style:style>
+  <style:style style:name="P5" style:family="paragraph" style:parent-style-name="Footer">
+   <style:text-properties fo:language="en" fo:country="GB"/>
+  </style:style>
+  <style:style style:name="P6" style:family="paragraph" style:parent-style-name="Header">
+   <style:text-properties fo:language="en" fo:country="GB" fo:font-style="italic" officeooo:rsid="0005e07e" officeooo:paragraph-rsid="0005e07e" style:font-style-asian="italic" style:font-style-complex="italic"/>
+  </style:style>
+  <style:style style:name="P7" style:family="paragraph" style:parent-style-name="Footnote">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:rsid="00014a3c" officeooo:paragraph-rsid="0006bc8e"/>
+  </style:style>
+  <style:style style:name="P8" style:family="paragraph" style:parent-style-name="Header">
+   <style:text-properties fo:language="en" fo:country="GB"/>
+  </style:style>
+  <style:style style:name="P9" style:family="paragraph" style:parent-style-name="Footer">
+   <style:text-properties fo:language="en" fo:country="GB"/>
+  </style:style>
+  <style:style style:name="P10" style:family="paragraph" style:parent-style-name="Footnote">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:rsid="00005e38" officeooo:paragraph-rsid="00005e38"/>
+  </style:style>
+  <style:style style:name="P11" style:family="paragraph" style:parent-style-name="Footnote">
+   <style:text-properties fo:language="en" fo:country="GB"/>
+  </style:style>
+  <style:style style:name="P12" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties fo:language="en" fo:country="GB"/>
+  </style:style>
+  <style:style style:name="P13" style:family="paragraph" style:parent-style-name="Table_20_Contents">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:paragraph-rsid="003ff560"/>
+  </style:style>
+  <style:style style:name="P14" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:paragraph-rsid="003ff560"/>
+  </style:style>
+  <style:style style:name="P15" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:paragraph-rsid="00425342"/>
+  </style:style>
+  <style:style style:name="P16" style:family="paragraph" style:parent-style-name="Footnote">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="7.2437in" style:type="right"/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+   <style:text-properties officeooo:rsid="00014a3c" officeooo:paragraph-rsid="0006bc8e"/>
+  </style:style>
+  <style:style style:name="P17" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties style:font-name="Liberation Serif" fo:font-size="13pt" fo:language="en" fo:country="GB" style:font-size-asian="13pt" style:font-size-complex="13pt"/>
+  </style:style>
+  <style:style style:name="P18" style:family="paragraph" style:parent-style-name="Standard">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties fo:font-size="18pt" fo:language="en" fo:country="GB" fo:font-weight="bold" style:font-size-asian="18pt" style:font-weight-asian="bold" style:font-size-complex="18pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P19" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties officeooo:paragraph-rsid="003ff560"/>
+  </style:style>
+  <style:style style:name="P20" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties officeooo:paragraph-rsid="003ff560"/>
+  </style:style>
+  <style:style style:name="P21" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties officeooo:rsid="003e52eb" officeooo:paragraph-rsid="003e52eb"/>
+  </style:style>
+  <style:style style:name="P22" style:family="paragraph" style:parent-style-name="Contents_20_2">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="6.4957in" style:type="right" style:leader-style="dotted" style:leader-text="."/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="P23" style:family="paragraph" style:parent-style-name="Contents_20_3">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="6.2984in" style:type="right" style:leader-style="dotted" style:leader-text="."/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="P24" style:family="paragraph" style:parent-style-name="Contents_20_4">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="6.102in" style:type="right" style:leader-style="dotted" style:leader-text="."/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="P25" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties fo:language="fr" fo:country="FR"/>
+  </style:style>
+  <style:style style:name="P26" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties fo:language="fr" fo:country="FR" officeooo:paragraph-rsid="005158dc"/>
+  </style:style>
+  <style:style style:name="P27" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties fo:language="fr" fo:country="FR"/>
+  </style:style>
+  <style:style style:name="P28" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+  </style:style>
+  <style:style style:name="P29" style:family="paragraph" style:parent-style-name="Footnote">
+   <style:text-properties officeooo:paragraph-rsid="00005e38"/>
+  </style:style>
+  <style:style style:name="P30" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties officeooo:paragraph-rsid="0058aa73"/>
+  </style:style>
+  <style:style style:name="P31" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties fo:language="zxx" fo:country="none" officeooo:paragraph-rsid="00627123" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
+  </style:style>
+  <style:style style:name="P32" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:text-properties fo:language="zxx" fo:country="none" officeooo:paragraph-rsid="0063de2c" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
+  </style:style>
+  <style:style style:name="P33" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:paragraph-properties fo:text-align="justify" style:justify-single-word="false"/>
+   <style:text-properties fo:language="zxx" fo:country="none" officeooo:paragraph-rsid="00627123" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
+  </style:style>
+  <style:style style:name="P34" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:paragraph-properties fo:text-align="end" style:justify-single-word="false"/>
+   <style:text-properties fo:language="zxx" fo:country="none" officeooo:paragraph-rsid="00627123" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
+  </style:style>
+  <style:style style:name="P35" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+   <style:text-properties fo:language="zxx" fo:country="none" officeooo:paragraph-rsid="00627123" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
+  </style:style>
+  <style:style style:name="P36" style:family="paragraph" style:parent-style-name="Text_20_body">
+   <style:paragraph-properties fo:break-before="page"/>
+  </style:style>
+  <style:style style:name="P37" style:family="paragraph" style:parent-style-name="Standard">
+   <style:text-properties fo:language="de" fo:country="DE"/>
+  </style:style>
+  <style:style style:name="P38" style:family="paragraph" style:parent-style-name="Contents_20_2">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="6.4957in" style:type="right" style:leader-style="dotted" style:leader-text="."/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="P39" style:family="paragraph" style:parent-style-name="Contents_20_3">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="6.2984in" style:type="right" style:leader-style="dotted" style:leader-text="."/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="P40" style:family="paragraph" style:parent-style-name="Contents_20_4">
+   <style:paragraph-properties>
+    <style:tab-stops>
+     <style:tab-stop style:position="6.102in" style:type="right" style:leader-style="dotted" style:leader-text="."/>
+    </style:tab-stops>
+   </style:paragraph-properties>
+  </style:style>
+  <style:style style:name="P41" style:family="paragraph" style:parent-style-name="Heading_20_2">
+   <style:paragraph-properties fo:break-before="page"/>
+  </style:style>
+  <style:style style:name="P42" style:family="paragraph" style:parent-style-name="Heading_20_2">
+   <style:text-properties fo:language="zxx" fo:country="none" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
+  </style:style>
+  <style:style style:name="P43" style:family="paragraph" style:parent-style-name="Heading_20_3">
+   <style:text-properties fo:color="#3465a4" loext:opacity="100%" fo:language="en" fo:country="GB"/>
+  </style:style>
+  <style:style style:name="P44" style:family="paragraph" style:parent-style-name="Heading_20_3">
+   <style:text-properties fo:color="#069a2e" loext:opacity="100%" fo:language="fr" fo:country="FR"/>
+  </style:style>
+  <style:style style:name="P45" style:family="paragraph" style:parent-style-name="Heading_20_3">
+   <style:text-properties fo:color="#ff0000" loext:opacity="100%" fo:language="de" fo:country="DE"/>
+  </style:style>
+  <style:style style:name="P46" style:family="paragraph" style:parent-style-name="Heading_20_3">
+   <style:paragraph-properties fo:break-before="page"/>
+  </style:style>
+  <style:style style:name="P47" style:family="paragraph" style:parent-style-name="Heading_20_3">
+   <style:text-properties fo:language="zxx" fo:country="none" officeooo:rsid="00627123" officeooo:paragraph-rsid="00627123" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
+  </style:style>
+  <style:style style:name="P48" style:family="paragraph" style:parent-style-name="Heading_20_3">
+   <style:text-properties fo:language="zxx" fo:country="none" style:language-asian="zxx" style:country-asian="none" style:language-complex="zxx" style:country-complex="none"/>
+  </style:style>
+  <style:style style:name="P49" style:family="paragraph" style:parent-style-name="Heading_20_4">
+   <style:text-properties fo:language="en" fo:country="GB"/>
+  </style:style>
+  <style:style style:name="P50" style:family="paragraph" style:parent-style-name="Heading_20_4">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:paragraph-rsid="00425342"/>
+  </style:style>
+  <style:style style:name="P51" style:family="paragraph" style:parent-style-name="Heading_20_4">
+   <style:text-properties fo:language="fr" fo:country="FR"/>
+  </style:style>
+  <style:style style:name="P52" style:family="paragraph" style:parent-style-name="Heading_20_4">
+   <style:text-properties fo:language="fr" fo:country="FR" officeooo:paragraph-rsid="00425342"/>
+  </style:style>
+  <style:style style:name="P53" style:family="paragraph" style:parent-style-name="Heading_20_4">
+   <style:text-properties fo:language="de" fo:country="DE"/>
+  </style:style>
+  <style:style style:name="P54" style:family="paragraph" style:parent-style-name="Heading_20_4">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false"/>
+  </style:style>
+  <style:style style:name="P55" style:family="paragraph" style:parent-style-name="Heading_20_4" style:master-page-name="">
+   <style:paragraph-properties fo:text-align="center" style:justify-single-word="false" style:page-number="auto" fo:break-before="auto" fo:break-after="auto"/>
+  </style:style>
+  <style:style style:name="P56" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L4"/>
+  <style:style style:name="P57" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L4">
+   <style:text-properties fo:language="de" fo:country="DE" officeooo:paragraph-rsid="0056ca82"/>
+  </style:style>
+  <style:style style:name="P58" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L7">
+   <style:text-properties fo:language="de" fo:country="DE"/>
+  </style:style>
+  <style:style style:name="P59" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L7">
+   <style:text-properties fo:language="de" fo:country="DE" officeooo:paragraph-rsid="003ff560"/>
+  </style:style>
+  <style:style style:name="P60" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L5">
+   <style:text-properties fo:language="en" fo:country="GB"/>
+  </style:style>
+  <style:style style:name="P61" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L4">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:paragraph-rsid="00425342"/>
+  </style:style>
+  <style:style style:name="P62" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L1">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:paragraph-rsid="003ff560"/>
+  </style:style>
+  <style:style style:name="P63" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L2">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:paragraph-rsid="003ff560"/>
+  </style:style>
+  <style:style style:name="P64" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L3">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:paragraph-rsid="003ff560"/>
+  </style:style>
+  <style:style style:name="P65" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L6">
+   <style:text-properties fo:language="fr" fo:country="FR"/>
+  </style:style>
+  <style:style style:name="P66" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L6">
+   <style:text-properties fo:language="fr" fo:country="FR" officeooo:paragraph-rsid="003ff560"/>
+  </style:style>
+  <style:style style:name="P67" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L4">
+   <style:text-properties fo:language="fr" fo:country="FR" officeooo:paragraph-rsid="00425342"/>
+  </style:style>
+  <style:style style:name="P68" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L4">
+   <style:text-properties fo:language="fr" fo:country="FR" officeooo:paragraph-rsid="0058aa73"/>
+  </style:style>
+  <style:style style:name="P69" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L8">
+   <style:text-properties fo:font-size="13pt" fo:language="de" fo:country="DE" fo:font-weight="bold" style:font-size-asian="13pt" style:font-weight-asian="bold" style:font-size-complex="13pt" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P70" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L9"/>
+  <style:style style:name="P71" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L9">
+   <style:text-properties officeooo:paragraph-rsid="003e52eb"/>
+  </style:style>
+  <style:style style:name="P72" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L9">
+   <style:text-properties fo:font-weight="bold" officeooo:paragraph-rsid="003e52eb" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P73" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L9">
+   <style:text-properties fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="P74" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L9">
+   <style:text-properties officeooo:rsid="003ff560" officeooo:paragraph-rsid="003ff560"/>
+  </style:style>
+  <style:style style:name="P75" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L9">
+   <style:text-properties officeooo:rsid="003ff560"/>
+  </style:style>
+  <style:style style:name="P76" style:family="paragraph" style:parent-style-name="Text_20_body" style:list-style-name="L9">
+   <style:text-properties officeooo:rsid="003e52eb" officeooo:paragraph-rsid="00425342"/>
+  </style:style>
+  <style:style style:name="P77" style:family="paragraph">
+   <loext:graphic-properties draw:fill-color="#158466"/>
+   <style:paragraph-properties style:writing-mode="lr-tb"/>
+  </style:style>
+  <style:style style:name="P78" style:family="paragraph">
+   <style:paragraph-properties style:writing-mode="lr-tb"/>
+  </style:style>
+  <style:style style:name="P79" style:family="paragraph">
+   <loext:graphic-properties draw:fill-color="#5b277d"/>
+   <style:paragraph-properties style:writing-mode="lr-tb"/>
+  </style:style>
+  <style:style style:name="T1" style:family="text">
+   <style:text-properties fo:language="en" fo:country="GB"/>
+  </style:style>
+  <style:style style:name="T2" style:family="text">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:rsid="0046db4c"/>
+  </style:style>
+  <style:style style:name="T3" style:family="text">
+   <style:text-properties fo:language="en" fo:country="GB" fo:font-weight="bold" officeooo:rsid="00170d6d" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="T4" style:family="text">
+   <style:text-properties fo:language="en" fo:country="GB"/>
+  </style:style>
+  <style:style style:name="T5" style:family="text">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:rsid="0046db4c"/>
+  </style:style>
+  <style:style style:name="T6" style:family="text">
+   <style:text-properties fo:language="en" fo:country="GB" fo:font-weight="bold" officeooo:rsid="00170d6d" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="T7" style:family="text">
+   <style:text-properties fo:language="en" fo:country="GB" officeooo:rsid="005158dc"/>
+  </style:style>
+  <style:style style:name="T8" style:family="text">
+   <style:text-properties officeooo:rsid="003e52eb"/>
+  </style:style>
+  <style:style style:name="T9" style:family="text">
+   <style:text-properties officeooo:rsid="003ff560"/>
+  </style:style>
+  <style:style style:name="T10" style:family="text">
+   <style:text-properties officeooo:rsid="005638d1"/>
+  </style:style>
+  <style:style style:name="T11" style:family="text">
+   <style:text-properties officeooo:rsid="0063de2c"/>
+  </style:style>
+  <style:style style:name="T12" style:family="text">
+   <style:text-properties fo:font-weight="bold" style:font-weight-asian="bold" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="T13" style:family="text">
+   <style:text-properties fo:font-style="italic" style:font-style-asian="italic" style:font-style-complex="italic"/>
+  </style:style>
+  <style:style style:name="T14" style:family="text">
+   <style:text-properties fo:font-style="italic" fo:font-weight="bold" style:font-style-asian="italic" style:font-weight-asian="bold" style:font-style-complex="italic" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="T15" style:family="text">
+   <style:text-properties fo:font-style="italic" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" style:font-style-asian="italic" style:font-style-complex="italic"/>
+  </style:style>
+  <style:style style:name="T16" style:family="text">
+   <style:text-properties fo:font-style="italic" style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color" fo:font-weight="bold" style:font-style-asian="italic" style:font-weight-asian="bold" style:font-style-complex="italic" style:font-weight-complex="bold"/>
+  </style:style>
+  <style:style style:name="T17" style:family="text">
+   <style:text-properties fo:font-size="14pt" style:font-size-asian="14pt" style:font-size-complex="14pt"/>
+  </style:style>
+  <style:style style:name="T18" style:family="text">
+   <style:text-properties fo:font-size="14pt" fo:font-style="italic" style:font-size-asian="12.25pt" style:font-style-asian="italic" style:font-size-complex="14pt" style:font-style-complex="italic"/>
+  </style:style>
+  <style:style style:name="T19" style:family="text">
+   <style:text-properties fo:font-size="9pt" style:font-size-asian="9pt" style:font-size-complex="9pt"/>
+  </style:style>
+  <style:style style:name="T20" style:family="text">
+   <style:text-properties style:text-underline-style="solid" style:text-underline-width="auto" style:text-underline-color="font-color"/>
+  </style:style>
+  <style:style style:name="T21" style:family="text">
+   <style:text-properties style:text-line-through-style="solid" style:text-line-through-type="single"/>
+  </style:style>
+  <style:style style:name="T22" style:family="text">
+   <style:text-properties fo:font-size="18pt" style:font-size-asian="18pt" style:font-size-complex="18pt"/>
+  </style:style>
+  <style:style style:name="T23" style:family="text">
+   <style:text-properties fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
+  </style:style>
+  <style:style style:name="T24" style:family="text">
+   <style:text-properties style:text-position="sub 58%"/>
+  </style:style>
+  <style:style style:name="T25" style:family="text">
+   <style:text-properties style:text-position="super 58%"/>
+  </style:style>
+  <style:style style:name="T26" style:family="text">
+   <style:text-properties fo:font-size="26pt" style:font-size-asian="26pt" style:font-size-complex="26pt"/>
+  </style:style>
+  <style:style style:name="T27" style:family="text">
+   <style:text-properties fo:font-size="7pt" style:font-size-asian="7pt" style:font-size-complex="7pt"/>
+  </style:style>
+  <style:style style:name="T28" style:family="text">
+   <style:text-properties fo:font-style="normal" style:text-underline-style="none" style:font-style-asian="normal" style:font-style-complex="normal"/>
+  </style:style>
+  <style:style style:name="T29" style:family="text">
+   <style:text-properties fo:language="de" fo:country="DE"/>
+  </style:style>
+  <style:style style:name="T30" style:family="text">
+   <style:text-properties fo:font-size="8pt" fo:font-style="italic"/>
+  </style:style>
+  <style:style style:name="T31" style:family="text">
+   <style:text-properties fo:language="es" fo:country="ES"/>
+  </style:style>
+  <style:style style:name="T32" style:family="text">
+   <style:text-properties fo:language="pl" fo:country="PL"/>
+  </style:style>
+  <style:style style:name="T33" style:family="text">
+   <style:text-properties fo:language="tr" fo:country="TR"/>
+  </style:style>
+  <style:style style:name="T34" style:family="text">
+   <style:text-properties fo:language="en" fo:country="NG" style:language-asian="zh" style:country-asian="CN" style:language-complex="hi" style:country-complex="IN"/>
+  </style:style>
+  <style:style style:name="fr1" style:family="graphic" style:parent-style-name="Frame">
+   <style:graphic-properties fo:margin-left="0in" fo:margin-right="0.1in" style:wrap="dynamic" style:number-wrapped-paragraphs="no-limit" style:vertical-pos="from-top" style:vertical-rel="paragraph" style:horizontal-pos="from-left" style:horizontal-rel="paragraph"/>
+  </style:style>
+  <style:style style:name="fr2" style:family="graphic" style:parent-style-name="Frame">
+   <style:graphic-properties fo:margin-left="0.1in" fo:margin-right="0in" style:run-through="foreground" style:wrap="left" style:number-wrapped-paragraphs="no-limit" style:vertical-pos="from-top" style:vertical-rel="paragraph" style:horizontal-pos="right" style:horizontal-rel="paragraph"/>
+  </style:style>
+  <style:style style:name="fr3" style:family="graphic" style:parent-style-name="Frame">
+   <style:graphic-properties style:wrap="dynamic" style:number-wrapped-paragraphs="no-limit" style:vertical-pos="from-top" style:vertical-rel="paragraph" style:horizontal-pos="from-left" style:horizontal-rel="paragraph"/>
+  </style:style>
+  <style:style style:name="fr4" style:family="graphic" style:parent-style-name="Graphics">
+   <style:graphic-properties fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0in" fo:margin-bottom="0in" style:run-through="foreground" style:wrap="none" style:vertical-pos="top" style:vertical-rel="paragraph-content" style:horizontal-pos="center" style:horizontal-rel="paragraph-content" fo:padding="0in" fo:border="none" style:shadow="none" draw:shadow-opacity="100%" style:mirror="none" fo:clip="rect(0in, 0in, 0in, 0in)" draw:luminance="0%" draw:contrast="0%" draw:red="0%" draw:green="0%" draw:blue="0%" draw:gamma="100%" draw:color-inversion="false" draw:image-opacity="100%" draw:color-mode="standard" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true" loext:rel-width-rel="paragraph"/>
+  </style:style>
+  <style:style style:name="fr5" style:family="graphic" style:parent-style-name="Graphics">
+   <style:graphic-properties style:vertical-pos="top" style:vertical-rel="baseline" style:mirror="none" fo:clip="rect(0in, 0in, 0in, 0in)" draw:luminance="0%" draw:contrast="0%" draw:red="0%" draw:green="0%" draw:blue="0%" draw:gamma="100%" draw:color-inversion="false" draw:image-opacity="100%" draw:color-mode="standard"/>
+  </style:style>
+  <style:style style:name="fr6" style:family="graphic" style:parent-style-name="Graphics">
+   <style:graphic-properties style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" style:mirror="none" fo:clip="rect(0in, 0in, 0in, 0in)" draw:luminance="0%" draw:contrast="0%" draw:red="0%" draw:green="0%" draw:blue="0%" draw:gamma="100%" draw:color-inversion="false" draw:image-opacity="100%" draw:color-mode="standard"/>
+  </style:style>
+  <style:style style:name="fr7" style:family="graphic" style:parent-style-name="OLE">
+   <style:graphic-properties style:vertical-pos="top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" draw:ole-draw-aspect="1"/>
+  </style:style>
+  <style:style style:name="Sect1" style:family="section">
+   <style:section-properties style:editable="false">
+    <style:columns fo:column-count="1" fo:column-gap="0in"/>
+   </style:section-properties>
+  </style:style>
+  <text:list-style style:name="L1">
+   <text:list-level-style-bullet text:level="1" text:style-name="Bullet_20_Symbols" loext:num-list-format="%1%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.5in" fo:text-indent="-0.25in" fo:margin-left="0.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="2" text:style-name="Bullet_20_Symbols" loext:num-list-format="%2%." style:num-suffix="." text:bullet-char="◦">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.75in" fo:text-indent="-0.25in" fo:margin-left="0.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="3" text:style-name="Bullet_20_Symbols" loext:num-list-format="%3%." style:num-suffix="." text:bullet-char="▪">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1in" fo:text-indent="-0.25in" fo:margin-left="1in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="4" text:style-name="Bullet_20_Symbols" loext:num-list-format="%4%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.25in" fo:text-indent="-0.25in" fo:margin-left="1.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="5" text:style-name="Bullet_20_Symbols" loext:num-list-format="%5%." style:num-suffix="." text:bullet-char="◦">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.5in" fo:text-indent="-0.25in" fo:margin-left="1.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="6" text:style-name="Bullet_20_Symbols" loext:num-list-format="%6%." style:num-suffix="." text:bullet-char="▪">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.75in" fo:text-indent="-0.25in" fo:margin-left="1.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="7" text:style-name="Bullet_20_Symbols" loext:num-list-format="%7%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2in" fo:text-indent="-0.25in" fo:margin-left="2in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="8" text:style-name="Bullet_20_Symbols" loext:num-list-format="%8%." style:num-suffix="." text:bullet-char="◦">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.25in" fo:text-indent="-0.25in" fo:margin-left="2.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="9" text:style-name="Bullet_20_Symbols" loext:num-list-format="%9%." style:num-suffix="." text:bullet-char="▪">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.5in" fo:text-indent="-0.25in" fo:margin-left="2.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="10" text:style-name="Bullet_20_Symbols" loext:num-list-format="%10%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.75in" fo:text-indent="-0.25in" fo:margin-left="2.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+  </text:list-style>
+  <text:list-style style:name="L2">
+   <text:list-level-style-bullet text:level="1" text:style-name="Bullet_20_Symbols" loext:num-list-format="%1%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.5in" fo:text-indent="-0.25in" fo:margin-left="0.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="2" text:style-name="Bullet_20_Symbols" loext:num-list-format="%2%." style:num-suffix="." text:bullet-char="◦">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.75in" fo:text-indent="-0.25in" fo:margin-left="0.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="3" text:style-name="Bullet_20_Symbols" loext:num-list-format="%3%." style:num-suffix="." text:bullet-char="▪">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1in" fo:text-indent="-0.25in" fo:margin-left="1in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="4" text:style-name="Bullet_20_Symbols" loext:num-list-format="%4%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.25in" fo:text-indent="-0.25in" fo:margin-left="1.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="5" text:style-name="Bullet_20_Symbols" loext:num-list-format="%5%." style:num-suffix="." text:bullet-char="◦">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.5in" fo:text-indent="-0.25in" fo:margin-left="1.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="6" text:style-name="Bullet_20_Symbols" loext:num-list-format="%6%." style:num-suffix="." text:bullet-char="▪">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.75in" fo:text-indent="-0.25in" fo:margin-left="1.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="7" text:style-name="Bullet_20_Symbols" loext:num-list-format="%7%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2in" fo:text-indent="-0.25in" fo:margin-left="2in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="8" text:style-name="Bullet_20_Symbols" loext:num-list-format="%8%." style:num-suffix="." text:bullet-char="◦">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.25in" fo:text-indent="-0.25in" fo:margin-left="2.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="9" text:style-name="Bullet_20_Symbols" loext:num-list-format="%9%." style:num-suffix="." text:bullet-char="▪">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.5in" fo:text-indent="-0.25in" fo:margin-left="2.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="10" text:style-name="Bullet_20_Symbols" loext:num-list-format="%10%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.75in" fo:text-indent="-0.25in" fo:margin-left="2.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+  </text:list-style>
+  <text:list-style style:name="L3">
+   <text:list-level-style-bullet text:level="1" text:style-name="Bullet_20_Symbols" loext:num-list-format="%1%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:space-before="0.4925in"/>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="2" text:style-name="Bullet_20_Symbols" loext:num-list-format="%2%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:space-before="0.7882in" text:min-label-width="0.1965in"/>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="3" text:style-name="Bullet_20_Symbols" loext:num-list-format="%3%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:space-before="1.2807in" text:min-label-width="0.1965in"/>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="4" text:style-name="Bullet_20_Symbols" loext:num-list-format="%4%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:space-before="1.7728in" text:min-label-width="0.1965in"/>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="5" text:style-name="Bullet_20_Symbols" loext:num-list-format="%5%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:space-before="2.2654in" text:min-label-width="0.1965in"/>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="6" text:style-name="Bullet_20_Symbols" loext:num-list-format="%6%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:space-before="2.7579in" text:min-label-width="0.1965in"/>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="7" text:style-name="Bullet_20_Symbols" loext:num-list-format="%7%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:space-before="3.25in" text:min-label-width="0.1965in"/>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="8" text:style-name="Bullet_20_Symbols" loext:num-list-format="%8%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:space-before="3.7425in" text:min-label-width="0.1965in"/>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="9" text:style-name="Bullet_20_Symbols" loext:num-list-format="%9%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:space-before="4.2346in" text:min-label-width="0.1965in"/>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="10" text:style-name="Bullet_20_Symbols" loext:num-list-format="%10%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:space-before="4.7272in" text:min-label-width="0.1965in"/>
+   </text:list-level-style-bullet>
+  </text:list-style>
+  <text:list-style style:name="L4">
+   <text:list-level-style-bullet text:level="1" text:style-name="Bullet_20_Symbols" loext:num-list-format="%1%" text:bullet-char="✔">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.552in" fo:text-indent="-0.25in" fo:margin-left="0.552in"/>
+    </style:list-level-properties>
+    <style:text-properties style:font-name="OpenSymbol"/>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="2" text:style-name="Bullet_20_Symbols" loext:num-list-format="%2%." style:num-suffix="." text:bullet-char="◦">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.802in" fo:text-indent="-0.25in" fo:margin-left="0.802in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="3" text:style-name="Bullet_20_Symbols" loext:num-list-format="%3%." style:num-suffix="." text:bullet-char="▪">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.052in" fo:text-indent="-0.25in" fo:margin-left="1.052in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="4" text:style-name="Bullet_20_Symbols" loext:num-list-format="%4%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.302in" fo:text-indent="-0.25in" fo:margin-left="1.302in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="5" text:style-name="Bullet_20_Symbols" loext:num-list-format="%5%." style:num-suffix="." text:bullet-char="◦">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.552in" fo:text-indent="-0.25in" fo:margin-left="1.552in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="6" text:style-name="Bullet_20_Symbols" loext:num-list-format="%6%." style:num-suffix="." text:bullet-char="▪">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.802in" fo:text-indent="-0.25in" fo:margin-left="1.802in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="7" text:style-name="Bullet_20_Symbols" loext:num-list-format="%7%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.052in" fo:text-indent="-0.25in" fo:margin-left="2.052in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="8" text:style-name="Bullet_20_Symbols" loext:num-list-format="%8%." style:num-suffix="." text:bullet-char="◦">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.302in" fo:text-indent="-0.25in" fo:margin-left="2.302in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="9" text:style-name="Bullet_20_Symbols" loext:num-list-format="%9%." style:num-suffix="." text:bullet-char="▪">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.552in" fo:text-indent="-0.25in" fo:margin-left="2.552in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="10" text:style-name="Bullet_20_Symbols" loext:num-list-format="%10%." style:num-suffix="." text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.802in" fo:text-indent="-0.25in" fo:margin-left="2.802in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+  </text:list-style>
+  <text:list-style style:name="L5">
+   <text:list-level-style-number text:level="1" text:style-name="Numbering_20_Symbols" loext:num-list-format="%1%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.5in" fo:text-indent="-0.25in" fo:margin-left="0.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="2" text:style-name="Numbering_20_Symbols" loext:num-list-format="(%2%)" style:num-prefix="(" style:num-suffix=")" style:num-format="a">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.75in" fo:text-indent="-0.25in" fo:margin-left="0.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="3" text:style-name="Numbering_20_Symbols" loext:num-list-format="(%3%)" style:num-prefix="(" style:num-suffix=")" style:num-format="a">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1in" fo:text-indent="-0.25in" fo:margin-left="1in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="4" text:style-name="Numbering_20_Symbols" loext:num-list-format="(%4%)" style:num-prefix="(" style:num-suffix=")" style:num-format="a">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.25in" fo:text-indent="-0.25in" fo:margin-left="1.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="5" text:style-name="Numbering_20_Symbols" loext:num-list-format="(%5%)" style:num-prefix="(" style:num-suffix=")" style:num-format="a">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.5in" fo:text-indent="-0.25in" fo:margin-left="1.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="6" text:style-name="Numbering_20_Symbols" loext:num-list-format="(%6%)" style:num-prefix="(" style:num-suffix=")" style:num-format="a">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.75in" fo:text-indent="-0.25in" fo:margin-left="1.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="7" text:style-name="Numbering_20_Symbols" loext:num-list-format="(%7%)" style:num-prefix="(" style:num-suffix=")" style:num-format="a">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2in" fo:text-indent="-0.25in" fo:margin-left="2in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="8" text:style-name="Numbering_20_Symbols" loext:num-list-format="(%8%)" style:num-prefix="(" style:num-suffix=")" style:num-format="a">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.25in" fo:text-indent="-0.25in" fo:margin-left="2.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="9" text:style-name="Numbering_20_Symbols" loext:num-list-format="(%9%)" style:num-prefix="(" style:num-suffix=")" style:num-format="a">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.5in" fo:text-indent="-0.25in" fo:margin-left="2.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="10" text:style-name="Numbering_20_Symbols" loext:num-list-format="(%10%)" style:num-prefix="(" style:num-suffix=")" style:num-format="a">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.75in" fo:text-indent="-0.25in" fo:margin-left="2.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+  </text:list-style>
+  <text:list-style style:name="L6">
+   <text:list-level-style-number text:level="1" text:style-name="Numbering_20_Symbols" loext:num-list-format="%1%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.5in" fo:text-indent="-0.25in" fo:margin-left="0.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="2" text:style-name="Numbering_20_Symbols" loext:num-list-format="%2%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.75in" fo:text-indent="-0.25in" fo:margin-left="0.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="3" text:style-name="Numbering_20_Symbols" loext:num-list-format="%3%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1in" fo:text-indent="-0.25in" fo:margin-left="1in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="4" text:style-name="Numbering_20_Symbols" loext:num-list-format="%4%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.25in" fo:text-indent="-0.25in" fo:margin-left="1.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="5" text:style-name="Numbering_20_Symbols" loext:num-list-format="%5%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.5in" fo:text-indent="-0.25in" fo:margin-left="1.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="6" text:style-name="Numbering_20_Symbols" loext:num-list-format="%6%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.75in" fo:text-indent="-0.25in" fo:margin-left="1.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="7" text:style-name="Numbering_20_Symbols" loext:num-list-format="%7%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2in" fo:text-indent="-0.25in" fo:margin-left="2in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="8" text:style-name="Numbering_20_Symbols" loext:num-list-format="%8%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.25in" fo:text-indent="-0.25in" fo:margin-left="2.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="9" text:style-name="Numbering_20_Symbols" loext:num-list-format="%9%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.5in" fo:text-indent="-0.25in" fo:margin-left="2.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="10" text:style-name="Numbering_20_Symbols" loext:num-list-format="%10%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.75in" fo:text-indent="-0.25in" fo:margin-left="2.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+  </text:list-style>
+  <text:list-style style:name="L7">
+   <text:list-level-style-number text:level="1" text:style-name="Numbering_20_Symbols" loext:num-list-format="%1%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.5in" fo:text-indent="-0.25in" fo:margin-left="0.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="2" text:style-name="Numbering_20_Symbols" loext:num-list-format="%2%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.75in" fo:text-indent="-0.25in" fo:margin-left="0.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="3" text:style-name="Numbering_20_Symbols" loext:num-list-format="%3%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1in" fo:text-indent="-0.25in" fo:margin-left="1in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="4" text:style-name="Numbering_20_Symbols" loext:num-list-format="%4%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.25in" fo:text-indent="-0.25in" fo:margin-left="1.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="5" text:style-name="Numbering_20_Symbols" loext:num-list-format="%5%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.5in" fo:text-indent="-0.25in" fo:margin-left="1.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="6" text:style-name="Numbering_20_Symbols" loext:num-list-format="%6%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.75in" fo:text-indent="-0.25in" fo:margin-left="1.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="7" text:style-name="Numbering_20_Symbols" loext:num-list-format="%7%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2in" fo:text-indent="-0.25in" fo:margin-left="2in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="8" text:style-name="Numbering_20_Symbols" loext:num-list-format="%8%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.25in" fo:text-indent="-0.25in" fo:margin-left="2.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="9" text:style-name="Numbering_20_Symbols" loext:num-list-format="%9%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.5in" fo:text-indent="-0.25in" fo:margin-left="2.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="10" text:style-name="Numbering_20_Symbols" loext:num-list-format="%10%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.75in" fo:text-indent="-0.25in" fo:margin-left="2.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+  </text:list-style>
+  <text:list-style style:name="L8">
+   <text:list-level-style-bullet text:level="1" text:style-name="Bullet_20_Symbols" loext:num-list-format="%1%" text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.5in" fo:text-indent="-0.25in" fo:margin-left="0.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="2" text:style-name="Bullet_20_Symbols" loext:num-list-format="%2%" text:bullet-char="◦">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.75in" fo:text-indent="-0.25in" fo:margin-left="0.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="3" text:style-name="Bullet_20_Symbols" loext:num-list-format="%3%" text:bullet-char="▪">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1in" fo:text-indent="-0.25in" fo:margin-left="1in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="4" text:style-name="Bullet_20_Symbols" loext:num-list-format="%4%" text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.25in" fo:text-indent="-0.25in" fo:margin-left="1.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="5" text:style-name="Bullet_20_Symbols" loext:num-list-format="%5%" text:bullet-char="◦">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.5in" fo:text-indent="-0.25in" fo:margin-left="1.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="6" text:style-name="Bullet_20_Symbols" loext:num-list-format="%6%" text:bullet-char="▪">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.75in" fo:text-indent="-0.25in" fo:margin-left="1.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="7" text:style-name="Bullet_20_Symbols" loext:num-list-format="%7%" text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2in" fo:text-indent="-0.25in" fo:margin-left="2in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="8" text:style-name="Bullet_20_Symbols" loext:num-list-format="%8%" text:bullet-char="◦">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.25in" fo:text-indent="-0.25in" fo:margin-left="2.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="9" text:style-name="Bullet_20_Symbols" loext:num-list-format="%9%" text:bullet-char="▪">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.5in" fo:text-indent="-0.25in" fo:margin-left="2.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+   <text:list-level-style-bullet text:level="10" text:style-name="Bullet_20_Symbols" loext:num-list-format="%10%" text:bullet-char="•">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.75in" fo:text-indent="-0.25in" fo:margin-left="2.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-bullet>
+  </text:list-style>
+  <text:list-style style:name="L9">
+   <text:list-level-style-number text:level="1" text:style-name="Numbering_20_Symbols" loext:num-list-format="%1%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.5in" fo:text-indent="-0.25in" fo:margin-left="0.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="2" text:style-name="Numbering_20_Symbols" loext:num-list-format="%2%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="0.75in" fo:text-indent="-0.25in" fo:margin-left="0.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="3" text:style-name="Numbering_20_Symbols" loext:num-list-format="%3%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1in" fo:text-indent="-0.25in" fo:margin-left="1in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="4" text:style-name="Numbering_20_Symbols" loext:num-list-format="%4%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.25in" fo:text-indent="-0.25in" fo:margin-left="1.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="5" text:style-name="Numbering_20_Symbols" loext:num-list-format="%5%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.5in" fo:text-indent="-0.25in" fo:margin-left="1.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="6" text:style-name="Numbering_20_Symbols" loext:num-list-format="%6%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="1.75in" fo:text-indent="-0.25in" fo:margin-left="1.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="7" text:style-name="Numbering_20_Symbols" loext:num-list-format="%7%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2in" fo:text-indent="-0.25in" fo:margin-left="2in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="8" text:style-name="Numbering_20_Symbols" loext:num-list-format="%8%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.25in" fo:text-indent="-0.25in" fo:margin-left="2.25in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="9" text:style-name="Numbering_20_Symbols" loext:num-list-format="%9%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.5in" fo:text-indent="-0.25in" fo:margin-left="2.5in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+   <text:list-level-style-number text:level="10" text:style-name="Numbering_20_Symbols" loext:num-list-format="%10%." style:num-suffix="." style:num-format="i">
+    <style:list-level-properties text:list-level-position-and-space-mode="label-alignment">
+     <style:list-level-label-alignment text:label-followed-by="listtab" text:list-tab-stop-position="2.75in" fo:text-indent="-0.25in" fo:margin-left="2.75in"/>
+    </style:list-level-properties>
+   </text:list-level-style-number>
+  </text:list-style>
+  <style:style style:name="gr1" style:family="graphic">
+   <style:graphic-properties draw:fill-color="#158466" draw:textarea-horizontal-align="justify" draw:textarea-vertical-align="middle" draw:auto-grow-height="false" fo:min-height="1.1in" fo:min-width="1.928in" style:writing-mode="lr-tb" loext:decorative="false" style:run-through="foreground" style:wrap="none" style:vertical-pos="from-top" style:vertical-rel="paragraph" style:horizontal-pos="from-left" style:horizontal-rel="paragraph" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true" style:flow-with-text="false"/>
+   <style:paragraph-properties style:writing-mode="lr-tb"/>
+  </style:style>
+  <style:style style:name="gr2" style:family="graphic">
+   <style:graphic-properties draw:textarea-horizontal-align="justify" draw:textarea-vertical-align="middle" draw:auto-grow-height="false" fo:min-height="1.3783in" fo:min-width="1.3854in" style:writing-mode="lr-tb" loext:decorative="false" style:run-through="foreground" style:wrap="none" style:vertical-pos="from-top" style:vertical-rel="paragraph" style:horizontal-pos="from-left" style:horizontal-rel="paragraph" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true" style:flow-with-text="false"/>
+   <style:paragraph-properties style:writing-mode="lr-tb"/>
+  </style:style>
+  <style:style style:name="gr3" style:family="graphic">
+   <style:graphic-properties svg:stroke-color="#a1467e" draw:fill-color="#5b277d" draw:textarea-horizontal-align="justify" draw:textarea-vertical-align="middle" draw:auto-grow-height="false" fo:min-height="1.0374in" fo:min-width="4.0508in" style:writing-mode="lr-tb" loext:decorative="false" style:run-through="foreground" style:wrap="none" style:vertical-pos="from-top" style:vertical-rel="paragraph" style:horizontal-pos="center" style:horizontal-rel="paragraph" draw:wrap-influence-on-position="once-concurrent" loext:allow-overlap="true" style:flow-with-text="false"/>
+   <style:paragraph-properties style:writing-mode="lr-tb"/>
+  </style:style>
+  <style:page-layout style:name="pm1">
+   <style:page-layout-properties fo:page-width="8.2681in" fo:page-height="11.6929in" style:num-format="1" style:print-orientation="portrait" fo:margin-top="0.7874in" fo:margin-bottom="0.7874in" fo:margin-left="0.7874in" fo:margin-right="0.7874in" style:writing-mode="lr-tb" style:layout-grid-color="#c0c0c0" style:layout-grid-lines="20" style:layout-grid-base-height="0.278in" style:layout-grid-ruby-height="0.139in" style:layout-grid-mode="none" style:layout-grid-ruby-below="false" style:layout-grid-print="false" style:layout-grid-display="false" style:footnote-max-height="0in" loext:margin-gutter="0in">
+    <style:footnote-sep style:width="0.0071in" style:distance-before-sep="0.0398in" style:distance-after-sep="0.0398in" style:line-style="solid" style:adjustment="left" style:rel-width="25%" style:color="#000000"/>
+   </style:page-layout-properties>
+   <style:header-style>
+    <style:header-footer-properties fo:min-height="0in" fo:margin-left="0in" fo:margin-right="0in" fo:margin-bottom="0.1965in" fo:background-color="transparent" draw:fill="none" draw:fill-color="#729fcf"/>
+   </style:header-style>
+   <style:footer-style>
+    <style:header-footer-properties fo:min-height="0in" fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0.1965in" fo:background-color="transparent" draw:fill="none" draw:fill-color="#729fcf"/>
+   </style:footer-style>
+  </style:page-layout>
+  <style:page-layout style:name="pm2">
+   <style:page-layout-properties fo:page-width="8.2681in" fo:page-height="11.6929in" style:num-format="1" style:print-orientation="portrait" fo:margin-top="0.7874in" fo:margin-bottom="0.7874in" fo:margin-left="0.7874in" fo:margin-right="0.7874in" style:writing-mode="lr-tb" style:layout-grid-color="#c0c0c0" style:layout-grid-lines="20" style:layout-grid-base-height="0.278in" style:layout-grid-ruby-height="0.139in" style:layout-grid-mode="none" style:layout-grid-ruby-below="false" style:layout-grid-print="false" style:layout-grid-display="false" style:footnote-max-height="0in" loext:margin-gutter="0in">
+    <style:footnote-sep style:line-style="solid" style:adjustment="left" style:rel-width="25%" style:color="#000000"/>
+   </style:page-layout-properties>
+   <style:header-style>
+    <style:header-footer-properties fo:min-height="0in" fo:margin-left="0in" fo:margin-right="0in" fo:margin-bottom="0.1965in" fo:background-color="transparent" draw:fill="none" draw:fill-color="#729fcf"/>
+   </style:header-style>
+   <style:footer-style>
+    <style:header-footer-properties fo:min-height="0in" fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0.1965in" fo:background-color="transparent" draw:fill="none" draw:fill-color="#729fcf"/>
+   </style:footer-style>
+  </style:page-layout>
+  <style:page-layout style:name="pm3">
+   <style:page-layout-properties fo:page-width="8.2681in" fo:page-height="11.6929in" style:num-format="1" style:print-orientation="portrait" fo:margin-top="0.3937in" fo:margin-bottom="0.3937in" fo:margin-left="0.7874in" fo:margin-right="0.3937in" style:writing-mode="lr-tb" style:layout-grid-color="#c0c0c0" style:layout-grid-lines="20" style:layout-grid-base-height="0.278in" style:layout-grid-ruby-height="0.139in" style:layout-grid-mode="none" style:layout-grid-ruby-below="false" style:layout-grid-print="false" style:layout-grid-display="false" style:footnote-max-height="0in" loext:margin-gutter="0in">
+    <style:footnote-sep style:width="0.0071in" style:distance-before-sep="0.0398in" style:distance-after-sep="0.0398in" style:line-style="solid" style:adjustment="left" style:rel-width="25%" style:color="#000000"/>
+   </style:page-layout-properties>
+   <style:header-style>
+    <style:header-footer-properties fo:min-height="0in" fo:margin-left="0in" fo:margin-right="0in" fo:margin-bottom="0.1965in" fo:background-color="transparent" draw:fill="none" draw:fill-color="#729fcf"/>
+   </style:header-style>
+   <style:footer-style>
+    <style:header-footer-properties fo:min-height="0in" fo:margin-left="0in" fo:margin-right="0in" fo:margin-top="0.1965in" fo:background-color="transparent" draw:fill="none" draw:fill-color="#729fcf"/>
+   </style:footer-style>
+  </style:page-layout>
+  <style:style style:name="dp1" style:family="drawing-page">
+   <style:drawing-page-properties draw:background-size="full"/>
+  </style:style>
+ </office:automatic-styles>
+ <office:master-styles>
+  <style:master-page style:name="Standard" style:page-layout-name="pm1" draw:style-name="dp1">
+   <style:header>
+    <text:p text:style-name="P1">Collabora Online doc</text:p>
+   </style:header>
+   <style:footer>
+    <text:p text:style-name="P2">Collabora Ltd </text:p>
+    <text:p text:style-name="P3"><text:span text:style-name="T1">All rights reserved. <text:s/></text:span><text:a xlink:type="simple" xlink:href="https://www.collaboraonline.com/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T2">www.collaboraonline.com</text:span></text:a><text:span text:style-name="T1"> | </text:span><text:a xlink:type="simple" xlink:href="mailto:hello@collaboraoffice.com" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1">hello@collaboraoffice.com</text:span></text:a><text:span text:style-name="T1"><text:tab/></text:span><text:span text:style-name="T3"><text:page-number text:select-page="current">12</text:page-number></text:span></text:p>
+   </style:footer>
+  </style:master-page>
+  <style:master-page style:name="Footnote" style:page-layout-name="pm2" draw:style-name="dp1">
+   <style:header>
+    <text:p text:style-name="P4"/>
+   </style:header>
+   <style:footer>
+    <text:p text:style-name="P5"/>
+   </style:footer>
+  </style:master-page>
+  <style:master-page style:name="Endnote" style:page-layout-name="pm2" draw:style-name="dp1">
+   <style:header>
+    <text:p text:style-name="P4"/>
+   </style:header>
+   <style:footer>
+    <text:p text:style-name="P5"/>
+   </style:footer>
+  </style:master-page>
+  <style:master-page style:name="HTML" style:page-layout-name="pm3" draw:style-name="dp1">
+   <style:header>
+    <text:p text:style-name="P4"/>
+   </style:header>
+   <style:footer>
+    <text:p text:style-name="P5"/>
+   </style:footer>
+  </style:master-page>
+ </office:master-styles>
+ <office:body>
+  <office:text text:use-soft-page-breaks="true">
+   <office:forms form:automatic-focus="false" form:apply-design-mode="false">
+    <form:form form:name="Form" form:apply-filter="true" form:command-type="table" form:control-implementation="ooo:com.sun.star.form.component.Form" office:target-frame="">
+     <form:properties>
+      <form:property form:property-name="PropertyChangeNotificationEnabled" office:value-type="boolean" office:boolean-value="true"/>
+      <form:property form:property-name="TargetURL" office:value-type="string" office:string-value=""/>
+     </form:properties>
+    </form:form>
+   </office:forms>
+   <text:tracked-changes text:track-changes="false">
+    <text:changed-region xml:id="ct519215008" text:id="ct519215008">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Mary J</dc:creator>
+       <dc:date>2024-10-03T17:31:57</dc:date>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct519525712" text:id="ct519525712">
+     <text:deletion>
+      <office:change-info>
+       <dc:creator>Mary J</dc:creator>
+       <dc:date>2024-10-10T16:18:21</dc:date>
+       <text:p>Comment deleted</text:p>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+      </office:change-info>
+     </text:deletion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct519562640" text:id="ct519562640">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Mary J</dc:creator>
+       <dc:date>2024-09-23T22:18:28</dc:date>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct519355728" text:id="ct519355728">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Mary J</dc:creator>
+       <dc:date>2024-09-23T22:17:38</dc:date>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct519719472" text:id="ct519719472">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Mary J</dc:creator>
+       <dc:date>2024-09-23T22:19:48</dc:date>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct519718512" text:id="ct519718512">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Mary J</dc:creator>
+       <dc:date>2024-09-23T22:19:13</dc:date>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct519716736" text:id="ct519716736">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Mary J</dc:creator>
+       <dc:date>2024-09-23T22:20:31</dc:date>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct519717776" text:id="ct519717776">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Mary J</dc:creator>
+       <dc:date>2024-09-23T22:19:35</dc:date>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct519788400" text:id="ct519788400">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Mary J</dc:creator>
+       <dc:date>2024-10-03T17:30:37</dc:date>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct519826944" text:id="ct519826944">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Mary J</dc:creator>
+       <dc:date>2024-10-03T17:58:06</dc:date>
+       <text:p>Comment added</text:p>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct519833824" text:id="ct519833824">
+     <text:deletion>
+      <office:change-info>
+       <dc:creator>Schmidt</dc:creator>
+       <dc:date>2024-10-03T17:22:51</dc:date>
+      </office:change-info>
+     </text:deletion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct520309184" text:id="ct520309184">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Jose P</dc:creator>
+       <dc:date>2024-10-11T04:36:09</dc:date>
+       <text:p>Comment added</text:p>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct520574560" text:id="ct520574560">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Jose P</dc:creator>
+       <dc:date>2024-10-11T04:36:35</dc:date>
+       <text:p>Comment added</text:p>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct520647296" text:id="ct520647296">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Mary J</dc:creator>
+       <dc:date>2024-10-11T04:35:20</dc:date>
+       <text:p>Comment added</text:p>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct520512848" text:id="ct520512848">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Jose P</dc:creator>
+       <dc:date>2024-10-11T04:38:05</dc:date>
+       <text:p>Comment added</text:p>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+    <text:changed-region xml:id="ct520700032" text:id="ct520700032">
+     <text:insertion>
+      <office:change-info>
+       <dc:creator>Jose P</dc:creator>
+       <dc:date>2024-10-11T04:37:09</dc:date>
+       <text:p>Comment added</text:p>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+       <text:p/>
+      </office:change-info>
+     </text:insertion>
+    </text:changed-region>
+   </text:tracked-changes>
+   <text:sequence-decls>
+    <text:sequence-decl text:display-outline-level="0" text:name="Illustration"/>
+    <text:sequence-decl text:display-outline-level="0" text:name="Table"/>
+    <text:sequence-decl text:display-outline-level="0" text:name="Text"/>
+    <text:sequence-decl text:display-outline-level="0" text:name="Drawing"/>
+    <text:sequence-decl text:display-outline-level="0" text:name="Figure"/>
+   </text:sequence-decls>
+   <text:p text:style-name="Title">Collabora Productivity</text:p>
+   <text:p text:style-name="P18"/>
+   <text:table-of-content text:style-name="Sect1" text:protected="true" text:name="Table of Contents1">
+    <text:table-of-content-source text:outline-level="10">
+     <text:index-title-template text:style-name="Contents_20_Heading">Table of Contents</text:index-title-template>
+     <text:table-of-content-entry-template text:outline-level="1" text:style-name="Contents_20_1">
+      <text:index-entry-link-start text:style-name="Index_20_Link"/>
+      <text:index-entry-chapter/>
+      <text:index-entry-text/>
+      <text:index-entry-tab-stop style:type="right" style:leader-char="."/>
+      <text:index-entry-page-number/>
+      <text:index-entry-link-end/>
+     </text:table-of-content-entry-template>
+     <text:table-of-content-entry-template text:outline-level="2" text:style-name="Contents_20_2">
+      <text:index-entry-link-start text:style-name="Index_20_Link"/>
+      <text:index-entry-chapter/>
+      <text:index-entry-text/>
+      <text:index-entry-tab-stop style:type="right" style:leader-char="."/>
+      <text:index-entry-page-number/>
+      <text:index-entry-link-end/>
+     </text:table-of-content-entry-template>
+     <text:table-of-content-entry-template text:outline-level="3" text:style-name="Contents_20_3">
+      <text:index-entry-link-start text:style-name="Index_20_Link"/>
+      <text:index-entry-chapter/>
+      <text:index-entry-text/>
+      <text:index-entry-tab-stop style:type="right" style:leader-char="."/>
+      <text:index-entry-page-number/>
+      <text:index-entry-link-end/>
+     </text:table-of-content-entry-template>
+     <text:table-of-content-entry-template text:outline-level="4" text:style-name="Contents_20_4">
+      <text:index-entry-link-start text:style-name="Index_20_Link"/>
+      <text:index-entry-chapter/>
+      <text:index-entry-text/>
+      <text:index-entry-tab-stop style:type="right" style:leader-char="."/>
+      <text:index-entry-page-number/>
+      <text:index-entry-link-end/>
+     </text:table-of-content-entry-template>
+     <text:table-of-content-entry-template text:outline-level="5" text:style-name="Contents_20_5">
+      <text:index-entry-link-start text:style-name="Index_20_Link"/>
+      <text:index-entry-chapter/>
+      <text:index-entry-text/>
+      <text:index-entry-tab-stop style:type="right" style:leader-char="."/>
+      <text:index-entry-page-number/>
+      <text:index-entry-link-end/>
+     </text:table-of-content-entry-template>
+     <text:table-of-content-entry-template text:outline-level="6" text:style-name="Contents_20_6">
+      <text:index-entry-link-start text:style-name="Index_20_Link"/>
+      <text:index-entry-chapter/>
+      <text:index-entry-text/>
+      <text:index-entry-tab-stop style:type="right" style:leader-char="."/>
+      <text:index-entry-page-number/>
+      <text:index-entry-link-end/>
+     </text:table-of-content-entry-template>
+     <text:table-of-content-entry-template text:outline-level="7" text:style-name="Contents_20_7">
+      <text:index-entry-link-start text:style-name="Index_20_Link"/>
+      <text:index-entry-chapter/>
+      <text:index-entry-text/>
+      <text:index-entry-tab-stop style:type="right" style:leader-char="."/>
+      <text:index-entry-page-number/>
+      <text:index-entry-link-end/>
+     </text:table-of-content-entry-template>
+     <text:table-of-content-entry-template text:outline-level="8" text:style-name="Contents_20_8">
+      <text:index-entry-link-start text:style-name="Index_20_Link"/>
+      <text:index-entry-chapter/>
+      <text:index-entry-text/>
+      <text:index-entry-tab-stop style:type="right" style:leader-char="."/>
+      <text:index-entry-page-number/>
+      <text:index-entry-link-end/>
+     </text:table-of-content-entry-template>
+     <text:table-of-content-entry-template text:outline-level="9" text:style-name="Contents_20_9">
+      <text:index-entry-link-start text:style-name="Index_20_Link"/>
+      <text:index-entry-chapter/>
+      <text:index-entry-text/>
+      <text:index-entry-tab-stop style:type="right" style:leader-char="."/>
+      <text:index-entry-page-number/>
+      <text:index-entry-link-end/>
+     </text:table-of-content-entry-template>
+     <text:table-of-content-entry-template text:outline-level="10" text:style-name="Contents_20_10">
+      <text:index-entry-link-start text:style-name="Index_20_Link"/>
+      <text:index-entry-chapter/>
+      <text:index-entry-text/>
+      <text:index-entry-tab-stop style:type="right" style:leader-char="."/>
+      <text:index-entry-page-number/>
+      <text:index-entry-link-end/>
+     </text:table-of-content-entry-template>
+    </text:table-of-content-source>
+    <text:index-body>
+     <text:index-title text:style-name="Sect1" text:name="Table of Contents1_Head" text:protected="true">
+      <text:p text:style-name="Contents_20_Heading">Table of Contents</text:p>
+     </text:index-title>
+     <text:p text:style-name="P38"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc510_380714148" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">1 Introduction<text:tab/>2</text:a></text:p>
+     <text:p text:style-name="P38"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc512_380714148" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">2 Collabora Productivity: A Brief Overview<text:tab/>2</text:a></text:p>
+     <text:p text:style-name="P38"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc928_380714148" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">3 Products – The Collabora Online Apps<text:tab/>3</text:a></text:p>
+     <text:p text:style-name="P39"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc574_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Writer<text:tab/>3</text:a></text:p>
+     <text:p text:style-name="P40"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc578_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Supports<text:tab/>3</text:a></text:p>
+     <text:p text:style-name="P40"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc585_3587465723%20Copy%201" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Features<text:tab/>3</text:a></text:p>
+     <text:p text:style-name="P39"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc587_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Calc<text:tab/>3</text:a></text:p>
+     <text:p text:style-name="P40"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc589_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Soutient<text:tab/>3</text:a></text:p>
+     <text:p text:style-name="P40"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc597_3587465723%20Copy%201" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Caractéristiques<text:tab/>3</text:a></text:p>
+     <text:p text:style-name="P39"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc593_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Impress<text:tab/>4</text:a></text:p>
+     <text:p text:style-name="P40"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc595_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Unterstützt<text:tab/>4</text:a></text:p>
+     <text:p text:style-name="P40"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc597_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Merkmale<text:tab/>4</text:a></text:p>
+     <text:p text:style-name="P38"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc722_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">4 Shapes and Chart<text:tab/>5</text:a></text:p>
+     <text:p text:style-name="P39"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc724_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Shapes<text:tab/>5</text:a></text:p>
+     <text:p text:style-name="P40"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc726_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Basic Shape<text:tab/>5</text:a></text:p>
+     <text:p text:style-name="P40"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc728_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Symbol Shape<text:tab/>5</text:a></text:p>
+     <text:p text:style-name="P40"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc730_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Block Arrow<text:tab/>5</text:a></text:p>
+     <text:p text:style-name="P39"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc732_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Chart<text:tab/>6</text:a></text:p>
+     <text:p text:style-name="P38"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc1200_959359226" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">5 Subscriptions<text:tab/>6</text:a></text:p>
+     <text:p text:style-name="P39"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc610_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Subscription Table<text:tab/>6</text:a></text:p>
+     <text:p text:style-name="P40"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc617_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">CODE - Collabora Online Development Edition<text:tab/>6</text:a></text:p>
+     <text:p text:style-name="P40"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc1146_380714148" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Collabora for Business<text:tab/>6</text:a></text:p>
+     <text:p text:style-name="P40"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc1150_380714148" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Collabora for Enterprise<text:tab/>7</text:a></text:p>
+     <text:p text:style-name="P39"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc612_3587465723" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Forms<text:tab/>8</text:a></text:p>
+     <text:p text:style-name="P38"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc11593_440631829" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">6 Lorem ipsum<text:tab/>9</text:a></text:p>
+     <text:p text:style-name="P39"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc11595_440631829" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Dolor sit amet<text:tab/>9</text:a></text:p>
+     <text:p text:style-name="P39"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc11597_440631829" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Fusce rhoncus lacinia pellentesque<text:tab/>10</text:a></text:p>
+     <text:p text:style-name="P39"><text:a xlink:type="simple" xlink:href="#__RefHeading___Toc11599_440631829" text:style-name="Index_20_Link" text:visited-style-name="Index_20_Link">Maecenas elit velit<text:tab/>11</text:a></text:p>
+    </text:index-body>
+   </text:table-of-content>
+   <text:p text:style-name="P17"/>
+   <text:p text:style-name="Text_20_body"/>
+   <text:p text:style-name="Text_20_body"/>
+   <text:p text:style-name="Text_20_body"/>
+   <text:p text:style-name="Text_20_body"/>
+   <text:p text:style-name="Text_20_body"/>
+   <text:p text:style-name="Text_20_body"/>
+   <text:p text:style-name="Text_20_body"><text:soft-page-break/></text:p>
+   <text:p text:style-name="Text_20_body"/>
+   <text:p text:style-name="Text_20_body"/>
+   <text:h text:style-name="Heading_20_2" text:outline-level="2"><text:bookmark-start text:name="__RefHeading___Toc510_380714148"/>Introduction <text:bookmark-end text:name="__RefHeading___Toc510_380714148"/></text:h>
+   <text:p text:style-name="P30"><text:span text:style-name="T1">In today&apos;s digital age, </text:span><office:annotation office:name="__Annotation__1177_2374539774" loext:resolved="false">
+     <dc:creator>TwoUsers (Guest)</dc:creator>
+     <dc:date>2024-07-31T03:33:27.789907482</dc:date>
+     <text:p text:style-name="Comment">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eget erat sagittis, porta augue sed, tempus massa. Proin ante erat, malesuada at commodo vitae, consequat nec urna. Donec sit amet molestie odio, faucibus rhoncus augue. Praesent et risus quis lectus convallis sagittis. Nunc tincidunt sed lacus pellentesque malesuada. Maecenas tristique justo orci, eu vehicula ante aliquam pharetra. Aenean eleifend, urna in vehicula luctus, dui diam commodo ante, ac laoreet augue ante in dui. In sit amet urna sed nisl commodo congue. Nullam lacus nibh, tincidunt nec odio ut, condimentum aliquet sem.</text:p>
+    </office:annotation><text:span text:style-name="T1">productivity</text:span><office:annotation-end office:name="__Annotation__1177_2374539774"/><office:annotation loext:parent-name="__Annotation__1177_2374539774" loext:resolved="false">
+     <dc:creator>Mary (Guest)</dc:creator>
+     <dc:date>2024-09-19T08:16:20.045914249</dc:date>
+     <text:p text:style-name="Comment">Vestibulum augue ex, tincidunt id luctus id, malesuada a urna. Nulla laoreet ante nec vehicula aliquam. Integer non lectus nisl. Cras pulvinar diam eget porta luctus. Proin interdum, mi ac aliquet viverra, quam massa aliquet nisi, vel blandit velit diam ut felis. Nunc fringilla, mauris in ultricies luctus, purus libero imperdiet odio, sed lacinia odio mi quis sem. Phasellus nec ligula in felis dapibus consectetur vitae venenatis enim.</text:p>
+    </office:annotation><office:annotation loext:parent-name="__Annotation__1177_2374539774" loext:resolved="false">
+     <dc:creator>Jose (Guest)</dc:creator>
+     <dc:date>2024-09-19T08:14:54.516331120</dc:date>
+     <text:p text:style-name="Comment">Suspendisse vel augue id ligula finibus aliquet. Mauris faucibus facilisis tortor vel bibendum. Etiam congue, eros eu iaculis pellentesque, dolor urna porttitor erat, eu commodo est sapien nec eros. In hac habitasse platea dictumst. Quisque egestas bibendum mi at convallis. Sed sed leo nec enim interdum imperdiet. Donec hendrerit nisi mollis euismod porta. Quisque iaculis ac ligula ac fringilla.</text:p>
+    </office:annotation><text:span text:style-name="T1"> tools are essential for individuals and organizations alike. Among the myriad of options available, </text:span><text:a xlink:type="simple" xlink:href="https://www.collaboraoffice.com/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1">Collabora Productivity</text:span></text:a><text:span text:style-name="T1"> stands out as a beacon of innovation and collaboration.</text:span><text:change-start text:change-id="ct519215008"/><text:span text:style-name="T1"> This piece aims to delve into the remarkable journey of Collabora Online highlighting its evolution, impact, and the tireless efforts behind its success.</text:span><text:change-end text:change-id="ct519215008"/></text:p>
+   <text:p text:style-name="Standard"/>
+   <text:p text:style-name="Standard"/>
+   <text:h text:style-name="Heading_20_2" text:outline-level="2"><text:bookmark-start text:name="__RefHeading___Toc512_380714148"/>Collabora Productivity: A Brief Overview<text:note text:id="ftn1" text:note-class="footnote"><text:note-citation>1</text:note-citation><text:note-body>
+      <text:p text:style-name="P29"><text:a xlink:type="simple" xlink:href="https://www.collaboraonline.com/collabora-online/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T2">https://www.collaboraonline.com/collabora-online/</text:span></text:a></text:p>
+      <text:p text:style-name="P10"/></text:note-body></text:note> <text:bookmark-end text:name="__RefHeading___Toc512_380714148"/></text:h>
+   <text:p text:style-name="P12"/>
+   <text:p text:style-name="P12"><draw:frame draw:style-name="fr3" draw:name="Frame1" text:anchor-type="char" svg:x="-0.2083in" svg:y="0.002in" svg:width="6.6929in" draw:z-index="0">
+     <draw:text-box fo:min-height="1.8173in">
+      <text:p text:style-name="Figure"><draw:frame draw:style-name="fr6" draw:name="Image1" text:anchor-type="char" svg:width="6.2783in" svg:height="2.6898in" draw:z-index="1"><draw:image draw:mime-type="image/png">
+         <office:binary-data>iVBORw0KGgoAAAANSUhEUgAAJxAAABOIAQMAAAAtmeULAAAABlBMVEVcKIOBAH6HPCHfAAAl
+          yUlEQVR42uzBgQAAAACAoP2pF6kCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGD24EAAAAAAAMj/tRFUVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYU9OBAAAAAAAPJ/
+          bQRVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVWEPDgQAAAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVFfbgQAAAAAAAyP+1
+          EVRVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVhT04EAAAAAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV2IMDAQAAAAAg/9dG
+          UFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVUV9uBAAAAAAADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVWFPTgQAAAAAADyf20EVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVhDw4EAAAAAID8XxtB
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVXYgwMBAAAAACD/10ZQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVRX24EAAAAAAAMj/tRFUVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYU9OBAAAAAAAPJ/bQRV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVWEPDgQAAAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVFfbgQAAAAAAAyP+1EVRV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVhT04EAAAAAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV2IMDAQAAAAAg/9dGUFVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVUV9uBAAAAAAADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVWFPTgQAAAAAADyf20EVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVhDw4EAAAAAID8XxtBVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVXYgwMBAAAAACD/10ZQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVRX24EAAAAAAAMj/tRFUVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYU9OBAAAAAAAPJ/bQRVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VWEPDgQAAAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVFfbgQAAAAAAAyP+1EVRVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          hT04EAAAAAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV2IMDAQAAAAAg/9dGUFVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVUV
+          9uBAAAAAAADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVWFPTgQAAAAAADyf20EVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVhDw4EAAAAAID8XxtBVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVXY
+          gwMBAAAAACD/10ZQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVRX24EAAAAAAAMj/tRFUVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYU9OBAAAAAAAPJ/bQRVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVWEP
+          DgQAAAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVFfbgQAAAAAAAyP+1EVRVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVhT04
+          EAAAAAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV2IMDAQAAAAAg/9dGUFVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVUV9uBA
+          AAAAAADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVWFPTgQAAAAAADyf20EVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVhDw4EAAAAAID8XxtBVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVXYgwMB
+          AAAAACD/10ZQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVRX24EAAAAAAAMj/tRFUVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYU9OBAAAAAAAPJ/bQRVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVWEPDgQA
+          AAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVFfbgQAAAAAAAyP+1EVRVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVhT04EAAA
+          AAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV2IMDAQAAAAAg/9dGUFVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVUV9uBAAAAA
+          AADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVWFPTgQAAAAAADyf20EVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVh346NAISBGAgKIkJKcv9VERA7t+zdKm7m
+          9QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHCkKwAAALCQ8QYAgD4qDgCg0BMAAAAAYMID
+          FwAAADszGwEAaKTiAACq/HuROwAANBoBAKDPBhXnKgwAAADAx94dpDAIA1EAHcWFiy48Qo7S
+          o3n0EiiFIhR3zUzeW3iE8EfjfAAAAOC2NbrN4l8AAAAG0ar83QBQ1xEAH8/vFOeEAADIaAuA
+          OpxpAAAZFUtxGnYAADKS4gCA2RzRtfTtLmcAGOqAmbxT3CMAABja2QKgNm/kgJLOdv0UuWTf
+          imkbFCDFAbOR4gAAEjO4ApUY7QBScNMP+J3ilgAAYGCL1lSgpvRb4QCkOAAAAAAYwr7qcgGm
+          sUd3ZO7Hd28ZkOIAABJa+yPzNAoAMKVLilssxQQA4G+yN+sAANzQat79BV7s3UGKwkAQBdCO
+          ZNFLj9BHydFy9EEIwhARUQR/9XsLcZlsiurQ9YuqBz4XmYHDsOQFAACAH7HI5wAq2tp/+7Cn
+          BihG0wZMaW03PXVINfW5gc+JUAIASHV0cf35SW9N/VinSQUAauumOwGymKwFCt/9Tc1HAb7R
+          5FyUBwAAAN5guglAnSv8aoASAKDOATPZrBQECJAaHgB8xaVYKGbiMwOfu57/343IagZgbzww
+          m2sDACDKUvzoqkEFXkxd2+VLAlncGwNmouYB2VQxoLw6+xkAzl3cudLtx89dVxaBTN1meaC8
+          XnioXdMJAMxGKCYQziZoYA5uygHVlO/inLWBuaoeMIP8kCSA961L285FcdHmAQH29tiQGAfM
+          aLSbLSxEV9MJ8XxXgz/27iC1YRiIAqgstDBd+Qg6io/QI/koPWpJCYWC3MSBgEZ6b5EssvFq
+          mFgzX2BIDhjfkm6KsgYMZUtnDmEdwCDuXdwcGwLOfwEAAJ7U+QFosOE3gF/rIO/ZDAwCMxu8
+          gANNq54HGIl2BhhAffXGvaO1uL5mjR0QQHkplKMIhwMCWdMlWTgcAAAAT3DWCswln796O04P
+          FPbUVkapiyXKgwJcV0UpwVx2t7gAAdXUcsjsBWaQxeUCcdU//zfX611clRgHhJWbK6kupQEG
+          lxNAEEXym7eJwI9dKCYQymkXt6UTy/WqGCaAJMhjAnRxMRnQKTMgAAA92lLLHicWBODddyiv
+          9y+DwEBXnuziipxMYBbVxgNATGZGYDz5UcKlUEwgoOO04NV3DMt9pM45IIERZS0ZMKB2F2dT
+          E5iRNg+YgxERIIzt/7JV0rVfypL2iEFF6jbMZQlVoQCaNk0MAAAAwdV0xdftY9k/U9cOYzGA
+          vSe+2bt744ZhGAyglE4Fz5WKDMAyY2g0juJRc66SnBNZtArx570hcKAAfIKhiIoDWmbWCgwj
+          ddrv+eEYjGY6WSg+frWBS+2Bk4ocjCA9ipIsXAAAGjhzNVMBAPq1PbU7saMUzarnvcDpyWlS
+          FgB8wQL6kAMAh35tkyueqCrnMIp0+gV6m/Pdtzugdtu/BSqpX0C/HHQCtHOIr2YDEoGB9rza
+          /Z1DoRRtzAEAdMTLFbjaWpKD2dEhPgBA15aw63P3hMuZFHCx+HSymcSLAIOoeYEX4A95b8Pf
+          SBXgp2UyTAXql0OxrGsD6rIdq0fR8xPo13KyHfR8BSo2lxziW4EDAGhfDA+r9HOgIjGUuAWA
+          kQgMB0ZgpAp0QeMGVG0nFLPkhMvRPtCG7dg6cAoA7VG7gI6tocDdlzkAgH3thWICXGw6VO5S
+          eIsbLqB9cQ6yRgAAALja8j21yE3s0n2xdwepDcNAAAAlo0LIyYc8IMc+w0/Ik/z0okKh1ASs
+          FhqtNHPwKdeI3dXuSmUQpnBJVf51R9wtAcTj6RlgYMWVKoBhVgCA7i2n1i0dfxLnphVAugoA
+          AAByauCvlpZ//zV9U3QPA73L9bMOP9RpBShMaq/Rl/QPAGB4Km5Ax9bU7iEtBWL42hgHMKCS
+          Pu3/kbAuCSCWLQEAEEJ+/rB+VXLXod1QXcyAac6frF4HANADDAwqZlWr5zoh8FpvwjcAvb7A
+          PO6p2ixqAwJ514ICDMhJBQxpjb803PkMHK9KrwlgPutonXPA5KzQBOhyzkuzHnBSEdIBg3AT
+          CdA1M/hAg8YKWJHUAl2LXa237xdQmANGlY/dvI90ThFIAUO5PE1nd3EeENAtNdlcagIT2Oun
+          7ydWgZmV6POtATY9AQ1aCmq5x0MJoMHccwL34F19wAd7d2wbMQwDAFAWXKg0ggzgMmNohIzk
+          UTJq4CDFP/J428EnT8l3hUuXgkiK5D49TQ4BeIy5+QSYGZ3AhtzqYeGlHnDl9fEx7dTg2QgQ
+          Pz/XYoUEeJKa7ptLvpUHK4qaAAD3RUvUT9+3u3SMcXHAH6k731yUmB1bAIeNT/9Be+2xQLeE
+          h0BoQ03HlexwA/oX45nILE4FVnm9fL0lANoR4zYJxFW2KqJZhQEAIICoLfUAR6cm5eXiXFtu
+          tnAtRx7yLrMTEjiRun6skQZ6UM2/BGJ7T1eKIeIAX4ZU4yyn0dsAJ1bTqtj3AuDtCdAXu10A
+          hK9AeMP6meT6ge4VYz0AAHo2pktDoNjVjRL4GZ1+KKkCnShpNTzuV9pTgWaJ/QDSOIhwgcji
+          dNID/FbVTAoA0LxBiAqc0nivvcsaVaA/+Xj9YnM7l4oJ8B+mtFfVCQEAsE/IFi7j4YD+TWnD
+          SwJ4hrx+Zpl8AIAzCHenM9IJsEgL+GTvDm4jBGIAABrEgye6CnikEJ4pi3SQkiORPBJFunB3
+          G50NMwUgXpZ3ba8R9YDCJo9dAmfxWVKV4gEAZNdJxwAajG51Wxztl/cAyKnb25DWxZKuYQ44
+          na+Sqpl7gG8Sb7Zxswg01HvcHKhmjEZeAgAAAP7bUr4oAVCth0TBAxBTALy7C5zPFBsbogEA
+          CstTaQDYF7KmNvdtl+HNuChwAFrfgKqm+MlKG+CI5l1HVBVXoL50Z9NRRx7w26g0CgAAAADZ
+          pCsxGP0Hmlvib6+1IyaA/AmobLCoFDi+Lm43BUAtc+PnzJdoYzAsBgBwzepODuAB7v2AW2W7
+          PANIZEnfEefUDGRZR7Nu35ITAtelPIVeYgfjFcBzrPfNj/YCFFCMsyTAfbnb2MfjZsUGIAcN
+          bEBKgzWqQFVDbNYoquyPAzlI2+CDvTs2chAGogC60hBwmcYVEFwhlEYJLvlmLrjI9hg4Cwne
+          CyhhZyV2vzijot8Czs9DCwB1ZeupwP8a4oG0eap4UaCAykbXZgAtSAFwrDFrCoEWpVjhOwAu
+          bRSqBNQ2Py0/S7wgmRzoT95adMZ4Yi76NKBB1lMB9psO36AFLsxtGQBAe4qLNwAHXKB/0+qW
+          7iYaEziTJVYZUswvQpXUPqCaUi3EI/9+B4khQNMGeUdAL2a78cCJpM3/P++OqkDHmnl+y/wJ
+          sO8HaamWJj4HQAc0V0DzsuYKoMtbPIAPKu8VQ9nAAAAAvGA0BLi0rwDoUnp7EnhPqFKKByz0
+          A29qbwpkGuWnA11QrAAArsNRFTjAuOJS/xaVyOYEWqZAAQA8d+L8t0lgCdCYEgAXU+LPojkD
+          mpFjJ8/dAwB0YWloLxbgoWYrH8An3KOKbM+fH/bu2IZBIIYCqIOuoGQECgahSJGxMnqkFKmQ
+          IgWk2HfvDYHO+NuG/mVL6QEAVLXGNyZcgX7pgQIjm3wtgQz2U7XirOQERqE3CvRhj2vcAyAN
+          x++BsrY4aTXjBfwk29YkezUBANKYS70BAQD4gyYrDKTV9EsBAEZk3gvIw58zoKL2jIhHAHBY
+          Yc7KU6BjxvOB1BYPMACA7LZPn+GyAwt72XUnAAAApHELAIRCgKHoFwD9OfiyNYUvUNxNIhgA
+          AIAMdttDACRPgNqa5DAAQBkivgAAfXMhGqhnDgAAAEhgCYBBTfHmQjRQ3uqRByA/DNQh6PZi
+          7w5uAASBIAAi4eGTEizF0izdt4boC4PcTBeEvV0gLk9VAIAh5dRUEgAAAHwli+kC0W3mGIAJ
+          aFICAPiJaloLACC4KiYMDKik91KlwyU/AAAAAPQhTQLMYGk0XpqjAQCIQWAEAACAblbjDcDE
+          VF8CAAAwmF0hOoAbLwAAAAAA4Kb6SgAmpjEEAACAwXiqAqgjAQAAAAAAnuQEAAAAAABw4cYL
+          4GQPDgQAAAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVFfbgQAAAAAAAyP+1EVRVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          hT04EAAAAAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV2IMDAQAAAAAg/9dGUFVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVUV
+          9uBAAAAAAADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVWFPTgQAAAAAADyf20EVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVhDw4EAAAAAID8XxtBVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVXY
+          gwMBAAAAACD/10ZQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVRX24EAAAAAAAMj/tRFUVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYU9OBAAAAAAAPJ/bQRVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVWEP
+          DgQAAAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVFfbgQAAAAAAAyP+1EVRVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVhT04
+          EAAAAAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV2IMDAQAAAAAg/9dGUFVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVUV9uBA
+          AAAAAADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVWFPTgQAAAAAADyf20EVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVhDw4EAAAAAID8XxtBVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVXYgwMB
+          AAAAACD/10ZQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVRX24EAAAAAAAMj/tRFUVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYU9OBAAAAAAAPJ/bQRVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVWEPDgQA
+          AAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVFfbgQAAAAAAAyP+1EVRVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVhT04EAAA
+          AAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV2IMDAQAAAAAg/9dGUFVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVUV9uBAAAAA
+          AADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVWFPTgQAAAAAADyf20EVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVpDw4EAAAAAAT5Ww9yBQAAAAAAAAAAAAAA
+          AAAAAAAAwElj/3ucDuWxYwAAAABJRU5ErkJggg==
+         </office:binary-data>
+        </draw:image>
+       </draw:frame>Figure <text:sequence text:ref-name="refFigure0" text:name="Figure" text:formula="ooow:Figure+1" style:num-format="1">1</text:sequence>: Image 1</text:p>
+     </draw:text-box>
+    </draw:frame></text:p>
+   <text:p text:style-name="P12"/>
+   <text:p text:style-name="Standard"><text:a xlink:type="simple" xlink:href="https://www.collaboraonline.com/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T1">Collabora Productivity</text:span></text:a><text:span text:style-name="T1"> has been at the </text:span><office:annotation office:name="__Annotation__1912_380714148" loext:resolved="false">
+     <dc:creator>Unknown Author</dc:creator>
+     <dc:date>2024-05-06T17:18:03.448990089</dc:date>
+     <text:p text:style-name="Comment"><text:span text:style-name="T34">Fusce vel tortor non neque auctor eleifend non sit amet mauris.</text:span></text:p>
+    </office:annotation><text:span text:style-name="T1">forefront</text:span><office:annotation-end office:name="__Annotation__1912_380714148"/><office:annotation loext:parent-name="__Annotation__1912_380714148" loext:resolved="false">
+     <dc:creator>Mary (Guest)</dc:creator>
+     <dc:date>2024-09-19T08:18:01.020551537</dc:date>
+     <text:p text:style-name="Comment">Sed sodales, diam sit amet tempus malesuada, odio nunc porttitor diam, id consectetur enim mauris ut elit. Fusce tristique rutrum felis, sed hendrerit urna auctor a. Ut elementum dictum hendrerit. Nullam elementum ex ac nisi rhoncus, luctus facilisis erat viverra.</text:p>
+    </office:annotation><office:annotation loext:parent-name="__Annotation__1912_380714148" loext:resolved="false">
+     <dc:creator>Jose (Guest)</dc:creator>
+     <dc:date>2024-09-19T08:17:10.823466033</dc:date>
+     <text:p text:style-name="Comment">Nunc ut metus non lorem cursus ultricies. Vestibulum lacinia egestas risus, id vehicula nisi scelerisque at. Cras sed lobortis tortor. Integer a mi vel turpis commodo posuere.</text:p>
+    </office:annotation><text:span text:style-name="T1"> of providing open-source productivity solutions. With a focus on empowering users with cutting-edge tools.</text:span></text:p>
+   <text:p text:style-name="Standard"/>
+   <text:p text:style-name="Standard"/>
+   <text:p text:style-name="P37">Collabora Productivity ist Vorreiter bei der Bereitstellung von Open-Source-Produktivitätslösungen. Der Schwerpunkt<text:change-start text:change-id="ct519525712"/><office:annotation office:name="__Annotation__1095_2603154482" loext:resolved="false">
+     <dc:creator>Mary J (Guest)</dc:creator>
+     <dc:date>2024-09-18T11:27:38.625596199</dc:date>
+     <text:p text:style-name="Comment">Sed sed nulla ac elit viverra consequat vitae sit amet velit. Mauris vitae augue odio. Nullam sagittis, dui sit amet ultrices venenatis, nulla enim eleifend dolor, auctor iaculis velit lacus quis ante.</text:p>
+    </office:annotation><text:change-end text:change-id="ct519525712"/><office:annotation loext:parent-name="__Annotation__963_2286044882" loext:resolved="false">
+     <dc:creator>Jose (Guest)</dc:creator>
+     <dc:date>2024-09-19T08:14:11.860089234</dc:date>
+     <text:p text:style-name="Comment">Nunc varius imperdiet nisi, et pellentesque neque euismod nec. Sed consequat porttitor mi et accumsan. Suspendisse feugiat nibh tellus, quis accumsan odio aliquam quis. Fusce ac est a velit scelerisque dignissim placerat blandit velit. Suspendisse gravida, metus a condimentum scelerisque, odio nibh pellentesque justo, quis hendrerit erat elit pellentesque ex.</text:p>
+    </office:annotation> liegt darauf, Benutzern modernste Tools bereitzustelle<text:change-start text:change-id="ct519562640"/>n<text:change-end text:change-id="ct519562640"/>.</text:p>
+   <text:p text:style-name="P27"/>
+   <text:p text:style-name="P27"/>
+   <text:p text:style-name="P26"><text:change-start text:change-id="ct519355728"/><text:soft-page-break/>Collabora Productivity est à l&apos;avant-garde de la fourniture de solutions de productivité open source. L&apos;accent est mis sur la mise à disposition des utilisateurs d&apos;outils de pointe.<text:change-end text:change-id="ct519355728"/></text:p>
+   <text:h text:style-name="Heading_20_2" text:outline-level="2"><text:bookmark-start text:name="__RefHeading___Toc928_380714148"/>Products – The Collabora Online Apps<text:note text:id="ftn2" text:note-class="footnote"><text:note-citation>2</text:note-citation><text:note-body>
+      <text:p text:style-name="Footnote"><text:a xlink:type="simple" xlink:href="https://www.collaboraonline.com/collabora-online/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link"><text:span text:style-name="T7">https://www.collaboraonline.com/collabora-online/</text:span></text:a></text:p></text:note-body></text:note><text:bookmark-end text:name="__RefHeading___Toc928_380714148"/></text:h>
+   <text:h text:style-name="P43" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc574_3587465723"/>Writer<text:bookmark-end text:name="__RefHeading___Toc574_3587465723"/></text:h>
+   <text:h text:style-name="P49" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc578_3587465723"/>Supports<text:bookmark-end text:name="__RefHeading___Toc578_3587465723"/></text:h>
+   <text:list text:style-name="L5">
+    <text:list-item>
+     <text:p text:style-name="P60">odt</text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P60">.docx, </text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P60">.doc, </text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P60">.docm</text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P60">.rtf</text:p>
+    </text:list-item>
+   </text:list>
+   <text:p text:style-name="P15"/>
+   <text:h text:style-name="P50" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc585_3587465723 Copy 1"/>Features<text:bookmark-end text:name="__RefHeading___Toc585_3587465723 Copy 1"/></text:h>
+   <text:list xml:id="list2795356671" text:style-name="L4">
+    <text:list-item>
+     <text:p text:style-name="P61">Provides a true WYSIWYG editing experience, making <office:annotation office:name="__Annotation__1931_380714148" loext:resolved="true">
+       <dc:creator>Unknown Author</dc:creator>
+       <dc:date>2024-05-06T20:19:30.809585769</dc:date>
+       <text:p text:style-name="Comment"><text:span text:style-name="T34">Vestibulum vitae aliquam diam, eu tristique justo. Integer accumsan quam in erat pulvinar, a malesuada dolor lobortis.</text:span></text:p>
+      </office:annotation>visualising<office:annotation-end office:name="__Annotation__1931_380714148"/> your document layout incredibly easy.</text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P61">Open any document, add comments and track changes from anywhere, with anyone.</text:p>
+    </text:list-item>
+   </text:list>
+   <text:h text:style-name="P44" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc587_3587465723"/>Calc<text:bookmark-end text:name="__RefHeading___Toc587_3587465723"/></text:h>
+   <text:h text:style-name="P51" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc589_3587465723"/>Soutient<text:bookmark-end text:name="__RefHeading___Toc589_3587465723"/></text:h>
+   <text:list text:style-name="L6">
+    <text:list-item>
+     <text:p text:style-name="P65"><text:s/>.ods</text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P65">.xlsx</text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P65">.xls</text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P66">.xlsm</text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P66"><text:s/>.csv</text:p>
+    </text:list-item>
+   </text:list>
+   <text:h text:style-name="P52" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc597_3587465723 Copy 1"/>Caractéristique<text:change-start text:change-id="ct519719472"/>s<text:bookmark-end text:name="__RefHeading___Toc597_3587465723 Copy 1"/><text:change-end text:change-id="ct519719472"/></text:h>
+   <text:list xml:id="list125930130177241" text:continue-list="list2795356671" text:style-name="L4">
+    <text:list-item>
+     <text:p text:style-name="P67">Bénéficiez de formules <office:annotation office:name="__Annotation__591_2686566679" loext:resolved="true">
+       <dc:creator>admin</dc:creator>
+       <dc:date>2024-09-19T08:19:29.237116228</dc:date>
+       <text:p text:style-name="Comment">Cras id tellus ac nibh placerat feugiat.</text:p>
+      </office:annotation>avancées<office:annotation-end office:name="__Annotation__591_2686566679"/><office:annotation loext:parent-name="__Annotation__591_2686566679" loext:resolved="true">
+       <dc:creator>Jose (Guest)</dc:creator>
+       <dc:date>2024-09-19T08:20:20.869161615</dc:date>
+       <text:p text:style-name="Comment">Cras tempus egestas placerat. Nullam metus arcu, lobortis ac sollicitudin faucibus, euismod convallis ex. Sed placerat, elit et porta egestas, ex mauris ultrices tortor, vitae laoreet tortor ligula at metus. Etiam fringilla finibus neque, ut malesuada diam condimentum id. Ut gravida ut metus sed suscipit. Ut fringilla blandit nisi, vel euismod diam interdum a. Quisque vehicula ante sit amet sem dapibus, vel malesuada lectus laoreet.</text:p>
+      </office:annotation><office:annotation loext:parent-name="__Annotation__591_2686566679" loext:resolved="true">
+       <dc:creator>Mary (Guest)</dc:creator>
+       <dc:date>2024-09-19T08:19:56.585862358</dc:date>
+       <text:p text:style-name="Comment">Quisque tempus ex vitae dignissim dictum. Pellentesque eu odio justo. Pellentesque nec mauris diam. Suspendisse et est in dui consequat feugiat a id magna. In hac habitasse platea dictumst. Suspendisse suscipit metus non metus efficitur pretium.</text:p>
+      </office:annotation>, de tableaux croisés dynamiques, de saisie de formules HTML, de mise en forme conditionnelle et de validation des donné<text:change-start text:change-id="ct519718512"/>es<text:change-end text:change-id="ct519718512"/>.</text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P67">Créez des feuilles de calcul géant<text:change-start text:change-id="ct519716736"/>es<text:change-end text:change-id="ct519716736"/> contenant jusqu&apos;à 16 000 colonnes, ajoutez des graphiques, des graphiques sparkline et des hyperlie<text:change-start text:change-id="ct519717776"/>ns<text:change-end text:change-id="ct519717776"/>.<text:change-start text:change-id="ct519788400"/></text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P68"><text:soft-page-break/>Tri et filtrage multicolonnes puissants.<text:change-end text:change-id="ct519788400"/></text:p>
+    </text:list-item>
+   </text:list>
+   <text:p text:style-name="P25"/>
+   <text:h text:style-name="P45" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc593_3587465723"/>Impress<text:bookmark-end text:name="__RefHeading___Toc593_3587465723"/></text:h>
+   <text:h text:style-name="P53" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc595_3587465723"/><office:annotation office:name="__Annotation__1106_738740471" loext:resolved="false">
+     <dc:creator>Kemal T</dc:creator>
+     <dc:date>2024-10-08T07:28:23.693283265</dc:date>
+     <meta:creator-initials>KT</meta:creator-initials>
+     <text:p text:style-name="Comment"><text:span text:style-name="T33">Pijamalı hasta yağız şoföre çabucak güvendi.</text:span></text:p>
+    </office:annotation>Unterstützt<office:annotation-end office:name="__Annotation__1106_738740471"/><text:bookmark-end text:name="__RefHeading___Toc595_3587465723"/></text:h>
+   <text:list text:style-name="L7">
+    <text:list-item>
+     <text:p text:style-name="P58">.odp</text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P59">.pptx</text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P59">.ppt</text:p>
+    </text:list-item>
+   </text:list>
+   <text:list text:style-name="L8">
+    <text:list-header>
+     <text:p text:style-name="P69"/>
+    </text:list-header>
+   </text:list>
+   <text:h text:style-name="P53" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc597_3587465723"/>Merkmale<text:bookmark-end text:name="__RefHeading___Toc597_3587465723"/></text:h>
+   <text:list text:continue-list="list125930130177241" text:style-name="L4">
+    <text:list-item>
+     <text:p text:style-name="P56"><text:span text:style-name="T29">Entwerfen Sie ganz einfach attraktive </text:span><office:annotation office:name="__Annotation__3796_3446878473" loext:resolved="false">
+       <dc:creator>Mary J</dc:creator>
+       <dc:date>2024-10-03T17:58:06.376489589</dc:date>
+       <meta:creator-initials>MJ</meta:creator-initials>
+       <text:p text:style-name="Comment">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sollicitudin ut massa convallis elementum.</text:p>
+      </office:annotation><text:span text:style-name="T29">Masterfolien, fügen Sie Text, Bilder, Tabellen und SmartArt</text:span><text:change-start text:change-id="ct519826944"/><office:annotation-end office:name="__Annotation__3796_3446878473"/><text:change-end text:change-id="ct519826944"/><text:span text:style-name="T29"> hinzu und bearbeiten Sie sie dann gemeinam mit Ihren Kollegen</text:span><text:change-start text:change-id="ct519833824"/></text:p>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P57">Entwerfen Sie ganz einfach attraktive Masterfolien, fügen Sie Text, Bilder, Tabellen und SmartArt hinzu und bearbeiten Sie sie dann gemeinam mit Ihren Kollegen<text:change-end text:change-id="ct519833824"/><text:span text:style-name="T29"/></text:p>
+    </text:list-item>
+   </text:list>
+   <text:h text:style-name="P41" text:outline-level="2"><text:bookmark-start text:name="__RefHeading___Toc722_3587465723"/>Shapes and Chart<text:bookmark-end text:name="__RefHeading___Toc722_3587465723"/></text:h>
+   <text:h text:style-name="Heading_20_3" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc724_3587465723"/>Shapes<text:bookmark-end text:name="__RefHeading___Toc724_3587465723"/></text:h>
+   <text:h text:style-name="P54" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc726_3587465723"/>Basic Shape<text:bookmark-end text:name="__RefHeading___Toc726_3587465723"/></text:h>
+   <text:p text:style-name="P28"/>
+   <text:p text:style-name="P28"><draw:custom-shape text:anchor-type="paragraph" draw:z-index="3" draw:name="Shape 1" draw:style-name="gr3" draw:text-style-name="P79" svg:width="4.3961in" svg:height="1.3823in" svg:x="1.1484in" svg:y="-0.0319in">
+     <text:p/>
+     <draw:enhanced-geometry svg:viewBox="0 0 21600 21600" draw:glue-points="?f7 0 ?f6 ?f1 0 ?f10 ?f6 21600 ?f4 ?f10 21600 ?f9" draw:path-stretchpoint-x="10800" draw:path-stretchpoint-y="10800" draw:text-areas="0 ?f1 ?f4 ?f12" draw:type="cube" draw:modifiers="5400" draw:enhanced-path="M 0 ?f12 L 0 ?f1 ?f2 0 ?f11 0 ?f11 ?f3 ?f4 ?f12 Z N M 0 ?f1 L ?f2 0 ?f11 0 ?f4 ?f1 Z N M ?f4 ?f12 L ?f4 ?f1 ?f11 0 ?f11 ?f3 Z N">
+      <draw:equation draw:name="f0" draw:formula="$0 "/>
+      <draw:equation draw:name="f1" draw:formula="top+?f0 "/>
+      <draw:equation draw:name="f2" draw:formula="left+?f0 "/>
+      <draw:equation draw:name="f3" draw:formula="bottom-?f0 "/>
+      <draw:equation draw:name="f4" draw:formula="right-?f0 "/>
+      <draw:equation draw:name="f5" draw:formula="right-?f2 "/>
+      <draw:equation draw:name="f6" draw:formula="?f5 /2"/>
+      <draw:equation draw:name="f7" draw:formula="?f2 +?f6 "/>
+      <draw:equation draw:name="f8" draw:formula="bottom-?f1 "/>
+      <draw:equation draw:name="f9" draw:formula="?f8 /2"/>
+      <draw:equation draw:name="f10" draw:formula="?f1 +?f9 "/>
+      <draw:equation draw:name="f11" draw:formula="right"/>
+      <draw:equation draw:name="f12" draw:formula="bottom"/>
+      <draw:handle draw:handle-position="left $0" draw:handle-switched="true" draw:handle-range-y-minimum="0" draw:handle-range-y-maximum="21600"/>
+     </draw:enhanced-geometry>
+    </draw:custom-shape></text:p>
+   <text:h text:style-name="P55" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc728_3587465723"/>Symbol Shape<text:bookmark-end text:name="__RefHeading___Toc728_3587465723"/></text:h>
+   <text:p text:style-name="P28"><draw:custom-shape text:anchor-type="paragraph" draw:z-index="4" draw:name="Shape 3" draw:style-name="gr2" draw:text-style-name="P78" svg:width="1.9579in" svg:height="1.948in" draw:transform="rotate (-0.715584993317675) translate (3.20347222222222in -0.0152777777777778in)">
+     <text:p/>
+     <draw:enhanced-geometry svg:viewBox="0 0 21600 21600" draw:mirror-horizontal="false" draw:mirror-vertical="false" draw:glue-points="10800 0 3163 3163 0 10800 3163 18437 10800 21600 18437 18437 21600 10800 18437 3163" draw:text-areas="3163 3163 18437 18437" draw:type="smiley" draw:modifiers="18520" draw:enhanced-path="U 10800 10800 10800 10800 0 360 Z N U 7305 7515 1000 1865 0 360 Z N U 14295 7515 1000 1865 0 360 Z N M 4870 ?f1 C 8680 ?f2 12920 ?f2 16730 ?f1 F N">
+      <draw:equation draw:name="f0" draw:formula="$0 -14510"/>
+      <draw:equation draw:name="f1" draw:formula="18520-?f0 "/>
+      <draw:equation draw:name="f2" draw:formula="14510+?f0 "/>
+      <draw:handle draw:handle-position="10800 $0" draw:handle-range-y-minimum="14510" draw:handle-range-y-maximum="18520"/>
+     </draw:enhanced-geometry>
+    </draw:custom-shape></text:p>
+   <text:p text:style-name="P28"/>
+   <text:h text:style-name="P54" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc730_3587465723"/>Block Arrow<text:bookmark-end text:name="__RefHeading___Toc730_3587465723"/></text:h>
+   <text:p text:style-name="P28"/>
+   <text:p text:style-name="P28"><draw:custom-shape text:anchor-type="char" draw:z-index="5" draw:name="Shape 2" draw:style-name="gr1" draw:text-style-name="P77" svg:width="1.9276in" svg:height="1.6496in" svg:x="2.3827in" svg:y="0.1055in">
+     <text:p/>
+     <draw:enhanced-geometry svg:viewBox="0 0 21600 21600" draw:mirror-horizontal="false" draw:mirror-vertical="false" draw:text-areas="0 ?f0 21600 21600" draw:type="up-arrow-callout" draw:modifiers="7200 5400 3600 8100" draw:enhanced-path="M 21600 ?f0 L 21600 21600 0 21600 0 ?f0 ?f3 ?f0 ?f3 ?f2 ?f1 ?f2 10800 0 ?f4 ?f2 ?f5 ?f2 ?f5 ?f0 Z N">
+      <draw:equation draw:name="f0" draw:formula="$0 "/>
+      <draw:equation draw:name="f1" draw:formula="$1 "/>
+      <draw:equation draw:name="f2" draw:formula="$2 "/>
+      <draw:equation draw:name="f3" draw:formula="$3 "/>
+      <draw:equation draw:name="f4" draw:formula="21600-?f1 "/>
+      <draw:equation draw:name="f5" draw:formula="21600-?f3 "/>
+      <draw:handle draw:handle-position="left $0" draw:handle-range-y-minimum="$2" draw:handle-range-y-maximum="21600"/>
+      <draw:handle draw:handle-position="$3 $2" draw:handle-range-x-minimum="$1" draw:handle-range-x-maximum="10800" draw:handle-range-y-minimum="0" draw:handle-range-y-maximum="$0"/>
+      <draw:handle draw:handle-position="$1 top" draw:handle-range-x-minimum="0" draw:handle-range-x-maximum="$3"/>
+     </draw:enhanced-geometry>
+    </draw:custom-shape></text:p>
+   <text:h text:style-name="Heading_20_3" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc732_3587465723"/><text:soft-page-break/>Chart<text:bookmark-end text:name="__RefHeading___Toc732_3587465723"/></text:h>
+   <text:p text:style-name="Text_20_body"/>
+   <text:p text:style-name="Text_20_body"><draw:frame draw:style-name="fr7" draw:name="Object1" text:anchor-type="char" svg:width="6.7689in" svg:height="3.9618in" draw:z-index="6"><draw:object>
+      <office:document xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xforms="http://www.w3.org/2002/xforms" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:chartooo="http://openoffice.org/2010/chart" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:rpt="http://openoffice.org/2005/report" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" office:version="1.3" office:mimetype="application/vnd.oasis.opendocument.chart">
+       <office:meta><meta:generator>CollaboraOfficeDev/24.04.12.3$Linux_X86_64 LibreOffice_project/7e5075fea733d68c8167ac33e5ce34d89b50a6a9</meta:generator></office:meta>
+       <office:styles/>
+       <office:automatic-styles>
+        <number:number-style style:name="N0">
+         <number:number number:min-integer-digits="1"/>
+        </number:number-style>
+        <number:date-style style:name="N10036" number:language="en" number:country="US" number:automatic-order="true">
+         <number:month number:style="long"/>
+         <number:text>/</number:text>
+         <number:day number:style="long"/>
+         <number:text>/</number:text>
+         <number:year number:style="long"/>
+        </number:date-style>
+        <style:style style:name="ch1" style:family="chart">
+         <style:graphic-properties draw:stroke="none"/>
+        </style:style>
+        <style:style style:name="ch2" style:family="chart">
+         <style:chart-properties chart:auto-position="true"/>
+         <style:graphic-properties draw:stroke="none" svg:stroke-color="#b3b3b3" draw:fill="none" draw:fill-color="#e6e6e6"/>
+         <style:text-properties fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
+        </style:style>
+        <style:style style:name="ch3" style:family="chart">
+         <style:chart-properties chart:include-hidden-cells="false" chart:auto-position="true" chart:auto-size="true" chart:treat-empty-cells="leave-gap" chart:right-angled-axes="true"/>
+        </style:style>
+        <style:style style:name="ch4" style:family="chart" style:data-style-name="N10036">
+         <style:chart-properties chart:display-label="true" chart:logarithmic="false" chart:reverse-direction="false" text:line-break="false" loext:try-staggering-first="false" chart:link-data-style-to-source="true" chart:axis-position="0"/>
+         <style:graphic-properties svg:stroke-color="#b3b3b3"/>
+         <style:text-properties fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
+        </style:style>
+        <style:style style:name="ch5" style:family="chart" style:data-style-name="N0">
+         <style:chart-properties chart:display-label="true" chart:logarithmic="false" chart:reverse-direction="false" text:line-break="false" loext:try-staggering-first="false" chart:link-data-style-to-source="true" chart:axis-position="0"/>
+         <style:graphic-properties svg:stroke-color="#b3b3b3"/>
+         <style:text-properties fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
+        </style:style>
+        <style:style style:name="ch6" style:family="chart">
+         <style:graphic-properties svg:stroke-color="#b3b3b3"/>
+        </style:style>
+        <style:style style:name="ch7" style:family="chart" style:data-style-name="N0">
+         <style:chart-properties chart:link-data-style-to-source="true"/>
+         <style:graphic-properties draw:stroke="none" draw:fill-color="#004586" dr3d:edge-rounding="5%"/>
+         <style:text-properties fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
+        </style:style>
+        <style:style style:name="ch8" style:family="chart" style:data-style-name="N0">
+         <style:chart-properties chart:link-data-style-to-source="true"/>
+         <style:graphic-properties draw:stroke="none" draw:fill-color="#ff420e" dr3d:edge-rounding="5%"/>
+         <style:text-properties fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
+        </style:style>
+        <style:style style:name="ch9" style:family="chart" style:data-style-name="N0">
+         <style:chart-properties chart:link-data-style-to-source="true"/>
+         <style:graphic-properties draw:stroke="none" draw:fill-color="#ffd320" dr3d:edge-rounding="5%"/>
+         <style:text-properties fo:font-size="10pt" style:font-size-asian="10pt" style:font-size-complex="10pt"/>
+        </style:style>
+        <style:style style:name="ch10" style:family="chart">
+         <style:graphic-properties draw:stroke="solid" svg:stroke-color="#b3b3b3" draw:fill="none" draw:fill-color="#e6e6e6"/>
+        </style:style>
+        <style:style style:name="ch11" style:family="chart">
+         <style:graphic-properties svg:stroke-color="#b3b3b3" draw:fill-color="#cccccc"/>
+        </style:style>
+       </office:automatic-styles>
+       <office:body>
+        <office:chart>
+         <chart:chart svg:width="17.192cm" svg:height="10.062cm" xlink:href="." xlink:type="simple" chart:class="chart:bar" chart:style-name="ch1">
+          <chart:legend chart:legend-position="end" svg:x="14.982cm" svg:y="4.234cm" style:legend-expansion="high" chart:style-name="ch2"/>
+          <chart:plot-area chart:style-name="ch3" chart:data-source-has-labels="both" svg:x="0.343cm" svg:y="0.201cm" svg:width="14.296cm" svg:height="9.66cm">
+           <chart:coordinate-region svg:x="0.964cm" svg:y="0.4cm" svg:width="13.675cm" svg:height="8.814cm"/>
+           <chart:axis chart:dimension="x" chart:name="primary-x" chart:style-name="ch4" chartooo:axis-type="auto">
+            <chartooo:date-scale/>
+            <chart:categories table:cell-range-address="local-table.$A$2:.$A$5"/>
+           </chart:axis>
+           <chart:axis chart:dimension="y" chart:name="primary-y" chart:style-name="ch5">
+            <chart:grid chart:style-name="ch6" chart:class="major"/>
+           </chart:axis>
+           <chart:series chart:style-name="ch7" chart:values-cell-range-address="local-table.$B$2:.$B$5" chart:label-cell-address="local-table.$B$1" chart:class="chart:bar">
+            <chart:data-point chart:repeated="4"/>
+           </chart:series>
+           <chart:series chart:style-name="ch8" chart:values-cell-range-address="local-table.$C$2:.$C$5" chart:label-cell-address="local-table.$C$1" chart:class="chart:bar">
+            <chart:data-point chart:repeated="4"/>
+           </chart:series>
+           <chart:series chart:style-name="ch9" chart:values-cell-range-address="local-table.$D$2:.$D$5" chart:label-cell-address="local-table.$D$1" chart:class="chart:bar">
+            <chart:data-point chart:repeated="4"/>
+           </chart:series>
+           <chart:wall chart:style-name="ch10"/>
+           <chart:floor chart:style-name="ch11"/>
+          </chart:plot-area>
+          <table:table table:name="local-table">
+           <table:table-header-columns>
+            <table:table-column/>
+           </table:table-header-columns>
+           <table:table-columns>
+            <table:table-column table:number-columns-repeated="3"/>
+           </table:table-columns>
+           <table:table-header-rows>
+            <table:table-row>
+             <table:table-cell>
+              <text:p/>
+             </table:table-cell>
+             <table:table-cell office:value-type="string">
+              <text:p>Column 1</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="string">
+              <text:p>Column 2</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="string">
+              <text:p>Column 3</text:p>
+             </table:table-cell>
+            </table:table-row>
+           </table:table-header-rows>
+           <table:table-rows>
+            <table:table-row>
+             <table:table-cell office:value-type="string">
+              <text:p>Row 1</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="float" office:value="9.1">
+              <text:p>9.1</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="float" office:value="3.2">
+              <text:p>3.2</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="float" office:value="4.54">
+              <text:p>4.54</text:p>
+             </table:table-cell>
+            </table:table-row>
+            <table:table-row>
+             <table:table-cell office:value-type="string">
+              <text:p>Row 2</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="float" office:value="2.4">
+              <text:p>2.4</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="float" office:value="8.8">
+              <text:p>8.8</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="float" office:value="9.65">
+              <text:p>9.65</text:p>
+             </table:table-cell>
+            </table:table-row>
+            <table:table-row>
+             <table:table-cell office:value-type="string">
+              <text:p>Row 3</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="float" office:value="3.1">
+              <text:p>3.1</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="float" office:value="1.5">
+              <text:p>1.5</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="float" office:value="3.7">
+              <text:p>3.7</text:p>
+             </table:table-cell>
+            </table:table-row>
+            <table:table-row>
+             <table:table-cell office:value-type="string">
+              <text:p>Row 4</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="float" office:value="4.3">
+              <text:p>4.3</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="float" office:value="9.02">
+              <text:p>9.02</text:p>
+             </table:table-cell>
+             <table:table-cell office:value-type="float" office:value="6.2">
+              <text:p>6.2</text:p>
+             </table:table-cell>
+            </table:table-row>
+           </table:table-rows>
+          </table:table>
+         </chart:chart>
+        </office:chart>
+       </office:body>
+      </office:document>
+     </draw:object><draw:image>
+      <office:binary-data>VkNMTVRGAQAxAAAAAAAAAAEAGwAAAAAAAAAAAAAAAAABAAAAAQAAAAEAAAABAAAAAChDAABO
+       JwAAIgIAAIsAAQACAAAA//+BAAEAEAAAAAAAAAAAAAAAJ0MAAE0nAACLAAEAAgAAACAAggAB
+       ACEAAAACABsAAAACAAIAAAAAAAAATScAAAEAAAAAACdDAAACAACVAAEABAAAAAAAAACWAAEA
+       AgAAAAkAiwABAAIAAAADAIUAAQAFAAAA////AAGEAAEABQAAAAAAAAAAbwACADYAAAABAAYA
+       lCEAAE4nAAAAAAAATicAAAAAAAAAAAAAKEMAAAAAAAAoQwAATicAAJQhAABOJwAAAACMAAEA
+       AAAAAIsAAQACAAAAAwCEAAEABQAAALOzswABAAIBAI4AAAAVAFhQQVRIU1RST0tFX1NFUV9C
+       RUdJTgAAAABvAAAAAQBpAAAAAQAzAAAABgB6HgAA/iMAAMQDAAD+IwAAxAMAAJABAAAvOQAA
+       kAEAAC85AAD+IwAAeh4AAP4jAAAAAQACAAAAAAABAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAEAAAAAAAAAAAAAAAAAhAABAAUAAACzs7MAAYUAAQAFAAAAAAAAAABtAAMAcwAAAAYAeh4A
+       AP4jAADEAwAA/iMAAMQDAACQAQAALzkAAJABAAAvOQAA/iMAAHoeAAD+IwAABQA6AAAAAQAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAA
+       AAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAA
+       AAEASQAAAAEAEwAAAAIALzkAAP0jAADEAwAA/SMAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0A
+       AwBTAAAAAgAvOQAA/SMAAMQDAAD9IwAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJP
+       S0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBu
+       AAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIALzkAAEAe
+       AADEAwAAQB4AAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAA
+       AAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgAvOQAAQB4AAMQDAABA
+       HgAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAAB
+       AAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFf
+       QkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIALzkAAIMYAADEAwAAgxgAAAABAAIAAAAAAAEA
+       AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQAB
+       AAUAAAAAAAAAAG0AAwBTAAAAAgAvOQAAgxgAAMQDAACDGAAABQA6AAAAAQAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAA
+       ABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUA
+       AACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEA
+       EwAAAAIALzkAAMYSAADEAwAAxhIAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgAv
+       OQAAxhIAAMQDAADGEgAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VO
+       RAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFU
+       SFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIALzkAAAkNAADEAwAACQ0A
+       AAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEA
+       BQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgAvOQAACQ0AAMQDAAAJDQAABQA6AAAA
+       AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEA
+       AgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAA
+       TwAAAAEASQAAAAEAEwAAAAIALzkAAEwHAADEAwAATAcAAAABAAIAAAAAAAEAAgAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAA
+       AG0AAwBTAAAAAgAvOQAATAcAAMQDAABMBwAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhT
+       VFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQAC
+       AQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIALzkA
+       AI8BAADEAwAAjwEAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAA
+       AAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgAvOQAAjwEAAMQD
+       AACPAQAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAA
+       jAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9T
+       RVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIAxAMAAJMkAADEAwAA/SMAAAABAAIAAAAA
+       AAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswAB
+       hQABAAUAAAAAAAAAAG0AAwBTAAAAAgDEAwAAkyQAAMQDAAD9IwAABQA6AAAAAQAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEA
+       HQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAAB
+       AAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAA
+       AAEAEwAAAAIAxAMAAJMkAADEAwAA/SMAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAA
+       AgDEAwAAkyQAAMQDAAD9IwAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VR
+       X0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBY
+       UEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIAHhEAAJMkAAAeEQAA
+       /SMAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACE
+       AAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgAeEQAAkyQAAB4RAAD9IwAABQA6
+       AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACL
+       AAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4A
+       AAAATwAAAAEASQAAAAEAEwAAAAIAHhEAAJMkAAAeEQAA/SMAAAABAAIAAAAAAAEAAgAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAA
+       AAAAAG0AAwBTAAAAAgAeEQAAkyQAAB4RAAD9IwAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBB
+       VEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MA
+       AQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIA
+       eR4AAJMkAAB5HgAA/SMAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA
+       AAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgB5HgAAkyQA
+       AHkeAAD9IwAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAA
+       AAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9L
+       RV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIAeR4AAJMkAAB5HgAA/SMAAAABAAIA
+       AAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOz
+       swABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgB5HgAAkyQAAHkeAAD9IwAABQA6AAAAAQAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMA
+       hAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEA
+       SQAAAAEAEwAAAAIA1CsAAJMkAADUKwAA/SMAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBT
+       AAAAAgDUKwAAkyQAANQrAAD9IwAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0Vf
+       U0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAA
+       FQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIA1CsAAJMkAADU
+       KwAA/SMAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA
+       AACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgDUKwAAkyQAANQrAAD9IwAA
+       BQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAA
+       AACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVH
+       SU4AAAAATwAAAAEASQAAAAEAEwAAAAIALzkAAJMkAAAvOQAA/SMAAAABAAIAAAAAAAEAAgAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUA
+       AAAAAAAAAG0AAwBTAAAAAgAvOQAAkyQAAC85AAD9IwAABQA6AAAAAQAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMA
+       WFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACz
+       s7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAA
+       AAIALzkAAJMkAAAvOQAA/SMAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgAvOQAA
+       kyQAAC85AAD9IwAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAA
+       AAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNU
+       Uk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIAxAMAAP0jAAAvOQAA/SMAAAAB
+       AAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAA
+       ALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgDEAwAA/SMAAC85AAD9IwAABQA6AAAAAQAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAA
+       AAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAA
+       AAEASQAAAAEAEwAAAAIALgMAAP0jAADEAwAA/SMAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0A
+       AwBTAAAAAgAuAwAA/SMAAMQDAAD9IwAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJP
+       S0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBu
+       AAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIALgMAAP0j
+       AADEAwAA/SMAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAA
+       AAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgAuAwAA/SMAAMQDAAD9
+       IwAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAAB
+       AAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFf
+       QkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIALgMAAEAeAADEAwAAQB4AAAABAAIAAAAAAAEA
+       AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQAB
+       AAUAAAAAAAAAAG0AAwBTAAAAAgAuAwAAQB4AAMQDAABAHgAABQA6AAAAAQAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAA
+       ABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUA
+       AACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEA
+       EwAAAAIALgMAAEAeAADEAwAAQB4AAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgAu
+       AwAAQB4AAMQDAABAHgAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VO
+       RAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFU
+       SFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIALgMAAIMYAADEAwAAgxgA
+       AAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEA
+       BQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgAuAwAAgxgAAMQDAACDGAAABQA6AAAA
+       AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEA
+       AgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAA
+       TwAAAAEASQAAAAEAEwAAAAIALgMAAIMYAADEAwAAgxgAAAABAAIAAAAAAAEAAgAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAA
+       AG0AAwBTAAAAAgAuAwAAgxgAAMQDAACDGAAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhT
+       VFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQAC
+       AQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIALgMA
+       AMYSAADEAwAAxhIAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAA
+       AAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgAuAwAAxhIAAMQD
+       AADGEgAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAA
+       jAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9T
+       RVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIALgMAAMYSAADEAwAAxhIAAAABAAIAAAAA
+       AAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswAB
+       hQABAAUAAAAAAAAAAG0AAwBTAAAAAgAuAwAAxhIAAMQDAADGEgAABQA6AAAAAQAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEA
+       HQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAAB
+       AAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAA
+       AAEAEwAAAAIALgMAAAkNAADEAwAACQ0AAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAA
+       AgAuAwAACQ0AAMQDAAAJDQAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VR
+       X0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBY
+       UEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIALgMAAAkNAADEAwAA
+       CQ0AAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACE
+       AAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgAuAwAACQ0AAMQDAAAJDQAABQA6
+       AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACL
+       AAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4A
+       AAAATwAAAAEASQAAAAEAEwAAAAIALgMAAEwHAADEAwAATAcAAAABAAIAAAAAAAEAAgAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAA
+       AAAAAG0AAwBTAAAAAgAuAwAATAcAAMQDAABMBwAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBB
+       VEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MA
+       AQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIA
+       LgMAAEwHAADEAwAATAcAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA
+       AAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgAuAwAATAcA
+       AMQDAABMBwAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAA
+       AAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9L
+       RV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIALgMAAI8BAADEAwAAjwEAAAABAAIA
+       AAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOz
+       swABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgAuAwAAjwEAAMQDAACPAQAABQA6AAAAAQAAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMA
+       hAABAAUAAACzs7MAAQACAQBuAAAAFQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEA
+       SQAAAAEAEwAAAAIALgMAAI8BAADEAwAAjwEAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAQAAAAAAAAAAAAAAAACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBT
+       AAAAAgAuAwAAjwEAAMQDAACPAQAABQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAA
+       AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0Vf
+       U0VRX0VORAAAAAAAAAAAjAABAAAAAACLAAEAAgAAAAMAhAABAAUAAACzs7MAAQACAQBuAAAA
+       FQBYUEFUSFNUUk9LRV9TRVFfQkVHSU4AAAAATwAAAAEASQAAAAEAEwAAAAIAxAMAAP0jAADE
+       AwAAjwEAAAABAAIAAAAAAAEAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAA
+       AACEAAEABQAAALOzswABhQABAAUAAAAAAAAAAG0AAwBTAAAAAgDEAwAA/SMAAMQDAACPAQAA
+       BQA6AAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+       AAAAAAAAAAAAAAAAAgEAHQAAABMAWFBBVEhTVFJPS0VfU0VRX0VORAAAAAAAAAAAjAABAAAA
+       AACLAAEAAgAAAAMAhQABAAUAAACGRQAAAYQAAQAFAAAAAAAAAABvAAIALgAAAAEABQBvBQAA
+       /SMAAMYIAAD9IwAAxggAAOEJAABvBQAA4QkAAG8FAAD9IwAAAACMAAEAAAAAAIsAAQACAAAA
+       AwCFAAEABQAAAIZFAAABhAABAAUAAAAAAAAAAG8AAgAuAAAAAQAFAMoSAAD9IwAAIBYAAP0j
+       AAAgFgAAGh0AAMoSAAAaHQAAyhIAAP0jAAAAAIwAAQAAAAAAiwABAAIAAAADAIUAAQAFAAAA
+       hkUAAAGEAAEABQAAAAAAAAAAbwACAC4AAAABAAUAJCAAAP0jAAB7IwAA/SMAAHsjAAAYGwAA
+       JCAAABgbAAAkIAAA/SMAAAAAjAABAAAAAACLAAEAAgAAAAMAhQABAAUAAACGRQAAAYQAAQAF
+       AAAAAAAAAABvAAIALgAAAAEABQB/LQAA/SMAANYwAAD9IwAA1jAAAKYXAAB/LQAAphcAAH8t
+       AAD9IwAAAACMAAEAAAAAAIsAAQACAAAAAwCFAAEABQAAAA5C/wABhAABAAUAAAAAAAAAAG8A
+       AgAuAAAAAQAFAMYIAAD9IwAAHAwAAP0jAAAcDAAAzhoAAMYIAADOGgAAxggAAP0jAAAAAIwA
+       AQAAAAAAiwABAAIAAAADAIUAAQAFAAAADkL/AAGEAAEABQAAAAAAAAAAbwACAC4AAAABAAUA
+       IBYAAP0jAAB3GQAA/SMAAHcZAAC9CgAAIBYAAL0KAAAgFgAA/SMAAAAAjAABAAAAAACLAAEA
+       AgAAAAMAhQABAAUAAAAOQv8AAYQAAQAFAAAAAAAAAABvAAIALgAAAAEABQB7IwAA/SMAANIm
+       AAD9IwAA0iYAAK8fAAB7IwAArx8AAHsjAAD9IwAAAACMAAEAAAAAAIsAAQACAAAAAwCFAAEA
+       BQAAAA5C/wABhAABAAUAAAAAAAAAAG8AAgAuAAAAAQAFANYwAAD9IwAALDQAAP0jAAAsNAAA
+       GwoAANYwAAAbCgAA1jAAAP0jAAAAAIwAAQAAAAAAiwABAAIAAAADAIUAAQAFAAAAINP/AAGE
+       AAEABQAAAAAAAAAAbwACAC4AAAABAAUAHAwAAP0jAABzDwAA/SMAAHMPAAD2FgAAHAwAAPYW
+       AAAcDAAA/SMAAAAAjAABAAAAAACLAAEAAgAAAAMAhQABAAUAAAAg0/8AAYQAAQAFAAAAAAAA
+       AABvAAIALgAAAAEABQB3GQAA/SMAAM4cAAD9IwAAzhwAAE0IAAB3GQAATQgAAHcZAAD9IwAA
+       AACMAAEAAAAAAIsAAQACAAAAAwCFAAEABQAAACDT/wABhAABAAUAAAAAAAAAAG8AAgAuAAAA
+       AQAFANImAAD9IwAAKCoAAP0jAAAoKgAAXxkAANImAABfGQAA0iYAAP0jAAAAAIwAAQAAAAAA
+       iwABAAIAAAADAIUAAQAFAAAAINP/AAGEAAEABQAAAAAAAAAAbwACAC4AAAABAAUALDQAAP0j
+       AACDNwAA/SMAAIM3AAAzEgAALDQAADMSAAAsNAAA/SMAAAAAjAABAAAAAAAAAgEAIAAAABYA
+       WFRFWFRfUEFJTlRTSEFQRV9CRUdJTgAAAAAAAAAAigABAEcAAAAFAEEAAAAPAExpYmVyYXRp
+       b24gU2FucwAAAAAAAGEBAAD//wAAAgAFAAAAAAAAAAkEAAAAAAAAAAEA/wMAAAAAAAAAAAAA
+       AIgAAQACAAAAAQCHAAEABQAAAP////8AhgABAAQAAAAAAAAAcQADAEIAAACUCAAANSYAAAUA
+       AABSAG8AdwAgADEAAAAFAAUAAADuAAAApwEAALACAAD/AgAAuQMAAAUAUgBvAHcAIAAxAAAA
+       AAAAAgEAEwAAAAkAWFRFWFRfRU9DAAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9DAQAAAAAA
+       AAAAAgEAEwAAAAkAWFRFWFRfRU9DAgAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9DAwAAAAAA
+       AAAAAgEAEwAAAAkAWFRFWFRfRU9XAwAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9DBAAAAAAA
+       AAAAAgEAEwAAAAkAWFRFWFRfRU9MAAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9QAAAAAAAA
+       AAAAAgEAHgAAABQAWFRFWFRfUEFJTlRTSEFQRV9FTkQAAAAAAAAAAAACAQAgAAAAFgBYVEVY
+       VF9QQUlOVFNIQVBFX0JFR0lOAAAAAAAAAACKAAEARwAAAAUAQQAAAA8ATGliZXJhdGlvbiBT
+       YW5zAAAAAAAAYQEAAP//AAACAAUAAAAAAAAACQQAAAAAAAAAAQD/AwAAAAAAAAAAAAAAiAAB
+       AAIAAAABAIcAAQAFAAAA/////wCGAAEABAAAAAAAAABxAAMAQgAAAO8VAAA1JgAABQAAAFIA
+       bwB3ACAAMgAAAAUABQAAAO4AAACnAQAAsAIAAP8CAAC5AwAABQBSAG8AdwAgADIAAAAAAAAC
+       AQATAAAACQBYVEVYVF9FT0MAAAAAAAAAAAACAQATAAAACQBYVEVYVF9FT0MBAAAAAAAAAAAC
+       AQATAAAACQBYVEVYVF9FT0MCAAAAAAAAAAACAQATAAAACQBYVEVYVF9FT0MDAAAAAAAAAAAC
+       AQATAAAACQBYVEVYVF9FT1cDAAAAAAAAAAACAQATAAAACQBYVEVYVF9FT0MEAAAAAAAAAAAC
+       AQATAAAACQBYVEVYVF9FT0wAAAAAAAAAAAACAQATAAAACQBYVEVYVF9FT1AAAAAAAAAAAAAC
+       AQAeAAAAFABYVEVYVF9QQUlOVFNIQVBFX0VORAAAAAAAAAAAAAIBACAAAAAWAFhURVhUX1BB
+       SU5UU0hBUEVfQkVHSU4AAAAAAAAAAIoAAQBHAAAABQBBAAAADwBMaWJlcmF0aW9uIFNhbnMA
+       AAAAAABhAQAA//8AAAIABQAAAAAAAAAJBAAAAAAAAAABAP8DAAAAAAAAAAAAAACIAAEAAgAA
+       AAEAhwABAAUAAAD/////AIYAAQAEAAAAAAAAAHEAAwBCAAAASSMAADUmAAAFAAAAUgBvAHcA
+       IAAzAAAABQAFAAAA7gAAAKcBAACwAgAA/wIAALkDAAAFAFIAbwB3ACAAMwAAAAAAAAIBABMA
+       AAAJAFhURVhUX0VPQwAAAAAAAAAAAAIBABMAAAAJAFhURVhUX0VPQwEAAAAAAAAAAAIBABMA
+       AAAJAFhURVhUX0VPQwIAAAAAAAAAAAIBABMAAAAJAFhURVhUX0VPQwMAAAAAAAAAAAIBABMA
+       AAAJAFhURVhUX0VPVwMAAAAAAAAAAAIBABMAAAAJAFhURVhUX0VPQwQAAAAAAAAAAAIBABMA
+       AAAJAFhURVhUX0VPTAAAAAAAAAAAAAIBABMAAAAJAFhURVhUX0VPUAAAAAAAAAAAAAIBAB4A
+       AAAUAFhURVhUX1BBSU5UU0hBUEVfRU5EAAAAAAAAAAAAAgEAIAAAABYAWFRFWFRfUEFJTlRT
+       SEFQRV9CRUdJTgAAAAAAAAAAigABAEcAAAAFAEEAAAAPAExpYmVyYXRpb24gU2FucwAAAAAA
+       AGEBAAD//wAAAgAFAAAAAAAAAAkEAAAAAAAAAAEA/wMAAAAAAAAAAAAAAIgAAQACAAAAAQCH
+       AAEABQAAAP////8AhgABAAQAAAAAAAAAcQADAEIAAACkMAAANSYAAAUAAABSAG8AdwAgADQA
+       AAAFAAUAAADuAAAApwEAALACAAD/AgAAuQMAAAUAUgBvAHcAIAA0AAAAAAAAAgEAEwAAAAkA
+       WFRFWFRfRU9DAAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9DAQAAAAAAAAAAAgEAEwAAAAkA
+       WFRFWFRfRU9DAgAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9DAwAAAAAAAAAAAgEAEwAAAAkA
+       WFRFWFRfRU9XAwAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9DBAAAAAAAAAAAAgEAEwAAAAkA
+       WFRFWFRfRU9MAAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9QAAAAAAAAAAAAAgEAHgAAABQA
+       WFRFWFRfUEFJTlRTSEFQRV9FTkQAAAAAAAAAAAACAQAgAAAAFgBYVEVYVF9QQUlOVFNIQVBF
+       X0JFR0lOAAAAAAAAAACKAAEARwAAAAUAQQAAAA8ATGliZXJhdGlvbiBTYW5zAAAAAAAAYQEA
+       AP//AAACAAUAAAAAAAAACQQAAAAAAAAAAQD/AwAAAAAAAAAAAAAAiAABAAIAAAABAIcAAQAF
+       AAAA/////wCGAAEABAAAAAAAAABxAAMAIgAAABECAAB1JAAAAQAAADAAAAABAAEAAAC5AAAA
+       AQAwAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9DAAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9M
+       AAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9QAAAAAAAAAAAAAgEAHgAAABQAWFRFWFRfUEFJ
+       TlRTSEFQRV9FTkQAAAAAAAAAAAACAQAgAAAAFgBYVEVYVF9QQUlOVFNIQVBFX0JFR0lOAAAA
+       AAAAAACKAAEARwAAAAUAQQAAAA8ATGliZXJhdGlvbiBTYW5zAAAAAAAAYQEAAP//AAACAAUA
+       AAAAAAAACQQAAAAAAAAAAQD/AwAAAAAAAAAAAAAAiAABAAIAAAABAIcAAQAFAAAA/////wCG
+       AAEABAAAAAAAAABxAAMAIgAAABECAAC4HgAAAQAAADIAAAABAAEAAAC5AAAAAQAyAAAAAAAA
+       AgEAEwAAAAkAWFRFWFRfRU9DAAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9MAAAAAAAAAAAA
+       AgEAEwAAAAkAWFRFWFRfRU9QAAAAAAAAAAAAAgEAHgAAABQAWFRFWFRfUEFJTlRTSEFQRV9F
+       TkQAAAAAAAAAAAACAQAgAAAAFgBYVEVYVF9QQUlOVFNIQVBFX0JFR0lOAAAAAAAAAACKAAEA
+       RwAAAAUAQQAAAA8ATGliZXJhdGlvbiBTYW5zAAAAAAAAYQEAAP//AAACAAUAAAAAAAAACQQA
+       AAAAAAAAAQD/AwAAAAAAAAAAAAAAiAABAAIAAAABAIcAAQAFAAAA/////wCGAAEABAAAAAAA
+       AABxAAMAIgAAABECAAD7GAAAAQAAADQAAAABAAEAAAC5AAAAAQA0AAAAAAAAAgEAEwAAAAkA
+       WFRFWFRfRU9DAAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9MAAAAAAAAAAAAAgEAEwAAAAkA
+       WFRFWFRfRU9QAAAAAAAAAAAAAgEAHgAAABQAWFRFWFRfUEFJTlRTSEFQRV9FTkQAAAAAAAAA
+       AAACAQAgAAAAFgBYVEVYVF9QQUlOVFNIQVBFX0JFR0lOAAAAAAAAAACKAAEARwAAAAUAQQAA
+       AA8ATGliZXJhdGlvbiBTYW5zAAAAAAAAYQEAAP//AAACAAUAAAAAAAAACQQAAAAAAAAAAQD/
+       AwAAAAAAAAAAAAAAiAABAAIAAAABAIcAAQAFAAAA/////wCGAAEABAAAAAAAAABxAAMAIgAA
+       ABECAAA+EwAAAQAAADYAAAABAAEAAAC5AAAAAQA2AAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9D
+       AAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9MAAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9Q
+       AAAAAAAAAAAAAgEAHgAAABQAWFRFWFRfUEFJTlRTSEFQRV9FTkQAAAAAAAAAAAACAQAgAAAA
+       FgBYVEVYVF9QQUlOVFNIQVBFX0JFR0lOAAAAAAAAAACKAAEARwAAAAUAQQAAAA8ATGliZXJh
+       dGlvbiBTYW5zAAAAAAAAYQEAAP//AAACAAUAAAAAAAAACQQAAAAAAAAAAQD/AwAAAAAAAAAA
+       AAAAiAABAAIAAAABAIcAAQAFAAAA/////wCGAAEABAAAAAAAAABxAAMAIgAAABECAACBDQAA
+       AQAAADgAAAABAAEAAAC5AAAAAQA4AAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9DAAAAAAAAAAAA
+       AgEAEwAAAAkAWFRFWFRfRU9MAAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9QAAAAAAAAAAAA
+       AgEAHgAAABQAWFRFWFRfUEFJTlRTSEFQRV9FTkQAAAAAAAAAAAACAQAgAAAAFgBYVEVYVF9Q
+       QUlOVFNIQVBFX0JFR0lOAAAAAAAAAACKAAEARwAAAAUAQQAAAA8ATGliZXJhdGlvbiBTYW5z
+       AAAAAAAAYQEAAP//AAACAAUAAAAAAAAACQQAAAAAAAAAAQD/AwAAAAAAAAAAAAAAiAABAAIA
+       AAABAIcAAQAFAAAA/////wCGAAEABAAAAAAAAABxAAMAKgAAAFgBAADEBwAAAgAAADEAMAAA
+       AAIAAgAAALkAAAByAQAAAgAxADAAAAAAAAACAQATAAAACQBYVEVYVF9FT0MAAAAAAAAAAAAC
+       AQATAAAACQBYVEVYVF9FT0MBAAAAAAAAAAACAQATAAAACQBYVEVYVF9FT0wAAAAAAAAAAAAC
+       AQATAAAACQBYVEVYVF9FT1AAAAAAAAAAAAACAQAeAAAAFABYVEVYVF9QQUlOVFNIQVBFX0VO
+       RAAAAAAAAAAAAAIBACAAAAAWAFhURVhUX1BBSU5UU0hBUEVfQkVHSU4AAAAAAAAAAIoAAQBH
+       AAAABQBBAAAADwBMaWJlcmF0aW9uIFNhbnMAAAAAAABhAQAA//8AAAIABQAAAAAAAAAJBAAA
+       AAAAAAABAP8DAAAAAAAAAAAAAACIAAEAAgAAAAEAhwABAAUAAAD/////AIYAAQAEAAAAAAAA
+       AHEAAwAqAAAAWAEAAAcCAAACAAAAMQAyAAAAAgACAAAAuQAAAHIBAAACADEAMgAAAAAAAAIB
+       ABMAAAAJAFhURVhUX0VPQwAAAAAAAAAAAAIBABMAAAAJAFhURVhUX0VPQwEAAAAAAAAAAAIB
+       ABMAAAAJAFhURVhUX0VPTAAAAAAAAAAAAAIBABMAAAAJAFhURVhUX0VPUAAAAAAAAAAAAAIB
+       AB4AAAAUAFhURVhUX1BBSU5UU0hBUEVfRU5EAAAAAAAAAACLAAEAAgAAAAMAhQABAAUAAACG
+       RQAAAYQAAQAFAAAAAAAAAABvAAIANgAAAAEABgBkOwAAHhIAAPo6AAAeEgAA+joAAEsRAADN
+       OwAASxEAAM07AAAeEgAAZDsAAB4SAAAAAIwAAQAAAAAAiwABAAIAAAADAIUAAQAFAAAADkL/
+       AAGEAAEABQAAAAAAAAAAbwACADYAAAABAAYAZDsAABAUAAD6OgAAEBQAAPo6AAA9EwAAzTsA
+       AD0TAADNOwAAEBQAAGQ7AAAQFAAAAACMAAEAAAAAAIsAAQACAAAAAwCFAAEABQAAACDT/wAB
+       hAABAAUAAAAAAAAAAG8AAgA2AAAAAQAGAGQ7AAACFgAA+joAAAIWAAD6OgAALxUAAM07AAAv
+       FQAAzTsAAAIWAABkOwAAAhYAAAAAjAABAAAAAAAAAgEAIAAAABYAWFRFWFRfUEFJTlRTSEFQ
+       RV9CRUdJTgAAAAAAAAAAigABAEcAAAAFAEEAAAAPAExpYmVyYXRpb24gU2FucwAAAAAAAGEB
+       AAD//wAAAgAFAAAAAAAAAAkEAAAAAAAAAAEA/wMAAAAAAAAAAAAAAIgAAQACAAAAAQCHAAEA
+       BQAAAP////8AhgABAAQAAAAAAAAAcQADAFoAAAAxPAAALBIAAAgAAABDAG8AbAB1AG0AbgAg
+       ADEAAAAIAAgAAADuAAAApwEAAPcBAACwAgAA0wMAAIwEAAD2BAAArwUAAAgAQwBvAGwAdQBt
+       AG4AIAAxAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9DAAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRf
+       RU9DAQAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9DAgAAAAAAAAAAAgEAEwAAAAkAWFRFWFRf
+       RU9DAwAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9DBAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRf
+       RU9DBQAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9DBgAAAAAAAAAAAgEAEwAAAAkAWFRFWFRf
+       RU9XBgAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9DBwAAAAAAAAAAAgEAEwAAAAkAWFRFWFRf
+       RU9MAAAAAAAAAAAAAgEAEwAAAAkAWFRFWFRfRU9QAAAAAAAAAAAAAgEAHgAAABQAWFRFWFRf
+       UEFJTlRTSEFQRV9FTkQAAAAAAAAAAAACAQAgAAAAFgBYVEVYVF9QQUlOVFNIQVBFX0JFR0lO
+       AAAAAAAAAACKAAEARwAAAAUAQQAAAA8ATGliZXJhdGlvbiBTYW5zAAAAAAAAYQEAAP//AAAC
+       AAUAAAAAAAAACQQAAAAAAAAAAQD/AwAAAAAAAAAAAAAAiAABAAIAAAABAIcAAQAFAAAA////
+       /wCGAAEABAAAAAAAAABxAAMAWgAAADE8AAAeFAAACAAAAEMAbwBsAHUAbQBuACAAMgAAAAgA
+       CAAAAO4AAACnAQAA9wEAALACAADTAwAAjAQAAPYEAACvBQAACABDAG8AbAB1AG0AbgAgADIA
+       AAAAAAACAQATAAAACQBYVEVYVF9FT0MAAAAAAAAAAAACAQATAAAACQBYVEVYVF9FT0MBAAAA
+       AAAAAAACAQATAAAACQBYVEVYVF9FT0MCAAAAAAAAAAACAQATAAAACQBYVEVYVF9FT0MDAAAA
+       AAAAAAACAQATAAAACQBYVEVYVF9FT0MEAAAAAAAAAAACAQATAAAACQBYVEVYVF9FT0MFAAAA
+       AAAAAAACAQATAAAACQBYVEVYVF9FT0MGAAAAAAAAAAACAQATAAAACQBYVEVYVF9FT1cGAAAA
+       AAAAAAACAQATAAAACQBYVEVYVF9FT0MHAAAAAAAAAAACAQATAAAACQBYVEVYVF9FT0wAAAAA
+       AAAAAAACAQATAAAACQBYVEVYVF9FT1AAAAAAAAAAAAACAQAeAAAAFABYVEVYVF9QQUlOVFNI
+       QVBFX0VORAAAAAAAAAAAAAIBACAAAAAWAFhURVhUX1BBSU5UU0hBUEVfQkVHSU4AAAAAAAAA
+       AIoAAQBHAAAABQBBAAAADwBMaWJlcmF0aW9uIFNhbnMAAAAAAABhAQAA//8AAAIABQAAAAAA
+       AAAJBAAAAAAAAAABAP8DAAAAAAAAAAAAAACIAAEAAgAAAAEAhwABAAUAAAD/////AIYAAQAE
+       AAAAAAAAAHEAAwBaAAAAMTwAABAWAAAIAAAAQwBvAGwAdQBtAG4AIAAzAAAACAAIAAAA7gAA
+       AKcBAAD3AQAAsAIAANMDAACMBAAA9gQAAK8FAAAIAEMAbwBsAHUAbQBuACAAMwAAAAAAAAIB
+       ABMAAAAJAFhURVhUX0VPQwAAAAAAAAAAAAIBABMAAAAJAFhURVhUX0VPQwEAAAAAAAAAAAIB
+       ABMAAAAJAFhURVhUX0VPQwIAAAAAAAAAAAIBABMAAAAJAFhURVhUX0VPQwMAAAAAAAAAAAIB
+       ABMAAAAJAFhURVhUX0VPQwQAAAAAAAAAAAIBABMAAAAJAFhURVhUX0VPQwUAAAAAAAAAAAIB
+       ABMAAAAJAFhURVhUX0VPQwYAAAAAAAAAAAIBABMAAAAJAFhURVhUX0VPVwYAAAAAAAAAAAIB
+       ABMAAAAJAFhURVhUX0VPQwcAAAAAAAAAAAIBABMAAAAJAFhURVhUX0VPTAAAAAAAAAAAAAIB
+       ABMAAAAJAFhURVhUX0VPUAAAAAAAAAAAAAIBAB4AAAAUAFhURVhUX1BBSU5UU0hBUEVfRU5E
+       AAAAAAAAAACMAAEAAAAAAIwAAQAAAAAA
+      </office:binary-data>
+     </draw:image>
+    </draw:frame></text:p>
+   <text:h text:style-name="Heading_20_2" text:outline-level="2"><text:bookmark-start text:name="__RefHeading___Toc1200_959359226"/>Subscriptions<text:note text:id="ftn3" text:note-class="footnote"><text:note-citation>3</text:note-citation><text:note-body>
+      <text:p text:style-name="P11"><text:a xlink:type="simple" xlink:href="https://www.collaboraonline.com/subscriptions/" text:style-name="Internet_20_link" text:visited-style-name="Visited_20_Internet_20_Link">https://www.collaborao<text:span text:style-name="T10">nlin</text:span>e.com/subscriptions/</text:a></text:p></text:note-body></text:note><text:bookmark-end text:name="__RefHeading___Toc1200_959359226"/></text:h>
+   <text:h text:style-name="Heading_20_3" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc610_3587465723"/><office:annotation office:name="__Annotation__1105_573016" loext:resolved="false">
+     <dc:creator>Mary J</dc:creator>
+     <dc:date>2024-09-25T14:34:28.088768585</dc:date>
+     <meta:creator-initials>MJ</meta:creator-initials>
+     <text:p text:style-name="Comment"><text:span text:style-name="T32">Stróż pchnął kość w quiz gędźb vel fax myjń.</text:span></text:p>
+    </office:annotation>Subscription Table<office:annotation-end office:name="__Annotation__1105_573016"/><text:bookmark-end text:name="__RefHeading___Toc610_3587465723"/></text:h>
+   <text:p text:style-name="P12"/>
+   <table:table table:name="Table2" table:style-name="Table2" table:template-name="Default Style">
+    <table:table-column table:style-name="Table2.A"/>
+    <table:table-column table:style-name="Table2.B"/>
+    <table:table-column table:style-name="Table2.C"/>
+    <table:table-column table:style-name="Table2.D"/>
+    <table:table-row table:style-name="Table2.1">
+     <table:table-cell table:style-name="Table2.A1" office:value-type="string">
+      <text:p text:style-name="P13">Serial Number</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="Table2.A1" office:value-type="string">
+      <text:p text:style-name="P13">Item</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="Table2.A1" office:value-type="string">
+      <text:p text:style-name="P13">COMPATIBILITY</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="Table2.D1" office:value-type="string">
+      <text:p text:style-name="P13">Features</text:p>
+     </table:table-cell>
+    </table:table-row>
+    <table:table-row table:style-name="Table2.1">
+     <table:table-cell table:style-name="Table2.A2" office:value-type="string">
+      <text:p text:style-name="P13">1</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="Table2.A2" office:value-type="string">
+      <text:h text:style-name="Heading_20_4" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc617_3587465723"/>CODE - Collabora Online Development Edition<text:bookmark-end text:name="__RefHeading___Toc617_3587465723"/></text:h>
+     </table:table-cell>
+     <table:table-cell table:style-name="Table2.A2" office:value-type="string">
+      <table:table table:name="Table1" table:style-name="Table1" table:template-name="Default Style">
+       <table:table-column table:style-name="Table1.A"/>
+       <table:table-column table:style-name="Table1.B"/>
+       <table:table-row>
+        <table:table-cell table:style-name="Table1.A1" office:value-type="string">
+         <text:p text:style-name="P13">Open Documents</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table1.B1" office:value-type="string">
+         <text:p text:style-name="P13">MS Documents</text:p>
+        </table:table-cell>
+       </table:table-row>
+       <table:table-row table:style-name="Table1.2">
+        <table:table-cell table:style-name="Table1.A2" office:value-type="string">
+         <text:p text:style-name="P13">.odt</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table1.B2" office:value-type="string">
+         <text:p text:style-name="P13">.docx</text:p>
+        </table:table-cell>
+       </table:table-row>
+       <table:table-row table:style-name="Table1.2">
+        <table:table-cell table:style-name="Table1.A2" office:value-type="string">
+         <text:p text:style-name="P13">.fodt</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table1.B2" office:value-type="string">
+         <text:p text:style-name="P13">.doc</text:p>
+        </table:table-cell>
+       </table:table-row>
+       <table:table-row table:style-name="Table1.2">
+        <table:table-cell table:style-name="Table1.A2" office:value-type="string">
+         <text:p text:style-name="P13">.ods</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table1.B2" office:value-type="string">
+         <text:p text:style-name="P13">xlsx</text:p>
+        </table:table-cell>
+       </table:table-row>
+       <table:table-row table:style-name="Table1.2">
+        <table:table-cell table:style-name="Table1.A2" office:value-type="string">
+         <text:p text:style-name="P13">.fods</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table1.B2" office:value-type="string">
+         <text:p text:style-name="P13">.xls</text:p>
+        </table:table-cell>
+       </table:table-row>
+      </table:table>
+      <text:p text:style-name="Text_20_body"/>
+     </table:table-cell>
+     <table:table-cell table:style-name="Table2.D2" office:value-type="string">
+      <text:list text:style-name="L1">
+       <text:list-item>
+        <text:p text:style-name="P62">On-Premise</text:p>
+       </text:list-item>
+       <text:list-item>
+        <text:p text:style-name="P62">Rolling Updates</text:p>
+       </text:list-item>
+       <text:list-item>
+        <text:p text:style-name="P62">For testing and home use</text:p>
+       </text:list-item>
+      </text:list>
+      <text:p text:style-name="P14"/>
+     </table:table-cell>
+    </table:table-row>
+    <table:table-row table:style-name="Table2.1">
+     <table:table-cell table:style-name="Table2.A2" office:value-type="string">
+      <text:p text:style-name="P13">2. </text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="Table2.A2" office:value-type="string">
+      <text:h text:style-name="Heading_20_4" text:outline-level="4"><text:bookmark-start text:name="__RefHeading___Toc1146_380714148"/>Collabora for Business<text:bookmark-end text:name="__RefHeading___Toc1146_380714148"/></text:h>
+      <text:p text:style-name="P14"><text:soft-page-break/>Supported Version up-to 99 users</text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="Table2.A2" office:value-type="string">
+      <table:table table:name="Table3" table:style-name="Table3" table:template-name="Default Style">
+       <table:table-column table:style-name="Table3.A"/>
+       <table:table-column table:style-name="Table3.B"/>
+       <table:table-row>
+        <table:table-cell table:style-name="Table3.A1" office:value-type="string">
+         <text:p text:style-name="P13">Open Documents</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table3.B1" office:value-type="string">
+         <text:p text:style-name="P13">MS Documents</text:p>
+        </table:table-cell>
+       </table:table-row>
+       <table:table-row>
+        <table:table-cell table:style-name="Table3.A2" office:value-type="string">
+         <text:p text:style-name="P13"><text:soft-page-break/>.odt</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table3.B2" office:value-type="string">
+         <text:p text:style-name="P13">.docx</text:p>
+        </table:table-cell>
+       </table:table-row>
+       <table:table-row>
+        <table:table-cell table:style-name="Table3.A2" office:value-type="string">
+         <text:p text:style-name="P13">.fodt</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table3.B2" office:value-type="string">
+         <text:p text:style-name="P13">.doc</text:p>
+        </table:table-cell>
+       </table:table-row>
+       <table:table-row>
+        <table:table-cell table:style-name="Table3.A2" office:value-type="string">
+         <text:p text:style-name="P13">.ods</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table3.B2" office:value-type="string">
+         <text:p text:style-name="P13">xlsx</text:p>
+        </table:table-cell>
+       </table:table-row>
+       <table:table-row>
+        <table:table-cell table:style-name="Table3.A2" office:value-type="string">
+         <text:p text:style-name="P13">.fods</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table3.B2" office:value-type="string">
+         <text:p text:style-name="P13">.xls</text:p>
+        </table:table-cell>
+       </table:table-row>
+      </table:table>
+      <text:p text:style-name="Text_20_body"/>
+     </table:table-cell>
+     <table:table-cell table:style-name="Table2.D2" office:value-type="string">
+      <text:list text:style-name="L2">
+       <text:list-item>
+        <text:p text:style-name="P63">Lifetime Maintenance</text:p>
+       </text:list-item>
+       <text:list-item>
+        <text:p text:style-name="P63"><text:soft-page-break/>Customer Portal Access</text:p>
+       </text:list-item>
+       <text:list-item>
+        <text:p text:style-name="P63">Service Level Agreement (SLA)</text:p>
+       </text:list-item>
+      </text:list>
+     </table:table-cell>
+    </table:table-row>
+    <table:table-row table:style-name="Table2.1">
+     <table:table-cell table:style-name="Table2.A2" office:value-type="string">
+      <text:p text:style-name="P13">3. </text:p>
+     </table:table-cell>
+     <table:table-cell table:style-name="Table2.A2" office:value-type="string">
+      <text:h text:style-name="Heading_20_4" text:outline-level="4" text:is-list-header="true"><text:bookmark-start text:name="__RefHeading___Toc1150_380714148"/>Collabora for Enterprise<text:bookmark-end text:name="__RefHeading___Toc1150_380714148"/></text:h>
+      <text:p text:style-name="P14">Supported Version for 100+ users</text:p>
+      <text:p text:style-name="P13"/>
+     </table:table-cell>
+     <table:table-cell table:style-name="Table2.A2" office:value-type="string">
+      <table:table table:name="Table4" table:style-name="Table4" table:template-name="Default Style">
+       <table:table-column table:style-name="Table4.A"/>
+       <table:table-column table:style-name="Table4.B"/>
+       <table:table-row>
+        <table:table-cell table:style-name="Table4.A1" office:value-type="string">
+         <text:p text:style-name="P13">Open Documents</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table4.B1" office:value-type="string">
+         <text:p text:style-name="P13">MS Documents</text:p>
+        </table:table-cell>
+       </table:table-row>
+       <table:table-row>
+        <table:table-cell table:style-name="Table4.A2" office:value-type="string">
+         <text:p text:style-name="P13">.odt</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table4.B2" office:value-type="string">
+         <text:p text:style-name="P13">.docx</text:p>
+        </table:table-cell>
+       </table:table-row>
+       <table:table-row>
+        <table:table-cell table:style-name="Table4.A2" office:value-type="string">
+         <text:p text:style-name="P13">.fodt</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table4.B2" office:value-type="string">
+         <text:p text:style-name="P13">.doc</text:p>
+        </table:table-cell>
+       </table:table-row>
+       <table:table-row>
+        <table:table-cell table:style-name="Table4.A2" office:value-type="string">
+         <text:p text:style-name="P13">.ods</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table4.B2" office:value-type="string">
+         <text:p text:style-name="P13">xlsx</text:p>
+        </table:table-cell>
+       </table:table-row>
+       <table:table-row>
+        <table:table-cell table:style-name="Table4.A2" office:value-type="string">
+         <text:p text:style-name="P13">.fods</text:p>
+        </table:table-cell>
+        <table:table-cell table:style-name="Table4.B2" office:value-type="string">
+         <text:p text:style-name="P13">.xls</text:p>
+        </table:table-cell>
+       </table:table-row>
+      </table:table>
+      <text:p text:style-name="Text_20_body"/>
+     </table:table-cell>
+     <table:table-cell table:style-name="Table2.D2" office:value-type="string">
+      <text:list text:style-name="L3">
+       <text:list-header>
+        <text:p text:style-name="P64"/>
+       </text:list-header>
+      </text:list>
+      <text:p text:style-name="P13"/>
+     </table:table-cell>
+    </table:table-row>
+   </table:table>
+   <text:p text:style-name="P19"/>
+   <text:p text:style-name="P20"/>
+   <text:h text:style-name="P46" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc612_3587465723"/>Forms<text:bookmark-end text:name="__RefHeading___Toc612_3587465723"/></text:h>
+   <text:list text:style-name="L9">
+    <text:list-item>
+     <text:p text:style-name="P72"><office:annotation office:name="__Annotation__1104_446268822" loext:resolved="false">
+       <dc:creator>Jose P</dc:creator>
+       <dc:date>2024-09-18T16:32:15.138944326</dc:date>
+       <meta:creator-initials>JP</meta:creator-initials>
+       <text:p text:style-name="Comment"><text:span text:style-name="T31">El veloz murciélago hindú comía feliz cardillo y kiwi. La cigüeña tocaba el saxofón detrás del palenque de paja.</text:span></text:p>
+      </office:annotation>Checkbox<office:annotation-end office:name="__Annotation__1104_446268822"/>:</text:p>
+     <text:p text:style-name="P71">What is your preferred theme?</text:p>
+     <text:p text:style-name="P74"><loext:content-control loext:checkbox="true" loext:checked-state="☒" loext:unchecked-state="☐" loext:alias="Dark mode" loext:tag="Dark mode" loext:id="526712800">☐</loext:content-control> Dark mode</text:p>
+     <text:p text:style-name="P74"><loext:content-control loext:checkbox="true" loext:checked="true" loext:checked-state="☒" loext:unchecked-state="☐" loext:alias="Light mode" loext:tag="Light mode" loext:id="161881055">☒</loext:content-control> Light mode</text:p>
+    </text:list-item>
+   </text:list>
+   <text:p text:style-name="Text_20_body"><text:s text:c="2"/></text:p>
+   <text:list text:continue-numbering="true" text:style-name="L9">
+    <text:list-item>
+     <text:p text:style-name="P73">Dropdown:</text:p>
+     <text:p text:style-name="P76">What is your favorite pet? </text:p>
+     <text:p text:style-name="P76"><loext:content-control loext:dropdown="true" loext:id="2123631847"><loext:list-item loext:display-text="Choose a pet" loext:value="Choose a pet"/><loext:list-item loext:display-text="Dog" loext:value="Dog"/><loext:list-item loext:display-text="Cat" loext:value="Cat"/><loext:list-item loext:display-text="Parrot" loext:value="Parrot"/><text:span text:style-name="T9">Choose a pet</text:span></loext:content-control></text:p>
+    </text:list-item>
+   </text:list>
+   <text:p text:style-name="P21"/>
+   <text:list text:continue-numbering="true" text:style-name="L9">
+    <text:list-item>
+     <text:p text:style-name="P73">Date:</text:p>
+     <text:p text:style-name="P75"><loext:content-control loext:showing-place-holder="true" loext:date="true" loext:date-format="MM/DD/YY" loext:date-rfc-language-tag="en-US" loext:id="1326074563">Choose a date</loext:content-control></text:p>
+     <text:p text:style-name="P70"/>
+    </text:list-item>
+    <text:list-item>
+     <text:p text:style-name="P73">Pictur<text:span text:style-name="T8">e:</text:span></text:p>
+     <text:p text:style-name="P70"><loext:content-control loext:picture="true" loext:id="353955409"><draw:frame draw:style-name="fr5" draw:name="Image2" text:anchor-type="as-char" svg:width="5.4846in" svg:height="2.0835in" draw:z-index="2"><draw:image draw:mime-type="image/png">
+         <office:binary-data>iVBORw0KGgoAAAANSUhEUgAAA+gAAAH0AQMAAACU5pVuAAAAIGNIUk0AAHomAACAhAAA+gAA
+          AIDoAAB1MAAA6mAAADqYAAAXcJy6UTwAAAAGUExUReQWOf7+/iVReKAAAAABYktHRAH/Ai3e
+          AAAAB3RJTUUH6AcfAxEHQ2KgfAAAAFRJREFUeNrtwTEBAAAAwqD1T20Gf6AAAAAAAAAAAAAA
+          AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPgP2
+          GAAB6sm75gAAACZ0RVh0Q3JlYXRpb24gVGltZQBXZWQgMzEgSnVsIDIwMjQgMDQ6MDU6Mza/
+          EuLTAAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDI0LTA3LTMxVDAzOjE3OjA3KzAwOjAwvM4iVQAA
+          ACV0RVh0ZGF0ZTptb2RpZnkAMjAyNC0wNy0zMVQwMzoxNzowNyswMDowMM2TmukAAAAodEVY
+          dGRhdGU6dGltZXN0YW1wADIwMjQtMDctMzFUMDM6MTc6MDcrMDA6MDCahrs2AAAAGXRFWHRT
+          b2Z0d2FyZQBnbm9tZS1zY3JlZW5zaG907wO/PgAAAABJRU5ErkJggg==
+         </office:binary-data>
+        </draw:image>
+       </draw:frame></loext:content-control><loext:content-control loext:picture="true" loext:id="256653819"/><loext:content-control loext:picture="true" loext:id="1465149563"/></text:p>
+    </text:list-item>
+   </text:list>
+   <text:p text:style-name="P36"/>
+   <text:h text:style-name="P42" text:outline-level="2"><text:bookmark-start text:name="__RefHeading___Toc11593_440631829"/>Lorem ipsum<text:bookmark-end text:name="__RefHeading___Toc11593_440631829"/></text:h>
+   <text:h text:style-name="P47" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc11595_440631829"/>Dolor sit amet<text:bookmark-end text:name="__RefHeading___Toc11595_440631829"/></text:h>
+   <text:p text:style-name="P33">Lorem ipsum dolor sit amet, consectetur adipiscing elit. <text:span text:style-name="T12">Vestibulum</text:span> congue mi nec gravida consequat. Sed mollis imperdiet fermentum. Cras id sem massa. Nam nec blandit lectus. Vivamus molestie suscipit <text:span text:style-name="T12">elementum</text:span>. Fusce dignissim ex eget <text:span text:style-name="T13">pellentesque</text:span> blandit. Nam tempus odio eu lorem porttitor placerat. Suspendisse est leo, tincidunt a facilisis id, <office:annotation office:name="__Annotation__11313_440631829" loext:resolved="true">
+     <dc:creator>Jose P</dc:creator>
+     <dc:date>2024-10-11T04:30:41.113176372</dc:date>
+     <meta:creator-initials>JP</meta:creator-initials>
+     <text:p text:style-name="Comment">Nam euismod egestas orci, ac mattis leo aliquam sed. Curabitur pharetra posuere mi id dapibus. Vestibulum vestibulum sit amet orci eget pulvinar. Donec iaculis luctus interdum. Nunc finibus porttitor maximus. Ut tincidunt dui eu urna tristique, nec euismod eros imperdiet. Nullam tincidunt, nunc et vestibulum sodales, sem ante lobortis turpis, non blandit neque libero sed est.</text:p>
+    </office:annotation>gravida at quam<office:annotation-end office:name="__Annotation__11313_440631829"/><office:annotation loext:parent-name="__Annotation__11313_440631829" loext:resolved="false">
+     <dc:creator>Mary J</dc:creator>
+     <dc:date>2024-10-11T04:32:35.521761451</dc:date>
+     <meta:creator-initials>MJ</meta:creator-initials>
+     <text:p text:style-name="Comment"><text:span text:style-name="T30">Reply to Jose P (11/10/2024, 04:31): &quot;...&quot;</text:span></text:p>
+     <text:p text:style-name="Comment">Duis sollicitudin ornare metus et tristique. Vivamus commodo purus vitae nulla lobortis, quis scelerisque quam imperdiet. Nam ante turpis, tincidunt eu est vel, vestibulum lobortis dui.</text:p>
+    </office:annotation><office:annotation loext:parent-name="__Annotation__11313_440631829" loext:resolved="true">
+     <dc:creator>Mary J</dc:creator>
+     <dc:date>2024-10-11T04:32:14.205755681</dc:date>
+     <meta:creator-initials>MJ</meta:creator-initials>
+     <text:p text:style-name="Comment"><text:span text:style-name="T30">Reply to Jose P (11/10/2024, 04:31): &quot;...&quot;</text:span></text:p>
+     <text:p text:style-name="Comment">Ut aliquam lorem sed egestas dignissim. Sed sem velit, hendrerit id imperdiet in, accumsan nec ante. Proin convallis, tortor non malesuada egestas, turpis mi fermentum sapien, ac dapibus nunc odio non diam.</text:p>
+    </office:annotation>. Fusce malesuada, lacus id gravida elementum, purus nunc euismod nibh, sit amet bibendum nunc nisl eu turpis. Mauris ut ligula metus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Aenean nec <text:span text:style-name="T14">lorem</text:span> ut risus ornare porta non sit amet est. Curabitur accumsan tristique lectus vel congue. Maecenas luctus pretium lorem id laoreet. In vehicula enim facilisis mollis viverra. Phasellus libero quam, dapibus at eros et, interdum fermentum odio.</text:p>
+   <text:p text:style-name="P34">Nullam sit amet quam et tortor sodales dapibus et non nibh. Suspendisse eu lectus urna. Fusce sit<draw:frame draw:style-name="fr2" draw:name="Frame2" text:anchor-type="char" svg:y="-0.05in" svg:width="3in" draw:z-index="7">
+     <draw:text-box fo:min-height="4.8in">
+      <text:p text:style-name="Figure"><draw:frame draw:style-name="fr4" draw:name="Image3" text:anchor-type="paragraph" svg:width="3in" style:rel-width="100%" svg:height="4.8in" style:rel-height="scale" draw:z-index="8"><draw:image draw:mime-type="image/png">
+         <office:binary-data>iVBORw0KGgoAAAANSUhEUgAAF3AAACWAAQMAAADz9LhiAAAABlBMVEX/f7b/frYvHgJ3AACI
+          kElEQVR42uzBgQAAAACAoP2pF6kCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGD24EAAAAAAAMj/tRFUVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYU9OBAAAAAAAPJ/
+          bQRVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVWEPDgQAAAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVFfbgQAAAAAAAyP+1
+          EVRVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVhT04EAAAAAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV2IMDAQAAAAAg/9dG
+          UFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVUV9uBAAAAAAADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVWFPTgQAAAAAADyf20EVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVhDw4EAAAAAID8XxtB
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVXYgwMBAAAAACD/10ZQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVRX24EAAAAAAAMj/tRFUVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYU9OBAAAAAAAPJ/bQRV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVWEPDgQAAAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVFfbgQAAAAAAAyP+1EVRV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVhT04EAAAAAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV2IMDAQAAAAAg/9dGUFVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVUV9uBAAAAAAADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVWFPTgQAAAAAADyf20EVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVh745xEIZhKICaioExR+Ao
+          PZqPzoCExJYiWiXxe7PXSE6+FQMAAAAAAAAAAAAAAAAAAAAAAAAAAGu7BwAAAFysBQAAAADA
+          aW4BZezxoy0AAAAAOMgsJXzJY8Wwrj1gKlIiAGBmehkAoDTfRgIsSZTKHDL+IcWs1PYMAPqM
+          2crADJpgFgDgLcWsAMAUHtEhP8WwIsMDVJKiLIDVbV4lAYBxZcdqp3RXBegx4uAvFNCcLuDF
+          3h3jIAzDUABNUIaOPQJHYeRYPTobohKiykDrOO9NiDlD8u3azMobFWA4D+1jAMAV6l+zyP2/
+          VRYJkF8tAHwylxe6aZwBAABc4UnuXg6tQiGmZc0HM3HeAQAgjq18ZcUBAJCCLJJAlq6z66AD
+          AEBe7vAc8YE2jMDoawAgGbu0AXppvwWgh31MjMRVhnlYKABGXwMAkT1LTLIbgE7adyEYtxnS
+          crgBAADQSQmQm8Zf6FDNGwAIpJXTLN6+AONp719GXwMAZ1pjh/cGE5CGBAYgo6bMym+SPrie
+          TjOI0sUAwGlu5jYBhCfnAWVWgNy2cqB5opLZqnwFkNBSdpraK8CLvTu5QRgGogBqEAcfUwKl
+          UFpKR4IDQorEoiBmea+AnOJ1vu2CbN0DhHQewM1BgB6gotWTrfCwWBIA5LOOF6bZDEA+Fy/H
+          05ojTGBXEqA897xThXkKVR3F30FAkpwOMsAAwO+cwm+EKLOys3TRlbNmAJDMUV2VvsKvLgBS
+          SFHNMZsBqMg2JEBsUmIA26olBKAxp5hI1pevO22hLwYi8v3+cgN8oe9etluv6SbMeAQAAEAc
+          pwF4xAMAZVYAANgWPbkypcQAWgV/4c+mZgXbHGIF55p4Vvba08V1qCSihwUA3hYyazjHFsUB
+          +rLIBKhohv8glZldgJ4WNAmAyC7jMy5hAkhgGXehPuy9SQBhXejMOT4iMrSAbp2KpHQAuvNQ
+          Bya7EIR6J1zZuWPchmEYCqB0kKGjjuChB8nRfPQWndpCReKgaEnxvdmLAVv6JinPmT4DuQu8
+          GwCOz0E1Q5oBaOCm5E81IyLMFAM0ZkiMvhRfKMc3JWihATzriKm0q+wWXw0zwAD1vEjq/LLX
+          AIBUtFkp5xo/uHn0AQCghEvcsZmPBFiBORjuSznwNePtAGjAkBhA7rPN13iQoRruKv5fIsez
+          Ic8uAX9gP3O+dpdm6Eg4YskHQrgBg2Po1MCKvLd0tI0ASyK9rVKsgXUcD1Uib5+uh7JGfPA4
+          A1QwYu7I98N6gAaSLqjKTDzD2SKAMvaARhoNDIhQ1HGcueBw7oPSZx7GmQtGoeIRNTUKRgCZ
+          7ac6MuWbUmI8UbeFKYtTg6Igj2hbmNFVA/g/19RpxngkZYwzT6//bJAovO9x2qXIrZHfWDcv
+          WOhpWbjWZwJaSBg87FZMrfLNCpVtmbcW6R3gu7JBWyWSFfP61uZOWYkSC+9q7PFWUwBgqk8F
+          +hpTI0VWA2BGCeeNvTvIkRAEogAKxoVLj8BR+mgefZbT6TjTmBhTUO+te9OJIPwqkD4uA5jx
+          T5BdK0UySnLt0o+9BADu1sJuNK1sEprkQi13bDODY4JiGUBSW+liHQdxdr/QTZmVczn6IcWF
+          AO4Ps1MFmJ8yK4msdr6E1crjqnAeIJy9fNhdRkAItdxvs2+Fb1aDgAl4eOmxBs8nPMcAedSi
+          NYg8jks/jlLb4jq95AAMYis324P26oAkEk5zFdcVMOOxbC8FPA8AAJDRq/xDDALA05Yrweqi
+          PTK5cernVV2BRMYZmfDGAQ+GspR3g2c3i6Z/JmdpRCLuFAOAyWkMhvGoM5HV4e6RxMQTPjcM
+          MAhTNaeqa/TgRISMs5rdAXrsljJSqkxq4rVAmj/KTI7Y3fQQ7VCJmZ5w6q2DommIAygDpyBW
+          KpTi5Cf8KUBd1ewOAMQg+AP4Nc8eznlpxraEHQ1LyGoAXUYt9nQI/8VhpjFuOr3ZJPNdM2DI
+          IvQ01x6f3V+a4fkQ+NUCzvXAiccjkT3AIJ01mmIwtXQLG/cTSOidah+LO37Yu4OchmEgCqAJ
+          yiLLHiFHydE4OpXYFNpGTtXKM+P3FqwQAuHY4+9x+tJZ45I7i9zj/4pwoEBpBHaXcGdp23J4
+          mLBLgyMaZyhNEAlAiwq7RqUYwDPfsSdwSG479c2OWwFqM7vzjMEGwC13ujlNU9h/HiSAMi4a
+          5Yhl7d2/MkuLAPCaGe4VH2BfE6QkVMQlBkA4Q3f71MJgJ9EGMdoZkKofII85+UoHABAo/uGQ
+          qE3gQgFjPnvUs083cuTxbnvQrMjoU/bQqkClI4qvZP79ag4z0olZX7z9rajeTQwAAL0stqQM
+          HDtrhgEAgKuwr/SFcnwaA4U7BGAEa/vsLoule7Vs5NDRppSxPWCAW6OOWcFHGtSV7r95mZpY
+          CKhg1dEIVy6oIheEP+R1ALWkC2YeskIBDGTV/AkAuBRiB0s4IiY0/jp45uNmUzHktGkdK0Ib
+          N2Mx4iFwy/iZn539FhWcIaMhw3mQMx0eCrlmFwrvC/0pNCtQf0M+zXWOLgVCrNI/7N1NboMw
+          EAZQU3nRJUfIUXo0jt5VFlFCCBGImfF761bKj8H2N2OyPXh6sOx0sqEoxy2Msp6CmSpzB8QS
+          ex5xqfKJ4DUddaKhze1z7p/R5ySAlbDPvRCGJ24vIXKLmEEGkFLsqQWA7/Rsob2mZR6lyzGV
+          WYGC8iZ9DngQ0q2tyzgc5UkAAOBxlzxIuLMDgOP1XX8siYQA/ToU0N1JAYB0T5hJSaMwCkMA
+          wTiIxkhu7b0YUfXv4cugLnMnqojjK+JrgrvMEyNH63mPrAJ36Q+DA2Q92mHfB8BOeowovfGq
+          +r4Yw9TO1l06hKGmAwDU1L/9PwENQGC9XWFWCs7sr70jE4e0Vxwjst+CohYrLqjQP80wq+Xb
+          JVvmRTRDZnYyDMQTpojDwgEAgGEJjZ2rIiyXJ0BOve2nM5lNpcqR8wmLoZ9BOjAoS0skJ0nw
+          M9jKtGRk3AI8m4ZpjFcvgm2zLW16vicAKpgz1c4olXwbTgRkWPp8SD+7vDAVeR8IZsBUDWtt
+          sJevZpb2gjLrPzv3ctNADAQA1LI4LF1sKSltS6FUDnAgAgnvEpT5vHeOlET+z4wNNQsfSNop
+          PNoF8JWj6IIyayCNG3BxdJb5XuLHIu6zNU+P5kBP+xCVZF38pQWAC3IfAF9OfdgiBaQT+TFd
+          kyWf0vT6YoHq2ei/Et+JLtc+V0emzQ6Em5ZmxKQsALnMsUoJT1cZW0uYkpC2TqMQ6hJq5yc6
+          GsHt4zGm3guBGG0NRM+Zir7ABR7FIVLDqhigjOi7JsD74KW8RW/AI1mRhDwwGTiBApg+oRZp
+          VgDbHQCA87ZHbop2R1uABhycq8lQ4KGUkqxu4xTXouCK7W/LxlQfDNCb2R3A9WwQieRDjbBg
+          qZ9pPJLA4QDaTpfd8i//U/EBCZh0ASoyuwMAwL+Z5fJM0OzSlcg73+hZhPI6LvE0IxR1G3c2
+          JWP0oX8TjT4J0JMoD3VIVgFtOL7JDQCEFGKBcixIwbO4EI/pE2DdPHvROeOzL4A0Kyw6LF65
+          JAvKHCnik9luGfYh1kEjnt+Cd/buIDeBGIYC6HTUxSznCByVo1dVWbRUFYNEwd9+7wQRSpzY
+          cQZoSj71w+TUiIE2PZMgEwKI4t+ZwFEdSFb5xtvBAa5YZVBAiRe0wEwFWgj26g8rKqc3ALrd
+          b/IDz1I/t0rrMTThaTu5AZjB/sTFtLyD+3X8XtDpjjELuLS9QTmL4XSzLy/1FnYNDUrccK3V
+          tkQm04YnWKu/ZFgzjzhvVnJ9d8791AJR9WoUwLK47wagYFIH1FKmuYgmbC38VqqkfZg6Ikwo
+          C53dMzGJ3aiE1Pwrddy82ilgFgmOUPw5RtXgQXdPLXFu3jzRV9eCEp35MzKgqxaXIeIu6QW+
+          mIFSWkj1IGSYME5q3x2HBBT1tuUfrSqU48kYncbIYYKCxYM0D6CQLTgO2wboe7qsPTpYahfk
+          feUDvitzcIQscg0gwMgOAdkynxIOuftykHSYkVq87cJRRqmE3lFvXQ6xpBhq67DgAKC18JQz
+          7CWoD6QCfwqO7tvDLzUfH91PjfcWAC7eW1w4UJ0KNV/G345CQq7aIOhveiOD7eEN3OHD58nW
+          m4Fz8mYCMITUFmIXTK3RwAd7d46bMBAFAHSMiOTSR+AolDkWR08KKhDCRsj+y3t1JJxktr+M
+          AR7slek8h0qLQhDmAi+rLUk/hUx0sD6aFLmAAi6HrGXLyocrWabN9rwAzbl2HZ1cGcjieOVd
+          SdPYokWryk3cSSCGGKRhuh5PWkFzAoA8j300oyXhFr2ky0QZ4ciEwxuZJo9FPSr/mS/Mj6tE
+          JISIHwD40EWYTSzX79b8Z8cXgHaXSxLV7jq4tRl4AABdTJt+OMmNRMY4Z80Ct20ehpfmMOmV
+          WcYG2NMS/9A5xXtth47GnMocgQ1AiKjMEgNaIhMI3UJgfOBWTaDQFQD+TepM6xTMEizpmsbD
+          PRCCQGCFRZTc1e/ILMRprWo6jGgc18i2H0/jWZsiGwDHCxgrAA1lXosEoXzmZwR3HvuazTuA
+          0NR0IABfDgRQkdWdFvQsBPVmBSqTRs9cf6Dlu4guwS8jyRHRk7t/bNemARpiOgkYojol2lut
+          vzRPiJWKtAGs7ne3FL+kPYhkRJUU4oYGRWTIO/Gs90BIkonUKhDc4bFcqcckrFSru45xyCzJ
+          +QwAiFeBXPs5gu06lAr97WAMFdtupA1gE0ffP/buJsVBIAgDqEoWLj2SR8vRZyBZZQhRCcNX
+          1e8dIIi0dlk/nbgPiGHN1W530aqYYhjwkc20eXzDWDQUArTMB9ePsCDd9ppOkXsB39OIZqAR
+          CaPWzkWjaqcAJdi7AeMhHYXmzkIvC8L5MzIyeIcDdDSbr+UhaGkd1KX6VfvGIU4+vXzbd193
+          d5MUvsLxJuTy+A5PGAMAx91tsgwsJ306rs34HIzq6DMuDUm49UryUqYTKCk6QJ+lNgAAoEbp
+          Y0ubOtWwW5/PPEhmigi7NgBcsJQ7w4kzjM69V/wws1FVXIgVr1lLJBdtYb/jbY6FAZ1I2A4r
+          upk4XXg7B8n0RcB/ujXPJgF0tgT9CsCDIicAQPFQZv7m2NSsppRsmX5t4QXBd9e39yjqrtoR
+          AJ7KN/rIs58h8C583YTpMFuzTl+y684nnnCBJNYjDEoinuMMx8Ifa8jydsQlQ6tZEq7lbvMG
+          4KlGYbTeriU7gw87QngdgQcG6NuQBzqUgXNa5es2YQCMaJ/4TMQJL1JfRX1zkU7SAH7YuXPc
+          hmEgAIBMoMKlkFfkGXkan54mRRBLRlhY3mOmdGH4oFbkHgrETB0kNNMlc4SaqOxLqeB/iZlK
+          jTNzXGYXyPklSgELOGDvTmbWHEC+PI85wM6SV/AtXqQzQHQHXk6FGgBS9IucCzhzogoF5Dbz
+          RPvb4YtpT4pGgnsLfKUBI9u5A2grdAuB6AcAEJwiFkdLIU5X6HvBY1JN+mevNl0AwLNtJaJ7
+          8vkUgBOd2lZM/VC2iArcEQQAopNn0Qd3mc8R3GsmgL4sV6C2j9HCNlbp6yCAhIl6yx2gDF3u
+          ANV53BJAkWwMdD0CalADOobC4AMoykygxyyApt22Ke5ijGFb0IE/JoC3cU74Be5tSqlrlKuh
+          i1Q7WxXesJJU85J8TN8K3BHW5My1PNeW6EhS5kcnCOERAJqoc9Ofi/WGGGXcOr8/LLnJRwLd
+          7QHeAR7TLwk/VHIAgGJCd778FewsDtCSciYe0BGFTCuAcx/kk2riHMCzQQEearhXPK2r7nUz
+          eX1ryQDf7N07coMwFAVQkTQpVbpkKVlKlsLS08RDEY+NZxLzPuc0blwAliXQfRIlMxsTpr81
+          i0rXcdTiIRfgho+Qa4PmvW6/wK2EQeioEj83nGLVBQH0kiCPqseQCtS2jStP5gB1uIfFznI3
+          9SqwAO0bW7JkYLQFAF51W34ZgAQMtPpYpoXxEJgJUkhsM6yyk+nQgCoxKM3os3Nxkx4zBFvn
+          JGblabGLAKC5bZzgzc7XwHH99orO0plDO4uwAeAx70RCPaHmCxDdPHuC6f25LwOAuch/NwtE
+          LoVDMJCUQtupVlotlMh63AAApVm9BQAFtRzg5QhajwweWXxBHfok4CF9C6goScz7agDC+hoA
+          tPZ5/TRFTD8K+n9ImcTsUIIN0IBOlHxBYVJVGj3SKlsywwV4FICUpv8jgLkMrP4AgKByxgWR
+          rbmvs7sulNzBbinT8vXuaETlTwi0cfh7l3GPmsiwmlzPJqcJeXyzdye3DcNAFEAJ5yIEOaQE
+          lZASUkpKUenJJUE2L4IBm3/mvbMPPogUOfNJRZ+SjxA/7ckN0penn0ZTvkgkRIpJcoAzxezQ
+          ueYRnuwAqOKzzWqan5AwyYfDHI+W/egNLWFTStgaHL4zHjjNsibmXQQwk6kjBM+3ShS8DMpR
+          FwAoQxIDMmzjHh72/RgANMsAoFNT3nsehciMnrBrFfifUQC1uTaEiD4UmR7H5ApE9HvvrgCA
+          utSPgGu8hjRQgfwqztOAC+jpAGhmTOFtABLP/CRMyx/dAlarng4XWyYv05U7gAUolwKAYoVN
+          J0Ahq+oNfVYFIX8TMLQBgC60VAEAAGJ0KkZrB5Nw6AoA+KJ10TPHDy5pASDV5lpDK1vYaa3Y
+          vihzQxT0tXkh077UCsMeBwCI0SkCDMBva/aX2OyXAf1HOGoJz8ouWk6odYBVDvSVVfFIqCFR
+          1mGc03p0vrN3RzkIwjAAQBdjCB9+eAgPwtE8ugkxJgZR+MG1fe8ECmPr2sIAjnQ1WZLdaFMO
+          gcgQU0uwEiBscjalA9Rhc81PNowws5WE4w0NcCrPO6EplCFghgAujXUyuJ2Y2g5iTYAVVjae
+          0qzTkX6zByaYiMN6ofPjdjJdYzjY6OtQOLkGFmO8RgAFeaggoxIDn91j5iKlPinIsAeA2mTf
+          QRidm1sVhXrWi2vrxWXIR/EMqNihPe04xkueB3olqWA2L8yKQgBm6X1kHP1PqEM2EgDU4gFg
+          S7GW7vl+AwAAAEBfIleZ6vSC6QAmz3MLAADkoEkH8LawtB0AlkkAdtEvwVFuLRUfOgRK7bdO
+          XsWlKC2R1Jnd09JBQA0lHmciCb5AAikJC/9raAAzs7tWXzD0AYA0Tu0rx+JVILQFuk91mah4
+          sHfHNgjDQBRArYgiJSMwQkbw/lPRUIDAIpaQuDu/19CCFMfn87cBIMCaDoARb3fxW5jmkoDq
+          0qfBYNZe+a6e9D/naAAsQzAHjwUUsT8+rwYzAAD8TpdpALvbwIATYLkDkulTDXCe4CUAAATj
+          X9CgNb21MGI17VLro9ajfDMA2KZIobdXys5wDADIa2szpGMAcrDZQ8Sp30LOcKbaOaFwXwiA
+          cG9ypYzEUfmawUNORJ5LAPhAWHrFtQis6mZhAOgeBFO/gATAftoXzh84mwVhqdYDMRkmV36K
+          BpUaEenzAgBADstciQDvtGeAE0y8Y5vdTMyGANWVuRASAIBnEroAAPLvwJ9c9OETOBoAAABM
+          0qoEWFKpU2Lg0lQAmOBktmoZuLN3BykIAzEAALOC9x58gE/r/18h9iJIEUspZJOZF4hsa5JN
+          IgB1+Gtwuze6cNYBirHiAAAANtM0seswAwAOUlGEq60B0LrdvZERAE3UbxKU29KULUzAJBbJ
+          GwBTGcLvgxRt2xdmsHoIcnKX68sEABilKw7AGUvB8l3qgpMlhb2UeaoAgI6EMvQhUQOgXAuJ
+          XY4AANQ26rQQWA8DAEzuGRtrxKhvxK5FRR+wYwaq00kJkNAtfmnSIPZ2D8j0wNCA4wQA17lV
+          6Yfj8m1Jj0hORRXYZXISYU1qT8WjL446eAMAQEYS4n3i9z/1HfsSqgIA1CM96mmK6dvkAygk
+          4kUGwJS0CH+4m2hH/AYk2M4JoBJJRMdU5MTHXAMAmJ/YF4Dp+PHaZUyoChcgL/buJQdBGAgA
+          aCFs3HEkj9aj68qYGKAYSDrT9y4gRiTT+QF6Dd4GHlUFwglSDoNhhq6gZzI6AEAbYQgAAE10
+          ysBo/FMBgBs9CgAMRwswtJtM5gCkpwpBGIuwntyD+F7RgVwHP6zz8bgEAOhHppgSdlnWFFst
+          m/zAtHK3AACQy6xRDADUOQAA/qDbHYaxfPKHWv5beHsEAGS2OsCI9SCliCvkIl4zSBCwQ0gW
+          eSEUAGRmvuCGBohVVHSJmib6hUNVmzsAQAcEZQAZpcospfoyACM2W1lJCwB9qaVRok++4rqr
+          cy7QM8UewFMjo6DZwO5FPZgAAJxQrREbRPBavHsU+KblFM6yCguIRnUKULYLZZbFAYAtSZKZ
+          oatMT1tl4dDkxMWLvXu3YRiGoQCoMiOk9CgaLaOnCuAiQGLABR95N4NBiz8JAPpxwgGoybwe
+          APxv+30C9PPQxgdybZV3oIvwTNuOL7ipE9Ed8QAAatPC4GzcbqezJjBSfHR32x3wofALAEni
+          UxEAYDaFAwDREM/XwkmrylmD6B6+n5LCqB0ARflFwSDPBQAA/Cb1TmFJEgAAAACU2xiowfg+
+          0IFgVIdjDAAEDjTZagYg0mtx4wUxh8IMA3R40nBa6DskNAAAZGqTKjtuA5V4Je479bOyfLKQ
+          oc3Mq6ADALQgMQUK0BspyP8BAKjLSeUCrZEh2nTfAJEAyKfaCwDMshcAvNm7YxyEgRgIgIcE
+          Ek+g5Kl5OgUNSCeIohTn9UxPRZQ4Pq+DlsE6tvHhqoMMAElLRaPKqZgNUUBxt8GbIVMAAACg
+          VcedRicSAIHuB35BIsfu0M5j4NEHEpFADmNmAOtzYAR45SzP+nZ6expzAv7Q7AIAAAAAAACQ
+          bA7j+No1DwBANkUqAABMnN1k9yX4L1ZEAgAAAMBCLlbq0ZRVtwBgCXlppg/EJ6FmcsDdCwCg
+          GE0CgHibzw8DVCVbCQAAFZlWAgBA/QjsIlENwIx6EwB+EolOtEZAnhl/NsDJRLyaUnW+2Lt3
+          HIRhIAqATpeSkuPkaBwd0YFIsFwg7WfmBAhFznr91iE3TzBACWpNgBpcFEYnIpHwsinrAQDQ
+          CAYAmhBSOhPyimsTqwAAEIwiHSCX3RkfcE0YuyeDInY5AADAjAtR10cKDvk8ACCd6+bwoYU8
+          5ZQJqGd7DH7ZBwCssncAAN7YxwOQkQkcAJopHXsGgBNephCWhACRWN0BkohTQMT5JfDNnMmM
+          FSE1kTKAiqzuAADoVgGgtwAAgEsCgDh8imlF2dW9fDIwzl+NoxRgwiBlKrcBAB+cjQOqSdor
+          32oFalOEA47nACADjbW/uQ+AdMTA7VoBOpMS5sneHRwhCANRAI2OBXi0AAtJ/1VZgCPxBNn9
+          73UADGHJLh8AIJIyEAAAs9M1aGUCv1hwAGArQjqBizw0B8kklAbwxUwhFm0AWLnVnLsI6S7e
+          B6BdAgC1eT5DLvc/QB3zOC952rQFkwiAt5wEVnfgHO/Birlt0qgzQYgY2GbvyiWFLCr7L/5l
+          AAAAAIB+ouMEGpOLBQCGiP5mQqO15wDoxedoAAAAUJoYMarTCAGI9BoQSO0OAOzACCS9qboB
+          YCOm1AEAkk3R/AAAAADAoX22JaE1ofoLzjgAfqoFkEnk1Ye9u8eBEATCALrFFlt6JI6yR/Ho
+          1safkGjB8L1X2kkkwDgzgBCcEQEAANTEAye0eyOV5RCeUVffYZGiAQDAPSkdVdnGMyGfNQAA
+          AADsieK/UdO+amoFkEV+9jii8nXftxpGAAAA6mkCA93+2vfCqMImX7t4bMwAAAAA7riGGQCd
+          9AGATNLCgBk4jMHkTPICdIQAAMCWMVfapURp7wuAICVANKdZAABgLvoLDmDRuwAASGAHAxwN
+          cLzyf/DoJ5YAAP3E62toHwDgTIHADABTils0vkYEIIMYLwBckMoFAMCIJJVVoBiNjb07uEEY
+          hgEAaCFGYABG4ckYHSWj8+GBgFKQEMT23QZN1cZx4hgA3iNWBIpwjgyYhh5cUlxJOEIw04e/
+          BMAshDL0IZPAcwK71vYBQFu2uQFLRjBzAhORpQGAB8cAXjkEAABQnF1cRWRARw0ToztV1gAI
+          6w1SJVbztOWHBGz5e9dP7UIBACCFhhumALBtyMcDt2zzAcAnzJ4AuCISAAAgnZaLMcWpq+R4
+          q9MICMwRACBOLMWrAwDSEcAAWUkeGzkAAAAmc4p1w135gOPuQGICGIhYgiulpCDYh28fzDgH
+          AMAdvfCghBEd9XxqAAAoSzkqFciQ/cKFvTvIQRiEggBKGw/G0T2ablyoJZGFLQPvXcGEwO/8
+          cS8AAADC8USTdgfOsZldAgBhxAaABlsIrEX3VA4pJgB8xQYAAAAAAADgIlVOGwBIZrkDAACA
+          A0pMAAC01YACiHRKsIF3rj0J/HcK0H0Kq/UEhlULzMWkBTgScdEHeNpskwED8b4CALUQAHMT
+          nP5kVRUG4lIJwpSmtwAANJjixPPqB7453ZdzLwC2e+NUK2csSsXSP+1+BYAJLZtl6SYPDG2m
+          DwC8VBMCANbiBRPA9AsAOt188AB+ZqVgSk53ACCauf2Dvbu5QRAIwgC6Gg+W4dEyLN3SjMaL
+          ZgUPJMzPex0QCAy7M9/+QwUZmZw2IAFvfgAA7AoCJGK4C8jK+wsASM0qGADIeQAAEjlaBsjO
+          QBkAAI7mpwPTvSDFIwGnY1OaB/wnVQ98CbSPBQA9+PffycXNAYA5o6oAAABL/DoBAEBUimug
+          kvuAVqQvTYkqAACAfqxyAsCTMe6YVisVUVnAJ7luAAAAywI2iN1697AetNkB2zgP0hCfX4up
+          BPrwqSGE01hzHUyk7eQAeIu3qJlR3ysHQN80AJCBXTcAoDAtF8Cc1lQgKtVLDe6j2JkXDxYA
+          AAAP9u4gBWEYiALopGbhMVx4UI/m0VwJhaogiGRm3jtAoYummeRn0sxwiBJYkIBkAU5nsmcr
+          AgBgVdZ0AGUYrbgmFfBHBIAUtHwEAGoRiAToSJIaAADoRDSPpDSJBAASm6blAADWemhLpxga
+          Ue0CAB85/wUAAABQhPYM8E/XQD9UAI6myN5e7gs+7tHUuMVrW3zlFEAn85nXlXYHALIy+wBy
+          MWoBBza7l7cFYOCpqG1sc7R985r8pnlPOQ8ARegHBFCR0R0seQEANKMMAtkWAGB1Y/kHAgAA
+          mRqiAm0YYn7iHJR1CZbiayMzEWsAAHiwdy83CsUwFEBfNCxmSUmURmmUBmKBhPgLAb7xOSUk
+          4CS2XwLal4D5eGgSulqpKQH3qTLRmJ1iJGmY6iwFPCKWQyJ/NUCf9IQcrgBobe1RRQBwXATg
+          mhrHLyhDz/ULlKh/Ygi1cxJ8zhlgAAiz8Y5oGabAlzHPKDx0LiGv7G+B+kSRmszLR/wbelpT
+          J3nLcMYEAOBEiQJIo9M0lmzlk79f455nZdgvuesKANEdqEy3MBCX4kHOBaAXvQfu1gCglrbp
+          NOspANCb5g4AJtY22wEAAIFS2nbbnjNUVZPJArsPFUhizaU+n30BAByMhVLkb4CjjfwLAIql
+          wDXqeaHkX+AbdktTYyvel+NGQgKktLtjAwrojJyYicrZcGvkAER3INlQRQS4ze0tcEOh9qQ9
+          e3dwwyAMQwE0IAbg0EEYsSN05Eo9cOiBgqhEzH9vg0CbxI5NJGYAQJnwyiYebls8FPt/NE/H
+          iP2N82HqgBq0b9OZRTMI7Fa6QLl/Hgnwg4gXAECUxX1JnNfm/QGAlRTojTZJ8y0AlgkAAMC9
+          Ogc8PYKKFIhdY/QCIFypbyyFGqyaAHCZRwMAAPewhsg8UswcNZy2NPR7xQg/SgwfPgDAFsHF
+          H0yqwcgkJ1nE0HZ7NfhmmwCAWR10V1ei2MuZKuYoUrjhEziuty8ER7a7Rg4aaM0ZdTTZBpjb
+          amzI+wKwpccMDgh0yGYuBeB6kZmhWVkYcIwKU+hYZpFD5qgJp9HyFGUVYJN+L9qdsjN74Iv3
+          QDdUfGSJDajtvgGRK9xG4LI+yh6DBRzQ6hdNhVmXAvflAJVNSmDf7NzNbcJAEAbQJfKBI0Wk
+          EJfm0lJakDgkUgSykQKz870nTtxslvXOn2vcvnj3klSq3wRYx42xhCnIHbx/dQOyN8/5sJGX
+          ch4v8jVCnTYBEKCDHHEtQHsO/QUT6GcFRmULoB8xM2CT6Hi7Ig/lAs6duq567lkNMO1kDAwe
+          8BhuxB7lXNPb4n239LPa7YHa0xKmqtw2sLBn46xYhBQZAACGKAGKkd+CwpmsuMFNkwCRpO/1
+          +QF9VWnyeaTqXh147266HeihlbgIVRAL1Cazf5xo539c7nz10hPFRajggkGgM53NTykgBQDk
+          GAAAwNwolP3zxBUZ4y74t9o1IADwLGKP3OpN4Irfrh9n+h8CI7K76AAasYeDxvkj06Rr8SoT
+          ZoWjhD3E7cnAjGbK+dOOd8cCBykkz0JdFWB2W3iWD6AvGzrUdIn7ey7Xj2JrrLDVPsYif5bh
+          c0Ap276dWJeljsayahbyHFcpvYDiztk0on2xjtVvBvwhboSb6s3zcQnnuAvuaq0XXNezifgn
+          YTQKINAynnKKqjNmXe03O3dzmzAQhAF017IicqMEl+ISUtKWklJSWiRySIwCGAvBrOc9iSvC
+          aNmfmY+FXbTE4zKfsEtTeaW5XDFE/dQA/TnY+ADswPH0Wnh9oVHfaqE5rgDB5Mu3wCWTvsAK
+          VdvooZpZuTtVkDieuZz456uHptdeMAAQ19BFYTHZbnaU8Y16mHSFAQDcYBOY3pSrrVpPRyrJ
+          jt5N4pCv8lYgJlsQXyfshiwTwDMdQ/WpQOQQgD4lS9vM1ukohq0Vztprsu3ZqtpxnMmDO7ji
+          F2kPbnEpF448sVhy4cdHAWywzjVLLHCvw7LcEaKOYj6CtK2CKla9Y8plS7P1L6mplK+SVP0d
+          46PZ4jlaOTffEU6STwYAACBuNXB06w1c91mQ+gf+19emh1yBCdJzmrlA4xJR057M0n0A3bJT
+          Amc3lfbQ0o08dsPYhYgS9V5quDdiFUXkDZpBC0BzO9t6/Zx7dVXp3Wioe2BIWZNKTl9A/zWF
+          9wILWeaJljJllqXNQPxfIJwx3T3kOY9yA6LnYPYE8tCfusyxMr7BthUA6IqIzDUB/zP2hwLq
+          Ns3oD3D2WUVEzPweUU8Dv4PVBzZpOl/WSL7Zu6OchmEYAKChmqZ99mMH2FF6tB0dhgQM0Y4i
+          qi623xPfMEbj2LHDyLx7w1aOjSWdbabj21eto5mDJnVcF1Nr1DGZZnrI4BJlOXUHgBkprjzp
+          qmLSChJW9Q5yAHI5VEzDRplqNePVqEfk/BPAIeQ3U5bD4+Acj8ASQcrvCezluiZT0cWFea5X
+          9klW5OmDX/t4sX9YOOIyygAE3MJ0QbozbNMlnSrF9tu7owArx34j29vK0P1YyouSjf+Z+jgy
+          GMUtADAVTUL+h9hNjbNalanozqeL9UAPLt18k/CkMw9FbL+d2hpD4XWgFZreJNBBucrM8EQf
+          qeHQ/qSvFx9BnSWdkj8f8INIQ72DyvTpWmpDmzNFqhfWs7pZ7WDKAOBdqaSx99enyCTeUGYg
+          mlFAGukzmlse401bkmgCz9ZMdD4qi8B0PgglUrx9eoJFVlJngLTObYGDsQA0Yx+oWhBAa1fx
+          IxnTo8AdSQ6ZPH8a8SxLAmhNemGGgS+69iVZ+t4tIBhtZ7AmAMBeCHREGOrH2PZ0KHzXKnY7
+          kA8vhlq1+XKyMYNgR0YbRPdjqaS2XIkCUKQacM9lTvrHaOrxHhZRjTtMDZ8yXTnc2UmWn0G5
+          5/aO6wqpebRf2be3m1ZiIACgJsq94tMlUAIluDSXRmkIJBAIFO0Cm3hmzikAorV37HksqK57
+          FItIXdUGspsVpo0uCXokzPTnT28vpvI8ABCSyu1FJvFgEd3bB5BQX72wubhupLi0SmNR8+Z/
+          gCu5t2JE4xDdwHTZsXq0z5oq8fABMtJVpWTnSS025+6xru9kriWpP0IZ6jN5jS33nLnmRexg
+          0w3w2heGp3Y7J4tNYfq0vApbshGpv7nZhV5RVNAAEeFnYvSxzwbeqWP/q/TYKlFwT0XS5JqC
+          IuRXw0xGLOP30ezeIUFx58y1em/ymxUKL3IpIhJFkimW2ixHjQE0km7lfysoZtCtd/eapufy
+          6Tb5R2PN2Q8EZIoa7TtR/80a7jwJiJt+7ZMyVFo4kpjthRLlzUliN+aY6z53W58d1o7jdYnE
+          tQnjwlK9+FGywahzUZ5oz37n8qccHGsa4f4LJ3eimCyEpwatdbl9oukBLq6O7B5LyAJsvQVZ
+          lOV6VP8arpvUZBq6mGHwQx0SqGfUCXAayuihAKQtc0X//dvvMeo+cYx6+xT4uQdh/QoetKbB
+          h8HHOrU2lhjuqOVSCJd0xpC/MwEkUTBrOOmwHaHL5AEgloLXQOA4/Y8mQZ4aH92pT+62xGH5
+          JSOe1khPbzvDc0B+zr9wjH185pVYkq8qjzDMGT2zcy+3kQJBAEB7ZtGKIyEQgkMgNELZUDa0
+          lUbWyhrbMowHU1313s0XS4amqB8GHjHHi+R6CWBUyNHmpw96LgL+M4wax0B6Nr9Fd4AULr4P
+          vum/Ieg+HGypO1vtKNl7aXQTs4DoRgMfSgjd3rM16ZpBjmhGZeJyVleBqqt+WRodVZ6pesjD
+          p2feI9WdVCcT/jNpDa36AGr6ies3PelgrymT9vdXak2af0bjQ2vSEQ8ASlpaa6e3v1Ln6NSh
+          QiCx6/3PWvdebl0a2wOGEC3UUBzuHUIc4kO8aCmRi0UO4EbSBNgTIn41Boedykmoi+ZP+8Sv
+          yuGp3B+chfIIIIP1PrrbVd5n8ckXiZ8FgzbSHOYfNmg/PyDi9nypzeGlbbF6kdArmfhXuhu3
+          XnU4U+8yQwC/Wzm9J7/KV2qOp9NkMhsoD9IYo9cae3RXSAEEyr+nbJn8VXDfK0yG8TFpO+hX
+          HzqqGHuLZK/U5lBbmqSmylsqljSlXxnuWGcWEfBDg7y0lN73HaJWVRWvawZTpt50mjIksvBP
+          +t/bUSiZu3oAulQs56ZHs+PdAV/ifamX2mrwaAEEfhmuAnLqfb209ApIShAmh6GdaW6brPUa
+          7SQgA4L9LrWC/dJedfSbszs/dLt3SjFgsxjbCMDNHCed+rbp/FFgEXn2xSHgTHppD1gjF8tP
+          t8gCqcaLl4rHQJQHz0xyS96beG33LtGLMDY6v/QFMhDx3+g6ts41wnn4f4bCSYYUfffJBldW
+          /9i5m+PGYRgMwyCXBx113KNKYQlbwpbC0vdnMpnETjSiY0UAvvcpILEtEgABSd1ehHrc9paP
+          pkmCna5lO5jON8VrLjdgSK8T3d+o9JxyG5f/AeBhPHrjC11J4WIBsPCROXguaNzroq3ILHXJ
+          b+ZUDzIADL4wmu3pVKSRBF+LgC/hA9dmh+V5PdBhrvre9yQ/o1ccdNMJH91xGPedAl61yfLl
+          h3i6XmzHoGOQ+8QidNNUSXfxBDV7Qa/zVcv71ULh/iLgu2qTQnSf1+hgubgO0CvT9LSvjIx+
+          GuDIav+QVN5gKIqPojsDsv86GwRE+Tvu0zJ2NZH4fc6KbMSSFAaTVsoWAI9Yec2LGsViMKcE
+          VSgvb4B8BllYk8gY3ZFSsadqlKYQFHq1d3uvHus0bpSI3oVelsDzNYryE1S6MWY16JQu9UZY
+          tYfFicjHFwAfIR/mUukh8GS8utJtVo28J0asUxMAEYuHcrLS0IfCEwJr+Ic8CqfJyAizAMwu
+          ryJ72PP8F/y2dIJPr5qdpdunNvIwsgt6wgHRHderdufymjWWxZ6mpm7LnaDZvvXEy1oknlYY
+          9ohKFeMmAgMxVTuAMtwL6hMVQbM17UCAnRBfIzP/xZumoHqhu8j3hBkbwUaaQwjgBoPbc4yj
+          xfjithcaAO3aHCIWJPAt5n0ncjuBzhRytajbzdmUX2WW3xBTZv+1RNJ6RM01WYZZsbK3CdZs
+          GZ8T+azzw3hxU0DTWQOi6TaJZuannHVFbmprnx9yH58ZkyhqZoKtfP9ZxC9rbvL+NTrrGThs
+          of+TVJ6JSqdaQdLDXpqTB564Sje94CZ3UpEXOm4DrGXMkT/fFYaDoC4ExBDpM+XxaMp3LswR
+          tDczSMJxDTvdlqaNvdoB8S4Q7qzMXwC58/cfdu4YuXEYhsIwqGHBUsUWW+ooPBqPvil2MvFE
+          psTEsvDA/+t2ZpPYMgmAABOqaodWu8ffiX9hP9uOGB/rKQLvlhrEUZmteHBXxuLvKs62B0YK
+          Ca1vDriyshsgK9s+34cR4CLVPm17W6XNdTgje4Wx2Y4mkUEiJSOx5xVKItDxrmPik4RTG1kP
+          cEP0tsztiGH9AxV/3PmlClv1DMeX8ZqdF+uHq7zm27tBICmzCBFwdDSC4lFY+tUXB4zuaYKk
+          Bdr0vay1RH/XmHnxZzsQ4Cc6JFHclamq/OX2NhuA4JZgSWJWNDshJhNpfiy7qgoVZ6JiFi4b
+          SZzXnb+8Ry4mFYhLPpEHaq1G5jHqirQjS7KO+uzZssugGN2ryLacT70lXBROtQirxAzijooy
+          SpcR9By1TNtlHKF5jhUfGHo88U/LTQ1BI5oH1xGn8Mv2oEaP7un5IiUpqm3/bKNSuM+v2qEs
+          /PYwHnNSu72bIYPT/6HqMxtu9mNZZ8kXM1tF0zNeqE4RuugTzoJ5B0BRvp/T6MQAgJRiPY3s
+          90F/WkoXAZPL7JBvcu/f4xau6wxLEXuC59GHBIAh5aU10B9zjo4gpj3+VuofAHNz84sm+zyU
+          d8+t5AcA8pyHMZrdmpq93MaSOMDd1AslB30P+naIhPWMqySBrvUEdxX8PfTYHBduafwrhKaq
+          yVbu7KLTYC8zVEF5ugwXVGGSBDd85lXHxZYzPKnJ+dzA/22eBmeun5RrfnoNTFUBYS1OLJpL
+          s29WoiGuVs/9L5V+X1MpZ7I9aMykEf7sJfIy8R417uJI9qF6uEjBlEOW4/KlJ7EIIxBdfT6t
+          9GTebOXIdMR1mUHKEJaVD4LbcNjYuEBtFm8aSucDE0lxt9/dMhFgj5upd2yVG4/4ooVtDGW7
+          VY5exupYvK6Rq/UPVFV5e4EWGpwr9oDGEPD+GeIWZei1kPyeC3R2Irpz/TcS1rPnDtI/9u4l
+          t20YCMDwkOCCiy646AF4hB6BR+lRdPQiQZy4rixLjR7z+D8ggIEAjm2Rw5kh5VDJGh3Vk9yp
+          l78ctiewUisya/gNTiQlhnVZrS8N3RGvIKvyJrOnCsKl3SIB345e/KNJ+Jv43Wux56bywGr6
+          N36BAyUZJAy8zfCiLP6Fxj1mNXvVSJRJ65qyi2hjV3XGUPAMOF6RN5Wr98FxLAKXy8fihA0r
+          Lz0LhOJ/lCZ5grsdtahyx0Z0D4E+5BfjUTdN8iiF+RYWn+8KZmYfcFnLpdg9PkPgXoesD4gg
+          XLchh3zXIU1d7rXVOU+zlNOwzQTp38nxq4X2ZmG0ezCur8aMHTWguwSRpDk2z2LbDVznB5XC
+          3Az6lsCOhdZgWTh0w6pRFc/RMPRtbpdqfC+ePrAzJVmWD/1jOdplzvIcOWpkxtqPtCRxC8ed
+          lXxfg/xc93qbl1bY5DO6M5uj4doBUXEo3rwUe9O1bq1dmUDOJPkLzQ7AhS6bFDWteV/40IB/
+          DVtpIq1m0j5tqqxVVM6pe0xW7LTL1HznYz1or+o8zX0jS/kandR82Gzw2WrrZosHyKos6nQe
+          /Bly0zil+sFLEMIr2W5usrNBDnKMHu1s+Xqu8mN6PYeZ/vNiZJ9V6btODIkum4qPwDmqFOvR
+          fUE5I/XILC54iVugMWcoeQ7QjLc2srrlHoiil5notCk2Xv8uOflajiFzspNqJBRtAVb3SvaO
+          79yJqVcKu3tRTsypwxh0tODF8Vsu0onu5CQXy2TAAOMdsKWqKdOmjaGjU2BFUNJtdP6QqNgD
+          jWH6ehQ9lWpE9whu0f1Te3xQ7N27MMmiQZ0U0iR3/NXY9N7da7LK8LwtmMxOUGxAbNzs+omG
+          ZwwNaK57bNls0PTfpquys/T2w8J58TmOtGEIN6VV8AMN97dgNaeXzWyVCxhLgXTMeChU89Px
+          0dbXoj9FuUYnMjLXycYwVzjgJDWz+gOWu2VJQRcsQP/WxUET88aJFWuVFX4JrjV9Pui7xKGh
+          e1eVO1HhdTwoqVMLbVILsqtBB9fqPtXBcDygrb5um/6wdy+3jcNAAIZHBrHgYQ8sgYcUsCVM
+          KVsKS9vSFoGBwIklW7Jsax7/B+SSg2HJ1HBmSElJzjarqnBkkjnFZR1gq25OFPNcaXKTWm3c
+          6wNjX+W+7MsZCMPelIRPIbLrN6jsIcqlyx0hp2gVdVC72vtGF0zOmoPtB3ewfxTxow9dD8xo
+          oYdLjKOAUYYTqiJHUKdnC8CiIP0OTVWhEW6jG69rUujhF+sqhY4NAMvKzneqxutFrhcm90RK
+          KrcpqxMpFdltOAxt9OPTUflBM24i+8lcNEmnDHmlSfT771LYZUKPEghwB9UhVDY40RsAcNvY
+          klI3qpQczs9Dpc8cq9bAW7SjuzvFSN5M2n6L4S5Cz7CeMoIfH+YQ4XC0LjK9LqRrE5kY4UhP
+          Waw/azzWJNowoC+Ruy9lhnoaos1IdOuyiCABPFch9jtSvG+NUtmsUX+vEXy/KCEKyXWzHYpi
+          9psRSB7xT2Bnf7rFHht4JDYimZgiibrOVLnLSOAu23vPH2JRm8l92FGx39+4Z43pBIs8FmQe
+          +6cshCL0OGaWwYu6LCPcGCToW9FF+ptG9++8T4XLcpwAvOrPzdRPRgriZ5XwNVhfDPPIdK2t
+          HHcWw2AMmyjO7J/YsuNdBjtUR6uqjOsfAjeGh8+vHYe/qsiIZuIjAL8mX8G9yi6/BIcbh6eg
+          zpdfapLjDMVEiB0JB4dS3KYxiH8IijbBnEG5b8WJm9V8Y7pExBu+cIUxYNDYcX5PcuGP4HDn
+          FzMlyjuthAATnTZE/2XqYhhulq8OAACwh3raW1tYd8CZmv2wb+hsh+Kq/glVqC7hrAHIqBp/
+          xFgTmbihBU6qSyOaXBmxC5uNYg0wlU2Kx2S1mgr1roo4S6pcsPDpdlIdom564+ofhB+jFyje
+          axgPiVW2oaWPlQw9JuTwSyHTzLfI6bgAcjkJnmqidPbTU5jkS2UCPz53gi8fcmk8cYS11R0o
+          5VWsITRZh+znQqdICoTMYw9e3e3deOg66Z9/VqN7N5U6U3gmlvjHZwUK/9m5myO3YRgMw6DD
+          yfDIQwrgIYWwlJSi0lJaJsnYY+/aa/3a+Ij3OWcUWSIhAIL2hnw7JAUobqQUv5n+AIXh2zMn
+          PDHcoi3MhEVXzUzjoK7iY+BCw6G3B1KZk5ov62xGCKgHt6Q7q1KBXJuKNYXRNNvohzlXX5WT
+          Jcpl7zQT8WaPTUdegMJalsK9YMII46yDFG3AU0vZ5V6kGa3lOkYiA7xTXxZgt+dihfQNKkkI
+          7U0ugQvtJn9qAt83JNuo8i2GJ93OftsxulwQGmDOJUJ9rBdHmt7dlHt1DXjKdzBSzC+2WHJc
+          r3WFVChCLuNGrz5inoeFB4Co/JyPsa1s+6lybeRuH7XZ/75SJawywAuJZq/QmXBDnDne/U1c
+          Nzh/lKxUhZ5jEND0eyzZBmoaA8CG2N1C9SAKbw+kObn8xZ4pw20dqDrZHa42ZvH5O9m9up2D
+          6vx423WVWwF6C04TOVxaYsNE/huF5YmvEddC/zAEMHnpH55V5nWcKy86RBuwBlA9b+ykqdUJ
+          vvEIEFMEwmDbLdY3vttwxV+v+q+u+V4m2QYT2RE8b0o85Sme7KnOXaHZ5emfkWdjiXIysyb9
+          LBb7DIX3CcNJsRYr8B9REP4JtdU97QBKdDHdHpq47/CIHsM6iegeS7IrPcy4SbsECqk8DoR9
+          Z9g9bhV7JLv8EvSx7P4Mo/hmojy1QNzjdYJCsiGWkedB9u/Qwxn3aeeLYvvkn4neythKqOVM
+          3g5gCG9P/NVNhHgAgRS7R/W/uZJd1Pi4llzdkWSPFP22PsngTLzJATvKu8k++26hlRe/LPpl
+          2M9JqrnebTk+zQDcoLO5yMntwdblBT8NgAPjD0qMhOQTEcXOF5k0h8xcdrJjFJriWC4P+ElC
+          tQupY+PexIFE9I2ObXG0yx9E5Yl+jTLiVfKKOpQSl18/MD/N4WZzOZ8z8HNJw9O5FWSfzoaA
+          oshHLNmJRPUwJy6eHLEit/JwwsDrG1Eluul3FTo7ABagAfJ2jQuLOE3Sz8rqZCRRyuykblpk
+          E+nkH/buHcdtGAjA8JBLLFiqSJGSRQ7Co+QoPHqMYLGA1w9JlmTN4/9KA4ZhUSRnhiNbnUQv
+          0vmy03mR6H7zJssc220C62kpzeCbipPpPHt3dx3TbCmz64izRAikb3CAG5hYMIoiktzmdtTd
+          nYk6oHX11fGSEIAyHXGaJV0OksLe6Bdso/ZV2WaKVpueZGfl/FUMw2PRd5JHBhHPC3SvI9hm
+          IrV5s8RZ21Oa8+7MDPDIx2buOf/AjpKaQhKwXPWVZ9Tzw3dsVXQf12VuLyAgpq62BCrT4fFE
+          fekC6D8rX0fh91JUnHTQ4jqoruNN2/zQsy8SjcST4q3ut3Tt5Tgo7JlUrLLvUDUHiDhBtXSS
+          2lZO+S73pbpqRaCyA0Cn0fzXHqmlRGUksF5Dc1LJRHOhaht3prEXQ15QzaSY3KwUhzRpsQay
+          yh6qoZrW4aYP0aCIJOlXA9Js1s/6+ncQYEey7MlsNX3C529P+BI9elOwuisLZaDECHh7d5nl
+          4jNxhSezEVS5eYEImAVdgSzzPuTNqqF8o8uM5jiQgzfEVpijLv89zthzdW/hEv04UshFlBh8
+          jt0Wuj7d+cxPCWn0cw6z/gqwBodM+K+fcfz/S5SblCYizDc/9e7KaMOYSX5Qthdt0ql5ArDa
+          DbvAb3GkE1rjTru7kpvs6Ts5iAUAdZGAekMuUpKHqoWDw9gGe70hXPnjehGKqXYHBejuek02
+          demHt4pFuhoLS0UzOBRw4wAMKU4eDvAp/+zGydRnNmkOYjzFmpyp2Y7m/XTdAUwDfwJXaAmu
+          4qF6sQj9YY5lOVDxsgQH3hidKmuezGblwx2Ows9280LwRTJ5Gl0AWMZMerHD9tNk53c1enK0
+          /FJdlkHc/S3pCIWwl0LUCZu68nocmwYrCNdANaZoRJ+yQHJRlSwPckiLqTkueHYNAHAt36t5
+          dk97dr35Ho06JIhpvPx3TyBdnmJawK2JMp2qx5lc/RLtMpmwEFgbJrYN7e7nt6DoQzgeXZKX
+          /RFAxXGd/wD9kXRITlTI7n0ongbPU+T1j727SW4bhsEw/FHlZLjUMksehUfpUXiUHqVH67RO
+          0onjH9kxLQB8nxPIFgWAAGVjNkU3ogEbHPEMnux/iDhOnU/nZahCZoxj/7iDLZKa35Pqhrtb
+          GMDYOxgeH5us0RIPYBhhdrtZwzQqHwD7K0ZC4iZWEhXdBADheP+7C+/Xj1usWVKj/cy8ybSF
+          uhHuvAjmpal27CGlb/YlOrf6rETitTLI4Q4AsYQZ9eJcDfFDT5cnOyJML+e/KGdJ6UPjHRkX
+          mFicUoWKBOEWfNEB3S6nsu6xcs/gTtMQPwXMbA2+4WY6bAP3ATBq//6GuU2IuQvyJ2msV31I
+          FjYTT1ECfAZvkh6sjj1vVl0PZbs+ZDMrnXRglq+u+yWdMxUAZpTsbEbHZZtFSvwK3z/G7owV
+          WSu1Kibha8xU9VljvBFa0UE6Ti/J5fK1iOfGtx4qwG9Yop1iFV8YnMWywjBWjRDdYUbTJd3B
+          KRbAnabTip3tW9UbE/9jY+JAQjAMuYEr6LtdMetgIrI+2ajTSN+mm70yOMKacag85cRR1kGv
+          0mKiJrGwWBNViH3sVoErLA5FB/f9+tbMQjRCPEXvaMSYlgzF4WIkut+uDfiGFhq1gYXJ1Is+
+          FKI0zlsZqVPunOb4y+MdTNzA4iarLGcLknWegwRJb0qUT4Qxso3snPd/vzzu2QtXss4pZlbb
+          PVwWhJ7mGLNKOmheVovN38zHFnbj2Bo2zSft5FUYkRDbo0Ja9xsenVzmXMIMcqyhsYotlpNV
+          irUe67G+/yUQ4lzqOkKNgTl42YBGax/Nquiz37qOlRRrcIDLlj32bSlcOVMDpT/D0qNuVq8P
+          WOnJ/RSwaJiF9e/lVh142eLSh4zAQ2Y3tY6niBx4vuYnoFZqbDyi2Vjd5KCNHy9Pk5RhRtJ0
+          JSGccN62TrqKjU5w1LIkESOsRVNr1/NFMxTd4Z33/FxcPbu406LutNvc5noeo3hRBKFWU9FG
+          nWp+I5/bI24dr2W4VI9nnPXBj8IvGRcqIUGaqPEi0YENzFRV0aTs+xRW0l8kDwDW/GHvbo7b
+          hoEwDC9oHHBECTykgJSAUlIKSkkpKS3J2DO2OKNfU+K3u+9zky+mSGB/AJjutqs321iCVzta
+          20x/DFrqyQexs7431X7rxXjBEfp4aMluwwRAnErm1GSNPaBx5Qe/8myxrPYEXXINDXcpTpZG
+          hao6Shcha0u6RNxsy88MwmGm/yc87L/GezvcIGMCeO2eU6XOiWV6Pddz65Be5NZ4IPSiuDCh
+          SnlyRrHYsYoNs+r+a2guvUv8MgD4UB+M7mN4ivmbA2LUM8hRxyAJrUPeOpjB6YU69HhFpy9F
+          5OXIap+4NV40O8AQrxeqXUQkR6YQ1s2s7jJfC21Rrjc4rA53KgnJeFdzDJxVoETyeu/y8hDK
+          IWe1S1hf9o7bHoPXfnXY8xSSnpBezWykaaXZWgZ5molznmYiFS0kfEf+fN8rsbRFZ9ovDlC3
+          HE6zRl5FTvHIrvxCWqZTv+cxu7CDH+YVtczB2q2LNuNJr4gsZtadLmEMxd6UHAARmq0TknPR
+          KMOXaJUsb5naSHOsykPlHeIJRAsZOfoY1et6xTUPhrGuaRvTeXzcb6wWgXIIZENAQCew4W7u
+          /sf4tC9KmkUJEumW7MpBsa3cY6FuLrhqPCa4kCC2A0BQ0Xbmu/eNA+zlN9tMlygdXACuWRiv
+          yHt+BoqWs9vgx6TY5no+TLNJoIbn91jorv9Ha/Xz8fwEyz696/Qw0zwYsgsMi50YPreZir2b
+          ev0v4IrnvIcAFN86AD0t7hjq9kXjgFhWEjuOqVD4P3qbftolVAjPis2dzTkV7dx2Cpvp1CSv
+          MGP1+8GTMfMhojffu5ldJhlV6b++TKMTtvy3HMAdFo5+ImlVDiDquUxEyevtrow12FvDY6b6
+          Al85e83bDxwQg8DKHmJbnhkfRzcrZjS08GbY/kr05kwlGblsknD8A1evl1Pu5x1t7JwbqsOC
+          ZrF/qruElI9q6muuDs536fIGKlbhsbEKdT5u8hw8l8cMR2XCzcvq5Dr3DOF92ncM9RouBr26
+          IhiGLsSa5kZVE08N+tTi9ARkBJdKnLn0l527yW0bBsIwPCSYggi60KIH4BF6BB5NR+vR6gAt
+          gghSLMmJ9c3wfZZe2RJ/ht/IuinLI1N3dpSCComjQ3+wgplZz+OaY6dKCrg8ACQfiDQ6OgAQ
+          TGLNBsLrweIqWLaF7D6KcDK04rXSwpjsgOzwbnbKMTyiOHoZXc4rE3rEHQcjoAc0kmxWs5m1
+          70hyXkxcYQX2Qqmj5Ga0lBF+JBzydd7FAYEXfq1fUTc+k9lCBiE2QpNagOJJ4zC8ze+86XbP
+          pF2k8ColCOm2QS2H5O8cgSQ7I/uobDNxPMYxEQu5MNshOv/QmOwAgW3K643CqlZHvSdicRjo
+          zohsTMyMG169sz7J3BcgcGQSWRK9SKxcF/tpSmbbLevOlby1JWWJucM+5ofXo+60NhlUN1rY
+          UuZ2bCnUJ/C9und7UNJv/EJw4K14kd49klmxZaZUfF9x/OMhdDyCAhsKqHMBxz3KRpw4Fl/D
+          0ympHsW45rBFMStxVD/sEXOAmC4fmaVNJHjhP8POtkPF74Q42uEdvZuV4ct7pT0rXtRrS9FC
+          5OrjpXmV4DWU3/du0MDhTTfrjGYAABBYInn6b6Dat58MHKesFXl8VJO9m+/9YIIXNY1l57iB
+          Vi3QThLoncKz7mfBU/5u8LFUNb2m15r0/S3WSr8qPuEh/lFnhZdUPT/VqhvN3DEFnunA5/h7
+          I8BJ+IQw51RH8STtngiavdGfQpM9TbNtTaTcSGwKKuag6/umNtipHIg6lyUUOyI5ufjCyZxc
+          YgsFA+7QhUuDo+HGLxM32RuNMw6c8dw9IZPcgZIBAPMYjg3X9+gaZwE8czmtD57Bumg6evdC
+          tUtPpom549hwWwMQEH2q85JomtYHDOry7h1JuQmAS5TtAj5dntWTG42i2kIdq8+U7KaJ1zJh
+          1/w/5pGzIf65Gu8nYZcw5UK3EzJP/yIKxqkCR4/T9QhPXrXNklwqb4Mv/tpMxXbjFHQ5LhwA
+          YJfXkyFxvz6a2VK2v/drsX3GrvniSPMYBZWTrwl8gUTm4kN7bpKZ/OeOuy+m+4wH2Idi/C97
+          95bcNgxDYRhkOB0+9IHdAacr0RK6hC5FS+80iSdtfIkky9YB+H+PuVpjEAQBZgLgLy9b6j2q
+          t4nvHn4aPJHZSPXK+eqq4g57ARhjkMlEzgnlJCd3EJPzm3o4GSNeb6tOKzDNQ9xDfTeE5DJx
+          REEhqVLPCJeiAuYFQawxbdebupNgsdkUpZNGfnVrwNOOGjo8HgXb+bOdqXKtGRwp22JNuGRf
+          9poLmRk31ChbBAUghtzdXaxOfBCKgGaHmLen8LrikZiASPpmT/fLxE12gdZVxsQpYl8lmVkL
+          MT7auFPN9BA9UtgO/cX+PwSzOyQkQiBqX9ah2faURLeSbTtdZY+S4LXv2+2yJD51b9yeAQBE
+          3JiPlPa+rDorTJk8GmuG7N9kb9Tivdz+rMjjE+0eiA9H1NodhVMqnMSqW+wc7on14BMnSuBV
+          Jr+KyOEyrlo2nRwddQDAlck+cfYbui2SOJeOIdu5qhKsevUVxLTtfZEkHG7NrvthwDLzoa37
+          fP/X593me7/5U4DRzXaU6uA1IhCNFMYBEgNo413txKswBQpw0iTnvVISyzeYefX/wYnZ5pY4
+          OFSB0QM2yIKHv779S7qdUOQ5VCSrmGLrBN1oFMbLoXTbWR6otVcjLyNgkIM5vhLqtEgiBoAz
+          017flRd/n8YjnJS1pU+ngMLa999hQZNpXy4VpO1Hfw1bvZhbKkuuGfBkxfrx5cwlMdf4OJLt
+          qUd/f6fAUzM80SRzEKs04rHLDl18bPD9qy2wr3yhrvpFodHO2nRala0nAbqgeBMjVqrKz2Ol
+          jGCyZbp+2DRXN5gdt2Gpt32RGkkRE4K6fgui23WVHOwMfQBypS+6EVvNLOkFXLY16vZ9oG8Z
+          JmSN0znOjbJu/5OoUKA8Fr1LW5ZHyyCLHQ8O9WmM7Bn9+QAwupPSuL+FVTHisyWYPh7EwzNM
+          9Gce4eXsA7E7Y/3JxXdi94ZDs12RHNxBwNN1zUCo9FXiSO9xNtrsCMA71n9Q3fZW7YbsYAwz
+          L/tEpguJMDrTUwwwA6P4wAh3w9Y2hQpLZDTFziQS7HBZwg2tHjcwoD/s3E1u4zAMhmFKFQoV
+          mIWXXXoxB9FRehQffYAgg8lP3bGdxP4ovs+mQBdpKsskRcnm4TlASLa1qIG6U18xmT5soSgv
+          S4COYnfafFTM6mVLthmFVbeaYWlMUozwB2ms9tG3bOvQGsM/Pns0lB2q1AtexxojrEyvP5C6
+          qvQnuyJztEh93Dz7tDAI6wDwbVBMna4Ik9ZR58H1YAIIR60LPdqJm8/F8UuxZJcmn62HLFHD
+          oG9sMwG3KDWwxOFnw6SCarNrRfSgDbaq2mvFzlXSkaI0fZm9O4zXUXxZv9S6Fq/1YTvL4meG
+          4TghVjtUe11faBAeddz4ZdC9SyHC4TzwV5mwPuoEFxK3eqjZAQCe9FmNTM8s9ksXp0XdGmxP
+          yeH9keyZRh4W7Ec6BS/H20wbeDwC6kbWfJPmpPGQ/k9Y4iMsv6/RpY43ewuyx3KikS0xS3Xh
+          hEu5l61i7CR3n4mrLSfz4jE8XdpyA2SFKqP8/ckCtXcxUzUVe2Q6bYoi/yWzmTVamOD6n4w0
+          GsIodqfJVhmNnlgsE0Ga3X7sJ9u1usM9lZnEYHeb/xPLDP5bndTm6LGhXdmoAL5DAkGXmIph
+          JHtEYx4tEa9q7J6DqX0xTxrzJ5Zquxttud92K3dzTIjby/kwFbrWnGl37O3uFz4TyqWB0xFx
+          HZ7Stzi8mqP1Ds4EQ12xGZ2vNrKdKA2n4ChhTTQWmkv9YTS2mOiU/LhhMBCFAVqNUM+xSeeL
+          klPdSXt/ziixUKUNiVDdQ57yAyBuCBnhqy0jPto4npM2XbZZSfRmQSxF/LZqNouFQyTFTqgM
+          dBqhCHIJBfMC0N1kdREMoFPWjk8qZ/L6XbK08o9Srp+pddQcPE3toeYf7b8UI0hM1a5wbdyX
+          TtjkUz7OrVYfSAXTASVJoe0fO+p2wHsj1SfSNXC8aos0jUArX8DhcaPHmigvr5OFqxeycghZ
+          oOdK2e0XWxgMIro1nH8Q2YNqs4Wr3z3Hs0GihrpXSSyROImRg9S9i12k6cvs/bFIPrqMUn/Y
+          uaMUx2EYjOOKCYMfcwQ/7jF8lD1KjrBHXtgOtANp64Rm80n6/56GgSlNYsuS7Mm68SvB4f/b
+          IJ9oSGUX0OWqzf2DSj5U7Vqd2Yvr8/3J3uhDf8NC9kjuNV5HVTff9GZiQYVXTto7+A++Llkq
+          Z+3oTrmUWhH/p+M/5/Qq6+CCsdp5mh0ze26nAeANDgCV3V35TB7RuKm56BSR1fZYrqghy9gd
+          I07FR4oFxNLthlAxQv3uKx5LfGq55LhM1djU70yUBKoBMsTKqsXBJ8JNM+XbdHlzcVgPkmi7
+          Sju1dJ4FcHDWNGv23i8T12zL+n2dxIfE1l1Jr+jKtGinL9ATvHNS7kGf6A7XOFMLIKx2WqRT
+          eGPLHDAtYx/AbzPZxAdDsffUrwE6FnuBCY5rdcIQ0lsV2ugE+yjUy6hm7nPQojgl/YwAiD9u
+          BhB0KYTYfF8duTBUh8mdLz/QUvbadXyrMq5dSZd7MiCBM5eacs5aWjnGhp90lobGScsdvGfc
+          x4uJ6uiUd338WXA/SvjWAYiHkAPsywImuVeQLHrJI6TIvQmH4hGuhGmzk/IFIbVNGnKPTqIr
+          hHTzA36FXV7DJEBIp1CowkywoxJ2uZBDZ1QghSZ+3q3UK9iJSgXwaJFah1Oq9mETWQ8AIraG
+          2TZUr9uPTzU2Mv0RP4I1nDQV/ZZPfQjDxYZQWCOGbjd0baHP6aqIIPyFtknh+vzdNimr6Gep
+          KTRjEBqnKkHkJxfxS+/2d3vO0RTkwCIAp/TWBQpEbGNA7bLQ+AfgTaPjBgAufAV6mVBkPAMa
+          uqEaQpmr+7DaQAOCk43wLVdwYpYhlzhplEeTbXJ6fEXrwgGPU+MixTgjmtw0nv7PjASco7+s
+          Or0ctxXDKzviKiHTnUlzw8PXTdSTs/DLedX4p/pr0832cYu9UFMlYwD2ovTLSiLx/8vOveS2
+          DsNQGKZ0hcJDLUFL8VLuUrT0Iu0gQKCkdmA7h9T/DRogKJyHLZGi6IDNwic6E1Fso5NUkpnV
+          6UeQYH9QoYcYEoWX0asXQrCEZI8WYjfAggxgon+QXBwSAEBGB8CzderimLdWQ0ru8IOM5zRf
+          tgl9CcylCFePbO/9f7oyY0rTTCRvyMH6QYBHwVugdvHyhUhHPWxT4mXF3d6VXjyZ2SbFBKjD
+          AMBGLnL1z+dWcST7IXBczgYA6GHrYmSmXAkbZIfZTbahxHQACJOdUX6Qfng6SU7eJmCSP0AJ
+          MJcy/DaR7eWWPjN0qkBcoHYTRpvUjZbd6W2b/rTYUXQyfitHzzDNx8FSkSvUgWpnyoMnThom
+          7ZKPmUgUcMdkOFJ3DO5KvJ1HoBqKl3sM8Re5etBVSvxIhHiXrV9ECAndfk1ai8xyaTRrZbyB
+          lUlM3u+WyTYSpVS02q8q8F4gmg6pXKzHL24WcptYuhVPl3OYZUho5faHysGUH41qmpLkJ16v
+          9lKNOmBwhaQ+LyU7WPOQsTkgXRtz0/bh5o0CgECgCFPO6HZTWDZHt05RDeiOSqVh5pCJFLta
+          D1jiY8Wxl3Iu9JpgHaaRxMyMjW+Ix7J8f9zWetbVk92wJvt2WbQAjJ/pe6lxfoRMB6RbVTmG
+          N4m1COWYyVDdAIDDs9gaLyb3cXWKiiw0eEtnWpgdOQAATlCOS4cXG0u2mpXdB0mWfKazq6c6
+          PJslH5VJUgHch39n7xdEcXjWQlyT3axvWkFRqAfgSibjIO1SV+0v/+xM3VMbwbkXbXo8RmPA
+          RFRsp4n7DABgQCZVj00r/ZrsVtV9vjamHoydEekc779B4gfDtaZD+EY4A5Q0eyoJFHSWQ0LU
+          yqSEGH1MyQ7XqaJqWGykW1tuD2woCiJ2SKlxJ/7PlwKgIlYJkhLTJL7ZuYMjt2EYCsOgwgOP
+          LIGlMLeUpdIzmRx27LG19I5sPQD/V4DXskgABKTd7c5OpqVeA2Un4L0OGLaCOAAgnm53OtGd
+          6I6QOKgiUHO90DVPodiXthHHREdL/M8CKd6j+5cm0Heiqo/pjwEArnKfYHvkJ2d+2/Uaz5uJ
+          U+279xMajSPT2QXA95LEz3+G9LfLcAHwv4sk0BUEM3YccDTAy6ww9Ayombn4zG/4fgWRZo60
+          yQEBDnV7qGbP4xSJShpP18kieyECCmx4RyxOaLJ4bmwyEwSqTfWZjvekX1JfPQA8033PmRDa
+          sPN01anqZqs2haMIbf/rJ91AWLPzvKumKO2v61R7zRb5fih2uyL8rvGEKrIkcpvs3vOqmxlR
+          iBUGILBiq2aI2ff27u/dSSf6yXbSBgZyvL0HuG7RjKv26V6YoUYz/dXsgE4jMwyJzn0EztcY
+          6RsAHvHU1nwdiRAfNC7fEsOe42GHfDbxKthrh8br98aCsJ32MG2V8KVmhCTseagabtviqa6y
+          aMoHrqg526iidetLKDxBBfMev+wR6hgkE3WVTv26nblABNVh4VVtDaULvLSNNGO8WgcUQBAl
+          ZHSnLMY5CX3akcZiRWwBmjtjbbuL5tUMquynzctvs1JdBcTG0B+ZbAZpeW5Qy335+LldZkIp
+          dHQBdHR7gEyZ0rTy81PX9Bwnq1mlseOErxvU7V6wKQAPfzlKlaMdbaBC/+0FjKVi25wE4FvD
+          GrFcT/Gw2YnygEQ8pGviyhAuB70vJV/n/Wx2W+L473Y7XU2wbQNRPhZtZm53FtEdLBzE16uZ
+          zZC9Ga8zX2qsG0Pr7bfhK0/sFwwFqh0ofiYW71X/X7Jsd0ZctuWCQzVS9geeqWIdw3WkOuAY
+          XSgf+HVPNxe7HrRZPm/Il9PVVuxSS+MvO3eMGzkMQ2GYElKodLmljqKj6Sh71AUWC2SwjhNN
+          4Iweyf8rJ0U8Mk1RlDzqYwolYXJVs+ewbHDlIU6puJBQjXvi3WfJIjqYDr3ZA8ld1SvSkxEB
+          KuyOmB9PhblesHY2XDMqpw9IbpDAUl5Atyue/xWAeObpA/V+NStLCPTeQc2KWCrJA2COdaS3
+          RAcBmm0wKGoicNgsG7aEVB5AmNeQgO/pPDfQVtQOiQFifrEA0sFeFwBERHb3a+r1LQkn3O9w
+          GluH0Lsy0HXYB7qfkB9tdTJilwneVRvfzs/V2NxLzuvBd4enH3DLflWzatOscTJJqk7POiXs
+          T6AtcnoM80WAix6l1K+A4Etu52hgnUxiCtBca9sHEThz3gHPuuiMJEB2J5FDYgH4LutlZu4Y
+          SWVSN/GyMpTHplel31TvLu5VfT8u8KXbB2Ynyaj96lfitDDsnVQfLg8OV1whLveajCg+Mw6z
+          kqirfDhvF+TQOTJgtj/ykZDLYrYS6EiFuh33ZPffJm4ud7k4cBoERz/MpuxMwYr4H9WRdVnD
+          Iy+qWSiqSh1N709JlZzCaBf5GVD1wrMvl/H7+7WscMVkyu7witsMbTQ/YnE+LwpqtkT9kLJl
+          vUzo7xaJ76o2myulHI8XnDjs1YqLq/Rp7mpbdfWJxUnFd1b4NYLXm92sigdGLhRBf2nP/Mo3
+          qdhPaPoTCB7laelTG6CfPkiz0lKYi0j/3qgndUeXSvBfGDr3vvgIp243O9gPfyC/ygq95XWt
+          +r10bFCdxkpj2Yowin1NuzqCj2omtDCNKEeG/ZTqrXuBLETe6BrSnewrRWSiFLmJ0J6GomiM
+          HpJ1Q5HP9rqCykTbvPyDxk618jLXX98wQDoIZbp6eY+CB1jCYj6K+XwOnHInAMnbuFD+Dw8K
+          BgBP4+RCItU2qcu9Gd7EwJ0LrJElDA6n3U3Q3wUCN9W8XndeU3XLcNqrzaB7q3/YuaPb1mEY
+          CsOUoAc9egSPotE0+sVF0cIt4sSO3eqQ+r8BCkdhKIqUyw2FWyRTGvl3+yPVzJL0vQM2HW2e
+          cuVWl/gTAFs+xCSyHvxabKvELD5ptwJQpNFF+bT4H64rbERe1uo16W9nsZ+WIhIBwI5xF94X
+          F3tQjKYp9KRBrZl25bha7CDOy6dIzUdmVs2MHWM2TGbgTCX8AQAvJGvzJPnVhunyTxhYub81
+          0hycwpkvTEevI6a1t2g9DcaqLtNn1ero8t81/IUQoKlptkEdFhDKlyViqKwzsYqz5svIzY7g
+          JyUt39toaYtZ4laPFJZShvOTs0JThB3glBhzRo/0hhZBJZUlb7ajusi7ZHcgRqWGpwgXxNbs
+          m0I/YU+0Egr9lojN6nE+vlbu2o8HNQ6mWrhFdZbKZDR3XVmKnv9E33QFoCHZASST2WTrZjX0
+          l6x+lAYAqT1ePam7O6hCGb1B+PP6wnsN0fKsdtnK4cGz/E4EF29FweaB0qWQTG8WhEV8gSJj
+          sQFARHVdM5/h+yoyX8wcFN9pSz8q50KJN6OyDQkPcQsAeIP7ivmhMqIYWxnHHRAg5JTvEzDj
+          8UYmaU6drTjY+JXPxO4aaY5VI25hOClg/1lrU8RBItkNcCt46gv+8QDe/sc+uhZ8VgDYyPqj
+          nWIPZIUjPocKoxZ9iNnqnLI90XmjSXkSnDgbKC3A8vFutsrj3KGMiPmVbWZSKlNV4EPoEK92
+          EHMtYYvY39GmXnEhEC7mkPUlVf5/DSJLtiNE4+8hWvhhKO6WwhEh/GiCp/4A0q9k8axyHk6H
+          Nxu1knCOHkIwikX8aldlQvg55f2t20ayFqnYzoc/i0KTOM66R6J4QIgaXg4eEUJqpN8n8EQe
+          c89uR3ZwsMEr2eFUNV8qsjtFYRR9Ncvuwve9ynf9yvJanR9+C57XpdhYhRICfiaLwlqsxATf
+          E0Ju/uK7PmMMLeOLc67DOLUe+FKbnSM6gSZi/16+lruXmAk7ZrBysP7Hzt0juQ3DYBgGOSo4
+          qXgEHoVHyJFU5thpvBmPx87aK8v6Puh96i28/AFBgPYOLtG36yTdwC5lviVtyKn7xO9F9FoO
+          wN9UOh2UZf7foKTQx5KLbPmwtm5ZD/EpK2Y+foW4dh05KRNa8HmSeDzSd2w13XLQYtplwpdJ
+          gpjrJGT70c8AhMPxEAqwlQgK4NzG1sLadCyOqGX1ZKcuqD9DVY2366pxqyhWRSXPFiTEGwtM
+          0eRa8ySTOLXOpcYjjYCXCRtKwqo+eSP2V3zaIXhgzfQkq958pi5TR5IaJivt+DUOeKkZy2iL
+          e6+A3B0qTPY8NmuWUZMHYgkUMvW0hGOHrxnXhMo8gCWFZypGiBPPqdvyockylbqqMvy7dil6
+          3OimZbVBsxNPaTXJHcm3EEPP1edrrMwV3m1ynwEe0wjhZcSndS6B9ma8S0+SqVvlWhzM/6ju
+          C71FY9uo9B09qJnxHIpAZ9XjmlkrRt9qXGcDSxzeqmUKvEEjAQe0sKNUDO8yGwnXqZnnJvb4
+          Uur/DZN1XA/vqvqhrLmf5U27YnhkCgrbjZTcctoMSVSymTv7KdQxyYkBokpCVTh17PExI0Xe
+          wCvl+7FG4oUHKLPAO8CyjCWUndbkSrA/HPdrYz0+pn0uSLSfJ9hDcehOhpF9FQkftOoLtC9x
+          Xz/VVY0LiTGCGM98cZpYDWwwGuc9aVNua74fRW0uCSPZKIC7Kqeudy+B6G5u+fxPoq4HVGIW
+          akNieER6cc6DAw/NjSnU7xCnsPWJ9wSYbGuaiT2zEj/BVRBfeI13fEynFY2Utc8STyOrOYsS
+          Slrc6gJxnRMBwEu42H2HrB2bFnnR2VgzItYdP3dnySfD7EFaj+hZ75kX+ZI0n2pUcn+imE5d
+          OeIca0/8iXDPIKtFuVEDvITuqu5mpU2U3FBMhrpQ7sUOgGFgp44Fm8WKPGZsN/+yd8fKbcMw
+          GMdBngaNvE4dOfYx+Gh69Cp3uZ4utVM6VSR8wP+3JFNiixQIgJTdJDuTPDoRmb/RLdd3wqvt
+          hkjaTA6EoJjaTlR76Ke9Wxhv+LOYjdC5kY/zD80+6jJnFtIRrDgBfcMus50ZZDuR2zGGwsVe
+          7pL8VMc0neEtd49Rt90guYOKqLuqsoU/JGy5bifMKpGyfvnuvoeDmpk1j9vvL/FVcgKvSJVT
+          E+yvUk9/WqHrl6yrPcQ2oBPl3kR42NdUGjwIjXUb7MC5stoDlQJ3mlJieWkno3KXYwJ7nH/h
+          owNwg/VD6N/saOEuhbjwUy/8G4yN9RpJrbYbYvGsPP59N7i7Q4nTuh5ue003XfMmf/jtO2xB
+          dqnfB1dyZgLAcz72nopggB124OdS3v7i4XDve+g9qFGkokEszW7V7R+G+wQfqazCdxt3QHrl
+          yimyOm4MNc6UgZQSuljMlY8Hcy7+VqPa69wUEgAm0EqHuO6wjwSCiVR2LlAQIKNhO5G/CuFP
+          5en2TaqLwLvZEyJXURkdciTC4gr8t7WyniKJevnW4bAjtzlwZff0Ztv5M2Cb+h9+bzB2baPb
+          OMXh84ICjzhOYYCdYjoDHIzQX89E3xYBUlaWBkxqdjDixr8qtUC4PB4STuASz11G5u4FSSq2
+          cxkYoxPNBGHW1+nxYxvIbZxCwEnFPMlDdKyrPRMuvyBHd07tGw0kRVtj3eJgDGS1NL1FGkR4
+          I9l5b7mLF2hWQs0kiLxMwRcrrQcdr43iMqZclehib+jsYk5R6V8Df/iOmcUuU301pZYo2aCI
+          6nZiAvB6c+aqiWRUmQnESsJDhj5mToTatF73fhoz91OcNeKtA0mUBKsrwLrkUfNWTACnVJ2D
+          U7aIbJ0JzaPtP4nVn6EXNosuLXCHbkdFJqchHOY07FxBPxWVRRATX8901vT6Ye51+4LCiRx1
+          EaM7cIpf5lz3Viqwy+SGbiD/zd4d5LgNw1AYpgwthK58BB1FR9MReuS2aFGkaZpMXHn8SP7f
+          cgYIHEemRJFK6on1g2oHDPIIL4qN1x+yZjsnoJw6NTPzev3z2f+EbgiAcKqdbl4/QRAr4ecX
+          DRiRcM5BIwLwQwsXfucpD+ekn0HNtDcEWaEo9I/5LWCksgeL7puPfJ8nRfOzcKDYYt0e2TS+
+          Kh8uMT6wwMHDqmPPU98Xe588+J9stPs/OFprFrs1PnqFDFlAevsH/LbqpjD/eLphkItdzdXV
+          wo3m/9m40RYkqp3t3+iERzBSI9B4IraNlV5NthtXtZJPplUAAKzbErO7PKMh0RDQFZaSUV2/
+          RPabf5VPriFVzoHlHWzA29opAa1tEhOH8qkpua2wFDa7QdNHqmcFizTWkJDVl9Ytqo04M27R
+          mQAk9o2c4x4CL0XYC/U86yAF8kPN0BHUzpfefRRDOb4mshd6thn2nSHFAEZC+hWiQaJKkBFT
+          i5ntLEoXqiTummr4QIqQtqNlqypfvtrtnzhMF9yUfCngCLeVyGZPuIn2nWRTB4kiEtntlstf
+          3xOdpHZ7jP6+C33xdz/Z6eEc5lF13dp6uInuL7mIwaLRSNpmy23qOVgnd8yKEPGbfBwBO+XA
+          pV1hxXqMGYScOB423pEWSxsk0u0dk7lfCQ3B37H0YcMEAP5XWVwA/2oKWCaAZBfB1QCnuwFL
+          m9EqXGulIdK1zeZfK169MeJ65Di5zED6u1lqvLgMf7w2tQAgBuA1hwc8ut2j/goAvwySPuTR
+          7Sd2yZAAQxPQrzP9iSiAiwqUvb1aMOk3pZHPAEAgfjs6OTx58rRdOAQhhGTDOJQBJNKvnP4L
+          kQaAS08a3osNsqc7CvkWJJDnQg/xGnhgdnrGF2jRygMKOLrD3jX4+PGNnTvGcRsGogBKGSpc
+          6ggscwyVKZMb6ehBgiAwEkewDHv3j/hevYXWkoYzw6EArAsMao2vrdaAEkb39SS6fRGNqUFs
+          rS3Fk5u4xQhb0hgzu6NGCeqmUVX4xlVv7zIf+EtlL/Jp7tFEuJEY/NeQ64DKirW5Cru2PQ54
+          /C+6By4+I0v4BXvbdznTPzt0IAA+So8IeBCtV+q1/7EF7BSoNo+yRzGoKmEl1tTeYJlL7Q3Z
+          eoBjrLlkBdje3mjRhaTKwwr78ksIuKtgZlLzjeoOADwptxE81dpZXyOugoqmtXJwUh+c39Ke
+          saUE57yjg5V/DOA8NifmYBSb/GUs2/kT14QxxMz+LA9ZT3IrI9rx7EmO7jCcfh3rNVLXD6z/
+          nnivtn1T5DJJu93XS8GnJz2Nz+wC8JxFCP5lcxSEMjEYeNik4CilVEOm1MUyYgU0aDpTdysP
+          4BCLBp+vXHL0k2/EwMfr3i7gZa4F23JBKdP6ytH6Va0BkKHQmoj7msTgfD1eC+op/NRGlHG9
+          Hbc5kvKPhPsCRQU19aCg7+0v31q4NfwTNopYcx7jMP5LAoXP6KYSZYQlDeCwKbITvmN5TS4z
+          K0fHk/DB3UfJkEBABs5gbimtGShpmQut9elzFHaZCLS2G4r/UIIHA5J0l1H4NEJJ8/7sSC81
+          XOLhAfNhwEkkhKuvjfKd09GUGhJL7/OlXx8wkktut0OwHNwiJQQYllmDWzotZ5ebjsPnPtBf
+          Epv6YDGFY1Z5D/xg7w5y24aBKIDSghZCVz6Clj2Glj2WjpKjFgWMNm1cQHZk5HP43iorI7DJ
+          4QyHoviHDgIVJB+T4PW+f2utvTU+Z3bvBxjtz9vOX5C3Tn4dCfB47KToMA/k2n5RuvUUMUy5
+          JHPb19YmvSxRg4MERIA0PzrZmgFbdMDZFr0kIMtVo4rOTe2w2cNK0OsrPDJ5md970Y/vaQgS
+          bq37SGuVdKvvXyGEUrMz1s7P2F4RAvd1lHMq13ZjTHfhNs49bGNxHNVQA1bqTB0OAHFXzvHy
+          KnspAECvVscI/uZ4QYqtneDkl2dfSheqNtW/XuTAQFQnhy4TObZ2h9YTp5rDd86z/zuAYOsi
+          syVYvbFZarPJ7mVtpQYrafYnK73L3Vg0td1Wseg+hojfZn/5R80WLSDY1G5szQBJ1ENASJmH
+          2MxxpjLpru1BoqgDbmC43xMWnCuHV4hsrIblRYvaoypLLqG29h9ZCVKYMuvXmJbMt6rXmSWr
+          bwG5KrzK6q4BYGRR9ztmpjObTgRAiqAtJ2rp/9bruWh2CIxl6a9cfJT2Fyc4NkMunSXdRvQw
+          RPPjlNIAVQjDlDIHfhIoNcik2UIMi+47a9DE9SQk8Ky3338Vzqj7302RDJ5oKj1UOmaUozbB
+          tRLVhSWICLABN5ZRu4rzbRB3+nVqD5GfQdIEpoQ/g6NKeqrI4zmzJjd8sEwxs0Hqzkdlcpef
+          7N27UcNAEADQs0eBQw8VuBSFlHUlUAKlEjAECsDII/B+3qsAM6e9/ckGoIH4uYxu/z3WkBrQ
+          QN0w468dO2NU+uCmLONSK6jGv7hE8Z+57EVcQkV3yO86NqZLe6tVBzWvdRxu3upnSpQTv9aD
+          UJF+DxlB4c9Rl1SdiNbC0R12mnVXPtxAHOV28eYcbUiKACLLkISnnRmoHqpI/JhQWN1yMv66
+          mwIH2CfCRvx5zAwBll6cSLqZ43CnsWZojtCQmokm5h81gJfT7n5kr63ZS+KJQRn+1ZAuvJ6D
+          1za/vPlm6dFIPMv3U+9T4C6QqS732QeBfOJ/DcI18d8OVLOMjVvc8Bq/wSTbA1KSgJJB/DQA
+          /sfs+mTYKuKe6+KgAATV/v0PRXdb1xzvdcc/oXZ6gKeb40hvA55q3WYCJfbdIUB0R4u/op3R
+          3e5VmjK7FlkIfLp5MqCuOfaQxnfVfhwLUJLoDslcxj56ktkpmCjHoQ4xiRDRd/Mg5GUzGADu
+          OHhZON7PGoTfELN5EVv76skKdGntzzeNbU7/Ejl1aPQ9T5CfPmQsoaN7RQoHIFz/Ln1gstTZ
+          ghQF2lE4AgCYcPPFWj6hnR+o5l5fxjhp90BcZ+2ZwuZ4fyS6l54z/e5DWHGrJUkeskY/fOpO
+          Wj2R9KWXQnhJfn0vYC5DKFLLh3hp+4O9O8dpIAgCADhrbbAhT9inzBN4kp9OgLBkgy0fAvqo
+          SsiI2jN9jV1Zl9Pd9m8fc1wR8zopWKi6am+L2OhQjJKBUWL5ZK29PWuycBmSSfsz7sLkgn9M
+          AIBqUmaP++efvDm7Rn8f0nvu5nCHRpZviUDMnMZREs/B2OnfLMM+5h2SzGsgpUVDgdrENEBi
+          DnEIq27DSNPgusCTJu1m4qp7XCbjdCdraJgZASm0mTP54hfOWAS+JAvqbHWSElj4uu/SjP4f
+          fUFSY/uW8TP1ABkeOdMZM7LyNgMogK6OL7TLljHHWNvkGwrV2I7qJNow2VCucH4pz1+7r9fk
+          zZxLm2c2KcWPLHCyAHoqJKMLSQZv6xhjRi8gBCtqgVt0Qrtbx0muw3cKV8JFJdDkcQsAAACv
+          PvDo82h5UTgnoXVIJ9OngO5svN9idyCtUyr+LpUEKGQ+uuc4n10EtrU+Dum6TjzpuEctgadk
+          GqhLMwZ6pDN6g9QlogHUB8AYXhICfDmMY4bvowk//kVCDXVeDWUX/1KDE/EPxl3FvN3VNcux
+          hLsIU24HwqZtQR/rOLP7OT/y0pIBfmJ1gDxEGLEVGfvGf9gClKVmBeDvasWtQqHq6gRi+GDv
+          jm4aiGEAgDr3BXz1gwEY5UZjFEYFqUIIpBx3ldpznPcWqNQ2ie04SZGCCMxJKZC5/wh2nWam
+          1xGAwQhcGKZZ3Z8VwOQ51MLFbkozcKqX4H+LhYei9IcBVCQn4hY6hch2PWe6SDXh5Kq/Guiz
+          DQPArluc3QJ8lTYv4m6W9/hWPXOEjEbsZfP8AVJq2GCdIGVCZQoWywwoZUnBWIK80vVUMN+P
+          k3LlYkizjBnAfADaf1NZY0uq6oriHgAgxuyyp4qtT8jIYCMVURIJ2WpnUq/xy0dgbWMAT3FE
+          tY8HqDqBKYYD9FrIFhMs1TQH/aF4cA8Y6Qx3fs2zHUQ0aSSUk6lhUmADPMhFoHt6EZcUajzh
+          kSmWATiiSMHwh+wQ4J7vWayyWEqxxQRoYairRZfXwAAADrKnyl7aCFKRsABnaW8RsRaOG54D
+          AIANyzwNpkANF1U1mwDA0Mw8X3yrc2sOwlGRvuwO54CLc2EK9fwNVJRmrjSIAQCQ047octTq
+          xCd793LbIBAEAHSNfHBulOBSKI0SUnJOUQSOLFAceT7vNWAEZpgZZherUQAAABUCANRk0Azg
+          7WZLEQCa0V4DAKp4+a7XU5lMSXUPpGBfDZrKvag499GTR4jNVMpUByi0gjAgRHBucaA+D2Pg
+          X9x1i0oK3r2/ezYC3QhYP5xcyJKy4YJCvX95zBZI/vMKtBczvKo7aWkah8Ts9xPNMt5oHpAl
+          CKYwJwsBPPJhVupbxgHXNHnotX6dDMBh0rnyrGQDvhkhaCVwSXqGPAWeEt37+Ez6hlLkRcIC
+          Xn0DsA/0U4WWvhk4ElsNCxP68uulQG4pMjkaks4A7c1jY432et26DjpR9gKUM4XOZ8IeGP0s
+          Yy/jTwCwo2LmwSXwAh3JMWms4+8+BrzS2nIyxJwBsYS689weoS3jqMl1BQD4he2LyO8ynrLK
+          GgDTVwBGTaCDgDWrEUkACOQ2NhalxNacI79qLNA4YaBDoadFb/uEuy+kBHYzogJnREtnhFLg
+          i727x00YCMIAukEuXKKcwEWKHIOjcfQoRQrLEnEBYr7Z9yRaZIS9Oz/rXV7fuPkc53R+eU6f
+          CSB6iaRCapY1sPvjHiNavehbXbaFi0QKANplPvPxfxwoulNE3UpMbIrNwWISoJnFwAUAWk+8
+          nWoI/3KsAUAXRmZBOkA5Wl8AKRvmQglCBwCgIi13AABo7Gsf/m/jjBnXqMiMgllSRiMhQ2YM
+          Zyv05PQmGqq7ywu05bGjuHU8lhtfWTwHClkA0M1Nogp9eTsynjoEoS6Jt7iCB4BABeRfkCCq
+          Cmml6NyiblYQ4xjdJ3Mdb7M5HZNXuxnHzXZQcgpkiEn/2FcDmI6dIgA4Qa2DQpaxc5Wk0dxW
+          8qsAmEpI+ybkMsGbMgwLgf1IJLX0tu2CVJM4QXRv4Eg4AzCT+5T1iE0dEsg35wAO2udM60Or
+          nSz3oAP1QDEcgGdbfz/2oQGhFaSzqo4HZiz9pF431XyP4kRhP+zdQW7CQAwF0AxiwTJH6FFy
+          NI5eVeoGJECBSHyP39tXQjSZ8dgeAzDrjU+9FHXdJxpbx6gmqBFOLoWy4UJ4Z1m/Da+Pei8L
+          APNYl2MMh4XiwkNhIJaFPdeB/5sWjcBO5vh9bWZyUiBnCiUDjuj3reQ3yiHhzFy9s0OI38F4
+          p0oeV5MfyyO5nxmglevyDRcLO7Z/gB7c95GMbGP77K9TAnUQdNveAO7UbiMQUhHXggzauQGA
+          qTmFwaxkxanmR2WMGzUvq4qseCao4UUiXbTEv6DqlHCGDJ5EehMckGs7fHW/lhvRAU0uB9mM
+          ssmlwOyEQw2NOtMXoVlgDCTRBpFNKgF6U93lIfdlAZh7dXdUBQCgslUvC4Gcs+AVnYrqUz2M
+          ZZ/KU68BqrJi+gLZZevca++sTwer5x0AinI4A0hkqhLc2rwhAPxpWb4p8jHJaRorHCqdPe8E
+          dlNC09EBgMGyfZ2nunEE0hMA4NQOsM/JmAue0b0OwOfl/os6jC2xrl/27iA3YSAIAqCNcuDI
+          k3zMs/z0KDmFSCG2IkT3btUHsMQytmd7h9vyQ+EnwAOGOgKAHDNfrJ/y68bWObzQmt7LVNsL
+          RSyqvTNuXHzKFkA9BBjH9fVP+OkdoIi3HkQCIMPmBwpwXk7gHai3SvQDDMhGGcB/7cEF9hIV
+          ViPTOk6YtvGauVMxF9g6A6j2lhce2wTE+viuYJBk7jPtghUYskc0jzNwx78MJI9BACgWVk1t
+          cAEAADzNev5sdtieUMAlAKDzx5yKA2ZhuwAAnzojMl5J6baZdMr01HFG9Et1v3a1ZtyMgFLF
+          DUMAYCoRE0bb6CMBqfa/ir5yBoAdGoDJqe4A30Q3249W7NacwzRTMLEcwHlrgDzbcpzqDo+Y
+          dwGDECJlIvJybXQOAW8SANBB8xuAXO8LAOFKtm9KLhPOu2m9c8imPJJBzIk5yc8wkYvkiFsi
+          QNxpQOCDvXvHTRgKogCKEUVKLyFllpGleQlZQpaKkCgAgT8CxHzOadKlwR6/uW+efckIMADw
+          SqPOAABI9P7cKmQylX077geQj7TDiAyYHK1oU3V35ZBcxENFP7vgfDcQ4LGDbQLqsTEDQILn
+          gUgJyGQ8/83zj++ROFLmBzWiBlCxuoewD95Js31qxkyhSIZWEvfYnNQv2zeLM9c/8bOO0NeV
+          IzHM+e1yIxDd1uqu9YO13n+HDJ4jZBM42vZIYl6a6CVdEAXh+mtIx9FBVpkSLtHpaVLi6KPl
+          S1FHaxkWBdk9FZmDvB200AAe+eSmr4PArKypdvV4RQJJFdqbCv+pBVJW94/5Mh/GSqbLCe7v
+          iZlY6Q90XNXDYnWfRDOsUGSfyRk5FgVuCiMVZS0DnchYgcYk3HRSuV20nAF4YHCAAxoecqq8
+          7AO4cOhV3SE8SSvSOkhjfjZHg8oGLhkAcld3nQshmFcHAAB7/ToJqocwz/nfUYGXGwEAuY36
+          XYhtX7Yp5kro6g6Y0aKiodDXXtyJR/bu3bZhGAgAqCiocOkiA2QUj6bR08SNYCgqQvs+7w1g
+          GMbxTB6PZEU5Y/GU3wiAxq0R5Dk1DQBg459ubKvSyG3+TszmfwcgNzVqcjCJ97M0ICEDVCS7
+          KxA15GGXp7ubSTCSAAr5nnvr2LB04CMe0+Yow4FRgNzkY4Bgbst1brUAe5CQ6GoDu6jI7gD5
+          WCyezGy+FlrZjQ0qck5t2XVyEppaCpnsgVvl5XeEDfwyVaGPbbkk5NaWdk6m26INn6eHaxoq
+          2sJ+GDDHam5D1tZGWJbA0yA4FTIFl8nj5jLUJbp5T3bfIwarDa7q1gBRBgefD/NyLLr7EfYA
+          lYzYB6CcsgKYYLxqtw3y7/KSZ6tAiRW1HFmcCyxGKenwPJMUSg3HUA7Xbgk53BOWZihtWL7S
+          3ZZoVqJ+yFHhTsJo3wcgBG/N0MBa50WD4F+PQGR3AAD7TABRhN4q1VHMnzId3wtVX1SeQmwA
+          ADUlbLnVZ8A/Gk2GDf0IU2hQ3Ce/PcyHAC/FHPUAwa06UuCHvXvHURgGAgAaIYqUPoKPknJL
+          jrRH34Zu+SQoEvN5r0GiwiJyxjNjG4DotuWFGeKMu58FzjGdjk4f48Dsrs5EEb+dZ3c5JwAA
+          Kqt3rEy9EfFIrGtAIJ56c2G9EQE8yaMP7eAABR2b3XO33wjdO5mq8QDUYx1Oqtv3ADC7y8fQ
+          lwsaAI67LZCaHdfgYg0AoB7b+ggmRh8u5JEqXZPqxxLQEOwQ21SLB7EAzawtlrNr0XGhtGlj
+          LUnM+6cnn9AE+mCChT2kT0lr3VmP8jbhS4a6KSRbyzqNgOJ1pk3oTs8VXrf6GgCQ3hDL8F/M
+          1IuUOTRfcOOPd3MBT113fDk9TGR3U14E6OXyKi0ipgbHlAGE0KcbfdUfxqeGzkMAoJwhNQPA
+          x4acFO8USmCqwgLEPeYFEM7wFdfK74FaowGIlWMBAKE7bdlQzqk2jxfcpQ0vdGgCHVi1QXb6
+          DDjPxSuEPlRj/9i7gxuEYRgAgFYFEuLFgwH6ZAxG6yiMyhehUhVBKye+G6DqI00cx3Vo2OEv
+          wcItAGA9ySicugDwgWw3lWhZClDMtOsyMNg0s727ineIGBUOQLNkjgCAZZdIT0ADAAAiY7p1
+          CmjWOd6VS9oAAGTnt2ygnNGOFKAvBSLaiz+yAHQBBsByQFkFtr0ATdEtEtzeDkDGm0KkhJgx
+          JnoKbEcXYOiKbxWgJ5NzBVKTS6EDJljyMBpBcgRmpWtBqUkrq6UdxcY9ezeIGQwhyGOQ2wRw
+          RwF0QSxD96uBrTTNjI/JARcN0PUaVlECxIJawThs7BGvjgEdWMzVZet3AADQUABU5DVJYGgy
+          qX4PAMyI4FwKACBVITAkp7IR4DcHV3jA9+fzwhnSM3FTjJmUKk5rJv1rAKoLANC9hid7d2zE
+          IAxDAdTnS0GZEXyZJmMxQkZOmSKBAAVI9nsTUBjOluRPPjX4VsdbAgAYI4BQdMcAApRmAMjK
+          pTuA6GZlEACiEANI8JkuSKmVNa8CwAFKMzDOXMCjAAAAI50BAPD7XnpnWYN2FABwmVaSkw2J
+          8XYAACCUm5Mqe0xSrwEAtHtgkfRhtjJGAMAf1YYAoEdz2rTotA8OsMyFa/hJqRuAJLTHCE4t
+          BQD4kFcNoVUHVRDDCnCGFnzMQGuXw+pNsiQE3k975wB6owpJGhYrwFlqoqmDeGVRAAC4UhXw
+          CwD0q5Ud/DUBIIl7WfQskM/srhwISIJVjqsMziAwAzHZyHbDLr8szwkQ1PRdjPGdhjd7d4yC
+          MBBEAXRWUmgXPIFHydE8uqWiECQo2b95r0qqVIHdz/AH4k2SFIARzYoZAY6m5fVKAgBsEVqp
+          DcDftJ7aKRnMtQAAgEiLmyIAAADoYQIAACCCmmt2t8hS4CfU3AAAG/TYveSiCgBEs8YVALDW
+          ABJIIYkx1xa6IQH2Nd3rk9kwkki6AQ6uvb3nfQAAGNG5gBX+OQCgI8vzsd3q1aUAAJKdTK2D
+          yUYAYGCOM3RtKmCd7ZIAABBPQxIAAABZzBlwUEIcAAAAuhrEVXPNbposBQAAUpzrC7OLKgA8
+          2LtjIwBhGAaAKSgoGYnRMjo9VKSK7P8ZKHycIoF+GzZgSxugrunuAHEZ+vGxAmQ6xjccbCob
+          AEgxlcMAAECI159IJZEUd6sgAAAAII0gMJ1INgIA4ZwzAAAAAAsWg8BbjPbBf8b2AIAOnDMg
+          ZwAAVOe9E8DmTouUAAAABLsGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDDHhwIAAAAAAD5
+          vzaCqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqwBwcCAAAAAED+r42gqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqirswYEAAAAAAJD/ayOoqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgp7cCAAAAAAAOT/
+          2giqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqsIeHAgAAAAAAPm/NoKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqrAHBwIAAAAAQP6vjaCqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqKuzBgQAAAAAAkP9r
+          I6iqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqCntwIAAAAAAA5P/aCKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqwh4cCAAAAAAA+b82gqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsAcHAgAAAABA/q+N
+          oKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqoq7MGBAAAAAACQ/2sjqKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqoKe3AgAAAAAADk/9oIqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqrCHhwIAAAAAAD5vzaC
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqwBwcCAAAAAED+r42gqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqirswYEAAAAAAJD/ayOoqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqgp7cCAAAAAAAOT/2giq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqsIeHAgAAAAAAPm/NoKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqrAHBwIAAAAAQP6vjaCqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqKuzBgQAAAAAAkP9rI6iq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqCntwIAAAAAAA5P/aCKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqwh4cCAAAAAAA+b82gqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsAcHAgAAAABA/q+NoKqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqoq7MGBAAAAAACQ/2sjqKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqoKe3AgAAAAAADk/9oIqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqrCHhwIAAAAAAD5vzaCqqqq
+          qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq
+          qqq0B4cEAAAAAIL+v3aFDQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          AAAAAAAAAAAAAAAAAAAAAAAAAAAAOAUdrmpFNhkCXgAAAABJRU5ErkJggg==
+         </office:binary-data>
+        </draw:image>
+       </draw:frame>Figure <text:sequence text:ref-name="refFigure1" text:name="Figure" text:formula="ooow:Figure+1" style:num-format="1">2</text:sequence>: Viverra risus quam</text:p>
+     </draw:text-box>
+    </draw:frame> amet ex viverra sem tempus convallis. Praesent <text:span text:style-name="T13">hendrerit</text:span> risus sed ante <office:annotation office:name="__Annotation__11314_440631829" loext:resolved="false">
+     <dc:creator>Jose P</dc:creator>
+     <dc:date>2024-10-11T04:31:35.595688686</dc:date>
+     <meta:creator-initials>JP</meta:creator-initials>
+     <text:p text:style-name="Comment">Integer bibendum urna elit, in ornare tortor egestas eget.</text:p>
+    </office:annotation>bibendum<office:annotation-end office:name="__Annotation__11314_440631829"/><office:annotation loext:parent-name="__Annotation__11314_440631829" loext:resolved="false">
+     <dc:creator>Mary J</dc:creator>
+     <dc:date>2024-10-11T04:33:12.707168321</dc:date>
+     <meta:creator-initials>MJ</meta:creator-initials>
+     <text:p text:style-name="Comment"><text:span text:style-name="T30">Reply to Jose P (11/10/2024, 04:31): &quot;...&quot;</text:span></text:p>
+     <text:p text:style-name="Comment">Mauris luctus condimentum eros, eget consectetur nisi malesuada id. Vestibulum dui odio, sodales et turpis id, ullamcorper varius felis. Suspendisse vel rutrum quam. Phasellus consectetur blandit ligula quis sagittis. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec nulla urna, placerat at faucibus ac, aliquet eu justo. Cras at volutpat justo.</text:p>
+    </office:annotation>, et mattis massa lacinia. Maecenas euismod tellus ac nisi aliquam, at semper ligula malesuada. Proin gravida velit id ultricies consectetur. Donec vulputate enim sapien, aliquet cursus est hendrerit in. Vestibulum ultrices nulla vitae lectus vestibulum <text:span text:style-name="T27">semper</text:span>. Pellentesque dapibus <text:span text:style-name="T18">dolor</text:span> nec elit accumsan, id maximus erat pellentesque. Curabitur hendrerit ullamcorper diam et iaculis. Fusce urna quam, ultricies non risus et, euismod condimentum lorem. Aenean lacus lacus, molestie nec dictum vel, imperdiet ut lacus. Maecenas placerat quam non odio dignissim varius. <text:span text:style-name="T12">Cras</text:span> at tellus et mi mollis lacinia quis in lacus. Integer porta ex eget ante dignissim <text:span text:style-name="T16">dignissim</text:span>.</text:p>
+   <text:p text:style-name="P35"><office:annotation loext:resolved="false">
+     <dc:creator>Jose P</dc:creator>
+     <dc:date>2024-10-11T04:31:19.956118514</dc:date>
+     <meta:creator-initials>JP</meta:creator-initials>
+     <text:p text:style-name="Comment">Maecenas ullamcorper, nunc quis elementum placerat, mi dolor tristique libero, quis maximus ante felis sollicitudin ante. Cras eros tortor, scelerisque congue blandit nec, sodales in elit. Suspendisse potenti. Sed ut aliquam ex. Etiam eget auctor urna. Integer ut condimentum lacus.</text:p>
+    </office:annotation>Duis viverra risus quam, et tempor risus volutpat eu. In hac habitasse platea dictumst. Quisque placerat, erat id fringilla hendrerit, eros arcu luctus augue, id posuere augue neque quis enim. Nunc et lacus a nunc iaculis commodo non vel ipsum. Aliquam id quam sit amet erat pharetra laoreet. Etiam finibus sodales risus, sit amet accumsan enim facilisis eu. Vivamus eget diam vel mauris dictum commodo. Sed eros felis, interdum a lacinia sit amet, rutrum vel quam. Nulla ut tellus ultricies risus <text:soft-page-break/>accumsan ornare nec ut augue. Aenean at urna et sem tincidunt pharetra eget in mi. <office:annotation office:name="__Annotation__11380_440631829" loext:resolved="false">
+     <dc:creator>Mary J</dc:creator>
+     <dc:date>2024-10-11T04:33:50.290619086</dc:date>
+     <meta:creator-initials>MJ</meta:creator-initials>
+     <text:p text:style-name="Comment">Curabitur id nunc non nisl rhoncus finibus. Aliquam elementum sem mauris, in auctor augue rhoncus nec. Sed vestibulum, justo sit amet condimentum ornare, lectus neque aliquam justo, eu dapibus risus mauris ut turpis. Nulla facilisi.</text:p>
+    </office:annotation>Morbi<office:annotation-end office:name="__Annotation__11380_440631829"/><text:change-start text:change-id="ct520309184"/><office:annotation loext:parent-name="__Annotation__11380_440631829" loext:resolved="false">
+     <dc:creator>Jose P</dc:creator>
+     <dc:date>2024-10-11T04:36:09.205363752</dc:date>
+     <meta:creator-initials>JP</meta:creator-initials>
+     <text:p text:style-name="Comment"><text:span text:style-name="T30">Reply to Mary J (11/10/2024, 04:35): &quot;...&quot;</text:span></text:p>
+     <text:p text:style-name="Comment">Donec nulla urna, placerat at faucibus ac, aliquet eu justo. Cras at volutpat justo. Aliquam vel velit rhoncus, blandit orci quis, accumsan est. Sed at ante commodo, consequat neque in, tincidunt ex. Aliquam aliquam mi sapien, non cursus erat finibus a. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.</text:p>
+    </office:annotation><text:change-end text:change-id="ct520309184"/> suscipit tempor ex. Aenean ornare sem nisi, vitae cursus tellus semper non.</text:p>
+   <text:h text:style-name="P48" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc11597_440631829"/>Fusce rhoncus lacinia pellentesque<text:bookmark-end text:name="__RefHeading___Toc11597_440631829"/></text:h>
+   <text:p text:style-name="P31"><text:span text:style-name="T17">Fusce rutrum</text:span> sodales tortor quis hendrerit. Nulla vestibulum ex leo, quis gravida erat eleifend a. Proin commodo interdum nunc ac ultrices. Vestibulum eu tincidunt velit. Mauris non nisl bibendum, mollis orci eget, feugiat sem. In hac habitasse platea dictumst. Praesent quis arcu congue, elementum leo nec, efficitur ipsum.</text:p>
+   <text:p text:style-name="P33">Pellentesque imperdiet <text:span text:style-name="T12">justo</text:span> id sem maximus molestie. Vestibulum pretium sed augue quis egestas. Curabitur diam nulla, venenatis eu lacinia iaculis, volutpat sit amet quam. Donec placerat non mauris in cursus. Mauris ut vehicula dolor. Aenean scelerisque fermentum sodales. Phasellus eu massa eros.</text:p>
+   <text:p text:style-name="P31">Proin feugiat elit vel malesuada interdum. Nulla quis est erat. Quisque in fermentum elit. Cras at tortor elit. In hac habitasse platea dictumst. Donec viverra scelerisque mattis. Suspendisse arcu quam, ultricies nec nulla at, auctor maximus nisl.</text:p>
+   <text:p text:style-name="P31">Donec ut lectus posuere, luctus orci ac, porttitor felis. Proin in pharetra massa. Etiam rutrum enim id elit porta vehicula. Suspendisse euismod tempor luctus. <text:span text:style-name="T26">Fusce</text:span> <office:annotation office:name="__Annotation__11379_440631829" loext:resolved="false">
+     <dc:creator>Mary J</dc:creator>
+     <dc:date>2024-10-11T04:33:31.668533796</dc:date>
+     <meta:creator-initials>MJ</meta:creator-initials>
+     <text:p text:style-name="Comment">Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Duis nec sapien ante. Aenean sit amet suscipit erat, non ullamcorper sem. In hac habitasse platea dictumst. Aliquam eu velit mi.</text:p>
+    </office:annotation>accumsan<office:annotation-end office:name="__Annotation__11379_440631829"/> lobortis suscipit. Vestibulum finibus et nibh ac sodales. In quis pharetra metus. Praesent pharetra venenatis augue sed tempus. Duis velit nibh, varius vitae elit id, malesuada eleifend massa. Curabitur auctor non metus non mattis. Vestibulum vitae justo quis tortor rutrum venenatis. Sed et maximus mauris, vel auctor urna.</text:p>
+   <text:p text:style-name="P31">Quisque hendrerit lorem quis dui sodales pharetra. Suspendisse vel elit sit amet purus volutpat placerat. Nulla malesuada, mauris at imperdiet blandit, turpis purus mattis lorem, eu venenatis ipsum lorem id lorem. Cras tristique vehicula elit nec posuere. <text:span text:style-name="T19">Mauris vel aliquet felis.</text:span> Mauris quis vulputate felis. Sed fringilla diam id sem sodales, cursus ultricies erat elementum. Praesent consequat nulla eget nunc efficitur, a finibus tellus suscipit.</text:p>
+   <text:p text:style-name="P31">Curabitur gravida lorem turpis, quis fermentum sem venenatis at. Proin lobortis felis sed dictum laoreet. Nunc eu lectus fermentum, iaculis arcu at, suscipit elit. Donec quis dolor justo. Phasellus tempus felis nec ex pharetra cursus. Sed accumsan <text:span text:style-name="T12">malesuada</text:span> tellus sit amet sollicitudin. Class aptent taciti <text:span text:style-name="T21">sociosqu</text:span> ad litora torquent per conubia nostra, per inceptos himenaeos. Quisque gravida blandit lacus nec posuere. Cras quis consectetur diam. <office:annotation office:name="__Annotation__11381_440631829" loext:resolved="false">
+     <dc:creator>Mary J</dc:creator>
+     <dc:date>2024-10-11T04:34:17.119566638</dc:date>
+     <meta:creator-initials>MJ</meta:creator-initials>
+     <text:p text:style-name="Comment">Cras fermentum, nunc cursus eleifend tempus, enim risus maximus lacus, sed accumsan libero est feugiat purus. Suspendisse semper odio in tellus accumsan, et convallis erat dictum. Quisque diam urna, fringilla semper nulla non, euismod feugiat nisl. Morbi consectetur augue vel augue porta mattis.</text:p>
+    </office:annotation>Fusce egestas, purus et eleifend suscipit, purus lacus fermentum massa, non iaculis elit neque eget nisl.<office:annotation-end office:name="__Annotation__11381_440631829"/><text:change-start text:change-id="ct520574560"/><office:annotation loext:parent-name="__Annotation__11381_440631829" loext:resolved="false">
+     <dc:creator>Jose P</dc:creator>
+     <dc:date>2024-10-11T04:36:35.315056655</dc:date>
+     <meta:creator-initials>JP</meta:creator-initials>
+     <text:p text:style-name="Comment"><text:span text:style-name="T30">Reply to Mary J (11/10/2024, 04:35): &quot;...&quot;</text:span></text:p>
+     <text:p text:style-name="Comment">Mauris luctus condimentum eros, eget consectetur nisi malesuada id. Vestibulum dui odio, sodales et turpis id, ullamcorper varius felis. Suspendisse vel rutrum quam. Phasellus consectetur blandit ligula quis sagittis. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</text:p>
+    </office:annotation><text:change-end text:change-id="ct520574560"/> Praesent vitae tellus in turpis interdum ullamcorper lacinia quis tellus. Aliquam sed feugiat urna, eu vestibulum justo.</text:p>
+   <text:p text:style-name="P31">Cras <text:span text:style-name="T20">elementum</text:span> sed tellus nec interdum. Suspendisse dictum urna ut libero tincidunt, et cursus risus tempor. Nulla iaculis ligula lacinia fermentum pharetra. Sed gravida nisi sapien, in bibendum <text:soft-page-break/>erat iaculis non. Nulla at <text:span text:style-name="T13">lectus</text:span> non purus <text:span text:style-name="T14">tempus</text:span> aliquet. Aliquam faucibus pellentesque diam, non porta nulla pharetra non. Vivamus molestie fermentum elementum. Donec dictum ligula vitae ex pellentesque finibus. Mauris molestie risus sit amet elementum placerat. Quisque dignissim augue vel nulla venenatis vehicula. <office:annotation office:name="__Annotation__11382_440631829" loext:resolved="true">
+     <dc:creator>Mary J</dc:creator>
+     <dc:date>2024-10-11T04:35:20.694488573</dc:date>
+     <meta:creator-initials>MJ</meta:creator-initials>
+     <text:p text:style-name="Comment">Aliquam aliquam mi sapien, non cursus erat finibus a. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.</text:p>
+    </office:annotation><text:span text:style-name="T12">Vivamus</text:span><text:change-start text:change-id="ct520647296"/><office:annotation-end office:name="__Annotation__11382_440631829"/><text:change-end text:change-id="ct520647296"/> vel aliquam massa. Proin pulvinar lacus in arcu mattis accumsan. Nam ac odio et arcu accumsan molestie vel sit amet tortor. In lobortis nisi a elit accumsan, ac scelerisque neque consequat.</text:p>
+   <text:p text:style-name="P31"><draw:frame draw:style-name="fr1" draw:name="Frame3" text:anchor-type="char" svg:x="0.0098in" svg:y="0.0098in" svg:width="2.1902in" draw:z-index="9">
+     <draw:text-box fo:min-height="3.5in">
+      <text:p text:style-name="Figure"><draw:frame draw:style-name="fr4" draw:name="Image4" text:anchor-type="paragraph" svg:width="2.1902in" style:rel-width="100%" svg:height="3.5in" style:rel-height="scale" draw:z-index="10"><draw:image draw:mime-type="image/png">
+         <office:binary-data>iVBORw0KGgoAAAANSUhEUgAAF3AAACWAAQMAAADz9LhiAAAABlBMVEUAlP8Ak/8oigi6AAAt
+          Z0lEQVR42uzBgQAAAACAoP2pF6kCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGD24EAAAAAAAMj/tRFUVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYU9OBAAAAAAAPJ/
+          bQRVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVWEPDgQAAAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVFfbgQAAAAAAAyP+1
+          EVRVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVhT04EAAAAAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV2IMDAQAAAAAg/9dG
+          UFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVUV9uBAAAAAAADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVWFPTgQAAAAAADyf20EVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVhDw4EAAAAAID8XxtB
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVXYgwMBAAAAACD/10ZQVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVRX24EAAAAAAAMj/tRFUVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYU9OBAAAAAAAPJ/bQRV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVWEPDgQAAAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVFfbgQAAAAAAAyP+1EVRV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVhT04EAAAAAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV2IMDAQAAAAAg/9dGUFVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVUV9uBAAAAAAADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVWFPTgkAAAAQADkFP+v9IYBAAAAAAAAAAAAAAAAAAAAAAAA
+          AAAAAAAAAAAAAAAAAAAAAAAAAAAAAACACw0AAAAAAAAAAAAAAAAAAAAAAIw9OCQAAABAAKT/
+          T3vDAADwrwEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          AAAAAAAAAAAAAADGzp3UAAgEQBCcEAQgASlIQzoKeO6RTJWOTgMAAAAAAAAAAAAAMNcRAAAA
+          AAAAAABocgcAAABWugIAAAAAAADAjzMA1PJIBQAAABjuDQAAsCHJDMWeQDmPVAAAAAAAAKCT
+          ZAAAAAAAAAAAAKCaRyrAx74dGwEAwjAQMx0lIzM6NROEI9IafgNAnRXA4QkAAIAyIwAAAPAU
+          XS8AAAAAInwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIDOdgAAAAAAAPibRQgA4DID
+          AAAAAAAcdu7YBmAQCILgyXLg0CVQCv1XRQEEiAzxMz18tK+DuylCAAAAAAAAAAAAAJMWAAAA
+          OMkfAABAEQIAAOBuihBAPU8AAAAAwC8cAAAAAAAAAAAAAAAAAAAA7DEQufAGSp8AAAAAAAAA
+          LPWAvE5xXwAAAAAAAABgsHMHNACAMAzAhgMkIx0Xz5O1QgoAAAAArCKIBAAAAAAAADoJIgGK
+          OVIBAAAAJrwAAADb3AAAAAAAAAAAAAAAAAAAAAAAAPRwpAIAAAAAAACVTgAAAAAAAAAAAEDJ
+          AQAA8Nm7cwKAQSCKgj+pIiNS8K+KFgRswTJj4+0BAABwK0UIAAAAAAAAAAAAAAAAuMcbOJR1
+          QAAAAAAAgO4UIQCK/IFDGfcCAAAAAADoThECAAAAAAAAAABg4a4TAAAArY0AAAAAAADeLAEA
+          Jb4AAJWeAACAIrRxHQFgsnfvRACAQAwFM6cACfhXiQB6Pje7IlKkeQAAwHUuBQAAAAAAAAAA
+          AAAA6GwEAAAAANhVAABAVgl4iTECAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOCgGQCAj1UA
+          AAAAAAAAFnt3cAIwCARRdBJyyDElpf+qPFmAIKjse2XswF8AAAAAAAAAAAAAAAAAqOUKAEAh
+          XwAAAAAAOJDn2QAAAAAAAIPuAAAAAAAAcBqBSAAAqEMjdY4nsLE/AAAAAIBTLwCS48uZrQAA
+          ADYgEAkAAJ3tCbCDAgAAAEARbwAAaOzcsREAIAwDMXPH4IxOQcUGkEhrOHkAAAAAAIhFHgAA
+          AEQjAAAAaEAjFQAAAAAAAOjJeTAAAHCsAAAAAAAAAAAAAAAXH30UpMMLAAAAAAAAAAAAAAAA
+          AEANMwAAAAAAvG2EF2mk8hOLEAAAwGbvjm0ACGEYAFpffckIjMroFFS0UBHdTREplg1w4QsA
+          AJsRAAAAAHhCCwAAABTXAwDwNOcMAAAAALBs9AcBAAAAgJwdAOf+AAAAAAAAUJuPEAAAAAAA
+          AAAAAAAAAAAAAAAAAAAAAAA3WgAowHwBAAAAk507qAEAhGEA2BCEIBXp2FjonYft07QAAAAA
+          AAAAAKU0pAAAAAAAAH4nEQIAAAAAAAAAAAAAAAAAAAAAYLAVAAAAAAAAAABocgL8x2UDAAAA
+          AAAAMJ2dFwAAAAAAAKDTDjDGTRsvCHjs3bENwCAQA0CnS5kRMgr7T0XBAtAgHt2N8N1Llg0A
+          wNlaAAAAgEX+c2CXNwAAAAAAAAAwTTsCAAAAAABABV8AAAAAAAAAAACQzSrKoQEAoBo7WAAA
+          AACbPQEAAACQxQYAAAAAAAAAAAAAAACA+/0BABhaADp7d0wEAAjEQDCDAiQhDemUNBS0D7s6
+          MjkAAODODAAAAAAAAAAAAAAAAAAAAAAAAAAAAABPknkEAAAAAAAAAKAwHXaAv7UAAAAAZyMA
+          ALD1AAAVWEIAAAAAAAAAAEAlPrAAAAAAAABY7NyrDQAgFAPAR4JgLEZjdDSGEAyf3On6mqYA
+          AAAAwJccRALwPWUHAAAAAAAAjEoAAABwvbScAwAAAACALTUAAAAAAAAAmMgBAAAAAAAAAADw
+          vBYAAJxnoA4AAAAAAAAAAIAFGgAAAAAAAABAZw+ObQCAoCgAPiqlkew/lVpP4id3BwAAAAAA
+          AAAAAAAA8NIIAAAAAAAAAPygBQAAAOAwAwAAAAAAAAAAANTWAwAAAAAAAAAAAAAAwCUrAAAA
+          AAAAAAAAAAAAAGx27twIQBgGAuDBEBBSAqW6dFIyAhwItFuEPfoOKMLhIwAAAAAAmsdQ1Ba4
+          89oDAAAw0R4AAABoayiXoTD7DAAAAAAAAAAASc4AAABgyxwAAAAAaGQJ7WiBA/BgBIC+SmSk
+          +ooAXloDAAAAAMDvmapNdwQAAAAAgNqkIwAAAAAAAAA4RAIA4EtkpF7s3bENACAIBEAKB3EU
+          95/KxAGMnQp3M1gY4OGM5DwAAAAAqIGl4G46F/UAeE0LHmaNDQD5CA4AAAAAol4AAMYhAQAA
+          AEByGwAAAAAAdlTaKck7BQAAAABrnABgcTcOAAAATGe6/wsAwKfK/MIBAAAAAADK0hECALDr
+          BAAABCABAACoRkconREAAADAZO+ObQCEgRgAWoiCkhEYhdEYnQkQ+SJFkrsdvnlLNgCdHQEA
+          AAAAAAAAAACAoifApysAAAAAADCB8RKhPQAAAAAAAAAAAAAAAAAAAAAAAACg2A4q3BEAAAAA
+          AIvxyW5hEgsAAErO8GsLAAAAAAAAMJs7AAAAALzs28kNgDAMBMBF4sGTEiiF/quiBaIkUo6Z
+          ImzL2gUAAABALx8AAAAAAAAAAIB9HAEAAAAAAAAAAAAAAAAAAHo7AwAAAAAAAABAngAAjMV9
+          AgAAAAAAQJUrAAAAAAWkYYFFvQFo7Q4AADAPr0oAlmO5Af8YPwB87N3BDYAgDAXQYjw4hqM6
+          ugdvJCZyMR99bwVIWmgpAAAQ6igAAAAYthafYkEBAAAAwNQ8AADkh/iNEAAggqZGAJzVAWCE
+          2AoAdDRMABdTK5mV3QYAAPBMKwCI1AQ3AAD5EAAAAAAARFsKAADAIQIAAO7IqSGeJygAAAAA
+          4KINfk35CQAAAACAOW0F0FNKA163FxBGAAc42bujGoBBIAagXTIBkzApSEM6JviAu/dktGkK
+          AAAAAAD09AYAAACK+AIAAHC6EQAAAAAAAACsHhMnHAAAAADQyAwAAAAAADTzBAAAAADY5Q8A
+          AAAAAAC1aYQAAAAAAIoR/AIAAHA5r+kAAAAAAAAAsNi7cyMAYRgIgIeHgJASKMWlUTotEPAZ
+          7bagRKMXAAAAAADgPVMA7rcGQJICAAAwhDJ3z1sAAABgeAYy4JdUrqii5Ql7+ANxBAAAAAAA
+          AKCIJQAAAAAAAIBGHAAAAAAAOF8NlNMDAAAA3+JbCgAADKvbS6OOrh0LAFI+AAAAAACA62zh
+          hBYAAAB42xzgYO8OjgCAISAA0n/Tnmo4dntIMjG4PJEnV82QpwzlnbnFAAAAnyUAAABASgcY
+          IQM8jgCQrAsAAAAAAAAAAFja5wEAAAAAAADgF0kRYIccAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          AJBO+gAAiboAAAAAgGHvjnEABIEgAK6JhaVP8Kk+3d5oS45j5gckEAp2DwAAAGhLOOTDGQBG
+          24PawTJsdwAAAAAAAAAAAAAAAAAAatJ3BgCgqi0jXAGqcS4BAADm5R8EAAAA4IenZWsDAAAA
+          ANMRAAAAqjoCAACAiDcAAADtmRQHAG93AAAAgBZ0YwAJUHBPAgAAAPCwd/coAMIwGEA/xMHR
+          I3t0V+ni1pL0vSMUAk3ID/OdgUqeDAwuAQAAAAAAuK878lQAAAAAQHvqlgAAAAAAAAAA0Id+
+          IACA5azspzEZBwBQng8N7EbUAwAAAAAAAMAVAABqO8LHHRBDAAAAAAAAAAAAAAAAAAAAAAAA
+          AH/sdgNedu7YhkEYCgLoRUqRkhEySkZj9CwAggIkfH5vAMuVC//7BwDAtdYAAAAA3OYVAAAA
+          AHigJQAAAAAAAADQ45dJvANAoU8AAAAAgPFMM6ECqKIgEgAADsm+UuIbAAAANliLOp8FGe78
+          HX57APB+AwAAAAAAAEAhcQAAalkSBgAAAADotWRgQ18eAIAqFa12p6wBJqoEBQAApmDmBsCf
+          nTs2ARCKgQB6ioWlIziKozm6YKU2YqHIz3tLBHLJldUFAO4IlgGk5AAAAADgUgt2FswAAAAA
+          AFCAUAsAAC50nQAAAAAAAPCyPgAnc6AuYxEAAAAAAAEKAAAAAAA/U7lDbggAAAC0ZQ0AAAAA
+          wMEYAAAAAACAr0wBb9w0w4cGPLQEAAAAAICNvTs4ARiGYQAo+upYHa2jBzJA3ia628FgsIUA
+          usiwXkzHLl6A0IECgN0QAAAAAAAAAIBW/mgBAAAAAADg7AnQwrwDAAAAAAAAANBFUwsAAAAA
+          AABAti8AAAAAAAAAAADU+AMAAACTiDcBAAAAI7wBAAAYwAUVAFjs3bENgDAMRcGPREHJCIzK
+          6NTpUConvlvD9jMAAADqCAAAAL0cAQAAAACAaWcAAAAAAACAXm6JVwAAAAAAAEp6AkVo/AEA
+          AABAOVfoTTVvOA6C1ZnFAAAAAAAAAMAfbwD2YWsIAAAAAAAAAAAAAAAAAAoTwQcAABj4w/ex
+          d+c2AMJAEAAX5ICQEiiF0iidBJEgkfqbKcLSre+xOgsAAADGcgQAAIZ1BgAAAAAAAAAAAKCO
+          NQAAAACVlQAAAAAA8CGNBQBsrwXAPZ95LAGAwRlphpl5AQCgQXsAAACgT0JnAOagqxAAAACQ
+          mAPAvysAAEB1mlwAxToAQLf0HQD0xUkCAB5bEEnD1HxSA61QqQO8SrjZu2MjAEAQBoCek7H/
+          VPZWFhZG/qfwBBKgOdN3eMH0zw4AADShhRYAAAAAAACIYWsTAAAAiOFmHKBPTqwMOQDY1AAA
+          AAAAwM4JAA4p4Wc5C27QiI5yAAAAAAAAAC3WIEkKAAAAAAAAAADOCM8CAMJ5gQAAmRz6AQAA
+          AAAAAMBVNQAAFjt3UAMgAMMAsBAEIAEpSEM6FuABybY7E0u6pgAAAAAAAAAAAAAAwGRmfwEA
+          AAAAAAC+saWpKwAAAAAAAAAAAADUtmaKIwAAAAAAAAAAwDxW8wBorn9J1jGHt84AAD9aAgAA
+          ALRUPm/fAwAA8JQvKgAAAABAA+JZAKhCyRNu9u7kBGAQCADgIj5SRvqvMgUEBH97zLQgHrgX
+          N54AAIrp3yASAACA/HYAAAAAAJyZOIq/Z0CZMgAAZOKDBQAAAIB8yo94B+BPj2UAAAAAIBtB
+          KRjL9qcJcwYbsqgAAHOp+gcAAAAAAJjsjSFWANDBmIsLAADoSvb2ROrLAajJuwUAQO4RDFM4
+          K0UPOchlxQ3z9QAAaGoHAEBehWMCQA7icwA0Iz8OqM45BvCxdwdHAEAwFAXjpiz9V6UCRzP5
+          7FaBkRcAAAAO/DkBAKAblWIAAIA/SMIBAADQS1QrRcsSAAAA3qMSBUC6UQAA9OfUBgAAANCJ
+          1xoAAAAAAAAzugAAAAAAAAAAAAAAdhoDEGgVAJDPRRMAAAAAuGYWAAAAAAAAAJu9O7YBEAZi
+          AGioKBkhozAaoyNR0dJ98ndDWC4sGQAAAAAAAAAAAAAAgOJGAACA0vZAe54nAQAAAAAAAKCb
+          KwAAAAAA8McZAAAAAFjTFgAA0CsBAAAA4OMIAAAAAAAAAAAAUMEIALOyy4bWREBTDqN53QHo
+          Q+sBAAAe9u7gBkAgBAIgGguwJPuvyp+J8WHuB5uZDu5FwgELAACYEAUAhQ2Ax1EAAADQi+UX
+          AAAAoAf3qQBoKP9qngIMAAAAAAAAgJ9n4O2sbFsBAHztBQAAAAAAiFkCAGCK9HnXHyK3wYg4
+          AABADom6AAAAAAAAmBSGcLH7qrEPW2HFAQCAGfQbAADQiAQAupOkSHvuvQEAwBBXAdzs3EEB
+          ADAIA7FJn3Qs8ASa6GgPALjhPwJ4qgIAAAAA9NjHAwAA2JwAAMBgQpdAEtU8AAAAAAAAAACA
+          fexdAQAAAAAAAABII+UMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABQ7d0wDAAgEQfBChQyk
+          4F8VDihoyOdnZGyxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQBErAAAA8GAEAAAAAACU
+          Z+CPGQAAAAAAgHb8IQAAAAAAAAAAAAC42wEAAADgsHcvJwACMRBAR7EAS7AUS9vSverBg4Jg
+          dt9rIh8SBmAUUwAAAAAAAP5P+CQAAAAAcLIE4L0WAAAAvrEGX/8AAAAAAAAA4J4AAAAAAAAA
+          APCJDzyyBwCobQsAAKDFBgC4kF4JAIocAAAAAMRSjRtzAAAAemC6AQBKs3QHAIA6WgAAAA72
+          7tAIABCIgWBwlEH/VaKZQSEQ/7tFRF4AAJ7NAAAAAAAAAABALyMARgIAAAAAAAAAAAAAAO5c
+          5AIAAAAAAAAAACf1TwAAAAAAAAAAAAAAAIBS5KMBAAAAAAAAAAAAAIAvVgA2O3dsA0AIA0Hw
+          /kVA2ZROCUQggWeKcOK1AQAAAAAA4H09LI0AAAAAAAAADnYBAAAAAAAAAAAAKEwaC1CAn2MA
+          D/oCAAAAAAAgDQIoyHQHAAAAgCP+AABwqRYAAAAAAAB26ZYxAAAAAICYGwAAAAAAJnt3bAMg
+          DARB8ExESEmU5tJJCRCObPmlmTr+fgEAAP7cAd7OAEBZLQAAQAUGjgAAAAAAAPP0AAAAAAAA
+          AAAkRwAAAAAAACBjzc9QAIAaRAYBAAAA0PwGPqiNAgAAAOzuCuA+FgAAAAAAWKUHAAAAtmL1
+          DwAAAAAAADzs3LEJACAQA8AoDub+U1nZK1io3E3x8EkALtYDAAAAAAAAnFUDAIioAADwCmNx
+          AMBVHCcAAADwkxYAAGCRvxuTsh8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAu3oAAAAAAAAA
+          AJISAAAAYLBzx0QAgEAMwDoyIglpSEcDC/BcoqFDr0MBAIANMwAAAAAAgPkdAAAAAAAAAAAA
+          AAA+0QMAAIW1AAAAD1HRAQAAAAAAAAAAAAAAgPu8a1GHtAIAAAAAL/IpBgAAAAAAAAAAAADA
+          aSMAALDYu2MbgEEgBoAflMEzepQuDf2/uRsCkC1hAAAAAADYWQUAMIJhMgAACCWjBGC2uwAA
+          AGhK+AgAAMCPphAAAAAgk48IAIB0eikAIIeNbQCCuNaABM4yOI7OAQAAAOjjKgAAoBFPdACS
+          PQUAAEBzIkpGkTUAAAAAAAAAAJ9VAAAAkMSKDQAAvOzdwQmAQAwEwH34uKclWIqlWbpYgQjC
+          HclMDXmFTRYAAACQp3x3hCJG8DEQAAAAAJazBwAAAAAAAAAAAAAAgHm2AAAAAAAAAAA0paEG
+          AAAAWIIlBQAAAAAAAAD0JDNAQcYaAOjhCgCFjORxBgAAAAAAAAAAAAAAPnO7BL+52btjKgBh
+          KAaAKY+BEQlIwb8qNNClv+2digx5yR0AAAAAAAAAAAAAAADGOQMAAAAAALCjKwAAAMAU3gAA
+          AMBcjgAAAAAAAAAAAAAAo7QALMRqHgAAAABAabZmAACgFBF9FYqAAAAAABTXHK8CAPCb538A
+          6PIEAACAj707OAEYBIIAuAQfeab/atOACPryuJkaROXY5ahFL4Z6RgAAAACoQ54GgKY8gQAA
+          gHY2t3GuAAAAAAAAAAAAAAAm9IwBACw0AACASnzRz30BAABAJAYAdzsAAAB0c1/i6AkAAAAA
+          LJlJAQAAG94AAAAAAAAAAB2NAAAAAAAAAPzs3bEVABAQRMElEipZ6SoQiHjMxFfBBfsBAPjL
+          CAAAAAAAAADwmrZ1VQIAAAAAAAAAIF4DAAAAsGQJEgAAAADgUS0Al6gBAAAAAACAfeozAAAA
+          AAAAAID6DAAAAABwIRN7XrkAAADH9QAAAAAAAMBk7w5OAAhhIADuwT2uDEux/6ruL/gSxOBM
+          FWFJssBUCwAANzH/AQfrAQAAgFo8WAIAAAAAALhU10sB9oIBAAAABlIWAAAAcH4NAAAAAAAA
+          AAAAAAAAAAAAAAAAAABs0AIAAAC1PAEAAAAAVn1B7AgAlPYGAAAA+Nm7AxoAQBAIgB/BCEYx
+          mtFt4WDchVAnDwAAAAAA08j9AgAAAAAGLYBOVQAAAAAAAACAAgSSuttBhy8AAAAA+BgGwO0A
+          QJIbAKCVFWAIGVYAAAAAAABFFgAA8BgGAAAAvjoBAAAAgE7s5QQAALB9BsBJBwAAAAAAwGPv
+          jm0AhGEgAFooAzAyo9PRIUpi/90KkT5yYT8AAAAAAPBYBbAvGQUAkKnD1n9wYUuH5wGAF/5F
+          AAAAAAD+chXMsNSDAgBAC2cBAAAA85j4AcIcBfBJ9gAAAJDMGAvQifYZgATuDwDyBAAABgou
+          bAQAAAAAAAAAAMhgkwMAAAAAAAAAAAAAALjZuwMaAEAgBIDoDGY0o7uZwte7GIzBMTyTAQAA
+          AAAAALj4BAAAAHhTCwAFrQAAAAAAAAAAAKgjAZfqAQAAAOBqomEAAAAAAAAAu+4AAAAARanE
+          AwAAAAAAfGUGAAAAAAAAAAAAAAAAgM3OHdQADMNAEDxVffRZCIVS/qiCIVIedjJD4+wFAAAA
+          gMWuAAAAAAAAAHCKJwAAAFDLGwAAAAAAAAAAUM0DGvoDQF1fAAAAAACgiztgmQaA4vTSAAAA
+          AAAAEocRAADAjoRqAAAAgEmmU8CnKgAAAAAA0FPPyULFHQAAgMHenRsBCAMxABREhJREaZRO
+          SOrIvjnvVuFnJAFs/UAGAAAAAAAAAABCVwAAYHkOAABY73ZPAQAAAAAAgMreAAA0pWUfAACA
+          aqRpAAAAAAAAAH5nAAAAAKwSAwAA7OcIAEz1hEquAAAAoGkfABinHxkAAKAJQ/LrSaoC9OAn
+          FQCQVIWyHNf52Lt3EwBAGAqAwcrSERzF/acSe8FGUMLdFPmQlxTMEQGAfHTRAAAAAAAAAAB/
+          8KwDAAAAAAAAgdYAcCBXDAAAAAAAAAAAAAAAAAAAAAAAAADk6gEABy0AwDMUAAAAAAAAnhsB
+          QDY1AAAAANhy7EEuLlUBWLqVESjm4ZISwGTv3m0ABoEYgDoSRcqMlP2noqVAiJLPe2Oc7DMA
+          AAAAAAAAAADAgHA7AAAAwKFKAAAAAAAAAAAAmGIqAwAAAADAPRQAAAC4jJfqAAAAAPf5AluQ
+          zAIAlvAGAAAAAAAAAOAQyuUAAAAMlPQ9mqoAAAAArT8AAFDZu2MbAGEgBoAGUVAyAqMyOiPk
+          u3yUuyUSWW8ZAAAAAAAAACg3VQGAxb0BAADYiEyzn0PrHwAAgGbOAAAAwBxXAAAAAJxUAwAA
+          AACQPAGauQMAAFv5AgAAAAASJaosC/WjqQoAAOBwHAAA6TkAAAAAAACAhX0AoMz/ggKrHMCY
+          5wQAAICfvTvGARAEggC4GgufwVN8mk+3sdDGqKEgMFNTkkAuuV0AAAAAAAAAAKALJQAAAAAA
+          N1MAAAAAAAAAUMcDwDO7fgAk2d4fBAAAgArWAAAAQJeWAAAAQA17AABe8Q+BdpSc5gAAAADw
+          02x2CQAAPVOOAAAMSodHA8QfAtCP4rWDKwliDMYtBQAAAAAA4LtNJCUAB3v3UgIACAUBcBED
+          GMn+qbwYQPDiw5kc+wEAAAAAAOBHMwAAAAAAAHBPUxUAr0wAAAAAQDan4wAA51oAAAAAAAD4
+          VA9AQSMAAAAAUImmKgAAAOWIZwAAAAAAAAAAAAAPmgEAAAAAAAAAACiuBUt5ALDYu2MTAEAg
+          CIInfGBZ9l+VYG5g9sJMH3sHAL1UAACApjT2wKMRAAAAAAAAAAAAAAAAQJZjNBMAADhmAAAA
+          AADAQygAAAAAAAAAAAAAAAAAAAAAAAAAAJ9aAQAAAAAAAOCmAgAAALDZu5MagGEgBoBuEBRC
+          oRRaofcTAMkr1wyKleWVAYCkpNUXAABgJ1cAAAAA6PcKWcC/HgCwrycAAEuwSAMAAMtxxgMA
+          AAAAAKDYDgAAAABMQsUdAAAAYLgSAAAAAOA4gkEAAAAAAAAAAAAAAAAAAACgugMAcCJDegAA
+          8LNzh1QAgAAMBScQxCAK0YiOIQACAY+7DpP7AAAAALCtZllaAADgYTUAAABwF69/eFE3cQAA
+          AAAAAABPVQAAAAAAAAAATigBAAAAAAAAAPjcCP/pAQAAAAAAAAAAAAAAAECjGAAAAAAAAEDB
+          EgBgsm/HOACCAAwAK3Fw5Ak81ac7MxgNk+DdK5q0BQAAAOCrWgAAAAAAAAC4UwIA8EACAQAA
+          AAAAAAAAAAAAGLYFAKZSAwAsz+sfAAAAAAAAAAAW4bgCAAAAAAAAAAPOTKLlpSMAAAAAAAAA
+          v1PS2dOrE9bEAGNsTAAAAICLnTumAQCEASDYEAQgCf+q2Bmazu2dj3/IDa2zAPhdg2sAAAAA
+          AAAAAHo7UbQDAAAAAAAAYLplYAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+          AAAAAAAAPPbgQAAAAAAAyP+1EVRVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVhT04EAAAAAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8b
+          QVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVV2IMDAQAAAAAg/9dGUFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVUV9uBAAAAAAADI/7URVFVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVWFPTgQAAAAAADyf20E
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVhDw4EAAAAAID8XxtBVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVXYgwMBAAAAACD/10ZQVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVRX24EAAAAAAAMj/tRFU
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVYU9OBAAAAAAAPJ/bQRVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVWEPDgQAAAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVFfbgQAAAAAAAyP+1EVRVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVhT04EAAAAAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVV2IMDAQAAAAAg/9dGUFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVUV9uBAAAAAAADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVWFPTgQAAAAAADyf20EVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVhDw4EAAAAAID8XxtBVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVXYgwMBAAAAACD/10ZQVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVRX24EAAAAAAAMj/tRFUVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VYU9OBAAAAAAAPJ/bQRVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVWEPDgQAAAAAgPxfG0FVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVdiDAwEAAAAAIP/XRlBVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          FfbgQAAAAAAAyP+1EVRVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVhT04EAAAAAAA8n9tBFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVYQ8OBAAAAACA/F8bQVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          2IMDAQAAAAAg/9dGUFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVUV9uBAAAAAAADI/7URVFVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVWFPTgQAAAAAADyf20EVVVVVVVV
+          VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVXZ
+          KBgFo2AUjIJRMAroBADg5HPj2I7XrgAAAABJRU5ErkJggg==
+         </office:binary-data>
+        </draw:image>
+       </draw:frame>Figure <text:sequence text:ref-name="refFigure2" text:name="Figure" text:formula="ooow:Figure+1" style:num-format="1">3</text:sequence>: Aliquam sed</text:p>
+     </draw:text-box>
+    </draw:frame>Aenean vehicula eros mi, eu condimentum urna fringilla a. Cras ac quam fringilla, bibendum nunc nec, malesuada magna. Ut sit amet sodales felis. Nam imperdiet sit amet leo a rutrum. Aenean ac lorem id urna scelerisque dapibus ut in dolor. Nulla nibh odio, lacinia nec justo eu, sagittis lobortis ligula. Integer mi diam, semper mattis laoreet nec, iaculis eu orci. In vel dictum massa, porttitor mattis urna. Phasellus dignissim lacus et lacus dignissim, et feugiat metus ornare. Integer aliquam mauris vehicula, posuere nulla vel, semper sem. Duis ipsum magna, ullamcorper at felis et, volutpat varius magna. Morbi venenatis nibh id tempor interdum. Praesent quis pellentesque libero, non viverra libero. Integer hendrerit, massa non hendrerit bibendum, mauris felis iaculis diam, at vestibulum erat eros sed lectus. Aliquam maximus dapibus convallis.</text:p>
+   <text:p text:style-name="P31">Aliquam sed ex ac nibh tincidunt interdum efficitur sed enim. <text:span text:style-name="T22">Duis id aliquet ex</text:span>, et tempus urna. Maecenas placerat, nisi eu congue faucibus, neque libero fermentum nibh, ut eleifend ante enim quis libero. Phasellus molestie erat id lectus placerat, non placerat metus commodo. Nam blandit finibus commodo. Maecenas vestibulum lorem et venenatis porttitor. Etiam enim erat, vulputate ut leo a, ullamcorper ultricies elit. Donec eget luctus mi, tempus suscipit dolor. Morbi egestas, dui consectetur egestas mollis, justo ex ornare enim, ac tempus augue tellus at neque. Integer volutpat congue est, vitae facilisis eros sodales <text:span text:style-name="T15">efficitur</text:span>. <text:span text:style-name="T28">Phasellus</text:span> non tincidunt quam.</text:p>
+   <text:h text:style-name="Heading_20_3" text:outline-level="3"><text:bookmark-start text:name="__RefHeading___Toc11599_440631829"/>Maecenas elit velit<text:bookmark-end text:name="__RefHeading___Toc11599_440631829"/></text:h>
+   <text:p text:style-name="P32"><text:span text:style-name="T11">C</text:span>onsequat vel sem et, accumsan semper nunc. Etiam <text:span text:style-name="T21">maximus</text:span> varius quam, ut scelerisque justo cursus nec. In elementum pretium egestas. Sed auctor massa porttitor varius pulvinar. Curabitur posuere euismod lorem, at porttitor ex egestas eu. Ut convallis auctor turpis, ac imperdiet elit dictum ac. Vestibulum fringilla tortor sed purus consectetur gravida. <office:annotation office:name="__Annotation__11384_440631829" loext:resolved="false">
+     <dc:creator>Jose P</dc:creator>
+     <dc:date>2024-10-11T04:38:05.136154136</dc:date>
+     <meta:creator-initials>JP</meta:creator-initials>
+     <text:p text:style-name="Comment">Cras id malesuada risus. In metus nisl, fermentum ac mattis nec, malesuada in mauris. Nunc auctor feugiat pharetra. Praesent mauris ante, luctus eget aliquam eu, maximus a nisi. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Morbi laoreet ac purus feugiat vulputate.</text:p>
+    </office:annotation>Nulla lobortis tempor lorem non ornare. Pellentesque dapibus tellus nec lorem mollis fermentum.<text:change-start text:change-id="ct520512848"/><office:annotation-end office:name="__Annotation__11384_440631829"/><text:change-end text:change-id="ct520512848"/><office:annotation office:name="__Annotation__11385_440631829" loext:parent-name="__Annotation__11384_440631829" loext:resolved="false">
+     <dc:creator>Mary N</dc:creator>
+     <dc:date>2024-10-11T04:38:48.420995702</dc:date>
+     <meta:creator-initials>MN</meta:creator-initials>
+     <text:p text:style-name="Comment"><text:span text:style-name="T30">Reply to Jose P (11/10/2024, 04:37): &quot;...&quot;</text:span></text:p>
+     <text:p text:style-name="Comment">Praesent lobortis et sem eu feugiat. Curabitur a commodo tellus, ut rutrum erat. Nunc vehicula aliquam nunc nec pellentesque. Nullam sollicitudin leo a nisl luctus, nec pulvinar massa lobortis.</text:p>
+    </office:annotation><office:annotation loext:parent-name="__Annotation__11385_440631829" loext:resolved="false">
+     <dc:creator>Jose P</dc:creator>
+     <dc:date>2024-10-11T04:39:22.692041473</dc:date>
+     <meta:creator-initials>JP</meta:creator-initials>
+     <text:p text:style-name="Comment"><text:span text:style-name="T30">Reply to Jose P (11/10/2024, 04:37): &quot;...&quot;</text:span></text:p>
+     <text:p text:style-name="Comment">Nulla condimentum ante lacus, non venenatis arcu lacinia eget. Interdum et malesuada fames ac ante ipsum primis in faucibus. Vestibulum id justo sit amet sapien vulputate rutrum. Aenean finibus metus nisi, ac aliquet odio mollis eu.</text:p>
+    </office:annotation></text:p>
+   <text:p text:style-name="P31">Donec nec accumsan augue. Sed viverra, neque quis lacinia dignissim, quam sapien lobortis lectus, ut mattis lectus lorem ut ex. Donec eget feugiat orci, eget malesuada lorem. Pellentesque habitant <text:soft-page-break/>morbi tristique senectus et netus et malesuada <text:span text:style-name="T13">fames</text:span> ac turpis egestas. <text:span text:style-name="T23">Nulla id diam enim.</text:span> Suspendisse facilisis et <text:span text:style-name="T25">mi</text:span> <text:span text:style-name="T24">sit</text:span> amet imperdiet. Nunc mollis tellus at orci ornare condimentum. Praesent nec interdum mi. Duis vulputate commodo nibh, id fringilla quam gravida sed.</text:p>
+   <text:p text:style-name="P31">Sed id rhoncus leo. Donec nec nisl est. Nulla vestibulum lorem id efficitur finibus. Sed faucibus pulvinar tortor sit amet volutpat. Phasellus rutrum turpis eget dui egestas, vel blandit erat gravida. Mauris dictum lectus non ipsum porta sodales. Nam bibendum faucibus finibus. Phasellus at eros nec purus malesuada placerat. In <text:span text:style-name="T12">interdum</text:span> orci eget venenatis sagittis. Vestibulum consectetur id purus id efficitur. Etiam sollicitudin condimentum tempus. Sed imperdiet venenatis finibus. Morbi ut varius ante. Duis congue elit in ex lacinia, sed feugiat nulla condimentum. Donec non ultricies lacus. Donec nunc lacus, viverra eget luctus sit amet, varius vitae urna.</text:p>
+   <text:p text:style-name="P31">In vestibulum nisi mauris, imperdiet accumsan diam efficitur vitae. Sed rhoncus, eros id varius dictum, est nibh convallis dui, nec bibendum lorem libero consectetur elit. Donec nec odio ac tortor faucibus porta. Nullam a ex non erat dapibus suscipit in a dolor. Etiam sem ipsum, eleifend commodo efficitur ac, dictum in diam. Curabitur ante neque, efficitur at magna a, ullamcorper luctus est. Praesent orci erat, vestibulum at sapien at, ultricies dignissim sapien. <office:annotation office:name="__Annotation__11383_440631829" loext:resolved="false">
+     <dc:creator>Jose P</dc:creator>
+     <dc:date>2024-10-11T04:37:09.460041141</dc:date>
+     <meta:creator-initials>JP</meta:creator-initials>
+     <text:p text:style-name="Comment">Aliquam rutrum gravida aliquam. Vestibulum varius, ipsum at mollis mattis, risus arcu commodo erat, id auctor felis ipsum eu elit. Aliquam auctor, sem in laoreet blandit, neque massa maximus arcu, a consequat justo quam quis eros. Aliquam justo dolor, eleifend sit amet erat id, blandit elementum lacus. Vivamus commodo lacus sit amet commodo rhoncus.</text:p>
+    </office:annotation>Nullam sodales<text:change-start text:change-id="ct520700032"/><office:annotation-end office:name="__Annotation__11383_440631829"/><text:change-end text:change-id="ct520700032"/> vitae risus et pellentesque. Phasellus ac vulputate mi, vel ultrices purus. Sed sagittis, sem a bibendum tristique, nisl nibh accumsan dui, eget facilisis velit magna non nisl.</text:p>
+   <text:p text:style-name="P31">Pellentesque et tellus ex. Quisque facilisis nibh leo, quis bibendum odio vestibulum sit amet. Mauris ut sapien sem. Proin hendrerit tempor eros at gravida. Mauris a tincidunt ante. Phasellus pretium, ligula a tempus ullamcorper, diam ante interdum tellus, sit amet pellentesque est mi eu nisl. Sed nec nunc vitae ligula condimentum congue. Suspendisse rutrum neque at mi imperdiet commodo. Pellentesque porttitor nibh augue, ut laoreet mauris laoreet ac. Quisque sed ex et tellus suscipit interdum.</text:p>
+  </office:text>
+ </office:body>
+</office:document>

--- a/cypress_test/integration_tests/desktop/writer/reconnect_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/reconnect_spec.js
@@ -1,0 +1,38 @@
+/* global describe it cy beforeEach require Cypress */
+
+var helper = require('../../common/helper');
+var desktopHelper = require('../../common/desktop_helper');
+
+describe(['tagdesktop'], 'WebSocket reconnection', function () {
+
+	beforeEach(function () {
+		helper.setupAndLoadDocument('writer/writer-edit.fodt');
+	});
+
+	it('Page position is preserved after WebSocket reconnection', function () {
+		desktopHelper.assertVisiblePage(1, 1, 12);
+
+		// Navigate to the last page
+		helper.typeIntoDocument('{ctrl}{End}');
+		desktopHelper.assertVisiblePage(12, 12, 12);
+
+		// Close the raw WebSocket to trigger automatic reconnection
+		cy.getFrameWindow().then(function (win) {
+			win.app.socket.socket.close();
+		});
+
+		// Can't use processToIdle with the socket closed
+		cy.wait(500);
+
+		// Wait for reconnection to complete
+		cy.cGet('#document-canvas').should('be.visible');
+		cy.getFrameWindow().its('app.socket._reconnecting')
+			.should('eq', false);
+		cy.getFrameWindow().then(function (win) {
+			helper.processToIdle(win);
+		});
+
+		// Verify the page position is preserved after reconnection
+		desktopHelper.assertVisiblePage(12, 12, 12);
+	});
+});


### PR DESCRIPTION
If we are on the later parts of a long document and the connection with
the server closes and reconnects, the view might restore to somewhere in
the middle of the document instead of where we were.

The code that restores the position send to core a simulated click on
the last know position of the user cursor. But if this is done too
early, the scroll that this triggers on online might be cut since online
still doesn't know the full size of the document after reconnection.

Thus it's necessary to wait until online can scroll to the cursor
position to send the click to core.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I943377b7418401a6f1cd0b68367d5ea1b1a765b0
