### PR TITLE
navigator: show and resize in task

### DIFF
--- a/browser/src/control/Control.NavigatorPanel.ts
+++ b/browser/src/control/Control.NavigatorPanel.ts
@@ -343,12 +343,14 @@ class NavigatorPanel extends SidebarBase {
 
 			this.markNavigatorTreeView(navigatorData);
 
-			this.builder.build(this.container, [navigatorData], false);
+			app.layoutingService.appendLayoutingTask(() => {
+				this.builder.build(this.container, [navigatorData], false);
+			});
+
 			// There is case where user can directly click navigator from notebookbar view option
 			// in that case we first show the navigation panel and then switch to tab view
 			this.showNavigationPanel(false);
-			// TODO: remove jQuery animation
-			$('#navigator-dock-wrapper').show(200);
+			this.navigatorDockWrapper.style.display = '';
 			app.showNavigator = true;
 			if (
 				app.map.isPresentationOrDrawing() &&

--- a/browser/src/control/Control.SidebarBase.ts
+++ b/browser/src/control/Control.SidebarBase.ts
@@ -25,6 +25,7 @@ enum SidebarType {
 
 abstract class SidebarBase extends JSDialogComponent {
 	type: SidebarType;
+	resizeTaskId: TaskId | null = null;
 
 	documentContainer: HTMLDivElement;
 	wrapper: HTMLElement;
@@ -170,13 +171,17 @@ abstract class SidebarBase extends JSDialogComponent {
 		return false;
 	}
 	onResize() {
-		app.layoutingService.appendLayoutingTask(() => {
+		if (this.resizeTaskId)
+			app.layoutingService.cancelLayoutingTask(this.resizeTaskId);
+
+		this.resizeTaskId = app.layoutingService.appendLayoutingTask(() => {
 			this.wrapper.style.maxHeight =
 				this.documentContainer.getBoundingClientRect().height + 'px';
 			if (this.container) {
 				(this.container as HTMLElement).style.height =
 					this.documentContainer.getBoundingClientRect().height + 'px';
 			}
+			this.resizeTaskId = null;
 		});
 	}
 

--- a/browser/src/control/Control.SidebarBase.ts
+++ b/browser/src/control/Control.SidebarBase.ts
@@ -170,12 +170,14 @@ abstract class SidebarBase extends JSDialogComponent {
 		return false;
 	}
 	onResize() {
-		this.wrapper.style.maxHeight =
-			this.documentContainer.getBoundingClientRect().height + 'px';
-		if (this.container) {
-			(this.container as HTMLElement).style.height =
+		app.layoutingService.appendLayoutingTask(() => {
+			this.wrapper.style.maxHeight =
 				this.documentContainer.getBoundingClientRect().height + 'px';
-		}
+			if (this.container) {
+				(this.container as HTMLElement).style.height =
+					this.documentContainer.getBoundingClientRect().height + 'px';
+			}
+		});
 	}
 
 	callback(


### PR DESCRIPTION
- avoid direct execution in message processing, schedule a task as in other jsdialog components
- removes jQuery animation
- helps with show/hide navigator flicker a bit


BEFORE:
<img width="1416" height="690" alt="Zrzut ekranu z 2026-04-21 09-30-36" src="https://github.com/user-attachments/assets/d3939981-0f14-4715-a371-1107ac57b413" />

AFTER:
<img width="1345" height="694" alt="Zrzut ekranu z 2026-04-21 09-49-29" src="https://github.com/user-attachments/assets/00c97162-c453-4c52-b52d-d4bb15d19968" />
