### PR TITLE
fix: clean up systemplate-<jailId> dirs on kit exit to prevent disk leak

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -310,9 +310,16 @@ void removeAssocTmpOfJail(const std::string &root)
 
     jailPath.popDirectory();
     jailPath.pushDirectory("tmp");
-    jailPath.pushDirectory(std::string("cool-") + jailId);
 
-    FileUtil::removeFile(jailPath.toString(), true);
+    Poco::Path coolTmpPath(jailPath);
+    coolTmpPath.pushDirectory(std::string("cool-") + jailId);
+    FileUtil::removeFile(coolTmpPath.toString(), true);
+
+    // Also remove the per-jail systemplate copy created when
+    // sysTemplateIncomplete is true (read-only systemplate).
+    Poco::Path sysTemplatePath(jailPath);
+    sysTemplatePath.pushDirectory(std::string("systemplate-") + jailId);
+    FileUtil::removeFile(sysTemplatePath.toString(), true);
 #endif
 }
 


### PR DESCRIPTION
When sysTemplateIncomplete is true (systemplate is read-only and dynamic files like /etc/passwd are out-of-date), each kit process creates a per-jail copy at <childRoot>/tmp/systemplate-<jailId>/ containing a full recursive copy of systemplate/etc/ (~500KB).

On kit exit, tryRemoveJail() calls removeAssocTmpOfJail() which removes tmp/cool-<jailId>/ but never tmp/systemplate-<jailId>/. These orphaned directories accumulate indefinitely, only cleaned on container restart via removeAuxFolders().

In production with hundreds of document sessions per day, this grows to multiple GB over weeks.

The sysTemplateIncomplete condition triggers when:
1. /etc/passwd in the container differs from systemplate/etc/passwd (common after container updates)
2. systemplate/etc/ is read-only (e.g. read-only container filesystem, read-only volume mount, or restrictive permissions)

ForKit logs when the condition is active:
  WRN The systemplate directory [/opt/cool/systemplate] is read-only
  WRN Failed to update the dynamic files in [/opt/cool/systemplate]

Regression commit: b1659bc18 changed systemplate-<jailId> from containing just an empty etc/ dir (~0 bytes) to a full recursive copy of systemplate/etc/ via copyDirectoryRecursive(), making the pre-existing cleanup gap impactful.

Steps to reproduce:
1. Start Collabora Online in Docker (privileged mode)
2. Make systemplate read-only: docker exec -u root <ctr> chmod -R a-w /opt/cool/systemplate/etc/
3. Restart the container
4. Open and close documents repeatedly
5. Observe tmp/systemplate-* dirs accumulating: find /opt/cool/child-roots/*/tmp/ -name 'systemplate-*' -type d | wc -l
   (count only goes up, never cleaned)

Fix: add removal of tmp/systemplate-<jailId> in removeAssocTmpOfJail() alongside the existing tmp/cool-<jailId> removal.

  ---
  Reproducing the leak

  Three helper scripts are attached. Place them in the same directory.
```
  docker-compose.yaml
  services:
    collabora:
      container_name: collabora-leak-test
      image: collabora/code:25.04.8.3.1
      environment:
        - aliasgroup1=http://your-nextcloud/opencloud-host
        - extra_params=--o:ssl.enable=false --o:security.seccomp=false
        - username=admin
        - password=admin
      privileged: true
      ports:
        - "9980:9980"
      volumes:
        - ./confirm-systemplate-leak.sh:/tmp/confirm-systemplate-leak.sh:ro
        - ./trigger-systpl-incomplete.sh:/tmp/trigger-systpl-incomplete.sh:ro
```

  Step 1: Start the container
```
  docker compose up -d
```
  Step 2: Trigger the sysTemplateIncomplete condition
  
  Make systemplate/etc/ read-only so updateDynamicFiles() fails on each kit fork:
```
  docker exec -u root -it collabora-leak-test bash /tmp/trigger-systpl-incomplete.sh
  docker restart collabora-leak-test
```

  Step 3: Monitor for the leak
```
  docker exec -it collabora-leak-test bash /tmp/confirm-systemplate-leak.sh --watch
```
  Step 4: Open and close documents

  Open several documents through Nextcloud/Opencloud, close them, repeat.

  Without the fix (systpl count only goes up)
  ```
  TIME        TMP SIZE   SYSTEMPLATE-*         COOL-*   INCOMING     PRESETS      JAILS
  ---
  [11:19:21]  tmp: 2.7M     systpl: 4   (1.9M  )  cool: 4    incoming: 1    presets: 0    jails: 4
  [11:20:11]  tmp: 47.6M    systpl: 14  (6.8M  )  cool: 9    incoming: 1    presets: 1    jails: 9
  [11:21:01]  tmp: 11.3M    systpl: 20  (9.7M  )  cool: 8    incoming: 1    presets: 1    jails: 8
  [11:22:01]  tmp: 85.5M    systpl: 24  (11.6M )  cool: 9    incoming: 1    presets: 1    jails: 9
  [11:23:41]  tmp: 19.6M    systpl: 37  (17.9M )  cool: 8    incoming: 1    presets: 1    jails: 8

  systpl climbs from 4 to 37 while jails stays around 8. Each orphaned dir is ~500KB. Over weeks of production use this grows to GB.
```
  With the fix (systpl tracks jails)
```
  TIME        TMP SIZE   SYSTEMPLATE-*         COOL-*   INCOMING     PRESETS      JAILS
  ---
  [12:48:12]  tmp: 2.8M     systpl: 4   (2.1M  )  cool: 4    incoming: 1    presets: 0    jails: 4
  [12:49:32]  tmp: 336.1M   systpl: 19  (9.9M  )  cool: 19   incoming: 1    presets: 1    jails: 19
  [12:50:02]  tmp: 5.7M     systpl: 8   (4.2M  )  cool: 8    incoming: 1    presets: 1    jails: 8
  [12:50:22]  tmp: 5.7M     systpl: 8   (4.2M  )  cool: 8    incoming: 1    presets: 1    jails: 8

  systpl now goes down when kits exit, staying in sync with cool-* and active jails. No more orphaned directories.
```
[scripts.zip](https://github.com/user-attachments/files/26711200/scripts.zip)

Change-Id: I617709517ce8212e223b5a247b862d91e13dfe74

* Target version: main