### PR TITLE
Clear up CHK_FILE_VAR() result message and combine two calls of it fo…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -658,7 +658,7 @@ AC_DEFUN([CHK_FILE_VAR], dnl $1:env-var, $2:filename-to-match, $3:cleartext-name
            fi
        done
        if test -n "$found_file"; then
-           AC_MSG_RESULT([$found_file])
+           AC_MSG_RESULT([$[$1][$4]])
        else
            AC_MSG_ERROR([This is not a [$3] [$4] directory, none of ($2) found in $[$1][$4]])
        fi
@@ -857,8 +857,7 @@ if test \( "$enable_iosapp" = "yes" -a `uname -s` = "Darwin" \) -o \( "$enable_m
 
    # Sanity checks
    if test "$enable_windowsapp" = "yes"; then
-      CHK_FILE_VAR(POCOLIB,PocoFoundationmd.lib,Poco lib)
-      CHK_FILE_VAR(POCOLIB,PocoFoundationmdd.lib,Poco lib)
+      CHK_FILE_VAR(POCOLIB,PocoFoundationmd.lib PocoFoundationmdd.lib,Poco lib)
    else
       CHK_FILE_VAR(POCOLIB,libPocoFoundation.a libPocoFoundation.so libPocoFoundation.dylib,Poco lib)
       CHK_FILE_VAR(POCOLIB,libPocoFoundation.a,Poco lib,_ARM64_V8A)


### PR DESCRIPTION
…r Windows

It is looking for a directory, so display that directory in AC_MSG_RESULT(). We know what file we are looking for, it is in the call.

We can call CHK_FILE_VAR() with several alternative file names to look for, so do that when looking for the Poco lib directory for Windows. Otherwise the configure output would look weird with one AC_MSG_CHECKING() followed by two AC_MSG_RESULT(). Also, if the point is that the files are alternatives, we need to look for either in one CHK_FILE_VAR() call, otherwise if the first one is not there, the first CHK_FILE_VAR() call would call AC_MSG_ERROR(), even if the second file would have been there.


Change-Id: I72b195f1d5ff9a68f7e45ec763cffa7c6ee0fa36


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

