### PR TITLE
cool#15305 browser: make Borders control behave additively

### DIFF
--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -51,6 +51,15 @@ function getBorderStyleUNOCommand(
 	vert,
 	color,
 ) {
+	// flags are the same as core's SvxBoxInfoItemValidFlags
+	const funParams = [top, bottom, left, right, horiz, vert]
+	const paramFlags = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20]
+	let valid = funParams.reduce((sum, val, i) => sum + +(val === 1)*paramFlags[i], 0);
+	// none set: means clear all borders
+	if (valid === 0) {
+		// 0x7f maps to all flags except DISABLE set
+		valid = 0x7f;
+	}
 	const params = {
 		OuterBorder: {
 			type: '[]any',
@@ -132,7 +141,7 @@ function getBorderStyleUNOCommand(
 					},
 				},
 				{ type: 'short', value: 0 },
-				{ type: 'short', value: 127 },
+				{ type: 'short', value: valid },
 				{ type: 'long', value: 0 },
 			],
 		},


### PR DESCRIPTION
SetBorderStyle needs a set of flags passed to it to know which borders to apply. Flags are the same as
SvxBoxInfoItemValidFlags.


Change-Id: I96146d8adab4a33497ee245fcdd316321736fa71 (cherry picked from commit 5583a27d15a8c36bd9cb72ddd7ccfa2b02245708)

* Resolves: #15305
* Target version: 25.04

### Summary

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

