### PR TITLE
Show an error message when failing to load a document

### DIFF
--- a/browser/src/app/Socket.ts
+++ b/browser/src/app/Socket.ts
@@ -2166,6 +2166,15 @@ class Socket {
 				if (this.ReconnectCount > 1) {
 					this._map.showBusy(errorMessages.docunloadingretry, false);
 				}
+			} else if (errorKind === 'io' && command.errorCode === '770') {
+				this._map._fatal = true;
+				this._map.fire('error', { msg: errorMessages.cantreaddoc });
+			} else {
+				// Any other load error (io, network, etc.)
+				this._map._fatal = true;
+				this._map.fire('error', {
+					msg: errorMessages.faileddocloading,
+				});
 			}
 
 			if (passwordNeeded) {

--- a/browser/src/errormessages.js
+++ b/browser/src/errormessages.js
@@ -31,6 +31,7 @@ errorMessages.wrongwopisrc = _('Wrong or missing WOPISrc parameter, please conta
 errorMessages.sessionexpiry = _('Your session will expire in {time}. Please save your work and refresh the session (or webpage) to continue. You might need to login again.');
 errorMessages.sessionexpired = _('Your session has expired. Further changes to the document might not be saved. Please refresh the session (or webpage) to continue. You might need to login again.');
 errorMessages.faileddocloading = _('Failed to load the document. Please ensure the file type is supported and not corrupted, and try again.');
+errorMessages.cantreaddoc = _('Failed to open the file. The content could not be read - it may be unavailable, damaged, or inaccessible.');
 errorMessages.invalidLink = _('Invalid link: \'{url}\'');
 errorMessages.leaving = _('You are leaving the document. The following web page will open in a new tab: ');
 errorMessages.docloadtimeout = _('Failed to load the document. This document is either malformed or is taking more resources than allowed. Please contact the administrator.');


### PR DESCRIPTION
### Summary

Previously, load failures with an unhandled errors fell through silently and no error was shown to the user. Add a fallback that surfaces a generic "failed to load" message for any such case.

Also handle the CANT_READ (io/770) error specifically with a more descriptive message, since core reports this for documents with external links it cannot read.

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

