### PR TITLE
Mobile dialogues use var(--header-height) not hardcoded

### DIFF
--- a/browser/css/device-mobile.css
+++ b/browser/css/device-mobile.css
@@ -169,7 +169,7 @@ textarea.cool-annotation-textarea {
 .toolbar-row {
 	display: flex;
 	flex-direction: row;
-	height: 38px !important;
+	height: var(--header-height);
 }
 
 .insertshape-grid {

--- a/browser/css/mobilewizard.css
+++ b/browser/css/mobilewizard.css
@@ -464,7 +464,7 @@ p.mobile-wizard.ui-combobox-text.selected {
 
 .ui-tabs.mobile-wizard {
 	text-align: center;
-	height: 42px;
+	height: var(--header-height);
 	display: flex;
 	width: 100%;
 	padding: 0px;
@@ -481,8 +481,7 @@ p.mobile-wizard.ui-combobox-text.selected {
 .ui-tab.mobile-wizard {
 	flex: auto;
 	display: table-cell;
-	height: 36px;
-	line-height: 36px;
+	line-height: var(--header-height);
 	vertical-align: middle;
 	margin: 0px 5%;
 	border-radius: 10px;


### PR DESCRIPTION
Change-Id: I4d4705d47252db5762a9762950e5ca1e52ca97e3

<img width="402" height="385" alt="image" src="https://github.com/user-attachments/assets/1d974237-58d4-4560-b98b-f5082d24dc35" />
