### PR TITLE
Fix other cursors are displayed unrelated slide

### DIFF
--- a/browser/src/canvas/sections/OtherViewCursorSection.ts
+++ b/browser/src/canvas/sections/OtherViewCursorSection.ts
@@ -190,6 +190,8 @@ class TextCursorSection extends HTMLObjectSection {
 		for (let i = 0; i < TextCursorSection.sectionPointers.length; i++) {
 			const section = TextCursorSection.sectionPointers[i];
 			section.setShowSection(section.checkMyVisibility());
+			if (!section.showSection)
+				CursorHeaderSection.deletePopUpNow(section.sectionProperties.viewId);
 			if (hideCursors) section.getHTMLObject().style.opacity = '0';
 			else section.getHTMLObject().style.opacity = '1';
 		}

--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2038,7 +2038,9 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 		if (section) {
 			const showCursor = obj.visible === 'true';
 			section.sectionProperties.showCursor = showCursor;
-			section.setShowSection(showCursor);
+			section.setShowSection(section.checkMyVisibility());
+			if (!section.showSection)
+				CursorHeaderSection.deletePopUpNow(viewId);
 		}
 	},
 


### PR DESCRIPTION
The _onViewCursorVisibleMsg handler was only checking whether the cursor is meant to be visible - it doesn't check whether the other user is on the same slide/part.

The new control returns false when the cursor's part differs from the local user's selected part.

Also hide the other users cursor tooltips immediately without waiting 10ms timeout.


Change-Id: I6ec4702159298fad2d1276d9b470513624a8909e


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

