### PR TITLE
Jump to image should be possible (backport 25.04)

### DIFF
--- a/browser/src/layer/tile/CanvasTileLayer.js
+++ b/browser/src/layer/tile/CanvasTileLayer.js
@@ -2907,7 +2907,7 @@ window.L.CanvasTileLayer = window.L.Layer.extend({
 			return;
 		}
 
-		if (!app.file.textCursor.visible) {
+		if (!app.file.textCursor.visible && !GraphicSelection.hasActiveSelection()) {
 			this._updateCursorAndOverlay();
 			TextCursorSection.updateVisibilities(true);
 			return;


### PR DESCRIPTION
- when we double-click on navigator's item like image which is placed on other page - we want to scroll to it
- it was blocked when text cursor wasn't shown
- we should take into account case when only graphic is selected

backport of: https://github.com/CollaboraOnline/online/pull/15548