### PR TITLE
Increase the maximum number of tiles we keep ready-to-draw.

### DIFF
--- a/browser/src/app/BitmapTileManager.ts
+++ b/browser/src/app/BitmapTileManager.ts
@@ -228,7 +228,11 @@ class BitmapTileManager {
 	// When a new bitmap is set on a tile we should see if we need to expire an old tile
 	private setBitmapOnTile(tile: Tile, bitmap: ImageBitmap) {
 		// 4k screen -> 8Mpixel, each tile is 64kpixel uncompressed
-		const highNumBitmaps = 250; // ~60Mb.
+		// Most tablets and larger displays (physical width >= 1280) get a
+		// higher cap so more tiles can stay decoded in memory.
+		const physicalScreenWidth =
+			window.screen.width * (window.devicePixelRatio || 1);
+		const highNumBitmaps = physicalScreenWidth >= 1280 ? 500 : 250; // ~120Mb / ~60Mb.
 
 		if (tile.image) {
 			// fast case - no impact on count of tiles or bitmap list:


### PR DESCRIPTION
Reason: Some new view types require many tiles to be drawn on the screen. This triggered some issues with tiles. Though those issues are fixed, we still wanted to increase the number for better user experience.

Fix: Increase the number of ready tiles.
Checked current average hardware stats and 60 MB addition doesn't seem like a high load for RAM.


Change-Id: If7798aaaa24f3e0cc7a883c3cdcad6e96d584f08


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

