### PR TITLE
fix embedded video svg dimensions

### DIFF
--- a/browser/src/app/GraphicSelectionMiddleware.ts
+++ b/browser/src/app/GraphicSelectionMiddleware.ts
@@ -65,7 +65,11 @@ class GraphicSelection {
 
 		var videoToInsert =
 			'<?xml version="1.0" encoding="UTF-8"?>\
-		<svg xmlns="http://www.w3.org/2000/svg">\
+		<svg xmlns="http://www.w3.org/2000/svg" width="' +
+			videoDesc.width +
+			'" height="' +
+			videoDesc.height +
+			'">\
 		<foreignObject overflow="visible" width="' +
 			videoDesc.width +
 			'" height="' +

--- a/cypress_test/integration_tests/desktop/impress/image_operation_spec.js
+++ b/cypress_test/integration_tests/desktop/impress/image_operation_spec.js
@@ -24,6 +24,18 @@ describe(['tagdesktop'], 'Image Operation Tests', function() {
 
 	it("Insert multimedia", function () {
 		desktopHelper.insertVideo();
+
+		// The video foreignObject lives inside a nested <svg> wrapper.
+		// Verify the wrapper has explicit dimensions so it does not
+		// fall back to the SVG default 300x150 and clip the video.
+		cy.cGet('#document-container svg svg').should('have.attr', 'width');
+		cy.cGet('#document-container svg svg').should('have.attr', 'height');
+		cy.cGet('#document-container svg svg foreignObject').then(function ($fo) {
+			var foWidth = $fo.attr('width');
+			var foHeight = $fo.attr('height');
+			cy.cGet('#document-container svg svg').should('have.attr', 'width', foWidth);
+			cy.cGet('#document-container svg svg').should('have.attr', 'height', foHeight);
+		});
 	});
 
 	it.skip('Crop Image', function () {


### PR DESCRIPTION
regression from:

commit 221ee06f481cfaf67a3bcf3d4d5814196c46b2c7
Date:   Wed Jan 14 08:54:42 2026 +0000

    tidy shapehandle svg data

which added a svg container to the embeddedobj, but its defaults are 300x150 pixels.

Extended the cypress video test to check for sizes


Change-Id: I34c3f0506e7949028d30b1b3b13ad472061e6742


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

