### PR TITLE
Impress Slide Show Tab fix ID's and spaces

### DIFF
--- a/browser/src/control/Control.NotebookbarImpress.js
+++ b/browser/src/control/Control.NotebookbarImpress.js
@@ -476,7 +476,7 @@ window.L.Control.NotebookbarImpress = window.L.Control.NotebookbarWriter.extend(
 			{
 				'type': 'overflowgroup',
 				'id': 'slide-start',
-				'name':_('Start Slide Show'),
+				'name': _('Start Slide Show'),
 				'children' : [
 					{
 						'id': 'slide-fullscreen-presentation',
@@ -504,8 +504,8 @@ window.L.Control.NotebookbarImpress = window.L.Control.NotebookbarWriter.extend(
 				} : {},
 			{
 				'type': 'overflowgroup',
-				'id': 'slide-start',
-				'name':_('Present'),
+				'id': 'slide-present',
+				'name': _('Present'),
 				'children' : [
 				!window.ThisIsAMobileApp || window.mode.isCODesktop() ?
 					{


### PR DESCRIPTION
Change-Id: I7b98084dfd0d9097e4cd16fa18510d7c90db40de

* Resolves: #15462

Follow up. There are some additional spaces between names missing, but I have to wait until the notebookbar file changes are in main, than I can fix the other ones.