### PR TITLE
Private/rparth07/text based img a11y

### DIFF
--- a/browser/src/control/jsdialog/Definitions.Types.ts
+++ b/browser/src/control/jsdialog/Definitions.Types.ts
@@ -22,6 +22,7 @@ interface WidgetJSON {
 	children?: Array<WidgetJSON>; // child nodes
 	title?: string;
 	text?: string; // TODO: remove, its for not yet defined widget types
+	editText?: string; // text content from WeldEditView (EditEngine)
 	tooltip?: string; // tooltip text (QuickHelpText from VCL)
 	top?: string; // placement in the grid - row
 	left?: string; // placement in the grid - column

--- a/browser/src/control/jsdialog/Widget.DrawingArea.js
+++ b/browser/src/control/jsdialog/Widget.DrawingArea.js
@@ -83,8 +83,14 @@ function _drawingAreaControl (parentContainer, data, builder) {
 		span.innerText = data.text;
 	}
 
+	_setupDrawingAreaMouseEvents(image, container, builder);
+	_setupDrawingAreaKeyboardEvents(image, container, builder);
+
+	return false;
+}
+
+function _setupDrawingAreaMouseEvents (imageElement, container, builder) {
 	var getCoordinatesFromEvent = function (e) {
-		var imageElement = document.getElementById(imageId);
 		var boundingBox = imageElement.getBoundingClientRect();
 		var ret = [e.x - boundingBox.left, e.y - boundingBox.top];
 
@@ -97,7 +103,7 @@ function _drawingAreaControl (parentContainer, data, builder) {
 	var moveTimer = null;
 	var moveFunc = null;
 
-	window.L.DomEvent.on(image, 'dblclick', function(e) {
+	window.L.DomEvent.on(imageElement, 'dblclick', function(e) {
 		var pos = getCoordinatesFromEvent(e);
 		var coordinates = pos[0] + ';' + pos[1];
 
@@ -107,7 +113,7 @@ function _drawingAreaControl (parentContainer, data, builder) {
 		builder.callback('drawingarea', 'dblclick', container.getCurrent(), coordinates, builder);
 	}, this);
 
-	window.L.DomEvent.on(image, 'click touchend', function(e) {
+	window.L.DomEvent.on(imageElement, 'click touchend', function(e) {
 		var pos = getCoordinatesFromEvent(e);
 		var coordinates = pos[0] + ';' + pos[1];
 
@@ -144,7 +150,7 @@ function _drawingAreaControl (parentContainer, data, builder) {
 		builder.callback('drawingarea', 'mouseup', container.getCurrent(), coordinates, builder);
 	};
 
-	image.addEventListener('mousedown', function (e) {
+	imageElement.addEventListener('mousedown', function (e) {
 		moveFunc = function () {
 			var pos = getCoordinatesFromEvent(e);
 			var coordinates = pos[0] + ';' + pos[1];
@@ -160,10 +166,12 @@ function _drawingAreaControl (parentContainer, data, builder) {
 		window.addEventListener('mousemove', onMove);
 		window.addEventListener('mouseup', endMove);
 	});
+}
 
+function _setupDrawingAreaKeyboardEvents (focusElement, container, builder) {
 	var modifier = 0;
 
-	image.addEventListener('keydown', function(event) {
+	focusElement.addEventListener('keydown', function(event) {
 		if (event.key === 'Enter') {
 			builder.callback('drawingarea', 'keypress', container.getCurrent(), UNOKey.RETURN | modifier, builder);
 			event.preventDefault();
@@ -210,7 +218,7 @@ function _drawingAreaControl (parentContainer, data, builder) {
 		}
 	});
 
-	image.addEventListener('keyup', function(event) {
+	focusElement.addEventListener('keyup', function(event) {
 		if (event.key === 'Shift') {
 			modifier = modifier & (~app.UNOModifier.SHIFT);
 			event.preventDefault();
@@ -220,11 +228,11 @@ function _drawingAreaControl (parentContainer, data, builder) {
 		}
 	});
 
-	image.addEventListener('blur', function() {
+	focusElement.addEventListener('blur', function() {
 		modifier = 0;
 	});
 
-	image.addEventListener('keypress', function(event) {
+	focusElement.addEventListener('keypress', function(event) {
 		if (event.key === 'Enter' ||
 			event.key === 'Escape' ||
 			event.key === 'Esc' ||
@@ -256,8 +264,6 @@ function _drawingAreaControl (parentContainer, data, builder) {
 
 		event.preventDefault();
 	});
-
-	return false;
 }
 
 JSDialog.drawingArea = function (parentContainer, data, builder) {

--- a/browser/src/control/jsdialog/Widget.DrawingArea.js
+++ b/browser/src/control/jsdialog/Widget.DrawingArea.js
@@ -39,52 +39,94 @@ function _drawingAreaControl (parentContainer, data, builder) {
 	if (!data.image)
 		return;
 
-	var image = window.L.DomUtil.create('img', builder.options.cssClass + ' ui-drawing-area', container);
+	var isTextbox = data.aria && data.aria.role === 'textbox';
 	var imageId = data.id + '-img';
-	image.id = imageId;
-	image.src = data.image.replace(/\\/g, '');
-	image.draggable = false;
-	image.ondragstart = function() { return false; };
 
-	const isFocusableImg = data.enabled && data.canFocus;
-	if (isFocusableImg) {
-		image.tabIndex = 0;
-		JSDialog.AddAltAttrOnFocusableImg(image, data, builder);
-		if (data.aria && data.aria.role) {
-			image.setAttribute('role', data.aria.role);
+	if (isTextbox) {
+		// Editable drawing areas (e.g. spell check sentence box) use a
+		// div with role="textbox" wrapping the visual image.
+		var wrapper = window.L.DomUtil.create('div', builder.options.cssClass + ' ui-drawing-area', container);
+		wrapper.id = imageId;
+		wrapper.tabIndex = 0;
+		wrapper.setAttribute('role', 'textbox');
+		wrapper.setAttribute('aria-multiline', 'true');
+
+		if (data.editText) {
+			wrapper.setAttribute('aria-label', data.editText);
 		}
+
+		if (data.aria.description) {
+			var descSpan = window.L.DomUtil.create('span', 'visuallyhidden', wrapper);
+			descSpan.id = imageId + '-desc';
+			descSpan.textContent = data.aria.description;
+			wrapper.setAttribute('aria-describedby', descSpan.id);
+		}
+
+		var img = window.L.DomUtil.create('img', '', wrapper);
+		img.src = data.image.replace(/\\/g, '');
+		img.style.display = 'block';
+		img.draggable = false;
+		img.ondragstart = function() { return false; };
+		img.alt = '';
+		img.setAttribute('aria-hidden', 'true');
+		img.addEventListener('mousedown', function() { wrapper.focus(); });
+
+		if (data.text) {
+			wrapper.setAttribute('data-cooltip', data.text);
+			if (builder.map) {
+				window.L.control.attachTooltipEventListener(wrapper, builder.map);
+			}
+		}
+
+		_setupDrawingAreaMouseEvents(img, container, builder);
+		_setupDrawingAreaKeyboardEvents(wrapper, container, builder);
 	} else {
-		image.alt = '';
-		image.classList.add('ui-decorative-image');
-	}
+		var image = window.L.DomUtil.create('img', builder.options.cssClass + ' ui-drawing-area', container);
+		image.id = imageId;
+		image.src = data.image.replace(/\\/g, '');
+		image.draggable = false;
+		image.ondragstart = function() { return false; };
 
-	if (data.text) {
-		image.setAttribute('data-cooltip', data.text);
-
-		if (builder.map) {
-			window.L.control.attachTooltipEventListener(image, builder.map);
+		const isFocusableImg = data.enabled && data.canFocus;
+		if (isFocusableImg) {
+			image.tabIndex = 0;
+			JSDialog.AddAltAttrOnFocusableImg(image, data, builder);
+			if (data.aria && data.aria.role) {
+				image.setAttribute('role', data.aria.role);
+			}
+		} else {
+			image.alt = '';
+			image.classList.add('ui-decorative-image');
 		}
-	}
 
-	// Line width dialog is affected from delay on image render.
-	// So If the image render is delayed, use width and height of the data
-	if (JSDialog.isWidgetInModalPopup(data) && image.width == 0 && image.height == 0) {
-		image.width = data.imagewidth;
-		image.height = data.imageheight;
-	}
+		if (data.text) {
+			image.setAttribute('data-cooltip', data.text);
 
-	if (data.loading && data.loading === 'true') {
-		var loaderContainer = window.L.DomUtil.create('div', 'ui-drawing-area-loader-container', container);
-		window.L.DomUtil.create('div', 'ui-drawing-area-loader', loaderContainer);
-	}
-	if (data.placeholderText && data.placeholderText === 'true') {
-		var spanContainer = window.L.DomUtil.create('div', 'ui-drawing-area-placeholder-container', container);
-		var span = window.L.DomUtil.create('span', 'ui-drawing-area-placeholder', spanContainer);
-		span.innerText = data.text;
-	}
+			if (builder.map) {
+				window.L.control.attachTooltipEventListener(image, builder.map);
+			}
+		}
 
-	_setupDrawingAreaMouseEvents(image, container, builder);
-	_setupDrawingAreaKeyboardEvents(image, container, builder);
+		// Line width dialog is affected from delay on image render.
+		// So If the image render is delayed, use width and height of the data
+		if (JSDialog.isWidgetInModalPopup(data) && image.width == 0 && image.height == 0) {
+			image.width = data.imagewidth;
+			image.height = data.imageheight;
+		}
+
+		if (data.loading && data.loading === 'true') {
+			var loaderContainer = window.L.DomUtil.create('div', 'ui-drawing-area-loader-container', container);
+			window.L.DomUtil.create('div', 'ui-drawing-area-loader', loaderContainer);
+		}
+		if (data.placeholderText && data.placeholderText === 'true') {
+			var spanContainer = window.L.DomUtil.create('div', 'ui-drawing-area-placeholder-container', container);
+			var span = window.L.DomUtil.create('span', 'ui-drawing-area-placeholder', spanContainer);
+			span.innerText = data.text;
+		}
+
+		_setupDrawingAreaMouseEvents(image, container, builder);
+		_setupDrawingAreaKeyboardEvents(image, container, builder);
+	}
 
 	return false;
 }


### PR DESCRIPTION
core patch: https://gerrit.collaboraoffice.com/c/core/+/1074

### Summary
Drawing areas with role="textbox" (i.e. the spell check sentence box) were inaccessible because the content is rendered as a bitmap. Screen readers cannot read image pixels.

- When the drawing area has aria role "textbox", wrap the image in a div[role="textbox"] instead of putting the role on the img element directly, since img cannot have role="textbox" per the ARIA in HTML spec.
- Set aria-label from the new editText property (emitted by core from WeldEditView's EditEngine) so screen readers announce the text content.
- Use aria-describedby with a hidden span for the widget description.
- The image inside is marked aria-hidden since it is a visual duplicate of the text.

- Mouse events route to the image (for coordinate-based interaction with core) while keyboard and focus events route to the wrapper div.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

