### PR TITLE
Check if selection exists before use #15515

### DIFF
--- a/browser/src/control/jsdialog/Widget.FormulabarEdit.js
+++ b/browser/src/control/jsdialog/Widget.FormulabarEdit.js
@@ -36,6 +36,9 @@ function _sendSelection(edit, builder, id) {
 		return;
 
 	var selection = document.getSelection();
+	if (!selection)
+		return;
+
 	var startPos = 0;
 	var anchorOffset = selection.anchorOffset;
 	var endPos = 0;
@@ -334,6 +337,9 @@ function _setSelection(builder, container, wrapper, cursorLayer, handleLayer, te
 	}
 
 	const selectionPositions = selectionTexts.flatMap(selectionText => Array.from(selectionText.getClientRects()));
+	if (!selectionPositions.length)
+		return;
+
 	const selectionStartPosition = selectionPositions[0];
 	const selectionEndPosition = selectionPositions[selectionPositions.length - 1];
 	const cursorLayerPosition = cursorLayer.getBoundingClientRect();


### PR DESCRIPTION
Fixes #15515

Steps to reproduce:
- Open Calc
- Switch to View-Only mode (top right corner)
- triple click any cell with text (select text inside cell)

Result: error

Exception TypeError: Cannot read properties of undefined (reading 'left') emitting event jsdialog: { "jsontype": "formulabar", "action": "action", "id": 0, "data": { "control_id": "sc_input_window", "separator": ".", "selection": "0;2;0;0", "text": "gg", "action_type": "setText"}} TypeError: Cannot read properties of undefined (reading 'left')
    at _setSelection (Widget.FormulabarEdit.js:341:70)
    at container.setText (Widget.FormulabarEdit.js:417:3)
    at FormulaBar.onJSAction (Control.FormulaBarJSDialog.js:341:21)
