### PR TITLE
fix: clean up systemplate-<jailId> dirs on kit exit to prevent disk leak

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -304,9 +304,16 @@ void removeAssocTmpOfJail(const std::string &root)
 
     jailPath.popDirectory();
     jailPath.pushDirectory("tmp");
-    jailPath.pushDirectory(std::string("cool-") + jailId);
 
-    FileUtil::removeFile(jailPath.toString(), true);
+    Poco::Path coolTmpPath(jailPath);
+    coolTmpPath.pushDirectory(std::string("cool-") + jailId);
+    FileUtil::removeFile(coolTmpPath.toString(), true);
+
+    // Also remove the per-jail systemplate copy created when
+    // sysTemplateIncomplete is true (read-only systemplate).
+    Poco::Path sysTemplatePath(jailPath);
+    sysTemplatePath.pushDirectory(std::string("systemplate-") + jailId);
+    FileUtil::removeFile(sysTemplatePath.toString(), true);
 }
 
 } // namespace


### PR DESCRIPTION
* Target version: co-25.04

