### PR TITLE
cool calc: add snackbar for #REF! warning on cell deletion

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -474,6 +474,7 @@ COOL_JS_LST =\
 	src/control/Control.ESignature.ts \
 	src/control/Control.ESignatureDialog.ts \
 	src/control/Control.AIChatSidebar.ts \
+	src/control/CalcNotifications.ts \
 	src/control/ColorPicker.ts \
 	src/control/jsdialog/Util.Shortcuts.ts \
 	src/control/jsdialog/Util.ModelState.ts \

--- a/browser/mocha_tests/sources.ts
+++ b/browser/mocha_tests/sources.ts
@@ -191,6 +191,7 @@
 /// <reference path="../src/control/jsdialog/Definitions.MenuCommands.ts" />
 /// <reference path="../src/control/jsdialog/Control.ts" />
 /// <reference path="../src/control/jsdialog/Control.ContextMenu.ts" />
+/// <reference path="../src/control/CalcNotifications.ts" />
 /// <reference path="../src/control/Control.UIManager.ts" />
 /// <reference path="../src/control/Notebookbar.WriterReferencesTab.ts" />
 /// <reference path="../src/control/Control.ContextToolbar.ts" />

--- a/browser/src/control/CalcNotifications.ts
+++ b/browser/src/control/CalcNotifications.ts
@@ -1,0 +1,52 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+/*
+ * CalcNotifications - calc-specific UI notifications from core
+ * (snackbars, toasts), kept separate from CalcTileLayer which
+ * handles tile/layer state.
+ */
+
+class CalcNotifications {
+	private map: any;
+
+	constructor(map: any) {
+		this.map = map;
+		this.map.on('commandstatechanged', this.onStateChanged, this);
+	}
+
+	private onStateChanged(e: any): void {
+		if (e.commandName === 'CalcRefError') {
+			this.onCalcRefError(e.state);
+		} else if (e.commandName === 'CalcRefErrorDismiss') {
+			this.map.uiManager.closeSnackbar();
+		}
+	}
+
+	private onCalcRefError(state: any): void {
+		if (!state || !state.cellAddress) return;
+		const map = this.map;
+		const cellAddr = state.cellAddress;
+		map.uiManager.showSnackbar(
+			_(
+				'The deletion created reference errors. Use Undo to restore the deleted cells.',
+			),
+			_('Go to First Error'),
+			function () {
+				map.sendUnoCommand('.uno:GoToCell', {
+					ToPoint: { type: 'string', value: cellAddr },
+				});
+			},
+			-1,
+			false,
+			true,
+		);
+	}
+}

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -602,6 +602,7 @@ class UIManager extends window.L.Control {
 			formulabarRow?.classList?.remove('hidden');
 			this.map.formulabar = JSDialog.FormulaBar(this.map);
 			this.map.addressInputField = JSDialog.AddressInputField(this.map);
+			this.map.calcNotifications = new CalcNotifications(this.map);
 			$('#toolbar-wrapper').addClass('spreadsheet');
 
 			// remove unused elements


### PR DESCRIPTION
Handle CalcRefError / CalcRefErrorDismiss state-change callbacks from core in Map.CalcNotifications.js handler. Shows a snackbar with a "Go to First Error" action when deleting rows, columns or sheets breaks cell references. Dismissed on undo or via the close button.

Known limitations:
- Any undo dismisses the snackbar, not only undo of the specific delete that caused the warning. Matches the desktop infobar behavior from the core patch.
- closeSnackbar() is unscoped — if an unrelated snackbar happens to be active at undo time, it gets closed too. The snackbar controller has no id-based close API; this affects all existing callers equally.

See: https://github.com/CollaboraOnline/online/issues/2861

related core commits:
0abd73e48409d931d08b03a3f8180bdfd7262bb2
b3354e376bee90dedf1fe84b5cf6f4f3c17b7f70

The feature is controlled by an Expert Configuration option at org.openoffice.Office.Calc/Input/WarnOnDeleteCellReferences
(default: off for now).

Change-Id: Iafd8bda09157f6b109762204c2109f66d47cb455


* Resolves: #2861
* Target version: main

### Summary


### TODO

- [ ] not merged yet: 0abd73e48409d931d08b03a3f8180bdfd7262bb2

### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

