### PR TITLE
allowlist the precanned providers

### DIFF
--- a/browser/admin/src/integrator/AdminIntegratorSettings.ts
+++ b/browser/admin/src/integrator/AdminIntegratorSettings.ts
@@ -351,6 +351,10 @@ try {
 	isCODesktop = false;
 }
 
+// Keep in sync with the pre-canned provider map in wsd/FileServer.cpp
+// fetchModels. The server ignores the baseUrl from the client for non-custom
+// providers and uses its own copy, so a caller cannot pair a pre-canned id
+// with an arbitrary url.
 const AI_PROVIDERS: Array<AIProvider> = [
 	{
 		id: 'openai',

--- a/wsd/FileServer.cpp
+++ b/wsd/FileServer.cpp
@@ -232,6 +232,18 @@ std::string stringifyBoolFromConfig(const Poco::Util::LayeredConfiguration& conf
     return config.getBool(propertyName, defaultValue) ? "true" : "false";
 }
 
+/// Returns the canonical base url for a pre-canned AI provider id, or an
+/// empty view if the id is not pre-canned. Keep in sync with AI_PROVIDERS in
+/// browser/admin/src/integrator/AdminIntegratorSettings.ts.
+std::string_view preCannedAIProviderBaseUrl(std::string_view id)
+{
+    if (id == "openai")   return "https://api.openai.com";
+    if (id == "groq")     return "https://api.groq.com/openai";
+    if (id == "together") return "https://api.together.xyz";
+    if (id == "mistral")  return "https://api.mistral.ai";
+    return {};
+}
+
 /// Returns true if the host is forbidden by KIT_HOST_ALLOWLIST, matching
 /// the convention of core's HostFilter::isForbidden.
 bool isForbiddenKitHost(const std::string& host)
@@ -1871,26 +1883,35 @@ void FileServerRequestHandler::fetchModels(const Poco::Net::HTTPRequest& request
         return;
     }
 
-    if (provider == "custom" && baseUrl.empty())
+    // Ignore the client's baseUrl for non-custom providers so a caller
+    // cannot pair a pre-canned id with an arbitrary url to bypass the KIT
+    // allowlist.
+    const bool isCustom = provider == "custom";
+    if (!isCustom)
+    {
+        const std::string_view preCanned = preCannedAIProviderBaseUrl(provider);
+        if (preCanned.empty())
+        {
+            sendError(http::StatusCode::BadRequest, getRequestPath(request), socket, shortMessage,
+                      "Unknown provider");
+            return;
+        }
+        baseUrl.assign(preCanned);
+    }
+    else if (baseUrl.empty())
     {
         sendError(http::StatusCode::BadRequest, getRequestPath(request), socket, shortMessage,
                   "Missing baseUrl for custom provider");
         return;
     }
 
-    if (baseUrl.empty())
-    {
-        sendError(http::StatusCode::BadRequest, getRequestPath(request), socket, shortMessage,
-                  "Missing baseUrl for provider");
-        return;
-    }
     if (baseUrl.back() == '/')
         baseUrl.pop_back();
     baseUrl += "/v1/models";
 
     Poco::URI uri(baseUrl);
 
-    if (isForbiddenKitHost(uri.getHost()))
+    if (isCustom && isForbiddenKitHost(uri.getHost()))
     {
         LOG_WRN("Rejected fetch-models request to host not in KIT allowlist ["
                 << COOLWSD::anonymizeUrl(baseUrl) << ']');


### PR DESCRIPTION
since:

commit b6b4074c7aefc0c0639c0ae659b9573b3ee39f42
Date:   Thu Apr 9 14:24:25 2026 +0000

    reuse the rules of what locations users can fetch from


Change-Id: Ibbb7fb3eb52ea605766f43f9fd3217a0169ec1f9


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

