### PR TITLE
fix: fix dynamic zoom display scaling issues in writer

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -394,6 +394,7 @@ export class CommentSection extends CanvasSectionObject {
 		return type === 'ViewLayoutMultiPage' || type === 'ViewLayoutCompareChanges';
 	}
 
+	/* todo: check if we need to apply scaling to `availableSpace`, or is it already done by `getTotalSideSpace()` */
 	public calculateAvailableSpace() {
 		if (CommentSection.isMultiColumnLayout()) {
 			const layout = app.activeDocument.activeLayout as ViewLayoutMultiPage | ViewLayoutCompareChanges;
@@ -402,7 +403,7 @@ export class CommentSection extends CanvasSectionObject {
 		}
 		else {
 			let availableSpace = (this.containerObject.getDocumentAnchorSection().size[0] - app.activeDocument.fileSize.pX) * 0.5;
-			availableSpace = Math.round(availableSpace / app.dpiScale);
+			availableSpace = Math.round(availableSpace);
 			return availableSpace;
 		}
 	}

--- a/browser/src/map/Map.js
+++ b/browser/src/map/Map.js
@@ -419,7 +419,7 @@ window.L.Map = window.L.Evented.extend({
 
 		if (this._docLayer && this._docLayer._docType === 'text' && offset.x != 0 &&
 			app.activeDocument.activeLayout.type === 'ViewLayoutWriter')
-			offset.x += (app.activeDocument.activeLayout).getDocumentScrollOffset();
+			offset.x += ((app.activeDocument.activeLayout).getDocumentScrollOffset() / app.dpiScale);
 
 		//If we pan too far then chrome gets issues with tiles
 		// and makes them disappear or appear in the wrong place (slightly offset) #2602


### PR DESCRIPTION
- calculateAvailableSpace gets scaled up values for document and container width, so no need to scale that further.

- panBy doesn't use scaled up values, but getDocumentScrollOffset returns the offset with scaling applied. So we need to divide that by the scaling factor.


Change-Id: I039761ae5c986c4a9959be509eb46a39370c252c


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

