### PR TITLE
Remove pdf_resolution_dpi from coolwsd.xml

### DIFF
--- a/.gitpod-files/coolwsd-gitpod.xml
+++ b/.gitpod-files/coolwsd-gitpod.xml
@@ -52,7 +52,6 @@
         <batch_priority desc="A (lower) priority for use by batch eg. convert-to processes to avoid starving interactive ones" type="uint" default="5">5</batch_priority>
         <bgsave_priority desc="A (lower) priority for use by background save processes to free time for interactive ones" type="uint" default="5">5</bgsave_priority>
         <redlining_as_comments desc="If true show red-lines as comments" type="bool" default="false">false</redlining_as_comments>
-        <pdf_resolution_dpi desc="The resolution, in DPI, used to render PDF documents as image. Memory consumption grows proportionally. Must be a positive value less than 385. Defaults to 96." type="uint" default="96">96</pdf_resolution_dpi>
         <idle_timeout_secs desc="The maximum number of seconds before unloading an idle document. Defaults to 1 hour." type="uint" default="3600">3600</idle_timeout_secs>
         <idlesave_duration_secs desc="The number of idle seconds after which document, if modified, should be saved. Disabled when 0. Defaults to 30 seconds." type="uint" default="30">30</idlesave_duration_secs>
         <autosave_duration_secs desc="The number of seconds after which document, if modified, should be saved. Disabled when 0. Defaults to 5 minutes." type="uint" default="300">300</autosave_duration_secs>

--- a/common/ConfigUtil.cpp
+++ b/common/ConfigUtil.cpp
@@ -215,7 +215,6 @@ static const std::unordered_map<std::string, std::string> DefAppConfig = {
     { "per_document.max_concurrency", "4" },
     { "per_document.min_time_between_saves_ms", "500" },
     { "per_document.min_time_between_uploads_ms", "5000" },
-    { "per_document.pdf_resolution_dpi", "96" },
     { "per_document.redlining_as_comments", "false" },
     { "per_view.custom_os_info", "" },
     { "per_view.idle_timeout_secs", "900" },

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -53,7 +53,6 @@
         <bgsave_priority desc="A (lower) priority for use by background save processes to free time for interactive ones" type="uint" default="5">5</bgsave_priority>
         <bgsave_timeout_secs desc="The default maximum number of seconds to wait for the background save processes to finish before giving up and reverting to synchronous saving" type="uint" default="120">120</bgsave_timeout_secs>
         <redlining_as_comments desc="If true show red-lines as comments" type="bool" default="false">false</redlining_as_comments>
-        <pdf_resolution_dpi desc="The resolution, in DPI, used to render PDF documents as image. Memory consumption grows proportionally. Must be a positive value less than 385. Defaults to 96." type="uint" default="96">96</pdf_resolution_dpi>
         <idle_timeout_secs desc="The maximum number of seconds before unloading an idle document. Defaults to 1 hour." type="uint" default="3600">3600</idle_timeout_secs>
         <idlesave_duration_secs desc="The number of idle seconds after which document, if modified, should be saved. Disabled when 0. Defaults to 30 seconds." type="uint" default="30">30</idlesave_duration_secs>
         <autosave_duration_secs desc="The number of seconds after which document, if modified, should be saved. Disabled when 0. Defaults to 5 minutes." type="uint" default="300">300</autosave_duration_secs>

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -1783,26 +1783,16 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
 
 #endif // !MOBILEAPP
 
-    int pdfResolution =
-        ConfigUtil::getConfigValue<int>(conf, "per_document.pdf_resolution_dpi", 96);
-    if (pdfResolution > 0)
-    {
-        constexpr int MaxPdfResolutionDpi = 384;
-        if (pdfResolution > MaxPdfResolutionDpi)
-        {
-            // Avoid excessive memory consumption.
-            LOG_WRN("The PDF resolution specified in per_document.pdf_resolution_dpi ("
-                    << pdfResolution << ") is larger than the maximum (" << MaxPdfResolutionDpi
-                    << "). Using " << MaxPdfResolutionDpi << " instead.");
+#if defined(DEBUG)
+    // Enable if you need more logging from core
+    //setenv("SAL_LOG", "+INFO+WARN", 0);
 
-            pdfResolution = MaxPdfResolutionDpi;
-        }
+    // Enable if you need to see the top left corner of tile that was rendered
+    //setenv("LOK_DEBUG_TILES", "1", 0);
+#endif
 
-        const std::string pdfResolutionStr = std::to_string(pdfResolution);
-        LOG_DBG("Setting envar PDFIMPORT_RESOLUTION_DPI="
-                << pdfResolutionStr << " per config per_document.pdf_resolution_dpi");
-        ::setenv("PDFIMPORT_RESOLUTION_DPI", pdfResolutionStr.c_str(), 1);
-    }
+    if (ConfigUtil::hasProperty("per_document.pdf_resolution_dpi"))
+        LOG_WRN("NOTE: Deprecated config option per_document.pdf_resolution_dpi is no longer supported");
 
     SysTemplate = ConfigUtil::getPathFromConfig("sys_template_path");
     if (SysTemplate.empty())


### PR DESCRIPTION
We have the PDF primitive, which rerenders the PDF with PDFium depending on the current viewport. So this setting is now not relevant anymore. We still log a deprecation warning if it is used in coolwsd.xml.

Backport from main

Change-Id: If64625fd325551ba49b7bb76c1186acd33f7bd70
