### PR TITLE
clientsession_fuzzer: fix bad child root path

### DIFF
--- a/fuzzer/ClientSession.cpp
+++ b/fuzzer/ClientSession.cpp
@@ -23,7 +23,7 @@
 
 bool DoInitialization()
 {
-    COOLWSD::ChildRoot = "/fuzz/child-root";
+    COOLWSD::ChildRoot = "/tmp/clientsession-fuzzer/child-root";
     UnitBase::init(UnitBase::UnitType::Wsd, std::string());
 
     fuzzer::DoInitialization();


### PR DESCRIPTION
This used to work on an empty input file in the past, but now fails
with:

	debug, createRandomTmpDir: trying to create '/fuzz/child-root/tmp/incoming/clipboards'
	terminate called after throwing an instance of 'Poco::FileAccessDeniedException'
	  what():  Access to file denied
	...
	    #10 0x7f1cbfcc51a7 in __cxa_throw (/lib64/libstdc++.so.6+0xc51a7) (BuildId: 4d04a908b82981978c709def74bcd86eef54cb54)
	...
	    #17 0x7f1cbf70795f in Poco::File::createDirectories() (/lib64/libPocoFoundation.so.112+0x10795f) (BuildId: 264c3a73276bc7dac44fd0c77ae528016cc50f5f)
	    #18 0x560b91d7b5e4 in FileUtil::createRandomTmpDir(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>) /home/vmiklos/git/collaboraonline/online-fuzz/common/FileUtil.cpp:152:26

I.e. previously it didn't matter that /fuzz is not a file path that a
normal user can't create. Now the fuzzer can reach
FileUtil::createRandomTmpDir(), so give it a directory which is possible
to create.

Signed-off-by: Miklos Vajna <vmiklos@collabora.com>
Change-Id: I2928307d7df215da1cccd8ece8999eccd1320248
