### PR TITLE
[Backport] Impress: fix slide sorter preview size issues

### DIFF
--- a/browser/src/control/Control.PartsPreview.js
+++ b/browser/src/control/Control.PartsPreview.js
@@ -855,11 +855,13 @@ window.L.Control.PartsPreview = window.L.Control.extend({
 
 		for (var part = 0; part < this._previewTiles.length; part++) {
 			this._previewTiles[part].fetched = false;
-			this._map.getPreview(part, part,
+			var imgSize = this._map.getPreview(part, part,
 					     this.options.maxWidth,
 					     this.options.maxHeight,
 					     {autoUpdate: this.options.autoUpdate,
 					      fetchThumbnail: this.options.fetchThumbnail});
+			window.L.DomUtil.setStyle(this._previewTiles[part], 'width', imgSize.width + 'px');
+			window.L.DomUtil.setStyle(this._previewTiles[part], 'height', imgSize.height + 'px');
 		}
 
 	},

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -237,10 +237,23 @@ window.L.ImpressTileLayer = window.L.CanvasTileLayer.extend({
 		textMsg = textMsg.replace('status: ', '');
 		textMsg = textMsg.replace('statusupdate: ', '');
 		if (statusJSON.width && statusJSON.height && this._documentInfo !== textMsg) {
+			let dimensionsChanged = false;
 			if (statusJSON.partdimensions) {
+				const oldDims = this._partDimensions;
 				this._partDimensions = [];
 				for (let i = 0; i < statusJSON.partdimensions.length; i++) {
 					this._partDimensions.push(new cool.SimplePoint(statusJSON.partdimensions[i].width, statusJSON.partdimensions[i].height));
+				}
+				if (!oldDims || oldDims.length !== this._partDimensions.length) {
+					dimensionsChanged = true;
+				} else {
+					for (let i = 0; i < oldDims.length; i++) {
+						if (oldDims[i].x !== this._partDimensions[i].x ||
+							oldDims[i].y !== this._partDimensions[i].y) {
+							dimensionsChanged = true;
+							break;
+						}
+					}
 				}
 			}
 
@@ -315,6 +328,10 @@ window.L.ImpressTileLayer = window.L.CanvasTileLayer.extend({
 			}
 
 			this._documentInfo = textMsg;
+
+			if (dimensionsChanged) {
+				this._invalidateAllPreviews();
+			}
 		}
 
 		if (app.file.fileBasedView)


### PR DESCRIPTION
Issues:
1. refresh was needed for preview size to be updated
2. previews in Notes View also inherited size from normal view

Fix:
1. use setStyle to change dimensions of preview on the fly
2. core now send notes pages' dimensions via partstatus message when in
   Notes View

Signed-off-by: Mohit Marathe <mohit.marathe@collabora.com>
Change-Id: Ib66c200eaa459c9f212e502850573ac61602b6c0

* Target version: main
* Backport: #15498 
