### PR TITLE
Issue: Some tiles are not rendered on load.

### DIFF
--- a/browser/src/app/TilesMiddleware.ts
+++ b/browser/src/app/TilesMiddleware.ts
@@ -1325,18 +1325,10 @@ class TileManager {
 	}
 
 	private static updateTileDistance(tile: Tile, zoom: number) {
-		let modes = [app.map._docLayer._selectedMode];
-		if (
-			app.activeDocument &&
-			app.activeDocument.activeLayout.type === 'ViewLayoutCompareChanges'
-		) {
-			// 2 modes are active at the same time in compare changes view mode.
-			modes = [TileMode.LeftSide, TileMode.RightSide];
-		}
 		if (
 			tile.coords.z !== zoom ||
 			tile.coords.part !== app.map._docLayer._selectedPart ||
-			!modes.includes(tile.coords.mode)
+			!app.activeDocument.isModeActive(tile.coords.mode)
 		)
 			tile.distanceFromView = Number.MAX_SAFE_INTEGER;
 		else {


### PR DESCRIPTION
Root cause: While backporting other fixes, unused _selectedMode was revived. The variable was undefined (_selectedMode).

Fix: Check main branch and follow the correct path: User app.activeDocument.isModeActive function for mode checks of the file.


Change-Id: I2c12fa80c9eb0945a936c2a9cbb52457f37f7444


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

