### PR TITLE
Dark mode icons are inverted in right click menu, but the correct ico…

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1500,7 +1500,7 @@ img.context-menu-icon {
 	border: 1px solid var(--color-primary);
 }
 
-[data-theme='dark'] .ui-combobox-entry img {
+[data-theme='dark'] .ui-combobox-entry img:not() {
 	filter: invert(1);
 }
 

--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1500,10 +1500,6 @@ img.context-menu-icon {
 	border: 1px solid var(--color-primary);
 }
 
-[data-theme='dark'] .ui-combobox-entry img:not() {
-	filter: invert(1);
-}
-
 /* Combobox entry with menu and thus arrow/chevron */
 .ui-combobox-entry.ui-has-menu {
 	display: grid;


### PR DESCRIPTION
…ns are available

Change-Id: I3f1486c0402b776c2d5ee9b2654404a007f3cefb

* Resolves: #15441 

<img width="787" height="105" alt="image" src="https://github.com/user-attachments/assets/6b7911df-2ba4-47cb-8b6a-e80c3ab56a24" />

I'm not sure cause this css rule is in cool since 3 years and I'm a bit surprize that it's not correct.

However, ordinary ALL collibre icons should be also available as dark variant. So an css invert isn't needed I think.

But you know css rules can change at different places, so please I don't know why this rule exist. 