### PR TITLE
jsdialog: hover style for comment menu and context menu entries

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -1450,6 +1450,12 @@ img.context-menu-icon {
 	background-color: var(--color-background-hover);
 }
 
+[id^='comment-menu-'][id$='-entries'] .ui-combobox-entry:hover,
+#jsd-context-menu-entries .ui-combobox-entry:hover {
+	background-color: var(--color-background-darker) !important;
+	color: var(--color-text-darker) !important;
+}
+
 .ui-combobox-entry.selected:not(:hover) span,
 .margin-item.selected {
 	background-color: var(--color-background-darker);


### PR DESCRIPTION
Change-Id: Iddbf946a3a69a8146b088cf3ae277c20bfedff7d


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
 - Fixed low visibility of hover state in context and comment menus
 - Used an attribute selector [id^="comment-menu-"][id$="-entries"] to match every comment menu dropdown instead of a single id, since each comment generates its own suffix

### PREVIEWS

#### Light mode
<img width="210" height="247" alt="2026-04-21_06-19_1" src="https://github.com/user-attachments/assets/1c726a31-9b17-42ea-9d63-df189daa5c2f" />

#### Dark mode
<img width="284" height="253" alt="2026-04-21_06-19" src="https://github.com/user-attachments/assets/3bfc053f-e77c-4639-8fc6-759e7f7d4d45" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

