### PR TITLE
wopi: Action_InsertLink: accept optional "text" label from the host

### DIFF
--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -657,9 +657,11 @@ window.L.Map.WOPI = window.L.Handler.extend({
 		else if (msg.MessageId == 'Action_InsertLink') {
 			if (msg.Values) {
 				var link = this._map.makeURLFromStr(msg.Values.url);
-				var text = this._map.getTextForLink();
+				var selection = this._map.getTextForLink();
 
-				text = text ? text.trim() : link;
+				var text = selection ? selection.trim()
+					: (msg.Values.text ? String(msg.Values.text).trim() : '')
+					|| link;
 
 				var command = {
 					'Hyperlink.Text': {


### PR DESCRIPTION
Until now Action_InsertLink only took a "url" argument, and the inserted
hyperlink was labelled with either the user's current selection or the
URL itself when no selection existed. The problem is that the
integrators often pass opaque or at least very lengthly URLs (file
IDs, full path + etc), the result: ugly links in the document where
they could have been set nicely with a title (using the document
name).

Better to, accept an additional optional "text" value so the host can
supply a human-friendly label (typically the filename from its link picker).

The selected text case still works as before:
Existing selection still wins over the optional new text, because the
user explicitly marked the text they want to turn into a link; only
when there is no selection does the host-supplied "text" take over. If
neither is available the URL is still used:
-> Label precedence: selection > host-supplied text > URL.

The change is backward-compatible: hosts that do not send "text" behave
exactly as before.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>
Change-Id: I70a5c0c1a453cc51ff704b30cc47f05eb20bfa72

----

So, instead getting the following in our document:

https://staging-perf.eu.collaboraonline.com/nextcloud/index.php/f/305801

we would get:

[Track-Changes-Example.docx](https://staging-perf.eu.collaboraonline.com/nextcloud/index.php/f/305801)

