### PR TITLE
Solved issue with disappearing tabs

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -480,10 +480,14 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 							contextTab = tabElement;
 						else
 							alreadySelected = tabElement;
+						// break so that next contexts don't add hidden on top of selected
+						break;
 					} else if (contexts[context] === 'default') {
 						tabElement.show();
 						if (!tabElement.hasClass('selected'))
 							defaultTab = tabElement;
+					} else if (tabs[tab].name !== 'Home') {
+						tabElement.addClass('hidden');
 					}
 				}
 			} else if (!this.map.uiManager.isTabVisible(tabs[tab].name)) {


### PR DESCRIPTION
Change-Id: If4964548334cd8ed8461b3a9c4b4be5f0dfc837c

Before, if for example a shape was selected the "Shape" tab would lose its "hidden" class to gain "selected". If the shape was deselected, the "Shape" tab would not gain back its "hidden" class.

Because of this, when moving through tabs using keyboard keys, the shape tab would still be accessible, even if no shape was selected. This applied to all context-dependent tabs.

* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

