### PR TITLE
jsdialog dropdown: Fix incorrect layout when no icon

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1510,6 +1510,12 @@ img.context-menu-icon {
 	grid-template-columns: 1fr 25px;
 	align-items: center;
 }
+
+/* add extra column space for the icon. */
+.ui-combobox-entry.ui-has-menu.ui-has-img {
+	grid-template-columns: 25px 1fr 25px;
+}
+
 /* Arrow/chevron */
 .ui-combobox-entry.ui-has-menu::after {
 	content: '';

--- a/browser/src/app/LOUtil.ts
+++ b/browser/src/app/LOUtil.ts
@@ -324,10 +324,15 @@ class LOUtil {
 		return url;
 	}
 
-	public static setImage(img: HTMLImageElement, name: string, map: any): void {
+	public static setImage(
+		img: HTMLImageElement,
+		name: string,
+		map: any,
+		imageIsLayoutCritical?: boolean,
+	): void {
 		const setupIcon = function () {
 			img.src = LOUtil.getImageURL(name);
-			LOUtil.checkIfImageExists(img);
+			LOUtil.checkIfImageExists(img, imageIsLayoutCritical);
 		};
 		setupIcon();
 

--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -45,6 +45,9 @@ JSDialog.comboboxEntry = function (parentContainer, data, builder) {
 		var icon = window.L.DomUtil.create('img', 'ui-combobox-icon', entry);
 		icon.alt = '';
 		builder._isStringCloseToURL(data.icon) ? icon.src = data.icon : app.LOUtil.setImage(icon,  app.LOUtil.getIconNameOfCommand(data.icon), builder.map, true);
+		if (data.hasSubMenu) {
+			window.L.DomUtil.addClass(entry, 'ui-has-img');
+		}
 	}
 
 	if (data.hint) {

--- a/browser/src/control/jsdialog/Widget.Combobox.js
+++ b/browser/src/control/jsdialog/Widget.Combobox.js
@@ -44,7 +44,7 @@ JSDialog.comboboxEntry = function (parentContainer, data, builder) {
 	if (data.icon) {
 		var icon = window.L.DomUtil.create('img', 'ui-combobox-icon', entry);
 		icon.alt = '';
-		builder._isStringCloseToURL(data.icon) ? icon.src = data.icon : app.LOUtil.setImage(icon,  app.LOUtil.getIconNameOfCommand(data.icon), builder.map);
+		builder._isStringCloseToURL(data.icon) ? icon.src = data.icon : app.LOUtil.setImage(icon,  app.LOUtil.getIconNameOfCommand(data.icon), builder.map, true);
 	}
 
 	if (data.hint) {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* Target version: main

### Summary

    Issue:
    Open any calc document and right-click on a cell.
    Note that the entry `Paste Special` and `Sparkline` does not align with
    the rest of the items in the context menu which have icons.
    
    Solution:
    Add placeholder image for the entries without an icon.

   Also submenu entries need extra space for submenu-icon in grid.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

