### PR TITLE
statusbar: persist user hidden items  across reloads

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -2107,6 +2107,7 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 		}
 
 		var scrollTop = control.scrollTop;
+		var userHidden = control.classList.contains('user-hidden');
 		var focusedElement = document.activeElement;
 		var focusedElementInDialog = focusedElement ? container.querySelector('[id=\'' + focusedElement.id + '\']') : null;
 		var focusedId = focusedElementInDialog ? focusedElementInDialog.id : null;
@@ -2135,6 +2136,8 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 			newControl.scrollTop = scrollTop;
 			newControl.style.gridColumn = backupGridColSpan;
 			newControl.style.gridRow = backupGridRowSpan;
+			if (userHidden)
+				window.L.DomUtil.addClass(newControl, 'user-hidden');
 
 			// todo: is that needed? should be in widget impl?
 			if (data.has_default === true && (data.type === 'pushbutton' || data.type === 'okbutton')) {

--- a/browser/src/control/Control.StatusBar.js
+++ b/browser/src/control/Control.StatusBar.js
@@ -372,14 +372,43 @@ class StatusBar extends JSDialog.Toolbar {
 				return;
 
 			const newHidden = !this.isItemUserHidden(entry.itemId);
-			this.userHideItem(entry.itemId, newHidden);
-			if (entry.targetId !== entry.itemId)
-				this.userHideItem(entry.targetId, newHidden);
-			for (const peer of entry.peers)
-				this.userHideItem(peer, newHidden);
+			this._applyUserHidden(entry.itemId, entry.targetId, entry.peers, newHidden);
+			this.map.uiManager.setDocTypePref('StatusbarUserHidden.' + entry.id, newHidden);
 		};
 
 		JSDialog.OpenDropdown('statusbar-context-menu', anchor, menuEntries, callback, 'top', false);
+	}
+
+	_applyUserHidden(itemId, targetId, peers, hide) {
+		this.userHideItem(itemId, hide);
+		if (targetId && targetId !== itemId)
+			this.userHideItem(targetId, hide);
+		if (peers) {
+			for (const peer of peers)
+				this.userHideItem(peer, hide);
+		}
+	}
+
+	_restoreUserHiddenState() {
+		const items = this.getToolItems();
+		const visible = {};
+		for (let i = 0; i < items.length; i++) {
+			const item = items[i];
+			if (!item.configLabel)
+				continue;
+
+			const configId = item.configId || item.id;
+			if (visible[configId])
+				continue;
+			visible[configId] = true;
+
+			const hide = this.map.uiManager.getBooleanDocTypePref(
+				'StatusbarUserHidden.' + configId, false);
+			if (!hide)
+				continue;
+
+			this._applyUserHidden(item.id, item.configTargetId, item.configPeers, true);
+		}
 	}
 
 	initialize() {
@@ -467,6 +496,7 @@ class StatusBar extends JSDialog.Toolbar {
 			this.updateLanguageItem(this.extractLanguageFromStatus(language));
 
 		this._updateToolbarsVisibility();
+		this._restoreUserHiddenState();
 		JSDialog.RefreshScrollables();
 	}
 


### PR DESCRIPTION
Change-Id: Iadb20a5216e64cd96e6b5574ac5fb2303128bed8

* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
 - Save toggled items from the context menu using UIManager.setDocTypePref
 - Preserve the user hidden class across widget rebuilds so state is retained after updates.

### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

