### PR TITLE
Private/rparth07/a11y general feedback fix

### DIFF
--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -385,12 +385,12 @@
   </div>
   <div class="sub-section">
     <p><span class="def">The status bar:</span> The status bar is shown in the bottom, and contains several useful options and features.</p>
-    <div class="screenshot"><img alt="The status bar" src="images/help/en/status-bar.png"/></div>
+    <div class="screenshot"><img alt="Status bar showing page number, word count, insert mode, selection mode, language, edit mode, navigation, zoom, and search" src="images/help/en/status-bar.png"/></div>
   </div>
   <div class="sub-section">
     <p><span class="def">The search bar:</span> Searching starts automatically when content is inserted in the search box, and the document window automatically moves to the first occurrence found. Searching is not case-sensitive. There are three buttons right next to the search box:</p>
     <ul>
-      <li>Search backwards></li>
+      <li>Search backwards</li>
       <li>Search forward</li>
       <li>Cancel the search (appears only when a text has been searched)</li>
     </ul>
@@ -402,7 +402,7 @@
   </div>
   <div class="sub-section">
     <p><span class="def">The information bar:</span> The information bar displays details about the current document. The actual information depends on the nature of the document.</p>
-    <div class="screenshot"><img alt="The information bar" src="images/help/en/information-bar.png"/></div>
+    <div class="screenshot"><img alt="Information bar showing page navigation arrows, zoom controls, and zoom level" src="images/help/en/information-bar.png"/></div>
   </div>
 </div>
     <div class="section">
@@ -426,13 +426,13 @@
     <h4>Document repair</h4>
     <p>When multiple people edit the same document concurrently, it is possible for their changes to conflict and this can cause some confusion. The Document Repair function allows users to undo other editor’s changes to the document to a previous state.</p>
     <p>To jump back to the selected state, select it with the mouse and hit <span class="ui">Jump to state</span>.</p>
-    <div class="screenshot"><img alt="document repair" src="images/help/en/repair-document.png"/></div>
+    <div class="screenshot"><img alt="Repair Document dialog listing past document states with columns for action type, author, and timestamp" src="images/help/en/repair-document.png"/></div>
     <p>This is particularly useful – say when a colleague inadvertently selected all text in the document with <kbd>Ctrl</kbd><span class="kbd--plus" aria-hidden="true">+</span><kbd>A</kbd> and proceeded to type over it destroying it – while you were concurrently editing.</p>
     </div>
     <div class="sub-section">
     <h4>Inactive document</h4>
     <p>When <span class="productname">{productname}</span> detects that there has not been any activity in the browser for a while, it puts the document in an “Inactive” state. The document is shown with a transparent gray overlay, with the message “Inactive document – please click to resume editing”.</p>
-    <div class="screenshot"><img alt="inactive document" src="images/help/en/inactive-document.png"/></div>
+    <div class="screenshot"><img alt="Idle document overlay with the message: Idle document - please click to reload and resume editing" src="images/help/en/inactive-document.png"/></div>
     <p>To continue editing, click on the document and the layover and message disappear. Any changes that may have been made by other users – while collaboratively editing the document – are re-loaded.</p>
     </div>
     <div class="sub-section">
@@ -454,10 +454,10 @@
       <li>
         Choose <span class="ui">Insert</span> → <span class="ui">Charts</span>. Customize your chart on the sidebar:
       </li>
-      <div class="screenshot"><img alt="chart" src="images/help/en/chart-wizard.png"/></div>
+      <div class="screenshot"><img alt="Chart Wizard dialog with chart type list on the left, chart style previews, 3D and shape options" src="images/help/en/chart-wizard.png"/></div>
       <li>If no table or range was selected, a prototype chart is displayed.</li>
     </ol>
-    <div class="screenshot"><img alt="chart" src="images/help/en/chart.png"/></div>
+    <div class="screenshot"><img alt="Column chart with grouped bars showing data for four rows across three columns" src="images/help/en/chart.png"/></div>
   </div>
   <div class="sub-section"><p><span class="def">Chart editing:</span> Double click the chart to select. Use context menus to add chart elements such as title, axis, and other. Choose <span class="ui">Data Range</span> and <span class="ui">Chart Type</span> to edit chart data and select chart type.</p></div>
   <div class="sub-section"><p><span class="def">Chart formatting:</span> The same context menu brings you to chart data table and chart type selection.</p></div>
@@ -472,13 +472,13 @@
   <div class="sub-section">
     <h4>Comments in documents</h4>
     <p>Insert comments in <span class="productname">{productname}</span> in places that need special reader attention. Comments are displayed on the right and carry the name and date of the issuer.</p>
-    <div class="screenshot"><img alt="comment" src="images/help/en/comment.png"/></div>
+    <div class="screenshot"><img alt="Comment box showing author name, date, and the comment text, displayed beside the document" src="images/help/en/comment.png"/></div>
     <p>Click on the submenu (<span class="cool-annotation-menu icon-size" ></span>) icon to reply, move and delete comments.</p>
   </div>
   <div class="sub-section">
     <h4>Spellchecking</h4>
     <p><span class="productname">{productname}</span> can check spelling in text documents, spreadsheets and presentations. A red wavy underline indicates misspelled words. Click on the right mouse button to open a context menu with suggested misspelling corrections.</p>
-    <div class="screenshot"><img alt="spellchecking" src="images/help/en/red-wavy-underline.png"/></div>
+    <div class="screenshot"><img alt="Text with a red wavy underline beneath a misspelled word" src="images/help/en/red-wavy-underline.png"/></div>
     <p>To systematically spell-check the whole document use the <span class="ui">Tools</span> menu’s <span class="ui">Spelling</span> option.</p>
   </div>
 </div>
@@ -493,7 +493,7 @@
     <div class="sub-section">
     <p>Formulas are entered in the formula bar. Enter '=' and insert the formula.</p>
     <p>All spreadsheets functions and mathematical rules applies.</p>
-    <div class="screenshot"><img alt="Formulas" src="images/help/en/formula-bar.png"/></div>
+    <div class="screenshot"><img alt="Formula bar showing cell reference B1, function wizard icon, and the formula =SIN(PI()*A1/10)" src="images/help/en/formula-bar.png"/></div>
     <p>The formula language should be extremely familiar to any spreadsheet user, and is specified in great detail in the <a href="https://www.oasis-open.org/committees/download.php/16826/openformula-spec-20060221.html" target="_blank" rel="noopener noreferrer">OASIS OpenFormula specification</a>.</p>
     </div>
     </div>
@@ -501,7 +501,7 @@
     <h3 id="1367" class="section-header">Formatting spreadsheets</h3>
     <div class="sub-section">
     <p><span class="def">Direct formatting:</span> You can format spreadsheet cells, columns, rows and sheets by formatting directly from the menus, toolbar or context menus. Direct formatting applies only to the current object selected. To format a cell either use the menu or hit <kbd>Ctrl</kbd><span class="kbd--plus" aria-hidden="true">+</span><kbd>1</kbd>. The dialog allows complex and custom number formatting, as well as font, complex border, background, cell protection and other options.</p>
-    <div class="screenshot"><img alt="format cells" src="images/help/en/format-cells.png"/></div>
+    <div class="screenshot"><img alt="Format Cells dialog on the Numbers tab with category list, format options, decimal places, and format code" src="images/help/en/format-cells.png"/></div>
     </div>
     </div>
     <div class="section">
@@ -511,7 +511,7 @@
     <ol>
       <li>
          One use for the <span class="ui">AutoFilter</span> function is to quickly restrict the display to records with identical entries in a data field.
-         <div class="screenshot"><img alt="filter" src="images/help/en/autofilter.png"/></div>
+         <div class="screenshot"><img alt="AutoFilter dropdown menu on a spreadsheet column with sort, filter by color, filter by condition, and checkboxes for individual values" src="images/help/en/autofilter.png"/></div>
         </li>
       <li>In the <span class="ui">Standard Filter</span> dialog, you can also define ranges which contain the values in particular data fields. You can use the standard filter to connect the conditions with either a logical AND or a logical OR operator.</li>
       <li>The <span class="ui">Advanced Filter</span> allows up to a total of eight filter conditions. With advanced filters you enter the conditions directly into the sheet.</li>
@@ -519,7 +519,7 @@
     </div>
     <div class="sub-section">
     <p><span class="def">Outlining:</span> You can create an outline of your data and group rows and columns together so that you can collapse and expand the groups with a single click making it easy to represent hierarchical data.</p>
-    <div class="screenshot"><img alt="outlining" src="images/help/en/outlining.png"/></div>
+    <div class="screenshot"><img alt="Spreadsheet with row and column grouping controls showing outline level buttons and collapse/expand toggles" src="images/help/en/outlining.png"/></div>
     </div>
     <div class="sub-section">
     <p><span class="def">Data validation:</span> For each cell, you can define entries to be valid. Invalid entries to a cell will be rejected. To enable data validation:</p>
@@ -527,22 +527,22 @@
       <li>
         Choose <span class="ui">Validity</span> from the <span class="ui">Data</span> menu. The <span class="ui">Validity</span> dialog opens.
       </li>
-      <div class="screenshot"><img alt="data validate" src="images/help/en/data-validation.png"/></div>
+      <div class="screenshot"><img alt="Validity dialog on the Criteria tab with Allow set to List, showing options for empty cells, selection list, and entry values" src="images/help/en/data-validation.png"/></div>
       <li>Select the validity criterion in the <span class="ui">Allow</span> drop-box list. Depending on the criterion, more options show. Fill the required data.</li>
       <li>
         Use the <span class="ui">Input Help</span> and <span class="ui">Error Alert</span> tabs to enhance the user interactions. Click <span class="ui">OK</span> to close the dialog.
       </li>
-      <div class="screenshot"><img alt="data validate" src="images/help/en/selection-list.png"/></div>
+      <div class="screenshot"><img alt="Cell dropdown list showing validated entries such as Apple, Pear, Banana, Kiwi, and Lemon" src="images/help/en/selection-list.png"/></div>
       <li>To remove the validity of the cell, open the dialog and set the <span class="ui">Allow</span> list to “All values”.</li>
     </ol>
     </div>
     <div class="sub-section">
     <p><span class="def">Comments:</span> In a spreadsheet you can insert one comment per cell. When you select <span class="ui">Insert comment</span>, a popup appears that allows you to write the content for the comment. A red dot shows on the top right corner of the cell when it has a comment. Hover the mouse on the cell to display comments.</p>
-    <div class="screenshot"><img alt="cell comments" src="images/help/en/cell-comment.png"/></div>
+    <div class="screenshot"><img alt="Spreadsheet cell with a comment popup showing the author, date, comment text, and Save/Cancel buttons" src="images/help/en/cell-comment.png"/></div>
     </div>
     <div class="sub-section">
     <p><span class="def">Conditional formatting:</span> <span class="productname">{productname}</span> adds symbols to each cell of a range based on cells conditions. Select the cell range and click the <span class="ui">Conditional Formatting</span> icon on the toolbar. Select the symbol set to apply on the range.</p>
-    <div class="screenshot"><img alt="conditional formatting" src="images/help/en/conditional-formatting.png"/></div>
+    <div class="screenshot"><img alt="Conditional formatting icon set picker showing arrows, circles, traffic lights, stars, smiley faces, and bar chart symbol sets" src="images/help/en/conditional-formatting.png"/></div>
     </div>
     </div>
 </div>
@@ -565,7 +565,7 @@
     <div class="sub-section"><p><span class="def">Direct formatting:</span> You can format text document objects by formatting directly from the menus, toolbar or context menus. Direct formatting applies only to the current object selected.</p></div>
     <div class="sub-section">
     <p><span class="def">Style formatting:</span> <span class="productname">{productname}</span> supports paragraph styles. You can apply an existing paragraph style to a paragraph. Choose menu <span class="ui">Edit</span> → <span class="ui">Edit styles</span> to change style.</p>
-    <div class="screenshot"><img alt="style formatting" src="images/help/en/paragraph-dialog.png"/></div>
+    <div class="screenshot"><img alt="Paragraph dialog on the Indents and Spacing tab with settings for indent, spacing, and line spacing, and a preview on the right" src="images/help/en/paragraph-dialog.png"/></div>
     </div>
     </div>
     <div class="section">
@@ -573,7 +573,7 @@
     <div class="sub-section">
     <h4>Handling Tables</h4>
     <p>Insert tables with proper icon in the toolbar. Select the initial number of rows and columns. Add rows and columns with the cell context menu. Merge cells with the <span class="ui">Table</span> menu. The default paragraph style inside cells is “Table contents”.</p>
-    <div class="screenshot"><img alt="insert table" src="images/help/en/insert-table.png"/></div>
+    <div class="screenshot"><img alt="Insert Table picker showing a grid to select the number of rows and columns, currently showing 5 by 3" src="images/help/en/insert-table.png"/></div>
     </div>
     <div class="sub-section">
     <p><span class="def">Formatting cells:</span> Click in the cell or range of cells and choose menu <span class="ui">Table</span> → <span class="ui">Properties</span>. Fine tune the table with the properties dialog.</p>
@@ -581,7 +581,7 @@
     <div class="sub-section">
     <h4>Track changes</h4>
     <p>When you turn on Track Changes, <span class="productname">{productname}</span> marks up new changes made to the document. Select this option again to turn it off.</p>
-    <div class="screenshot"><img alt="track changes" src="images/help/en/track-changes-comment.png"/></div>
+    <div class="screenshot"><img alt="Tracked change shown as a comment box beside the document with author name, date, and change description" src="images/help/en/track-changes-comment.png"/></div>
     <p>Changes made by different people are shown in different colors and each tracked change can be accepted or rejected, using the box that appears on the right. You can also add a comment there.</p>
     </div>
     <div class="sub-section">
@@ -619,7 +619,7 @@
     <h3 id="1401" class="section-header">Advanced features</h3>
     <div class="sub-section">
     <p><span class="def">Slide layouts:</span> <span class="productname">{productname}</span> Impress lets you change the slide layout. Select the desired slide layout in the drop-down layout list.</p>
-    <div class="screenshot"><img alt="slide layouts" src="images/help/en/slide-layouts.png"/></div>
+    <div class="screenshot"><img alt="Slide properties panel showing format, orientation, background, and master slide settings, with a layout gallery of thumbnail options below" src="images/help/en/slide-layouts.png"/></div>
     </div>
     <div class="sub-section"><p><span class="def">Master slide:</span> Select the master slide associated to the current slide. Format and arrange slide elements in the master slide.</p></div>
     <div class="sub-section"><p><span class="def">Slide transitions:</span> <span class="productname">{productname}</span> Impress provides visual effects when displaying a new slide in the slide show. Slide transitions are property of the slide, use the side bar to set the slide transition when in edit mode.</p></div>
@@ -669,7 +669,7 @@
   <div class="sub-section">
     <h4>Is there a thesaurus?</h4>
     <p>Yes. Click in the word you want and choose <span class="ui">Tools</span> → <span class="ui">Thesaurus</span>. A dialog opens with many suggestions for replacements.</p>
-    <div class="screenshot"><img alt="thesaurus" src="images/help/en/thesaurus.png"/></div>
+    <div class="screenshot"><img alt="Thesaurus dialog for the word company, listing alternatives such as institution, establishment, and troupe, with a Replace with field" src="images/help/en/thesaurus.png"/></div>
   </div>
   <div class="sub-section">
     <h4>What are the blue <span class="blue">¶</span> symbols and how can I remove them from my text document?</h4>
@@ -682,7 +682,7 @@
     <div class="sub-section">
     <h4>How do I get a word count of my document?</h4>
     <p>Word count is available in <span class="ui">Tools</span> → <span class="ui">Word count</span>. A dialog shows word counts for selection and for the whole document.</p>
-    <div class="screenshot"><img alt="word count" src="images/help/en/word-count.png"/></div>
+    <div class="screenshot"><img alt="Word Count dialog showing word and character counts for the current selection and for the whole document" src="images/help/en/word-count.png"/></div>
     <p>Word count is also displayed in the status bar. If no text is selected the word count is for the whole document. Otherwise the word count is for the selected text.</p>
     </div>
     <div class="sub-section">
@@ -693,7 +693,7 @@
       <li>
         Choose <span class="ui">Insert</span> → <span class="ui">Special Characters </span> or click the corresponding icon in the toolbar. A dialog opens.
       </li>
-      <div class="screenshot"><img alt="Special Characters" src="images/help/en/special-character.png"/></div>
+      <div class="screenshot"><img alt="Special Characters dialog with a character grid, search and font fields, hexadecimal and decimal code inputs, and recent and favorite characters at the bottom" src="images/help/en/special-character.png"/></div>
       <li>You can either browse the characters displayed with the drop lists or type a search key in the <span class="ui">Search</span> box. If you know the Unicode numeric code of the special character, enter in the boxes on the right.</li>
       <li>Press <span class="ui">Insert</span> button. To close the dialog, press <span class="ui">Cancel</span>.</li>
     </ol>
@@ -708,11 +708,11 @@
       <li>All changes are marked with a vertical bar in the right margin.</li>
       <li>Changes are displayed as comment in the right of the document area.</li>
     </ul>
-    <div class="screenshot"><img alt="track changes" src="images/help/en/track-changes-comment.png"/></div>
+    <div class="screenshot"><img alt="Tracked change shown as a comment box beside the document with author name, date, and change description" src="images/help/en/track-changes-comment.png"/></div>
     <p>The color assigned to the changes depends on the user that changes the document.</p>
     <p>To display or hide track changes choose <span class="ui">Edit</span> → <span class="ui">Track Changes </span> → <span class="ui">Show</span>. Beware that if track changes are enabled but hidden, you still record changes and may inadvertently leave unwanted text available in the document.</p>
     <p>Changes can be accepted or rejected. To accept or reject changes, click on the corresponding icons in the comment box on the right of the document. Alternatively, choose <span class="ui">Edit</span> → <span class="ui">Track Changes </span> → <span class="ui">Accept</span> or <span class="ui">Reject</span>. Furthermore, if you need to filter changes before accepting or rejecting, choose <span class="ui">Edit</span> → <span class="ui">Track Changes </span> → <span class="ui">Manage</span>. A dialog shows a list of all tracked changes. Use the dialog buttons accordingly.</p>
-    <div class="screenshot"><img alt="manage changes" src="images/help/en/manage-changes.png"/></div>
+    <div class="screenshot"><img alt="Manage Changes dialog with a list of tracked changes showing action, author, date, and comment columns, and Accept, Reject, Accept All, Reject All buttons" src="images/help/en/manage-changes.png"/></div>
     </div>
     <div class="sub-section">
     <h4>How do I set the margins of the document?</h4>
@@ -722,7 +722,7 @@
       <li>Choose <span class="ui">Format</span> → <span class="ui">Page</span> and select the <span class="ui">Page</span> tab</li>
       <li>Set the page margins in the dialog.</li>
     </ol>
-    <div class="screenshot"><img alt="page style" src="images/help/en/page-style.png"/></div>
+    <div class="screenshot"><img alt="Page Style dialog on the Organizer tab showing style name, next style, inherit from, and category fields, with a summary of page properties" src="images/help/en/page-style.png"/></div>
     </div>
     <div class="sub-section">
     <h4>How do I change the page orientation to landscape inside my document?</h4>
@@ -772,7 +772,7 @@
       <li>
         Paste from the browser <span class="ui">Edit</span> → <span class="ui">Paste</span> or press <kbd>Ctrl</kbd><span class="kbd--plus" aria-hidden="true">+</span><kbd>V</kbd>. The <span class="ui">Text Import</span> dialog opens to let you describe the precise format of the CSV data.
       </li>
-      <div class="screenshot"><img alt="import" src="images/help/en/text-import.png"/></div>
+      <div class="screenshot"><img alt="Text Import dialog with character set, locale, separator options, and a preview of the imported CSV data" src="images/help/en/text-import.png"/></div>
       <li>Select the character set, language and separator options for the CSV file.</li>
     </ol>
     <p>The CSV data is loaded into the selected cell where you pasted, according to these settings.</p>
@@ -813,7 +813,7 @@
       <li>
         Choose <span class="ui">Format</span> → <span class="ui">Line</span> (or <span class="ui">Area</span>, or <span class="ui">Position and Size</span>). A dialog opens.
       </li>
-      <div class="screenshot"><img alt="Position and Size" src="images/help/en/area-dialog.png"/></div>
+      <div class="screenshot"><img alt="Area dialog on the Color tab with a color palette, active and new color previews, RGB value fields, and a custom palette section" src="images/help/en/area-dialog.png"/></div>
       <li>Set the properties of the element of the object.</li>
     </ol>
     </div>

--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1525,14 +1525,16 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			controls['label'] = span;
 		}
 
-		const hasPopUp = hasPopupRole || JSDialog.IsDialogButton(id, data.command) || JSDialog.IsDropdownButton(id, data.command);
+		const isDialogButton = JSDialog.IsDialogButton(id, data.command);
+		const hasPopUp = hasPopupRole || isDialogButton || JSDialog.IsDropdownButton(id, data.command);
 
 		if (hasPopUp) {
-			button.setAttribute('aria-expanded', false);
-			if (JSDialog.IsDialogButton(id, data.command))
+			if (isDialogButton) {
 				button.setAttribute('aria-haspopup', 'dialog');
-			else
+			} else {
 				button.setAttribute('aria-haspopup', true);
+				button.setAttribute('aria-expanded', false);
+			}
 		}
 
 		JSDialog.SetupA11yLabelForNonLabelableElement(button, data, builder);


### PR DESCRIPTION
### Summary
- sets aria-expanded attributes for non-dialog popups only
- a11y: enhance alt text for screenshots in online help documentation dialog

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

