### PR TITLE
jsdialog: disable Find and Replace "Replace" tab in viewmode and readonly 

### DIFF
--- a/browser/src/control/jsdialog/Definitions.DialogModification.ts
+++ b/browser/src/control/jsdialog/Definitions.DialogModification.ts
@@ -24,6 +24,37 @@ const dialogModifications = new Map<string, DialogModificationCallback>();
 dialogModifications.set('FindReplaceDialog', function (instance: any) {
 	if (!instance.container) return;
 
+	// In view mode, disable the Replace tab so the user cannot switch to
+	// replace controls.
+	if (!(window as any).app.map.isEditMode()) {
+		const disableReplaceTab = () => {
+			const tab = instance.container.querySelector(
+				'#replace_tab_btn',
+			) as HTMLElement;
+			if (tab) {
+				tab.setAttribute('disabled', 'true');
+				tab.setAttribute('data-cooltip', _('You are currently in View mode'));
+				tab.style.pointerEvents = 'auto';
+				(window as any).L.control.attachTooltipEventListener(
+					tab,
+					(window as any).app.map,
+				);
+			}
+		};
+
+		disableReplaceTab();
+
+		// Observe the parent container for child changes and re-apply the disabled state.
+		const replaceTab = instance.container.querySelector(
+			'#replace_tab_btn',
+		) as HTMLElement;
+		if (replaceTab && replaceTab.parentNode) {
+			new MutationObserver(disableReplaceTab).observe(replaceTab.parentNode, {
+				childList: true,
+			});
+		}
+	}
+
 	instance.container.addEventListener('keydown', function (e: KeyboardEvent) {
 		if (e.code !== 'Enter') return; // Only handle Enter key
 


### PR DESCRIPTION
Change-Id: Icae0a1ddca8f261daadbf634d85e84588481d6b0


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
 - Use a MutationObserver on the Replace tab in the Find & Replace dialog to ensure it cannot be re-enabled during dialog DOM updates when in view mode or read-only mode.
 
 
### PREVIEW
<img width="600" height="259" alt="2026-04-16_16-03" src="https://github.com/user-attachments/assets/131725b6-47d9-4b82-8dc9-544e51829ead" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

