### PR TITLE
Don't bother logging the numeric thread id for CODA-W either

### DIFF
--- a/common/Log-common.cpp
+++ b/common/Log-common.cpp
@@ -114,10 +114,8 @@ namespace Log
             std::chrono::system_clock::now();
         char* buffer = _buffer.data();
 
-#if defined(IOS) || defined(__FreeBSD__)
-        // Don't bother with the "Source" which would be just "Mobile" always (or whatever the app
-        // process is called depending on platform and configuration) and non-informative as there
-        // is just one process in the app anyway.
+#if defined(IOS) || defined(__FreeBSD__) || defined(_WIN32)
+        // Don't bother with identifying the process as there is just one process in the app anyway.
 
         // FIXME: Not sure why FreeBSD is here, too. Surely on FreeBSD COOL runs just like on Linux,
         // as a set of separate processes, so it would be useful to see from which process a log
@@ -127,7 +125,7 @@ namespace Log
 
         // Don't bother with the thread identifier either. We output the thread name which is much
         // more useful anyway.
-#else // !IOS && !__FreeBSD__
+#else // !IOS && !__FreeBSD__  && !_WIN32
         // Note that snprintf is deemed signal-safe in most common implementations.
         char* pos = strcopy((Static.getInited() ? Static.getId().c_str() : "<shutdown>"), buffer);
         *pos++ = '-';
@@ -274,16 +272,14 @@ namespace Log
     char* prefixReference(const std::chrono::time_point<std::chrono::system_clock>& tp,
                           char* buffer, const std::string_view level)
     {
-#if defined(IOS) || defined(__FreeBSD__)
-        // Don't bother with the "Source" which would be just "Mobile" always (or whatever the app
-        // process is called depending on platform and configuration) and non-informative as there
-        // is just one process in the app anyway.
+#if defined(IOS) || defined(__FreeBSD__) || defined(_WIN32)
+        // Don't bother with identifying the process as there is just one process in the app anyway.
 
         // FIXME: Not sure why FreeBSD is here, too. Surely on FreeBSD COOL runs just like on Linux,
         // as a set of separate processes, so it would be useful to see from which process a log
         // line is?
 
-        char *pos = buffer;
+        char* pos = buffer;
 
         // Don't bother with the thread identifier either. We output the thread name which is much
         // more useful anyway.


### PR DESCRIPTION
Logging in CODA-W is only for use when actually debugging interactively, and besides, we already give each thread a name that shows up in the log lines.

Also make sure that there are no gratuitous comment or whitespace differences between the code snippets in Prefix::reset() and prefixReference() which are intentionally identical. (I didn't dare to attempt a de-duplication now.)


Change-Id: I7c23205c41bc62a8ab4166319b21f96544a99853


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

