### PR TITLE
Sidebar Header bold like Navigation header

### DIFF
--- a/browser/css/jssidebar.css
+++ b/browser/css/jssidebar.css
@@ -77,6 +77,7 @@ img.sidebar.ui-image {
 	color: var(--color-main-text);
 	font-size: var(--header-font-size);
 	line-height: var(--sidebar-header-height);
+	font-weight: bold;
 	padding-inline: 8px;
 	flex: 1;
 	display: flex;


### PR DESCRIPTION
Change-Id: Ie0a5451995013356f6f4976707c701b9fa225c30

* Resolves: #15125
* Target version: main
 
<img width="1136" height="365" alt="grafik" src="https://github.com/user-attachments/assets/dc11b6f0-5b1f-4866-a93f-a09625944eee" />

I only add bold. No height change, cause I want to change as less as possible.

As the Sidebar get a lot of string labels, I think it's good to separate headers from labels.