### PR TITLE
String to Integer Conversion -- Part 5

### DIFF
--- a/common/NumUtil.hpp
+++ b/common/NumUtil.hpp
@@ -341,52 +341,9 @@ inline std::uint64_t u64FromString(const std::string_view input, const std::uint
 */
 inline int safe_atoi(const char* p, int len)
 {
-    long ret{};
-    if (!p || !len)
-    {
-        return ret;
-    }
-
-    int multiplier = 1;
-    int offset = 0;
-    while (isspace(p[offset]))
-    {
-        ++offset;
-        if (offset >= len)
-        {
-            return ret;
-        }
-    }
-
-    switch (p[offset])
-    {
-        case '-':
-            multiplier = -1;
-            ++offset;
-            break;
-        case '+':
-            ++offset;
-            break;
-    }
-    if (offset >= len)
-    {
-        return ret;
-    }
-
-    while (isdigit(p[offset]))
-    {
-        std::int64_t next = ret * 10 + (p[offset] - '0');
-        if (next >= std::numeric_limits<int>::max())
-            return multiplier * std::numeric_limits<int>::max();
-        ret = next;
-        ++offset;
-        if (offset >= len)
-        {
-            return multiplier * ret;
-        }
-    }
-
-    return multiplier * ret;
+    std::size_t offset = 0;
+    const auto [value, res] = parseStrTo<std::int32_t>(std::string_view(p, len), offset);
+    return value;
 }
 
 /// Fast string to 32-bit signed int conversion.

--- a/common/NumUtil.hpp
+++ b/common/NumUtil.hpp
@@ -334,18 +334,6 @@ inline std::uint64_t u64FromString(const std::string_view input, const std::uint
     return strTo<std::uint64_t>(input, def);
 }
 
-/**
-* Similar to std::atoi() but does not require p to be null-terminated.
-*
-* Returns std::numeric_limits<int>::min/max() if the result would overflow.
-*/
-inline int safe_atoi(const char* p, int len)
-{
-    std::size_t offset = 0;
-    const auto [value, res] = parseStrTo<std::int32_t>(std::string_view(p, len), offset);
-    return value;
-}
-
 /// Fast string to 32-bit signed int conversion.
 /// Optimized for performance with manual parsing and minimal branches.
 /// Drop-in replacement to std::stoi() that accepts string_view.

--- a/common/StringVector.cpp
+++ b/common/StringVector.cpp
@@ -16,6 +16,8 @@
 
 #include <common/NumUtil.hpp>
 
+#include <tuple>
+
 bool StringVector::equals(std::size_t index, const StringVector& other, std::size_t otherIndex)
 {
     if (index >= _tokens.size())
@@ -49,8 +51,10 @@ bool StringVector::getUInt32(std::size_t index, const std::string& key, uint32_t
             _string.compare(token._index, key.size(), key, 0, key.size()) == 0 &&
             _string[token._index + key.size()] == '=')
     {
-        value = NumUtil::safe_atoi(&_string[token._index + offset], token._length - offset);
-        return value < std::numeric_limits<uint32_t>::max();
+        bool res = false;
+        std::tie(value, res) = NumUtil::u32FromString(
+            std::string(&_string[token._index + offset], token._length - offset));
+        return res;
     }
 
     return false;
@@ -82,8 +86,10 @@ bool StringVector::getNameIntegerPair(std::size_t index, std::string& name, int&
 
     name = _string.substr(token._index, mid - token._index);
     size_t offset = mid + 1;
-    value = NumUtil::safe_atoi(&_string[offset], token._index + token._length - offset);
-    return value > std::numeric_limits<int>::min() && value < std::numeric_limits<int>::max();
+    bool res = false;
+    std::tie(value, res) = NumUtil::i32FromString(
+        std::string(&_string[offset], token._index + token._length - offset));
+    return res;
 }
 
 StringVector StringVector::tokenizeAnyOf(std::string s, const std::string_view delimiters)

--- a/net/HttpRequest.cpp
+++ b/net/HttpRequest.cpp
@@ -268,8 +268,10 @@ FieldParseState StatusLine::parse(const char* p, int64_t& len)
         LOG_ERR("StatusLine::parse: expected valid integer number");
         return FieldParseState::Invalid;
     }
-    _statusCode = NumUtil::safe_atoi(&p[off], len - off);
-    if (_statusCode < MinValidStatusCode || _statusCode > MaxValidStatusCode)
+
+    bool res = false;
+    std::tie(_statusCode, res) = NumUtil::u32FromString(std::string(&p[off], len - off));
+    if (!res || _statusCode < MinValidStatusCode || _statusCode > MaxValidStatusCode)
     {
         LOG_ERR("StatusLine::parse: Invalid StatusCode [" << _statusCode << "]");
         return FieldParseState::Invalid;

--- a/test/NumUtilWhiteBoxTests.cpp
+++ b/test/NumUtilWhiteBoxTests.cpp
@@ -34,7 +34,6 @@ class NumUtilWhiteBoxTests : public CPPUNIT_NS::TestFixture
     CPPUNIT_TEST(testU32FromString);
     CPPUNIT_TEST(testU64FromString);
     CPPUNIT_TEST(testStoi);
-    CPPUNIT_TEST(testSafeAtoi);
     CPPUNIT_TEST(testStrtoint64MatchesStrtol);
     CPPUNIT_TEST(testStrtouint64MatchesStrtoul);
     CPPUNIT_TEST(testStrtoint64MatchesStrtoll);
@@ -47,7 +46,6 @@ class NumUtilWhiteBoxTests : public CPPUNIT_NS::TestFixture
     void testU32FromString();
     void testU64FromString();
     void testStoi();
-    void testSafeAtoi();
     void testStrtoint64MatchesStrtol();
     void testStrtouint64MatchesStrtoul();
     void testStrtoint64MatchesStrtoll();
@@ -793,106 +791,6 @@ void NumUtilWhiteBoxTests::testStoi()
     {
         LOK_ASSERT_FAIL("Unexpected: " << exc.what());
     }
-}
-
-void NumUtilWhiteBoxTests::testSafeAtoi()
-{
-    constexpr std::string_view testname = __func__;
-
-    // Helper to compare safe_atoi with std::atoi for non-overflow cases.
-    // std::atoi has UB on overflow, so we only compare within int range.
-    auto compareWithAtoi = [&](const char* str)
-    {
-        const int stdResult = std::atoi(str);
-        const int safeResult = NumUtil::safe_atoi(str, std::strlen(str));
-        LOK_ASSERT_EQUAL_CTX(stdResult, safeResult, std::string(str));
-    };
-
-    // Basic positive numbers.
-    compareWithAtoi("0");
-    compareWithAtoi("1");
-    compareWithAtoi("7");
-    compareWithAtoi("42");
-    compareWithAtoi("123");
-    compareWithAtoi("999");
-    compareWithAtoi("12345");
-
-    // Negative numbers.
-    compareWithAtoi("-1");
-    compareWithAtoi("-7");
-    compareWithAtoi("-42");
-    compareWithAtoi("-123");
-    compareWithAtoi("-999");
-    compareWithAtoi("-12345");
-
-    // Plus sign prefix.
-    compareWithAtoi("+7");
-    compareWithAtoi("+42");
-    compareWithAtoi("+0");
-
-    // Leading whitespace.
-    compareWithAtoi("  42");
-    compareWithAtoi("\t123");
-    compareWithAtoi("   -456");
-    compareWithAtoi(" \t +789");
-
-    // Leading zeros.
-    compareWithAtoi("0042");
-    compareWithAtoi("00123");
-    compareWithAtoi("-00456");
-
-    // Trailing non-numeric characters.
-    compareWithAtoi("42xy");
-    compareWithAtoi("123abc");
-    compareWithAtoi("-456def");
-
-    // Zero variants.
-    compareWithAtoi("-0");
-    compareWithAtoi("+0");
-    compareWithAtoi("0000");
-
-    // Single digit numbers.
-    compareWithAtoi("1");
-    compareWithAtoi("9");
-    compareWithAtoi("-1");
-    compareWithAtoi("-9");
-
-    // INT_MAX boundary.
-    compareWithAtoi("2147483647");
-
-    // Empty and invalid strings (atoi returns 0).
-    compareWithAtoi("");
-    compareWithAtoi("abc");
-    compareWithAtoi("   ");
-
-    // Overflow: safe_atoi clamps to INT_MAX / -INT_MAX.
-    LOK_ASSERT_EQUAL(std::numeric_limits<int>::max(), NumUtil::safe_atoi("9999999990", 10));
-    LOK_ASSERT_EQUAL(std::numeric_limits<int>::min(), NumUtil::safe_atoi("-9999999990", 11));
-    LOK_ASSERT_EQUAL(std::numeric_limits<int>::max(),
-                     NumUtil::safe_atoi("2147483648", 10)); // INT_MAX + 1.
-
-    // Length-limiting (not null-terminated behavior).
-    {
-        std::string s("42");
-        LOK_ASSERT_EQUAL(4, NumUtil::safe_atoi(s.data(), 1));
-    }
-    {
-        std::string s("12345");
-        LOK_ASSERT_EQUAL(123, NumUtil::safe_atoi(s.data(), 3));
-    }
-
-    // Embedded null (safe_atoi uses length, stops at non-digit).
-    {
-        std::string s("123");
-        s[1] = '\0';
-        LOK_ASSERT_EQUAL(1, NumUtil::safe_atoi(s.data(), s.size()));
-    }
-
-    // Null pointer.
-    LOK_ASSERT_EQUAL(0, NumUtil::safe_atoi(nullptr, 0));
-
-    // Zero length.
-    LOK_ASSERT_EQUAL(0, NumUtil::safe_atoi("42", 0));
 }
 
 void NumUtilWhiteBoxTests::testStrtoint64MatchesStrtol()

--- a/test/NumUtilWhiteBoxTests.cpp
+++ b/test/NumUtilWhiteBoxTests.cpp
@@ -867,7 +867,7 @@ void NumUtilWhiteBoxTests::testSafeAtoi()
 
     // Overflow: safe_atoi clamps to INT_MAX / -INT_MAX.
     LOK_ASSERT_EQUAL(std::numeric_limits<int>::max(), NumUtil::safe_atoi("9999999990", 10));
-    LOK_ASSERT_EQUAL(-std::numeric_limits<int>::max(), NumUtil::safe_atoi("-9999999990", 11));
+    LOK_ASSERT_EQUAL(std::numeric_limits<int>::min(), NumUtil::safe_atoi("-9999999990", 11));
     LOK_ASSERT_EQUAL(std::numeric_limits<int>::max(),
                      NumUtil::safe_atoi("2147483648", 10)); // INT_MAX + 1.
 


### PR DESCRIPTION
- **wsd: replace safe_atoi() implementation with NumUtil::strto()**
- **wsd: replace safe_atoi usage**
- **wsd: remove safe_atoi implementation**
