### PR TITLE
common: improve error handling in macaron::Base64::Decode()

### DIFF
--- a/common/base64.hpp
+++ b/common/base64.hpp
@@ -109,10 +109,10 @@ class Base64 {
     out.resize(out_len);
 
     for (size_t i = 0, j = 0; i < in_len;) {
-      uint32_t a = input[i] == '=' ? 0 & i++ : decodingTable[static_cast<int>(input[i++])];
-      uint32_t b = input[i] == '=' ? 0 & i++ : decodingTable[static_cast<int>(input[i++])];
-      uint32_t c = input[i] == '=' ? 0 & i++ : decodingTable[static_cast<int>(input[i++])];
-      uint32_t d = input[i] == '=' ? 0 & i++ : decodingTable[static_cast<int>(input[i++])];
+      uint32_t a = input[i] == '=' ? 0 & i++ : decodingTable[static_cast<unsigned char>(input[i++])];
+      uint32_t b = input[i] == '=' ? 0 & i++ : decodingTable[static_cast<unsigned char>(input[i++])];
+      uint32_t c = input[i] == '=' ? 0 & i++ : decodingTable[static_cast<unsigned char>(input[i++])];
+      uint32_t d = input[i] == '=' ? 0 & i++ : decodingTable[static_cast<unsigned char>(input[i++])];
 
       uint32_t triple = (a << 3 * 6) + (b << 2 * 6) + (c << 1 * 6) + (d << 0 * 6);
 

--- a/fuzzer/admin-data/crash-bb6ab57a77d2f4eaa603ff240cc2ed5172a336b7
+++ b/fuzzer/admin-data/crash-bb6ab57a77d2f4eaa603ff240cc2ed5172a336b7
@@ -1,0 +1,1 @@
+auth jwt=i9.Ÿy9ö.x


### PR DESCRIPTION
Fixes:
	common/base64.hpp:112:48: runtime error: index -97 out of bounds for type 'const unsigned char[256]'
	    #0 0x55de1393893f in macaron::Base64::Decode(std::basic_string_view<char, std::char_traits<char>>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>&) /home/vmiklos/git/collaboraonline/online-fuzz/./common/base64.hpp:112:48
	    #1 0x55de14576d2b in Util::base64Decode(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /home/vmiklos/git/collaboraonline/online-fuzz/common/Util.cpp:737:9
	    #2 0x55de13b4104a in JWTAuth::verify(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) /home/vmiklos/git/collaboraonline/online-fuzz/wsd/Auth.cpp:131:44
	    #3 0x55de13941782 in AdminSocketHandler::handleMessage(std::vector<char, std::allocator<char>> const&) /home/vmiklos/git/collaboraonline/online-fuzz/wsd/Admin.cpp:96:34
	    #4 0x55de14685b71 in LLVMFuzzerTestOneInput /home/vmiklos/git/collaboraonline/online-fuzz/fuzzer/Admin.cpp:39:18
	    #5 0x55de1382e782 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /home/abuild/rpmbuild/BUILD/llvm19-19.1.7-build/llvm-19.1.7.src/projects/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:614:13
	    #6 0x55de13815ea5 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /home/abuild/rpmbuild/BUILD/llvm19-19.1.7-build/llvm-19.1.7.src/projects/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:328:6
	    #7 0x55de1381c1a8 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /home/abuild/rpmbuild/BUILD/llvm19-19.1.7-build/llvm-19.1.7.src/projects/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:863:9
	    #8 0x55de138492d3 in main /home/abuild/rpmbuild/BUILD/llvm19-19.1.7-build/llvm-19.1.7.src/projects/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
	    #9 0x7f46ca83033f in __libc_start_call_main (/lib64/libc.so.6+0x2a33f) (BuildId: 09f0d581f82df95136a7f988671000cd633b639d)
	    #10 0x7f46ca830408 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2a408) (BuildId: 09f0d581f82df95136a7f988671000cd633b639d)
	    #11 0x55de13810404 in _start /home/abuild/rpmbuild/BUILD/glibc-2.40-build/glibc-2.40/csu/../sysdeps/x86_64/start.S:115

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: Id66ce47f77194fd11ba94000f488f2a257f335bc
