### PR TITLE
Calc: Fix read-only file opening in edit mode

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -427,12 +427,13 @@ window.L.CalcTileLayer = window.L.CanvasTileLayer.extend({
 		if (statusJSON.width && statusJSON.height && this._documentInfo !== textMsg) {
 			const previousStatusJSON = this._lastStatusJSON ? Object.assign({}, this._lastStatusJSON): null;
 			this._lastStatusJSON = statusJSON;
-			this._documentInfo = textMsg;
-
-			var firstSelectedPart = (typeof this._selectedPart !== 'number');
 
 			if (statusJSON.readonly && !this._documentInfo)
 				this._map.setPermission('readonly');
+
+			this._documentInfo = textMsg;
+
+			var firstSelectedPart = (typeof this._selectedPart !== 'number');
 
 			app.activeDocument.fileSize = new cool.SimplePoint(statusJSON.width, statusJSON.height);
 			app.activeDocument.activeLayout.viewSize = app.activeDocument.fileSize.clone();


### PR DESCRIPTION
The guard `!this._documentInfo` was intended to call `setPermission` only on the first status message. However, `this._documentInfo` was assigned to `textMsg` one line before the check, causing the guard to always evaluate to false and preventing `setPermission` from ever executing.

Move the `_documentInfo` assignment after the read-only check so the guard functions as intended.


Change-Id: Ifc9ba699eb15fb69e74776856142c6a0267f3d03


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

