### PR TITLE
Add Get_Comments WOPI postMessage command

### DIFF
--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -717,6 +717,46 @@ window.L.Map.WOPI = window.L.Handler.extend({
 
 			this._postMessage({msgId: 'Get_Export_Formats_Resp', args: exportFormatsResp});
 		}
+		else if (msg.MessageId === 'Get_Comments') {
+			let commentsResp = [];
+			const commentSection = app.sectionContainer.getSectionWithName(app.CSections.CommentList.name);
+			if (commentSection) {
+				if (this._map._docLayer._docType === 'spreadsheet') {
+					// calcMasterList has raw data for all sheets.
+					const masterList = commentSection.sectionProperties.calcMasterList;
+					for (let i = 0; i < masterList.length; i++) {
+						const data = masterList[i];
+						const entry = {
+							Id: data.id,
+							Author: data.author,
+							DateTime: data.dateTime,
+							Text: data.text,
+						};
+						if (data.threaded) {
+							entry.Resolved = data.resolved;
+							entry.Parent = data.parent;
+						}
+						commentsResp.push(entry);
+					}
+				} else {
+					const commentList = commentSection.sectionProperties.commentList;
+					for (let i = 0; i < commentList.length; i++) {
+						const data = commentList[i].sectionProperties.data;
+						if (data.trackchange)
+							continue;
+						commentsResp.push({
+							Id: data.id,
+							Author: data.author,
+							DateTime: data.dateTime,
+							Text: commentList[i].sectionProperties.contentText.textContent,
+							Resolved: data.resolved,
+							Parent: data.parent,
+						});
+					}
+				}
+			}
+			this._postMessage({msgId: 'Get_Comments_Resp', args: { Comments: commentsResp }});
+		}
 		else if (msg.MessageId === 'Action_SaveAs') {
 			if (msg.Values) {
 				if (msg.Values.Filename !== null && msg.Values.Filename !== undefined) {

--- a/cypress_test/integration_tests/desktop/calc/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/annotation_spec.js
@@ -257,6 +257,68 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 		cy.cGet(helper.addressInputSelector).should('have.prop', 'value', 'B2');
 	});
 
+	it('Get_Comments postMessage returns note and threaded comments from all sheets', function() {
+		// Insert a legacy Note comment on Sheet 1.
+		calcHelper.enterCellAddressAndConfirm(this.win, 'B2');
+		desktopHelper.insertComment('note comment');
+		cy.cGet('#comment-container-1').should('exist');
+
+		// Avoid notebookbar collapse before the next insertion.
+		cy.cGet('#Home-tab-label').click();
+
+		// Insert a Threaded comment on Sheet 1.
+		calcHelper.enterCellAddressAndConfirm(this.win, 'D4');
+		cy.cGet('#Insert-tab-label').click();
+		cy.cGet('#insert-insert-threaded-comment').click();
+		cy.cGet('#comment-container-new').should('exist');
+		cy.cGet('.cool-annotation').last().find('.modify-annotation .cool-annotation-textarea')
+			.should('not.have.attr', 'disabled');
+		cy.cGet('.cool-annotation').last().find('.modify-annotation .cool-annotation-textarea')
+			.type('threaded comment', {force: true});
+		cy.cGet('.cool-annotation').last().find('[value="Save"]').click({force: true});
+		cy.cGet('#comment-container-2').should('exist');
+		cy.getFrameWindow().then(win => { helper.processToIdle(win); });
+
+		// Create a new sheet and switch to it, so we're not on the sheet with comments.
+		cy.cGet('#spreadsheet-toolbar #insertsheet').click();
+		calcHelper.assertNumberofSheets(2);
+
+		// Stub postMessage to capture the response.
+		cy.getFrameWindow().then(win => {
+			cy.stub(win.parent, 'postMessage').as('postMessage');
+		});
+
+		// Send Get_Comments postMessage from Sheet 2.
+		cy.getFrameWindow().then(win => {
+			const message = { 'MessageId': 'Get_Comments' };
+			win.postMessage(JSON.stringify(message), '*');
+		});
+
+		// Verify the response contains both comments from Sheet 1.
+		cy.get('@postMessage').should(stub => {
+			const calls = stub.getCalls().filter(call => {
+				try {
+					const msg = typeof call.args[0] === 'string' ? JSON.parse(call.args[0]) : call.args[0];
+					return msg.MessageId === 'Get_Comments_Resp';
+				} catch (e) { return false; }
+			});
+			expect(calls.length, 'Get_Comments_Resp was not posted').to.be.greaterThan(0);
+			const resp = typeof calls[0].args[0] === 'string' ? JSON.parse(calls[0].args[0]) : calls[0].args[0];
+			const comments = resp.Values.Comments;
+			expect(comments.length).to.equal(2);
+			// Legacy Note: has Text, Author, DateTime; no Resolved.
+			expect(comments[0].Text).to.equal('note comment');
+			expect(comments[0]).to.have.property('Author');
+			expect(comments[0]).to.have.property('DateTime');
+			expect(comments[0]).to.not.have.property('Resolved');
+			// Threaded comment: has Text, Author, DateTime, Resolved.
+			expect(comments[1].Text).to.equal('threaded comment');
+			expect(comments[1]).to.have.property('Author');
+			expect(comments[1]).to.have.property('DateTime');
+			expect(comments[1].Resolved).to.equal('false');
+		});
+	});
+
 });
 
 describe(['tagdesktop'], 'Annotation Autosave Tests', function() {

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -404,6 +404,51 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 			.should(el => expect(el.width()).gte(200));
 	});
 
+	it('Get_Comments postMessage returns all comments', function() {
+		desktopHelper.insertComment('first comment');
+		cy.cGet('#annotation-content-area-1').should('contain', 'first comment');
+
+		// Avoid notebookbar collapse before the second insertComment.
+		cy.cGet('#Home-tab-label').click();
+		helper.typeIntoDocument('{end}{enter}');
+
+		desktopHelper.insertComment('second comment');
+		cy.cGet('#annotation-content-area-2').should('contain', 'second comment');
+
+		// Stub postMessage to capture the response.
+		cy.getFrameWindow().then(win => {
+			cy.stub(win.parent, 'postMessage').as('postMessage');
+		});
+
+		// Send Get_Comments postMessage.
+		cy.getFrameWindow().then(win => {
+			const message = { 'MessageId': 'Get_Comments' };
+			win.postMessage(JSON.stringify(message), '*');
+		});
+
+		// Verify the response contains both comments.
+		cy.get('@postMessage').should(stub => {
+			const calls = stub.getCalls().filter(call => {
+				try {
+					const msg = typeof call.args[0] === 'string' ? JSON.parse(call.args[0]) : call.args[0];
+					return msg.MessageId === 'Get_Comments_Resp';
+				} catch (e) { return false; }
+			});
+			expect(calls.length, 'Get_Comments_Resp was not posted').to.be.greaterThan(0);
+			const resp = typeof calls[0].args[0] === 'string' ? JSON.parse(calls[0].args[0]) : calls[0].args[0];
+			const comments = resp.Values.Comments;
+			expect(comments.length).to.equal(2);
+			expect(comments[0].Id).to.equal('1');
+			expect(comments[0].Text).to.equal('first comment');
+			expect(comments[0]).to.have.property('Author');
+			expect(comments[0]).to.have.property('DateTime');
+			expect(comments[0].Resolved).to.equal('false');
+			expect(comments[0].Parent).to.equal('0');
+			expect(comments[1].Id).to.equal('2');
+			expect(comments[1].Text).to.equal('second comment');
+		});
+	});
+
 });
 
 describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {


### PR DESCRIPTION
Allow WOPI hosts to query all document comments via a Get_Comments
postMessage. Returns Id, Author, DateTime, Text, and for Writer /
Calc threaded comments also Resolved and Parent. For Calc, returns
comments from all sheets.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I5d48549691f405df8c13f81ee52f733b7ca9116e
