### PR TITLE
Calc NB Home move ToggleMergeCells to Cells from alignment group

### DIFF
--- a/browser/src/control/Control.NotebookbarCalc.js
+++ b/browser/src/control/Control.NotebookbarCalc.js
@@ -758,13 +758,6 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 					],
 					'vertical': 'true'
 				},
-				{
-					'id': 'home-merge-cells',
-					'type': 'bigtoolitem',
-					'text': _('Merge & Center'),
-					'command': '.uno:ToggleMergeCells',
-					'accessibility': { focusBack: true, combination: 'MC', de: null }
-				}
 			]
 		},
 			{ type: 'separator', id: 'home-pararighttoleft-break', orientation: 'vertical' },
@@ -877,6 +870,13 @@ window.L.Control.NotebookbarCalc = window.L.Control.NotebookbarWriter.extend({
 				'name': _('Cells'),
 				'accessibility': { focusBack: true,	combination: 'RB', de: null },
 				'children' : [
+				{
+					'id': 'home-merge-cells',
+					'type': 'bigtoolitem',
+					'text': _('Merge & Center'),
+					'command': '.uno:ToggleMergeCells',
+					'accessibility': { focusBack: true, combination: 'MC', de: null }
+				},
 				{
 					'id': 'Home-Section-Cell1',
 					'type': 'container',


### PR DESCRIPTION
Change-Id: I558731b906b82d992f3e9c4380ef3b3daa2d164c

Move Merge & Center to Cell group from Alignment group. Excel has it in Alignment group. In general it's an Cell feature and after thatn an alignemnt one in Addition the cell group didn't has that much commands and large groups aren't that good for collaps.

### After

<img width="1920" height="123" alt="image" src="https://github.com/user-attachments/assets/e56902c1-ef43-49d5-9d1a-1144d0f64cdd" />


### Before

<img width="1920" height="123" alt="image" src="https://github.com/user-attachments/assets/4b9cf706-9fa9-4f47-9209-5e99a2edaec5" />

From my point of view it's 1st an cell command, so I would see it in the cell group.