### PR TITLE
wsd: add MCP endpoint at /cool/mcp

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -206,6 +206,8 @@ coolwsd_sources = \
                   wsd/FileServer.cpp \
                   wsd/FileServerUtil.cpp \
                   wsd/HostUtil.cpp \
+                  wsd/McpHandler.cpp \
+                  wsd/McpResponseUtil.cpp \
                   wsd/ProofKey.cpp \
                   wsd/ProxyProtocol.cpp \
                   wsd/ProxyRequestHandler.cpp \
@@ -573,6 +575,8 @@ wsd_headers = \
               wsd/Exceptions.hpp \
               wsd/FileServer.hpp \
               wsd/HostUtil.hpp \
+              wsd/McpHandler.hpp \
+              wsd/McpResponseUtil.hpp \
               wsd/PlatformDesktop.hpp \
               wsd/PlatformMobile.hpp \
               wsd/PlatformUnix.hpp \

--- a/coolwsd.xml.in
+++ b/coolwsd.xml.in
@@ -218,6 +218,9 @@
 
       <!-- this setting radically changes how online works, it should not be used in a production environment -->
       <proxy_prefix type="bool" default="false" desc="Enable a ProxyPrefix to be passed-in through which to redirect requests">false</proxy_prefix>
+      <mcp desc="Model Context Protocol settings.">
+        <api_key type="string" default="" desc="API key for MCP endpoint. When set, clients must include Authorization: Bearer header. When empty, MCP endpoint is disabled."></api_key>
+      </mcp>
     </net>
 
     <ssl desc="SSL settings">

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -111,7 +111,8 @@ all_la_unit_tests = \
 	unit-wopi-httpredirect.la \
 	unit-convert-to-password-protected.la \
 	unit-bad-doc-load.la \
-	unit-hosting.la
+	unit-hosting.la \
+	unit-mcp.la
 # 	unit-fuzz.la
 #	unit-admin.la
 #	unit-tilecache.la # Empty test.
@@ -158,6 +159,8 @@ wsd_sources = \
 	../wsd/FileServer.cpp \
 	../wsd/FileServerUtil.cpp \
 	../wsd/HostUtil.cpp \
+	../wsd/McpHandler.cpp \
+	../wsd/McpResponseUtil.cpp \
 	../wsd/ProofKey.cpp \
 	../wsd/ProxyProtocol.cpp \
 	../wsd/ProxyRequestHandler.cpp \
@@ -183,6 +186,7 @@ test_base_sources = \
 	HttpWhiteBoxTests.cpp \
 	KitQueueTests.cpp \
 	LoggingWhiteBoxTests.cpp \
+	McpHandlerTests.cpp \
 	NetUtilWhiteBoxTests.cpp \
 	NumUtilWhiteBoxTests.cpp \
 	RequestDetailsTests.cpp \
@@ -245,6 +249,7 @@ unittest_SOURCES = \
 	$(kit_sources) \
 	../wsd/FileServerUtil.cpp \
 	../wsd/HostUtil.cpp \
+	../wsd/McpResponseUtil.cpp \
 	../wsd/ProofKey.cpp \
 	../wsd/RequestDetails.cpp \
 	../wsd/TestStubs.cpp \
@@ -309,6 +314,8 @@ unit_copy_paste_writer_la_SOURCES = UnitCopyPasteWriter.cpp
 unit_copy_paste_writer_la_LIBADD = $(CPPUNIT_LIBS)
 unit_convert_la_SOURCES = UnitConvert.cpp
 unit_convert_csv_la_SOURCES = UnitConvertCSV.cpp
+unit_mcp_la_SOURCES = UnitMcp.cpp
+unit_mcp_la_LIBADD = $(CPPUNIT_LIBS)
 unit_convert_to_password_protected_la_SOURCES = UnitConvertToPasswordProtected.cpp
 unit_initial_load_fail_la_SOURCES = UnitInitialLoadFail.cpp
 unit_initial_load_fail_la_LIBADD = $(CPPUNIT_LIBS)

--- a/test/McpHandlerTests.cpp
+++ b/test/McpHandlerTests.cpp
@@ -1,0 +1,188 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * White-box unit tests for MCP response utilities.
+ */
+
+#include <config.h>
+
+#include <test/lokassert.hpp>
+
+#include <wsd/McpResponseUtil.hpp>
+
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Array.h>
+#include <Poco/JSON/Parser.h>
+
+#include <cppunit/extensions/HelperMacros.h>
+
+#include <string>
+
+namespace
+{
+
+/// Parse a JSON string and return the root object.
+Poco::JSON::Object::Ptr parseJson(const std::string& json)
+{
+    Poco::JSON::Parser parser;
+    auto result = parser.parse(json);
+    return result.extract<Poco::JSON::Object::Ptr>();
+}
+
+} // anonymous namespace
+
+/// McpResponseUtil unit tests.
+class McpHandlerTests : public CPPUNIT_NS::TestFixture
+{
+    CPPUNIT_TEST_SUITE(McpHandlerTests);
+
+    CPPUNIT_TEST(testMakeJsonRpcError);
+    CPPUNIT_TEST(testMakeJsonRpcErrorCodes);
+    CPPUNIT_TEST(testWrapJsonResult);
+    CPPUNIT_TEST(testWrapJsonResultEmbedding);
+    CPPUNIT_TEST(testWrapBinaryResult);
+    CPPUNIT_TEST(testWrapBinaryResultMimeType);
+
+    CPPUNIT_TEST_SUITE_END();
+
+    void testMakeJsonRpcError();
+    void testMakeJsonRpcErrorCodes();
+    void testWrapJsonResult();
+    void testWrapJsonResultEmbedding();
+    void testWrapBinaryResult();
+    void testWrapBinaryResultMimeType();
+};
+
+void McpHandlerTests::testMakeJsonRpcError()
+{
+    constexpr std::string_view testname = __func__;
+
+    std::string response = McpResponseUtil::makeJsonRpcError("5", -32600, "Invalid Request");
+    auto obj = parseJson(response);
+
+    LOK_ASSERT_EQUAL_STR("2.0", obj->getValue<std::string>("jsonrpc"));
+    LOK_ASSERT_EQUAL_STR("5", obj->getValue<std::string>("id"));
+
+    auto error = obj->getObject("error");
+    LOK_ASSERT(error != nullptr);
+    LOK_ASSERT_EQUAL(-32600, error->getValue<int>("code"));
+    LOK_ASSERT_EQUAL_STR("Invalid Request", error->getValue<std::string>("message"));
+}
+
+void McpHandlerTests::testMakeJsonRpcErrorCodes()
+{
+    constexpr std::string_view testname = __func__;
+
+    // Parse error
+    auto obj = parseJson(McpResponseUtil::makeJsonRpcError("1", -32700, "Parse error"));
+    LOK_ASSERT_EQUAL(-32700, obj->getObject("error")->getValue<int>("code"));
+
+    // Method not found
+    obj = parseJson(McpResponseUtil::makeJsonRpcError("2", -32601, "Method not found"));
+    LOK_ASSERT_EQUAL(-32601, obj->getObject("error")->getValue<int>("code"));
+
+    // Invalid params
+    obj = parseJson(McpResponseUtil::makeJsonRpcError("3", -32602, "Invalid params"));
+    LOK_ASSERT_EQUAL(-32602, obj->getObject("error")->getValue<int>("code"));
+
+    // Internal error
+    obj = parseJson(McpResponseUtil::makeJsonRpcError("4", -32603, "Internal error"));
+    LOK_ASSERT_EQUAL(-32603, obj->getObject("error")->getValue<int>("code"));
+}
+
+void McpHandlerTests::testWrapJsonResult()
+{
+    constexpr std::string_view testname = __func__;
+
+    std::string jsonBody = "{\"headings\":[\"Chapter 1\",\"Chapter 2\"]}";
+    std::string response = McpResponseUtil::wrapJsonResult("10", jsonBody);
+    auto obj = parseJson(response);
+
+    LOK_ASSERT_EQUAL_STR("2.0", obj->getValue<std::string>("jsonrpc"));
+    LOK_ASSERT_EQUAL_STR("10", obj->getValue<std::string>("id"));
+
+    auto result = obj->getObject("result");
+    LOK_ASSERT(result != nullptr);
+
+    auto content = result->getArray("content");
+    LOK_ASSERT(content != nullptr);
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), content->size());
+
+    auto item = content->getObject(0);
+    LOK_ASSERT_EQUAL_STR("text", item->getValue<std::string>("type"));
+    LOK_ASSERT_EQUAL_STR(jsonBody, item->getValue<std::string>("text"));
+}
+
+void McpHandlerTests::testWrapJsonResultEmbedding()
+{
+    constexpr std::string_view testname = __func__;
+
+    // Verify that special characters in JSON are preserved correctly.
+    std::string jsonBody = "{\"key\":\"value with \\\"quotes\\\"\"}";
+    std::string response = McpResponseUtil::wrapJsonResult("11", jsonBody);
+    auto obj = parseJson(response);
+
+    auto content = obj->getObject("result")->getArray("content");
+    auto item = content->getObject(0);
+    LOK_ASSERT_EQUAL_STR(jsonBody, item->getValue<std::string>("text"));
+}
+
+void McpHandlerTests::testWrapBinaryResult()
+{
+    constexpr std::string_view testname = __func__;
+
+    const char data[] = "Hello PDF";
+    std::string response =
+        McpResponseUtil::wrapBinaryResult("20", data, sizeof(data) - 1, "application/pdf");
+    auto obj = parseJson(response);
+
+    LOK_ASSERT_EQUAL_STR("2.0", obj->getValue<std::string>("jsonrpc"));
+    LOK_ASSERT_EQUAL_STR("20", obj->getValue<std::string>("id"));
+
+    auto result = obj->getObject("result");
+    LOK_ASSERT(result != nullptr);
+
+    auto content = result->getArray("content");
+    LOK_ASSERT(content != nullptr);
+    LOK_ASSERT_EQUAL(static_cast<std::size_t>(1), content->size());
+
+    auto item = content->getObject(0);
+    LOK_ASSERT_EQUAL_STR("resource", item->getValue<std::string>("type"));
+
+    auto resource = item->getObject("resource");
+    LOK_ASSERT(resource != nullptr);
+    LOK_ASSERT_EQUAL_STR("application/pdf", resource->getValue<std::string>("mimeType"));
+    LOK_ASSERT(resource->has("blob"));
+
+    // "Hello PDF" in base64 is "SGVsbG8gUERG"
+    std::string blob = resource->getValue<std::string>("blob");
+    LOK_ASSERT_EQUAL_STR("SGVsbG8gUERG", blob);
+}
+
+void McpHandlerTests::testWrapBinaryResultMimeType()
+{
+    constexpr std::string_view testname = __func__;
+
+    const char data[] = "\x89PNG";
+    std::string response =
+        McpResponseUtil::wrapBinaryResult("30", data, sizeof(data) - 1, "image/png");
+    auto obj = parseJson(response);
+
+    auto resource =
+        obj->getObject("result")->getArray("content")->getObject(0)->getObject("resource");
+    LOK_ASSERT_EQUAL_STR("image/png", resource->getValue<std::string>("mimeType"));
+    LOK_ASSERT_EQUAL_STR("data:image/png;base64,", resource->getValue<std::string>("uri"));
+}
+
+CPPUNIT_TEST_SUITE_REGISTRATION(McpHandlerTests);
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/UnitMcp.cpp
+++ b/test/UnitMcp.cpp
@@ -1,0 +1,907 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Integration test for MCP (Model Context Protocol) endpoint.
+ */
+
+#include <config.h>
+
+#include <iostream>
+
+#include <Common.hpp>
+#include <Protocol.hpp>
+#include <Unit.hpp>
+#include <common/FileUtil.hpp>
+#include <common/Util.hpp>
+#include <common/base64.hpp>
+#include <test/helpers.hpp>
+#include <test/lokassert.hpp>
+
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Array.h>
+#include <Poco/JSON/Parser.h>
+#include <Poco/Net/FilePartSource.h>
+#include <Poco/Net/HTTPServerRequest.h>
+#include <Poco/Net/HTMLForm.h>
+#include <Poco/StreamCopier.h>
+#include <Poco/Util/LayeredConfiguration.h>
+
+#include <fstream>
+
+using namespace std::literals;
+
+namespace
+{
+
+/// Parse a JSON string and return the root object.
+Poco::JSON::Object::Ptr parseJson(const std::string& json)
+{
+    Poco::JSON::Parser parser;
+    auto result = parser.parse(json);
+    return result.extract<Poco::JSON::Object::Ptr>();
+}
+
+/// Send a JSON-RPC request to /cool/mcp and return the response body.
+std::string sendMcpRequest(Poco::Net::HTTPClientSession& session, const std::string& jsonBody,
+                           const std::string& apiKey = "test-mcp-key")
+{
+    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/mcp");
+    request.setContentType("application/json");
+    request.setContentLength(jsonBody.size());
+    if (!apiKey.empty())
+        request.set("Authorization", "Bearer " + apiKey);
+
+    std::ostream& os = session.sendRequest(request);
+    os << jsonBody;
+
+    Poco::Net::HTTPResponse response;
+    std::istream& rs = session.receiveResponse(response);
+    std::string body;
+    Poco::StreamCopier::copyToString(rs, body);
+    return body;
+}
+
+/// Read a test file and return its contents as a base64-encoded string.
+std::string readFileAsBase64(const std::string& path)
+{
+    std::ifstream ifs(path, std::ios::binary);
+    std::string data((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+    return macaron::Base64::Encode(data);
+}
+
+} // anonymous namespace
+
+// Inside the WSD process
+class UnitMcp : public UnitWSD
+{
+    bool _workerStarted;
+    std::thread _worker;
+
+    TestResult testInitialize(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string body =
+                R"({"jsonrpc":"2.0","id":"1","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{}}})";
+            std::string response = sendMcpRequest(session, body);
+            TST_LOG("Response: " << response);
+
+            auto obj = parseJson(response);
+            LOK_ASSERT_EQUAL_STR("2.0", obj->getValue<std::string>("jsonrpc"));
+            LOK_ASSERT_EQUAL_STR("1", obj->getValue<std::string>("id"));
+            LOK_ASSERT(obj->has("result"));
+
+            auto result = obj->getObject("result");
+            LOK_ASSERT(result->has("protocolVersion"));
+            LOK_ASSERT(result->has("serverInfo"));
+            LOK_ASSERT(result->has("capabilities"));
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testToolsList(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string body = R"({"jsonrpc":"2.0","id":"2","method":"tools/list"})";
+            std::string response = sendMcpRequest(session, body);
+            TST_LOG("Response: " << response);
+
+            auto obj = parseJson(response);
+            auto result = obj->getObject("result");
+            LOK_ASSERT(result != nullptr);
+            LOK_ASSERT(result->has("tools"));
+
+            auto tools = result->getArray("tools");
+            LOK_ASSERT_EQUAL(static_cast<std::size_t>(5), tools->size());
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testUnknownTool(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string body =
+                R"({"jsonrpc":"2.0","id":"3","method":"tools/call","params":{"name":"nonexistent","arguments":{}}})";
+            std::string response = sendMcpRequest(session, body);
+            TST_LOG("Response: " << response);
+
+            auto obj = parseJson(response);
+            LOK_ASSERT(obj->has("error"));
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testMissingData(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string body =
+                R"({"jsonrpc":"2.0","id":"4","method":"tools/call","params":{"name":"convert_document","arguments":{"format":"pdf"}}})";
+            std::string response = sendMcpRequest(session, body);
+            TST_LOG("Response: " << response);
+
+            auto obj = parseJson(response);
+            LOK_ASSERT(obj->has("error"));
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testExtractDocumentStructure(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string testDocPath = std::string(TDOC) + "/hello.odt";
+            std::string base64Doc = readFileAsBase64(testDocPath);
+
+            std::string body =
+                R"({"jsonrpc":"2.0","id":"5","method":"tools/call","params":{"name":"extract_document_structure","arguments":{"data":")" +
+                base64Doc + R"(","filename":"hello.odt"}}})";
+            std::string response = sendMcpRequest(session, body);
+            TST_LOG("Response length: " << response.size());
+
+            auto obj = parseJson(response);
+            LOK_ASSERT_MESSAGE("expected result, got error", !obj->has("error"));
+            LOK_ASSERT_EQUAL_STR("5", obj->getValue<std::string>("id"));
+            LOK_ASSERT(obj->has("result"));
+
+            auto result = obj->getObject("result");
+            LOK_ASSERT(result->has("content"));
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testConvertDocument(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string testDocPath = std::string(TDOC) + "/hello.odt";
+            std::string base64Doc = readFileAsBase64(testDocPath);
+
+            std::string body =
+                R"({"jsonrpc":"2.0","id":"6","method":"tools/call","params":{"name":"convert_document","arguments":{"data":")" +
+                base64Doc + R"(","filename":"hello.odt","format":"pdf"}}})";
+            std::string response = sendMcpRequest(session, body);
+            TST_LOG("Response length: " << response.size());
+
+            auto obj = parseJson(response);
+            LOK_ASSERT_MESSAGE("expected result, got error", !obj->has("error"));
+            LOK_ASSERT_EQUAL_STR("6", obj->getValue<std::string>("id"));
+            LOK_ASSERT(obj->has("result"));
+
+            auto result = obj->getObject("result");
+            auto content = result->getArray("content");
+            LOK_ASSERT(content != nullptr);
+            LOK_ASSERT(content->size() > 0);
+
+            auto item = content->getObject(0);
+            LOK_ASSERT_EQUAL_STR("resource", item->getValue<std::string>("type"));
+
+            auto resource = item->getObject("resource");
+            LOK_ASSERT(resource->has("blob"));
+            LOK_ASSERT(resource->has("mimeType"));
+
+            std::string blob = resource->getValue<std::string>("blob");
+            LOK_ASSERT(!blob.empty());
+
+            // Decode and check it starts with %PDF.
+            std::string decoded;
+            std::string err = macaron::Base64::Decode(blob, decoded);
+            LOK_ASSERT_MESSAGE("base64 decode failed", err.empty());
+            LOK_ASSERT_EQUAL_STR("%PDF", decoded.substr(0, 4));
+            TST_LOG("PDF size: " << decoded.size() << " bytes");
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testAuthWrongKey(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string jsonBody = R"({"jsonrpc":"2.0","id":"auth1","method":"initialize"})";
+            Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/mcp");
+            request.setContentType("application/json");
+            request.setContentLength(jsonBody.size());
+            request.set("Authorization", "Bearer wrong-key");
+
+            std::ostream& os = session.sendRequest(request);
+            os << jsonBody;
+
+            Poco::Net::HTTPResponse response;
+            session.receiveResponse(response);
+            LOK_ASSERT_EQUAL(static_cast<int>(Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED),
+                             static_cast<int>(response.getStatus()));
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testAuthMissingHeader(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string jsonBody = R"({"jsonrpc":"2.0","id":"auth2","method":"initialize"})";
+            Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/mcp");
+            request.setContentType("application/json");
+            request.setContentLength(jsonBody.size());
+            // No Authorization header.
+
+            std::ostream& os = session.sendRequest(request);
+            os << jsonBody;
+
+            Poco::Net::HTTPResponse response;
+            session.receiveResponse(response);
+            LOK_ASSERT_EQUAL(static_cast<int>(Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED),
+                             static_cast<int>(response.getStatus()));
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testNumericId(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            // JSON-RPC 2.0 allows numeric ids.
+            std::string body =
+                R"({"jsonrpc":"2.0","id":42,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{}}})";
+            std::string response = sendMcpRequest(session, body);
+            TST_LOG("Response: " << response);
+
+            auto obj = parseJson(response);
+            LOK_ASSERT_MESSAGE("expected result for numeric id", obj->has("result"));
+            LOK_ASSERT_EQUAL_STR("2.0", obj->getValue<std::string>("jsonrpc"));
+            // Numeric id 42 is echoed back as the string "42".
+            LOK_ASSERT_EQUAL_STR("42", obj->getValue<std::string>("id"));
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testExtractLinkTargets(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string testDocPath = std::string(TDOC) + "/hello.odt";
+            std::string base64Doc = readFileAsBase64(testDocPath);
+
+            std::string body =
+                R"({"jsonrpc":"2.0","id":"link1","method":"tools/call","params":{"name":"extract_link_targets","arguments":{"data":")" +
+                base64Doc + R"(","filename":"hello.odt"}}})";
+            std::string response = sendMcpRequest(session, body);
+            TST_LOG("Response length: " << response.size());
+
+            auto obj = parseJson(response);
+            LOK_ASSERT_MESSAGE("expected result, got error", !obj->has("error"));
+            LOK_ASSERT_EQUAL_STR("link1", obj->getValue<std::string>("id"));
+            LOK_ASSERT(obj->has("result"));
+
+            auto result = obj->getObject("result");
+            auto content = result->getArray("content");
+            LOK_ASSERT(content != nullptr);
+            LOK_ASSERT(content->size() > 0);
+
+            auto item = content->getObject(0);
+            LOK_ASSERT_EQUAL_STR("text", item->getValue<std::string>("type"));
+
+            // The text field should be parseable JSON.
+            std::string text = item->getValue<std::string>("text");
+            Poco::JSON::Parser parser;
+            parser.parse(text);
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testTransformDocumentStructure(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string testDocPath = std::string(TDOC) + "/empty.odp";
+            std::string base64Doc = readFileAsBase64(testDocPath);
+
+            // Simple transform: rename the first slide.
+            std::string body =
+                R"({"jsonrpc":"2.0","id":"xform1","method":"tools/call","params":{"name":"transform_document_structure","arguments":{"data":")" +
+                base64Doc +
+                R"(","filename":"empty.odp","transform":"{\"Transforms\":{\"SlideCommands\":[{\"RenameSlide\":\"TestSlide\"}]}}","format":"odp"}}})";
+            std::string response = sendMcpRequest(session, body);
+            TST_LOG("Response length: " << response.size());
+
+            auto obj = parseJson(response);
+            LOK_ASSERT_MESSAGE("expected result, got error", !obj->has("error"));
+            LOK_ASSERT_EQUAL_STR("xform1", obj->getValue<std::string>("id"));
+            LOK_ASSERT(obj->has("result"));
+
+            auto result = obj->getObject("result");
+            auto content = result->getArray("content");
+            LOK_ASSERT(content != nullptr);
+            LOK_ASSERT(content->size() > 0);
+
+            auto item = content->getObject(0);
+            LOK_ASSERT_EQUAL_STR("resource", item->getValue<std::string>("type"));
+
+            auto resource = item->getObject("resource");
+            LOK_ASSERT(resource->has("blob"));
+            std::string blob = resource->getValue<std::string>("blob");
+            LOK_ASSERT(!blob.empty());
+            LOK_ASSERT_EQUAL_STR("application/vnd.oasis.opendocument.presentation",
+                                 resource->getValue<std::string>("mimeType"));
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testUploadAndConvert(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            // Step 1: Upload a file via multipart POST to /cool/mcp/upload.
+            std::string testDocPath = std::string(TDOC) + "/hello.odt";
+
+            Poco::Net::HTMLForm form(Poco::Net::HTMLForm::ENCODING_MULTIPART);
+            form.addPart("file",
+                         new Poco::Net::FilePartSource(testDocPath, "application/octet-stream"));
+
+            Poco::Net::HTTPRequest uploadRequest(Poco::Net::HTTPRequest::HTTP_POST,
+                                                 "/cool/mcp/upload");
+            uploadRequest.set("Authorization", "Bearer test-mcp-key");
+            form.prepareSubmit(uploadRequest);
+
+            std::ostream& os = session.sendRequest(uploadRequest);
+            form.write(os);
+
+            Poco::Net::HTTPResponse uploadResponse;
+            std::istream& rs = session.receiveResponse(uploadResponse);
+            std::string uploadBody;
+            Poco::StreamCopier::copyToString(rs, uploadBody);
+            TST_LOG("Upload response: " << uploadBody);
+
+            LOK_ASSERT_EQUAL(static_cast<int>(Poco::Net::HTTPResponse::HTTP_OK),
+                             static_cast<int>(uploadResponse.getStatus()));
+
+            auto uploadObj = parseJson(uploadBody);
+            LOK_ASSERT(uploadObj->has("file_id"));
+            std::string fileId = uploadObj->getValue<std::string>("file_id");
+            LOK_ASSERT(!fileId.empty());
+            TST_LOG("Got file_id: " << fileId);
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+
+        // Step 2: Reconnect (upload closes connection) and convert using file_id.
+        try
+        {
+            std::unique_ptr<Poco::Net::HTTPClientSession> newSession(
+                helpers::createSession(Poco::URI(helpers::getTestServerURI())));
+            newSession->setTimeout(Poco::Timespan(30, 0));
+
+            // Re-upload since we need a fresh session and file_id.
+            std::string testDocPath = std::string(TDOC) + "/hello.odt";
+
+            Poco::Net::HTMLForm form(Poco::Net::HTMLForm::ENCODING_MULTIPART);
+            form.addPart("file",
+                         new Poco::Net::FilePartSource(testDocPath, "application/octet-stream"));
+
+            Poco::Net::HTTPRequest uploadRequest(Poco::Net::HTTPRequest::HTTP_POST,
+                                                 "/cool/mcp/upload");
+            uploadRequest.set("Authorization", "Bearer test-mcp-key");
+            form.prepareSubmit(uploadRequest);
+
+            std::ostream& os = newSession->sendRequest(uploadRequest);
+            form.write(os);
+
+            Poco::Net::HTTPResponse uploadResponse;
+            std::istream& rs = newSession->receiveResponse(uploadResponse);
+            std::string uploadBody;
+            Poco::StreamCopier::copyToString(rs, uploadBody);
+
+            auto uploadObj = parseJson(uploadBody);
+            std::string fileId = uploadObj->getValue<std::string>("file_id");
+            TST_LOG("Got file_id for convert: " << fileId);
+
+            // Reconnect for the convert call.
+            newSession = helpers::createSession(Poco::URI(helpers::getTestServerURI()));
+            newSession->setTimeout(Poco::Timespan(30, 0));
+
+            std::string body =
+                R"({"jsonrpc":"2.0","id":"upload1","method":"tools/call","params":{"name":"convert_document","arguments":{"file_id":")" +
+                fileId + R"(","format":"pdf"}}})";
+            std::string response = sendMcpRequest(*newSession, body);
+            TST_LOG("Convert response length: " << response.size());
+
+            auto obj = parseJson(response);
+            LOK_ASSERT_MESSAGE("expected result, got error", !obj->has("error"));
+            LOK_ASSERT_EQUAL_STR("upload1", obj->getValue<std::string>("id"));
+
+            auto result = obj->getObject("result");
+            auto content = result->getArray("content");
+            LOK_ASSERT(content != nullptr);
+            LOK_ASSERT(content->size() > 0);
+
+            auto item = content->getObject(0);
+            LOK_ASSERT_EQUAL_STR("resource", item->getValue<std::string>("type"));
+
+            auto resource = item->getObject("resource");
+            LOK_ASSERT(resource->has("blob"));
+            std::string blob = resource->getValue<std::string>("blob");
+            LOK_ASSERT(!blob.empty());
+
+            // Decode and check it starts with %PDF.
+            std::string decoded;
+            std::string err = macaron::Base64::Decode(blob, decoded);
+            LOK_ASSERT_MESSAGE("base64 decode failed", err.empty());
+            LOK_ASSERT_EQUAL_STR("%PDF", decoded.substr(0, 4));
+            TST_LOG("Upload+convert PDF size: " << decoded.size() << " bytes");
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    /// POST hello.odt to /cool/mcp/upload with the given Bearer value on a fresh
+    /// session. Returns the HTTP status code and populates outBody.
+    static int postUpload(const std::string& bearer, std::string& outBody)
+    {
+        std::unique_ptr<Poco::Net::HTTPClientSession> s(
+            helpers::createSession(Poco::URI(helpers::getTestServerURI())));
+        s->setTimeout(Poco::Timespan(30, 0));
+
+        std::string testDocPath = std::string(TDOC) + "/hello.odt";
+        Poco::Net::HTMLForm form(Poco::Net::HTMLForm::ENCODING_MULTIPART);
+        form.addPart("file",
+                     new Poco::Net::FilePartSource(testDocPath, "application/octet-stream"));
+
+        Poco::Net::HTTPRequest req(Poco::Net::HTTPRequest::HTTP_POST, "/cool/mcp/upload");
+        req.set("Authorization", "Bearer " + bearer);
+        form.prepareSubmit(req);
+
+        std::ostream& os = s->sendRequest(req);
+        form.write(os);
+
+        Poco::Net::HTTPResponse response;
+        std::istream& rs = s->receiveResponse(response);
+        outBody.clear();
+        Poco::StreamCopier::copyToString(rs, outBody);
+        return static_cast<int>(response.getStatus());
+    }
+
+    TestResult testPrepareUpload(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string body =
+                R"({"jsonrpc":"2.0","id":"prep1","method":"tools/call","params":{"name":"prepare_upload","arguments":{}}})";
+            std::string response = sendMcpRequest(session, body);
+            TST_LOG("Response: " << response);
+
+            auto obj = parseJson(response);
+            LOK_ASSERT_MESSAGE("expected result, got error", !obj->has("error"));
+
+            auto content = obj->getObject("result")->getArray("content");
+            auto item = content->getObject(0);
+            LOK_ASSERT_EQUAL_STR("text", item->getValue<std::string>("type"));
+
+            std::string text = item->getValue<std::string>("text");
+            auto info = parseJson(text);
+
+            LOK_ASSERT(info->has("upload_url"));
+            const std::string uploadUrl = info->getValue<std::string>("upload_url");
+            LOK_ASSERT_MESSAGE("upload_url must be absolute",
+                               uploadUrl.compare(0, 7, "http://") == 0
+                                   || uploadUrl.compare(0, 8, "https://") == 0);
+            const std::string suffix = "/cool/mcp/upload";
+            LOK_ASSERT_MESSAGE("upload_url must point at /cool/mcp/upload",
+                               uploadUrl.size() >= suffix.size()
+                                   && uploadUrl.compare(uploadUrl.size() - suffix.size(),
+                                                        suffix.size(), suffix)
+                                          == 0);
+            LOK_ASSERT(info->has("upload_token"));
+            LOK_ASSERT(!info->getValue<std::string>("upload_token").empty());
+            LOK_ASSERT(info->has("expires_in"));
+            LOK_ASSERT_MESSAGE("prepare_upload must not leak the master api_key",
+                               !info->has("api_key"));
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testUploadWithToken(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string body =
+                R"({"jsonrpc":"2.0","id":"prep2","method":"tools/call","params":{"name":"prepare_upload","arguments":{}}})";
+            std::string response = sendMcpRequest(session, body);
+            auto text = parseJson(response)
+                            ->getObject("result")
+                            ->getArray("content")
+                            ->getObject(0)
+                            ->getValue<std::string>("text");
+            std::string token = parseJson(text)->getValue<std::string>("upload_token");
+
+            std::string uploadBody;
+            int status = postUpload(token, uploadBody);
+            TST_LOG("Upload with token status=" << status << " body=" << uploadBody);
+            LOK_ASSERT_EQUAL(static_cast<int>(Poco::Net::HTTPResponse::HTTP_OK), status);
+
+            auto uploadObj = parseJson(uploadBody);
+            LOK_ASSERT(uploadObj->has("file_id"));
+            LOK_ASSERT(!uploadObj->getValue<std::string>("file_id").empty());
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testUploadTokenSingleUse(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string body =
+                R"({"jsonrpc":"2.0","id":"prep3","method":"tools/call","params":{"name":"prepare_upload","arguments":{}}})";
+            std::string response = sendMcpRequest(session, body);
+            auto text = parseJson(response)
+                            ->getObject("result")
+                            ->getArray("content")
+                            ->getObject(0)
+                            ->getValue<std::string>("text");
+            std::string token = parseJson(text)->getValue<std::string>("upload_token");
+
+            std::string first;
+            LOK_ASSERT_EQUAL(static_cast<int>(Poco::Net::HTTPResponse::HTTP_OK),
+                             postUpload(token, first));
+
+            std::string second;
+            int status = postUpload(token, second);
+            TST_LOG("Second upload status=" << status);
+            LOK_ASSERT_EQUAL(static_cast<int>(Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED), status);
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+    TestResult testUploadTokenWrongEndpoint(Poco::Net::HTTPClientSession& session)
+    {
+        setTestname(__func__);
+        TST_LOG("Starting test");
+        try
+        {
+            std::string body =
+                R"({"jsonrpc":"2.0","id":"prep4","method":"tools/call","params":{"name":"prepare_upload","arguments":{}}})";
+            std::string response = sendMcpRequest(session, body);
+            auto text = parseJson(response)
+                            ->getObject("result")
+                            ->getArray("content")
+                            ->getObject(0)
+                            ->getValue<std::string>("text");
+            std::string token = parseJson(text)->getValue<std::string>("upload_token");
+
+            // Use the upload token to authenticate a JSON-RPC call. Must be rejected.
+            std::unique_ptr<Poco::Net::HTTPClientSession> s(
+                helpers::createSession(Poco::URI(helpers::getTestServerURI())));
+            s->setTimeout(Poco::Timespan(30, 0));
+
+            std::string jsonBody = R"({"jsonrpc":"2.0","id":"rpc1","method":"initialize"})";
+            Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_POST, "/cool/mcp");
+            request.setContentType("application/json");
+            request.setContentLength(jsonBody.size());
+            request.set("Authorization", "Bearer " + token);
+
+            std::ostream& os = s->sendRequest(request);
+            os << jsonBody;
+
+            Poco::Net::HTTPResponse resp;
+            s->receiveResponse(resp);
+            TST_LOG("RPC-with-upload-token status=" << static_cast<int>(resp.getStatus()));
+            LOK_ASSERT_EQUAL(static_cast<int>(Poco::Net::HTTPResponse::HTTP_UNAUTHORIZED),
+                             static_cast<int>(resp.getStatus()));
+        }
+        catch (const Poco::Exception& exc)
+        {
+            LOK_ASSERT_FAIL(exc.displayText());
+        }
+        return TestResult::Ok;
+    }
+
+public:
+    UnitMcp()
+        : UnitWSD("UnitMcp")
+        , _workerStarted(false)
+    {
+        setHasKitHooks();
+        setTimeout(60s);
+    }
+
+    ~UnitMcp()
+    {
+        LOG_INF("Joining MCP test worker thread\n");
+        _worker.join();
+    }
+
+    void configure(Poco::Util::LayeredConfiguration& config) override
+    {
+        UnitWSD::configure(config);
+
+        config.setBool("ssl.enable", true);
+        config.setInt("per_document.limit_load_secs", 30);
+        config.setBool("storage.filesystem[@allow]", false);
+
+        // Enable MCP endpoint by setting an API key.
+        config.setString("net.mcp.api_key", "test-mcp-key");
+    }
+
+    void invokeWSDTest() override
+    {
+        if (_workerStarted)
+            return;
+        _workerStarted = true;
+        _worker = std::thread(
+            [this]
+            {
+                std::unique_ptr<Poco::Net::HTTPClientSession> session(
+                    helpers::createSession(Poco::URI(helpers::getTestServerURI())));
+                session->setTimeout(Poco::Timespan(30, 0));
+
+                TestResult result;
+
+                // Auth tests first (use separate sessions since rejected connections may close).
+                result = testAuthWrongKey(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                // Reconnect after auth rejection.
+                session = helpers::createSession(Poco::URI(helpers::getTestServerURI()));
+                session->setTimeout(Poco::Timespan(30, 0));
+
+                result = testAuthMissingHeader(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                // Reconnect after auth rejection.
+                session = helpers::createSession(Poco::URI(helpers::getTestServerURI()));
+                session->setTimeout(Poco::Timespan(30, 0));
+
+                result = testInitialize(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                result = testToolsList(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                result = testUnknownTool(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                result = testMissingData(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                result = testNumericId(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                result = testExtractDocumentStructure(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                result = testConvertDocument(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                result = testExtractLinkTargets(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                result = testTransformDocumentStructure(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                // Reconnect for upload test (uses separate sessions internally).
+                session = helpers::createSession(Poco::URI(helpers::getTestServerURI()));
+                session->setTimeout(Poco::Timespan(30, 0));
+
+                result = testUploadAndConvert(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                session = helpers::createSession(Poco::URI(helpers::getTestServerURI()));
+                session->setTimeout(Poco::Timespan(30, 0));
+
+                result = testPrepareUpload(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                result = testUploadWithToken(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                result = testUploadTokenSingleUse(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                result = testUploadTokenWrongEndpoint(*session);
+                if (result != TestResult::Ok)
+                {
+                    exitTest(result);
+                    return;
+                }
+
+                exitTest(TestResult::Ok);
+            });
+    }
+};
+
+// Inside the forkit & kit processes
+class UnitKitMcp : public UnitKit
+{
+public:
+    UnitKitMcp()
+        : UnitKit("UnitKitMcp")
+    {
+        setTimeout(60s);
+    }
+};
+
+UnitBase* unit_create_wsd(void) { return new UnitMcp(); }
+
+UnitBase* unit_create_kit(void) { return new UnitKitMcp(); }
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/AIChatSession.cpp
+++ b/wsd/AIChatSession.cpp
@@ -208,7 +208,9 @@ Poco::JSON::Array::Ptr AIChatSession::buildToolDefinitions() const
             "Transform the currently-open document's structure using a JSON command "
             "sequence. Supports Impress slide operations, Writer/Calc content control "
             "updates, and arbitrary UNO commands.\n\n")
-            + DocumentToolDescriptions::TRANSFORM_PARAM_DESCRIPTION,
+            + DocumentToolDescriptions::TRANSFORM_PARAM_PRE_IMAGE
+            + DocumentToolDescriptions::TRANSFORM_PARAM_IMAGE_GEN
+            + DocumentToolDescriptions::TRANSFORM_PARAM_POST_IMAGE,
         makeParamSchema(
             {{"transform", {"string", "JSON transformation commands"}},
              {"summary", {"string",

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -37,6 +37,7 @@
 #include <net/Uri.hpp>
 #include <wsd/COOLWSD.hpp>
 #include <wsd/ClientSession.hpp>
+#include <wsd/McpHandler.hpp>
 #include <wsd/DocumentBroker.hpp>
 #include <wsd/Exceptions.hpp>
 #include <wsd/FileServer.hpp>
@@ -44,6 +45,7 @@
 #include <wsd/ProxyRequestHandler.hpp>
 #include <wsd/RequestDetails.hpp>
 #include <wsd/RequestVettingStation.hpp>
+#include <wsd/ServerURL.hpp>
 #include <wsd/UserMessages.hpp>
 
 #if !MOBILEAPP
@@ -406,8 +408,8 @@ public:
     }
 };
 
-/// Constructs ConvertToBroker implamentation based on request type
-static std::shared_ptr<ConvertToBroker>
+/// Constructs ConvertToBroker implementation based on request type.
+std::shared_ptr<ConvertToBroker>
 getConvertToBrokerImplementation(const std::string& requestType, const std::string& fromPath,
                                  const Poco::URI& uriPublic, const std::string& docKey,
                                  const std::string& format, const std::string& options,
@@ -2244,6 +2246,106 @@ bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
             return true;
         }
         return false;
+    }
+
+    if (requestDetails.equals(1, "mcp"))
+    {
+        std::string configuredKey = ConfigUtil::getConfigValue<std::string>("net.mcp.api_key", "");
+        if (configuredKey.empty())
+        {
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::NotFound, socket);
+            return true;
+        }
+
+        std::string authHeader = request.get("Authorization", "");
+        const std::string prefix = "Bearer ";
+        bool validMaster = false;
+        bool validToken = false;
+        if (authHeader.size() > prefix.size() && authHeader.compare(0, prefix.size(), prefix) == 0)
+        {
+            const std::string presented = authHeader.substr(prefix.size());
+            // Constant-time comparison against the master key to prevent timing attacks.
+            // The loop runs over max(lengths) regardless of size match.
+            const std::size_t maxLen = std::max(presented.size(), configuredKey.size());
+            validMaster = (presented.size() == configuredKey.size());
+            for (std::size_t i = 0; i < maxLen; ++i)
+            {
+                const char a = i < presented.size() ? presented[i] : '\0';
+                const char b = i < configuredKey.size() ? configuredKey[i] : '\0';
+                validMaster &= (a == b);
+            }
+
+            // Ephemeral upload tokens authenticate only /cool/mcp/upload.
+            // 128 bits of entropy makes map-lookup timing irrelevant.
+            if (!validMaster && requestDetails.equals(2, "upload"))
+                validToken = McpHandler::consumeUploadToken(presented);
+        }
+        if (!validMaster && !validToken)
+        {
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::Unauthorized, socket,
+                                             std::string_view(), "WWW-Authenticate: Bearer\r\n");
+            return true;
+        }
+
+        // /cool/mcp/upload - file upload, returns a file_id for use in tool calls.
+        if (requestDetails.equals(2, "upload"))
+        {
+            ConvertToPartHandler handler;
+            Poco::Net::HTMLForm form(request, message, handler);
+
+            const auto& filenames = handler.getFilenames();
+            if (filenames.empty())
+            {
+                HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
+                return true;
+            }
+
+            // Take the first uploaded file regardless of field name.
+            std::string fromPath = filenames.begin()->second;
+            handler.takeFiles(); // Prevent destructor from cleaning up the file.
+            std::string fileId = McpHandler::registerUpload(std::move(fromPath));
+
+            Poco::JSON::Object::Ptr resp = new Poco::JSON::Object;
+            resp->set("file_id", fileId);
+            std::ostringstream oss;
+            resp->stringify(oss);
+
+            http::Response httpResponse(http::StatusCode::OK);
+            httpResponse.setBody(oss.str(), "application/json");
+            socket->sendAndShutdown(httpResponse);
+            return true;
+        }
+
+        // /cool/mcp - JSON-RPC endpoint.
+        const std::string contentType = request.getContentType();
+        if (contentType.find("application/json") == std::string::npos)
+        {
+            LOG_ERR("MCP: invalid Content-Type: " << contentType);
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::UnsupportedMediaType, socket);
+            return true;
+        }
+
+        constexpr std::streamsize maxMcpBodySize = 100 * 1024 * 1024; // 100 MB
+        const auto contentLength = request.getContentLength();
+        if (contentLength != Poco::Net::HTTPMessage::UNKNOWN_CONTENT_LENGTH &&
+            contentLength > maxMcpBodySize)
+        {
+            LOG_ERR("MCP: request body too large: " << contentLength << " bytes");
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::PayloadTooLarge, socket);
+            return true;
+        }
+
+        std::string body(std::istreambuf_iterator<char>(message), {});
+        if (static_cast<std::streamsize>(body.size()) > maxMcpBodySize)
+        {
+            LOG_ERR("MCP: request body too large: " << body.size() << " bytes");
+            HttpHelper::sendErrorAndShutdown(http::StatusCode::PayloadTooLarge, socket);
+            return true;
+        }
+
+        const std::string uploadUrl =
+            ServerURL(requestDetails).getSubURLForEndpoint("/cool/mcp/upload");
+        return McpHandler::handleRequest(body, socket, disposition, _id, uploadUrl);
     }
 
     if (requestDetails.equals(2, "insertfile"))

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -38,6 +38,7 @@
 #include <wsd/FileServer.hpp>
 #if !MOBILEAPP
 #include <wsd/AIChatSession.hpp>
+#include <wsd/McpResponseUtil.hpp>
 #endif
 #include <wsd/TileDesc.hpp>
 
@@ -51,6 +52,7 @@
 #include <Poco/URI.h>
 
 #include <cctype>
+#include <fstream>
 #include <ios>
 #include <map>
 #include <memory>
@@ -3117,6 +3119,7 @@ ClientSession::handleOpenDocKitToClientMessage(const std::shared_ptr<Message>& p
         return status;
     }
 #endif
+#if !MOBILEAPP
     else if (tokens.equals(0, "extractedlinktargets:"))
     {
 #if !MOBILEAPP
@@ -3127,6 +3130,8 @@ ClientSession::handleOpenDocKitToClientMessage(const std::shared_ptr<Message>& p
         LOG_TRC("Sending extracted link targets response.");
         if (!saveAsSocket)
             LOG_ERR("Error in extractedlinktargets: not in isConvertTo mode");
+        else if (_mcpContext)
+            sendMcpJsonResult(saveAsSocket, payload->jsonString());
         else
         {
             http::Response httpResponse(http::StatusCode::OK);
@@ -3151,6 +3156,8 @@ ClientSession::handleOpenDocKitToClientMessage(const std::shared_ptr<Message>& p
         LOG_TRC("Sending extracted document structure response.");
         if (!saveAsSocket)
             LOG_ERR("Error in extracteddocumentstructure: not in isConvertTo mode");
+        else if (_mcpContext)
+            sendMcpJsonResult(saveAsSocket, payload->jsonString());
         else
         {
             http::Response httpResponse(http::StatusCode::OK);
@@ -3175,6 +3182,8 @@ ClientSession::handleOpenDocKitToClientMessage(const std::shared_ptr<Message>& p
         LOG_TRC("Sending transformed document structure response.");
         if (!saveAsSocket)
             LOG_ERR("Error in transformeddocumentstructure: not in isConvertTo mode");
+        else if (_mcpContext)
+            sendMcpJsonResult(saveAsSocket, payload->jsonString());
         else
         {
             http::Response httpResponse(http::StatusCode::OK);
@@ -3189,6 +3198,7 @@ ClientSession::handleOpenDocKitToClientMessage(const std::shared_ptr<Message>& p
         docBroker->closeDocument("transformeddocumentstructure");
         return true;
     }
+#endif // !MOBILEAPP
     else if (tokens.equals(0, "sendthumbnail:"))
     {
         LOG_TRC("Sending get-thumbnail response.");
@@ -3261,6 +3271,28 @@ static std::string getDocTypeFromExtension(const std::string& ext)
     return (it != extToType.end()) ? it->second : "writer";
 }
 
+#if !MOBILEAPP
+void ClientSession::sendMcpJsonResult(const std::shared_ptr<StreamSocket>& socket,
+                                      const std::string& jsonPayload)
+{
+    assert(_mcpContext && "sendMcpJsonResult called without MCP context");
+    std::string body = McpResponseUtil::wrapJsonResult(_mcpContext->jsonRpcId, jsonPayload);
+    http::Response httpResponse(http::StatusCode::OK);
+    httpResponse.setBody(body, "application/json");
+    socket->sendAndShutdown(httpResponse);
+}
+
+void ClientSession::sendMcpError(const std::shared_ptr<StreamSocket>& socket, int code,
+                                 const std::string& message)
+{
+    assert(_mcpContext && "sendMcpError called without MCP context");
+    std::string body = McpResponseUtil::makeJsonRpcError(_mcpContext->jsonRpcId, code, message);
+    http::Response httpResponse(http::StatusCode::OK);
+    httpResponse.setBody(body, "application/json");
+    socket->sendAndShutdown(httpResponse);
+}
+#endif // !MOBILEAPP
+
 void ClientSession::abortConversion(const std::shared_ptr<DocumentBroker>& docBroker,
                                     const std::shared_ptr<StreamSocket>& saveAsSocket,
                                     std::string errorKind)
@@ -3270,6 +3302,12 @@ void ClientSession::abortConversion(const std::shared_ptr<DocumentBroker>& docBr
     LOG_DBG("Conversion request of [" << docBroker->getDocKey() << "] failed: " << errorKind);
     if (!saveAsSocket)
         LOG_ERR("Error saveas socket missing in isConvertTo mode");
+#if !MOBILEAPP
+    else if (_mcpContext)
+    {
+        sendMcpError(saveAsSocket, -32603, "Conversion failed: " + errorKind);
+    }
+#endif // !MOBILEAPP
     else if (errorKind == "passwordrequired:to-view" ||
              errorKind == "passwordrequired:to-modify")
     {
@@ -3406,17 +3444,38 @@ bool ClientSession::handleSaveAs(const std::shared_ptr<Message>& payload,
         {
             LOG_TRC("Sending file: " << resultURL.getPath());
 
-            const std::string fileName = Poco::Path(resultURL.getPath()).getFileName();
-            http::Response response(http::StatusCode::OK);
-            FileServerRequestHandler::hstsHeaders(response);
-            if (!fileName.empty())
-                response.set("Content-Disposition", "attachment; filename=\"" + fileName + '"');
-            response.setContentType("application/octet-stream");
-
             if (!saveAsSocket)
+            {
                 LOG_ERR("Error saveas socket missing in isConvertTo mode");
+            }
+            else if (_mcpContext)
+            {
+                // MCP mode: read the file, base64-encode it, wrap in JSON-RPC.
+                std::ifstream ifs(resultURL.getPath(), std::ios::binary);
+                std::string fileData((std::istreambuf_iterator<char>(ifs)),
+                                     std::istreambuf_iterator<char>());
+
+                const std::string fileName = Poco::Path(resultURL.getPath()).getFileName();
+                const std::string ext = Poco::Path(fileName).getExtension();
+                const std::string mimeType = McpResponseUtil::mimeTypeFromExtension(ext);
+
+                std::string body = McpResponseUtil::wrapBinaryResult(
+                    _mcpContext->jsonRpcId, fileData.data(), fileData.size(), mimeType);
+                http::Response response(http::StatusCode::OK);
+                response.setBody(body, "application/json");
+                saveAsSocket->sendAndShutdown(response);
+            }
             else
+            {
+                const std::string fileName = Poco::Path(resultURL.getPath()).getFileName();
+                http::Response response(http::StatusCode::OK);
+                FileServerRequestHandler::hstsHeaders(response);
+                if (!fileName.empty())
+                    response.set("Content-Disposition",
+                                 "attachment; filename=\"" + fileName + '"');
+                response.setContentType("application/octet-stream");
                 HttpHelper::sendFileAndShutdown(saveAsSocket, resultURL.getPath(), response);
+            }
         }
 
         // Conversion is done, cleanup this fake session.

--- a/wsd/ClientSession.hpp
+++ b/wsd/ClientSession.hpp
@@ -39,6 +39,13 @@ class DocumentBroker;
 class AIChatSession;
 #endif
 
+/// Context for MCP (Model Context Protocol) JSON-RPC requests.
+/// When set on a ClientSession, response handlers wrap results in JSON-RPC envelopes.
+struct McpContext
+{
+    std::string jsonRpcId; // The JSON-RPC request id
+};
+
 /// Represents a session to a COOL client, in the WSD process.
 class ClientSession final : public Session
 {
@@ -177,6 +184,9 @@ public:
         _saveAsSocket = socket;
         _isConvertTo = static_cast<bool>(socket);
     }
+
+    /// Set MCP context so response handlers wrap results in JSON-RPC envelopes.
+    void setMcpContext(McpContext ctx) { _mcpContext = std::move(ctx); }
 
     std::shared_ptr<DocumentBroker> getDocumentBroker() const { return _docBroker.lock(); }
 
@@ -423,6 +433,16 @@ private:
                          const std::shared_ptr<StreamSocket>& saveAsSocket, std::string errorKind);
 
 #if !MOBILEAPP
+    /// Send a JSON payload as an MCP JSON-RPC result via the saveAs socket.
+    void sendMcpJsonResult(const std::shared_ptr<StreamSocket>& socket,
+                           const std::string& jsonPayload);
+
+    /// Send a JSON-RPC error via the saveAs socket for MCP mode.
+    void sendMcpError(const std::shared_ptr<StreamSocket>& socket, int code,
+                      const std::string& message);
+#endif // !MOBILEAPP
+
+#if !MOBILEAPP
 
     /// Handles saveas: and exportas: in handleKitToClientMessage.
     bool handleSaveAs(const std::shared_ptr<Message>& payload,
@@ -545,6 +565,9 @@ private:
 
     /// If Session is for convert-to
     bool _isConvertTo;
+
+    /// MCP context - when set, response handlers wrap results in JSON-RPC envelopes
+    std::optional<McpContext> _mcpContext;
 
     Poco::SharedPtr<Poco::JSON::Object> _viewSettingsJSON;
 

--- a/wsd/DocumentToolDescriptions.hpp
+++ b/wsd/DocumentToolDescriptions.hpp
@@ -19,6 +19,19 @@
 namespace DocumentToolDescriptions
 {
 
+/// Description for the convert_document tool.
+inline constexpr const char* CONVERT_DOCUMENT_DESCRIPTION =
+    "Convert a document to a different format. Returns the converted file as "
+    "base64-encoded binary.\n\n"
+    "Supported input formats - Writer: odt, docx, doc, rtf, txt, html, md, fodt, wpd, pages. "
+    "Calc: ods, xlsx, xls, csv, fods, numbers. "
+    "Impress: odp, pptx, ppt, fodp, key. "
+    "Draw: odg, svg, vsdx, pub, png, pdf.\n\n"
+    "Supported output formats - Writer: odt, docx, pdf, rtf, txt, html, png. "
+    "Calc: ods, xlsx, csv, pdf, html, png. "
+    "Impress: odp, pptx, pdf, html, svg, png. "
+    "Draw: odg, pdf, svg, png.";
+
 /// Description for the extract_link_targets tool.
 inline constexpr const char* EXTRACT_LINK_TARGETS_DESCRIPTION =
     "Extract all link targets from a document. Returns a JSON object with "
@@ -35,8 +48,11 @@ inline constexpr const char* EXTRACT_DOC_STRUCTURE_DESCRIPTION =
     "For Impress: slide names, object names per slide. "
     "Useful for understanding document layout before applying transformations.";
 
-/// Description for the transform parameter of transform_document_structure.
-inline constexpr const char* TRANSFORM_PARAM_DESCRIPTION =
+/// Transform description - part 1 of 3 (up to and including the "Text content"
+/// section). Concatenate with TRANSFORM_PARAM_IMAGE_GEN (AI only) and
+/// TRANSFORM_PARAM_POST_IMAGE to form the full description; MCP skips the
+/// image-gen piece because it does not require an AI provider.
+inline constexpr const char* TRANSFORM_PARAM_PRE_IMAGE =
     R"(JSON transformation commands. The top-level object can contain "Transforms" and/or "UnoCommand" objects in any order.
 
 --- Impress/ODP Presentations ---
@@ -82,10 +98,22 @@ Available layouts (use ChangeLayoutByName with these names):
 Text content:
 - {"SetText.N": "text"} - set text of placeholder N on current slide (0=title, 1=first content, 2=second content, etc.). Use \n for paragraph breaks.
 
-Image generation (inserts AI-generated image into a placeholder):
+)";
+
+/// Transform description - part 2 of 3 (AI image generation). Depends on an
+/// AI image provider being configured, so it is only included by consumers
+/// that require AI (the AI sidebar). Omitted on the MCP path.
+inline constexpr const char* TRANSFORM_PARAM_IMAGE_GEN =
+    R"(Image generation (inserts AI-generated image into a placeholder):
 - {"GenerateImage.N": "prompt"} - generate an image from the text prompt using the AI image provider and insert it into placeholder N on the current slide, replacing the placeholder content. N is the 0-based object index (same as SetText.N). A loading placeholder is inserted immediately when the transform is applied, then the real image progressively replaces it after generation completes. Use descriptive prompts for best results. Example: {"GenerateImage.1": "A modern office building with glass facade at sunset, professional photography"}
 
-Object selection:
+)";
+
+/// Transform description - part 3 of 3 (object selection onwards through
+/// the final example). Concatenate after PRE_IMAGE (and optionally
+/// IMAGE_GEN) to form the full description.
+inline constexpr const char* TRANSFORM_PARAM_POST_IMAGE =
+    R"(Object selection:
 - {"MarkObject": N} - select object at index on current slide
 - {"UnMarkObject": N} - deselect object at index
 

--- a/wsd/McpHandler.cpp
+++ b/wsd/McpHandler.cpp
@@ -1,0 +1,663 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * MCP (Model Context Protocol) handler implementation.
+ * Exposes existing stateless batch APIs as MCP tools via JSON-RPC 2.0.
+ */
+
+#include <config.h>
+
+#include "McpHandler.hpp"
+#include "McpResponseUtil.hpp"
+
+#include <ClientSession.hpp>
+#include <COOLWSD.hpp>
+#include <common/FileUtil.hpp>
+#include <common/JailUtil.hpp>
+#include <common/JsonUtil.hpp>
+#include <common/Log.hpp>
+#include <common/Util.hpp>
+#include <common/base64.hpp>
+#include <net/HttpHelper.hpp>
+#include <wsd/DocumentBroker.hpp>
+#include <wsd/DocumentToolDescriptions.hpp>
+#include <wsd/SpecialBrokers.hpp>
+
+#include <Poco/JSON/Array.h>
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Parser.h>
+#include <Poco/Path.h>
+#include <Poco/URI.h>
+
+#include <algorithm>
+#include <chrono>
+#include <fstream>
+#include <mutex>
+#include <sstream>
+#include <unordered_map>
+
+extern std::map<std::string, std::shared_ptr<DocumentBroker>> DocBrokers;
+extern std::mutex DocBrokersMutex;
+
+namespace
+{
+/// Uploaded files: file_id -> (path, expiry). Consumed on lookup, expired by
+/// TTL, and evicted once the map is full. The broker deletes the source file
+/// after a successful conversion; this map's sweep deletes the file when an
+/// entry expires or is evicted without ever being claimed.
+struct UploadEntry
+{
+    std::string path;
+    std::chrono::steady_clock::time_point expiry;
+};
+std::unordered_map<std::string, UploadEntry> uploads;
+std::mutex uploadsMutex;
+constexpr std::chrono::minutes uploadTtl{ 10 };
+constexpr std::size_t maxUploads = 256;
+
+/// Pending upload tokens: token -> expiry time. Single-use; consumed on auth.
+/// A token only authenticates a POST to /cool/mcp/upload.
+std::unordered_map<std::string, std::chrono::steady_clock::time_point> uploadTokens;
+std::mutex uploadTokensMutex;
+constexpr std::chrono::seconds uploadTokenTtl{ 60 };
+
+/// Drop expired token entries. Call with uploadTokensMutex held.
+void sweepExpiredUploadTokens(std::chrono::steady_clock::time_point now)
+{
+    for (auto it = uploadTokens.begin(); it != uploadTokens.end();)
+        it = (it->second <= now) ? uploadTokens.erase(it) : std::next(it);
+}
+
+/// Drop expired upload entries and delete their on-disk temp files.
+/// Call with uploadsMutex held.
+void sweepExpiredUploads(std::chrono::steady_clock::time_point now)
+{
+    for (auto it = uploads.begin(); it != uploads.end();)
+    {
+        if (it->second.expiry <= now)
+        {
+            LOG_TRC("MCP: expiring upload " << it->first);
+            StatelessBatchBroker::removeFile(it->second.path);
+            it = uploads.erase(it);
+        }
+        else
+            ++it;
+    }
+}
+
+/// Build a JSON Schema object describing an input parameter.
+Poco::JSON::Object::Ptr makeParam(const std::string& type, const std::string& description)
+{
+    Poco::JSON::Object::Ptr obj = new Poco::JSON::Object;
+    obj->set("type", type);
+    obj->set("description", description);
+    return obj;
+}
+
+/// Build a complete MCP tool definition.
+Poco::JSON::Object::Ptr
+makeTool(const std::string& name, const std::string& description,
+         std::initializer_list<std::pair<std::string, Poco::JSON::Object::Ptr>> params,
+         std::initializer_list<std::string> required)
+{
+    Poco::JSON::Object::Ptr properties = new Poco::JSON::Object;
+    for (const auto& p : params)
+        properties->set(p.first, p.second);
+
+    Poco::JSON::Array::Ptr reqArr = new Poco::JSON::Array;
+    for (const auto& r : required)
+        reqArr->add(r);
+
+    Poco::JSON::Object::Ptr inputSchema = new Poco::JSON::Object;
+    inputSchema->set("type", "object");
+    inputSchema->set("properties", properties);
+    inputSchema->set("required", reqArr);
+
+    Poco::JSON::Object::Ptr tool = new Poco::JSON::Object;
+    tool->set("name", name);
+    tool->set("description", description);
+    tool->set("inputSchema", inputSchema);
+    return tool;
+}
+
+/// Map an MCP tool name to the internal request type used by getConvertToBrokerImplementation.
+std::string toolNameToRequestType(const std::string& toolName)
+{
+    if (toolName == "convert_document")
+        return "convert-to";
+    if (toolName == "extract_link_targets")
+        return "extract-link-targets";
+    if (toolName == "extract_document_structure")
+        return "extract-document-structure";
+    if (toolName == "transform_document_structure")
+        return "transform-document-structure";
+    return std::string();
+}
+
+/// Write raw data to a temp file in the incoming directory. Returns the file path, or empty on error.
+std::string writeToTempFile(const std::string& data, const std::string& filename)
+{
+    std::string tempDir =
+        FileUtil::createRandomTmpDir(COOLWSD::ChildRoot + JailUtil::CHILDROOT_TMP_INCOMING_PATH);
+    if (tempDir.empty())
+    {
+        LOG_ERR("MCP: failed to create temp directory");
+        return std::string();
+    }
+
+    std::string cleanName = Util::cleanupFilename(filename);
+    if (cleanName.empty())
+        cleanName = "incoming_file";
+
+    Poco::Path tempPath = Poco::Path::forDirectory(tempDir + '/');
+    tempPath.setFileName(Poco::Path(cleanName).getFileName());
+
+    std::string filePath = tempPath.toString();
+    std::ofstream ofs(filePath, std::ios::binary);
+    if (!ofs.is_open())
+    {
+        LOG_ERR("MCP: failed to open temp file: " << filePath);
+        return std::string();
+    }
+    ofs.write(data.data(), data.size());
+    ofs.close();
+    if (!ofs)
+    {
+        LOG_ERR("MCP: failed to write temp file: " << filePath);
+        FileUtil::removeFile(filePath);
+        return std::string();
+    }
+
+    LOG_TRC("MCP: wrote " << data.size() << " bytes to " << filePath);
+    return filePath;
+}
+
+/// Decode base64 data and write it to a temp file. Returns the file path, or empty on error.
+std::string decodeToTempFile(const std::string& base64Data, const std::string& filename)
+{
+    std::string decoded;
+    std::string error = macaron::Base64::Decode(base64Data, decoded);
+    if (!error.empty())
+    {
+        LOG_ERR("MCP: base64 decode failed: " << error);
+        return std::string();
+    }
+    return writeToTempFile(decoded, filename);
+}
+
+/// Send a JSON-RPC response as HTTP and shutdown the socket.
+void sendJsonRpcResponse(const std::shared_ptr<StreamSocket>& socket, const std::string& body)
+{
+    http::Response httpResponse(http::StatusCode::OK);
+    httpResponse.setBody(body, "application/json");
+    socket->sendAndShutdown(httpResponse);
+}
+
+/// Extract a string value from a JSON object, or return a default.
+std::string getString(const Poco::JSON::Object::Ptr& obj, const std::string& key,
+                      const std::string& def = std::string())
+{
+    if (obj && obj->has(key))
+        return obj->getValue<std::string>(key);
+    return def;
+}
+
+} // anonymous namespace
+
+std::string McpHandler::registerUpload(std::string path)
+{
+    const auto now = std::chrono::steady_clock::now();
+    std::lock_guard<std::mutex> lock(uploadsMutex);
+    sweepExpiredUploads(now);
+
+    // If still at capacity after the sweep, evict the entry with the earliest
+    // expiry so a burst of uploads can't pin arbitrary disk/memory.
+    if (uploads.size() >= maxUploads)
+    {
+        auto oldest = std::min_element(
+            uploads.begin(), uploads.end(),
+            [](const auto& a, const auto& b) { return a.second.expiry < b.second.expiry; });
+        LOG_WRN("MCP: upload map full, evicting " << oldest->first);
+        StatelessBatchBroker::removeFile(oldest->second.path);
+        uploads.erase(oldest);
+    }
+
+    std::string id = Util::rng::getHexString(16);
+    uploads[id] = UploadEntry{ std::move(path), now + uploadTtl };
+    LOG_TRC("MCP: registered upload " << id);
+    return id;
+}
+
+std::string McpHandler::lookupUpload(const std::string& fileId)
+{
+    const auto now = std::chrono::steady_clock::now();
+    std::lock_guard<std::mutex> lock(uploadsMutex);
+    sweepExpiredUploads(now);
+    auto it = uploads.find(fileId);
+    if (it == uploads.end())
+        return std::string();
+    std::string path = std::move(it->second.path);
+    uploads.erase(it);
+    return path;
+}
+
+std::string McpHandler::registerUploadToken()
+{
+    const auto now = std::chrono::steady_clock::now();
+    std::lock_guard<std::mutex> lock(uploadTokensMutex);
+    sweepExpiredUploadTokens(now);
+    std::string token = Util::rng::getHexString(16);
+    uploadTokens[token] = now + uploadTokenTtl;
+    LOG_TRC("MCP: issued upload token " << token);
+    return token;
+}
+
+bool McpHandler::consumeUploadToken(const std::string& token)
+{
+    const auto now = std::chrono::steady_clock::now();
+    std::lock_guard<std::mutex> lock(uploadTokensMutex);
+    sweepExpiredUploadTokens(now);
+    auto it = uploadTokens.find(token);
+    if (it == uploadTokens.end())
+    {
+        LOG_TRC("MCP: upload token miss");
+        return false;
+    }
+    uploadTokens.erase(it);
+    LOG_TRC("MCP: upload token consumed");
+    return true;
+}
+
+std::string McpHandler::handleInitialize(const std::string& requestId)
+{
+    Poco::JSON::Object::Ptr serverInfo = new Poco::JSON::Object;
+    serverInfo->set("name", "collabora-online");
+    serverInfo->set("version", Util::getCoolVersion());
+
+    Poco::JSON::Object::Ptr toolsCap = new Poco::JSON::Object;
+    Poco::JSON::Object::Ptr uploadCap = new Poco::JSON::Object;
+    uploadCap->set("endpoint", "/cool/mcp/upload");
+    uploadCap->set("maxSize", 100 * 1024 * 1024);
+
+    Poco::JSON::Object::Ptr capabilities = new Poco::JSON::Object;
+    capabilities->set("tools", toolsCap);
+    capabilities->set("x-fileUpload", uploadCap);
+
+    Poco::JSON::Object::Ptr result = new Poco::JSON::Object;
+    result->set("protocolVersion", "2025-03-26");
+    result->set("serverInfo", serverInfo);
+    result->set("capabilities", capabilities);
+
+    Poco::JSON::Object::Ptr response = new Poco::JSON::Object;
+    response->set("jsonrpc", "2.0");
+    response->set("id", requestId);
+    response->set("result", result);
+
+    std::ostringstream oss;
+    response->stringify(oss);
+    return oss.str();
+}
+
+/// Build the JSON-RPC 2.0 response listing all available MCP tools.
+/// Each entry describes a single tool (name, description, and JSON Schema
+/// for its parameters) that can be invoked via the MCP interface.
+std::string McpHandler::handleToolsList(const std::string& requestId)
+{
+    Poco::JSON::Array::Ptr tools = new Poco::JSON::Array;
+
+    tools->add(makeTool(
+        "convert_document", DocumentToolDescriptions::CONVERT_DOCUMENT_DESCRIPTION,
+        { { "data",
+            makeParam("string",
+                      "Base64-encoded input file content. Provide this or 'file_id'.") },
+          { "file_id",
+            makeParam("string", "ID of a previously uploaded file (via POST /cool/mcp/upload). "
+                                "Use for large files that exceed base64 parameter limits.") },
+          { "filename",
+            makeParam("string",
+                      "Original filename with extension (e.g. 'report.odt'). "
+                      "The extension determines the input format. Required when using 'data'.") },
+          { "format", makeParam("string", "Target output format (e.g. 'pdf', 'docx', 'pptx', "
+                                          "'html', 'txt', 'png', 'csv', 'svg')") },
+          { "options",
+            makeParam("string",
+                      "Export filter options as JSON. "
+                      "For PDF: {\"PageRange\":{\"type\":\"string\",\"value\":\"1,3-5\"}}, "
+                      "{\"Watermark\":{\"type\":\"string\",\"value\":\"DRAFT\"}}, "
+                      "{\"SelectPdfVersion\":{\"type\":\"long\",\"value\":2}} for PDF/A-2b, "
+                      "{\"EncryptFile\":{\"type\":\"boolean\",\"value\":\"true\"},"
+                      "\"DocumentOpenPassword\":{\"type\":\"string\",\"value\":\"secret\"}}. "
+                      "For CSV: comma-separated filter codes (e.g. '44,34,76' for comma separator, "
+                      "quote delimiter, UTF-8). "
+                      "For spreadsheet-to-PDF: {\"SinglePageSheets\":{\"type\":\"boolean\","
+                      "\"value\":\"true\"}} to fit each sheet on one page.") },
+          { "lang",
+            makeParam(
+                "string",
+                "BCP 47 language tag for locale-dependent formatting (e.g. 'en-US', 'de-DE')") } },
+        { "format" }));
+
+    tools->add(makeTool(
+        "extract_link_targets", DocumentToolDescriptions::EXTRACT_LINK_TARGETS_DESCRIPTION,
+        { { "data",
+            makeParam("string",
+                      "Base64-encoded input file content. Provide this or 'file_id'.") },
+          { "file_id",
+            makeParam("string", "ID of a previously uploaded file (via POST /cool/mcp/upload). "
+                                "Use for large files that exceed base64 parameter limits.") },
+          { "filename",
+            makeParam("string",
+                      "Original filename with extension (e.g. 'report.odt'). "
+                      "The extension determines the input format. Required when using 'data'.") },
+          { "lang",
+            makeParam(
+                "string",
+                "BCP 47 language tag for locale-dependent formatting (e.g. 'en-US', 'de-DE')") } },
+        {}));
+
+    tools->add(makeTool(
+        "extract_document_structure", DocumentToolDescriptions::EXTRACT_DOC_STRUCTURE_DESCRIPTION,
+        { { "data",
+            makeParam("string",
+                      "Base64-encoded input file content. Provide this or 'file_id'.") },
+          { "file_id",
+            makeParam("string", "ID of a previously uploaded file (via POST /cool/mcp/upload). "
+                                "Use for large files that exceed base64 parameter limits.") },
+          { "filename",
+            makeParam("string",
+                      "Original filename with extension (e.g. 'report.odt'). "
+                      "The extension determines the input format. Required when using 'data'.") },
+          { "filter", makeParam("string", "Filter results to a specific structure type. "
+                                          "For Impress: 'slides'. For Writer: 'contentcontrol'. "
+                                          "Omit to get the full structure.") },
+          { "lang",
+            makeParam(
+                "string",
+                "BCP 47 language tag for locale-dependent formatting (e.g. 'en-US', 'de-DE')") } },
+        {}));
+
+    tools->add(makeTool(
+        "transform_document_structure",
+        "Transform a document's structure using a JSON command sequence and return "
+        "the modified document. Supports Impress slide operations (insert, delete, "
+        "duplicate, reorder, rename slides; change layouts; set text on placeholders; "
+        "format text with UNO commands), Writer/Calc content control updates, and "
+        "arbitrary UNO commands. Provide a base document (can be a blank ODP for "
+        "creating presentations from scratch) and a transform JSON.",
+        { { "data",
+            makeParam("string",
+                      "Base64-encoded input file content. Provide this or 'file_id'.") },
+          { "file_id",
+            makeParam("string", "ID of a previously uploaded file (via POST /cool/mcp/upload). "
+                                "Use for large files that exceed base64 parameter limits.") },
+          { "filename",
+            makeParam("string",
+                      "Original filename with extension (e.g. 'presentation.odp'). "
+                      "The extension determines the input format. Required when using 'data'.") },
+          { "transform",
+            makeParam("string",
+                      std::string(DocumentToolDescriptions::TRANSFORM_PARAM_PRE_IMAGE)
+                          + DocumentToolDescriptions::TRANSFORM_PARAM_POST_IMAGE) },
+          { "format",
+            makeParam("string",
+                      "Output format for the transformed document (e.g. 'odp', 'pptx', 'pdf'). "
+                      "Defaults to the input file's format.") },
+          { "lang",
+            makeParam(
+                "string",
+                "BCP 47 language tag for locale-dependent formatting (e.g. 'en-US', 'de-DE')") } },
+        { "transform" }));
+
+    tools->add(makeTool(
+        "prepare_upload",
+        "Obtain a short-lived, single-use credential for uploading a file that is too "
+        "large for the base64 'data' parameter. Returns an 'upload_url' (absolute), an "
+        "'upload_token', and 'expires_in' (seconds). The MCP client should then upload "
+        "the file itself by issuing a POST multipart/form-data request to 'upload_url' "
+        "with header 'Authorization: Bearer <upload_token>' and a single 'file' form "
+        "field containing the document. The response is a JSON object of the form "
+        "{\"file_id\": \"...\"}; pass that 'file_id' to subsequent tool calls "
+        "(convert_document, extract_link_targets, extract_document_structure, "
+        "transform_document_structure) via their 'file_id' argument. The token is valid "
+        "for 60 seconds and is consumed on use.",
+        {}, {}));
+
+    Poco::JSON::Object::Ptr result = new Poco::JSON::Object;
+    result->set("tools", tools);
+
+    Poco::JSON::Object::Ptr response = new Poco::JSON::Object;
+    response->set("jsonrpc", "2.0");
+    response->set("id", requestId);
+    response->set("result", result);
+
+    std::ostringstream oss;
+    response->stringify(oss);
+    return oss.str();
+}
+
+bool McpHandler::handleRequest(const std::string& body, const std::shared_ptr<StreamSocket>& socket,
+                               SocketDisposition& disposition, const std::string& id,
+                               const std::string& uploadUrl)
+{
+    Poco::JSON::Object::Ptr request;
+    if (!JsonUtil::parseJSON(body, request) || !request)
+    {
+        sendJsonRpcResponse(socket,
+                            McpResponseUtil::makeJsonRpcError("null", -32700, "Parse error"));
+        return true;
+    }
+
+    // Validate JSON-RPC envelope.
+    std::string jsonrpc = getString(request, "jsonrpc");
+    if (jsonrpc != "2.0")
+    {
+        sendJsonRpcResponse(socket,
+                            McpResponseUtil::makeJsonRpcError(
+                                "null", -32600, "Invalid Request: missing or wrong jsonrpc field"));
+        return true;
+    }
+
+    // JSON-RPC 2.0 allows id to be a string, number, or null.
+    std::string requestId = "null";
+    if (request->has("id"))
+    {
+        Poco::Dynamic::Var idVar = request->get("id");
+        if (idVar.isString())
+            requestId = idVar.convert<std::string>();
+        else if (idVar.isNumeric())
+            requestId = std::to_string(idVar.convert<int64_t>());
+    }
+
+    std::string method = getString(request, "method");
+
+    if (method.empty())
+    {
+        sendJsonRpcResponse(socket, McpResponseUtil::makeJsonRpcError(
+                                        requestId, -32600, "Invalid Request: missing method"));
+        return true;
+    }
+
+    // Handle synchronous methods.
+    if (method == "initialize")
+    {
+        sendJsonRpcResponse(socket, handleInitialize(requestId));
+        return true;
+    }
+
+    if (method == "tools/list")
+    {
+        sendJsonRpcResponse(socket, handleToolsList(requestId));
+        return true;
+    }
+
+    if (method == "notifications/initialized")
+    {
+        // Client notification after initialize - no response needed per MCP spec.
+        http::Response httpResponse(http::StatusCode::NoContent);
+        httpResponse.setContentLength(0);
+        socket->sendAndShutdown(httpResponse);
+        return true;
+    }
+
+    if (method != "tools/call")
+    {
+        sendJsonRpcResponse(socket, McpResponseUtil::makeJsonRpcError(
+                                        requestId, -32601, "Method not found: " + method));
+        return true;
+    }
+
+    // tools/call - extract tool name and arguments.
+    Poco::JSON::Object::Ptr params;
+    if (request->has("params"))
+        params = request->getObject("params");
+
+    if (!params || !params->has("name"))
+    {
+        sendJsonRpcResponse(socket, McpResponseUtil::makeJsonRpcError(
+                                        requestId, -32602, "Invalid params: missing tool name"));
+        return true;
+    }
+
+    std::string toolName = params->getValue<std::string>("name");
+
+    if (toolName == "prepare_upload")
+    {
+        Poco::JSON::Object::Ptr info = new Poco::JSON::Object;
+        info->set("upload_url", uploadUrl);
+        info->set("upload_token", registerUploadToken());
+        info->set("expires_in", static_cast<int>(uploadTokenTtl.count()));
+        std::ostringstream oss;
+        info->stringify(oss);
+        sendJsonRpcResponse(socket, McpResponseUtil::wrapJsonResult(requestId, oss.str()));
+        return true;
+    }
+
+    std::string requestType = toolNameToRequestType(toolName);
+    if (requestType.empty())
+    {
+        sendJsonRpcResponse(socket, McpResponseUtil::makeJsonRpcError(requestId, -32602,
+                                                                      "Unknown tool: " + toolName));
+        return true;
+    }
+
+    Poco::JSON::Object::Ptr arguments;
+    if (params->has("arguments"))
+        arguments = params->getObject("arguments");
+
+    std::string base64Data = getString(arguments, "data");
+    std::string fileId = getString(arguments, "file_id");
+
+    if (base64Data.empty() && fileId.empty())
+    {
+        sendJsonRpcResponse(socket,
+                            McpResponseUtil::makeJsonRpcError(
+                                requestId, -32602, "Invalid params: provide 'data' or 'file_id'"));
+        return true;
+    }
+
+    std::string filename = getString(arguments, "filename");
+    std::string format = getString(arguments, "format");
+    std::string options = getString(arguments, "options");
+    std::string lang = getString(arguments, "lang");
+    std::string filter = getString(arguments, "filter");
+
+    if (filename.empty())
+        filename = "document";
+
+    std::string transformJSON;
+    if (arguments && arguments->has("transform"))
+    {
+        std::string transform = arguments->getValue<std::string>("transform");
+        Poco::URI::encode(transform, "", transformJSON);
+    }
+
+    // convert_document requires a format.
+    if (requestType == "convert-to" && format.empty())
+    {
+        sendJsonRpcResponse(
+            socket, McpResponseUtil::makeJsonRpcError(
+                        requestId, -32602, "Invalid params: convert_document requires format"));
+        return true;
+    }
+
+    std::string fromPath;
+    if (!fileId.empty())
+    {
+        fromPath = lookupUpload(fileId);
+        if (fromPath.empty())
+        {
+            sendJsonRpcResponse(socket, McpResponseUtil::makeJsonRpcError(
+                                            requestId, -32602, "Invalid or expired file_id"));
+            return true;
+        }
+        if (filename == "document")
+            filename = Poco::Path(fromPath).getFileName();
+    }
+    else
+        fromPath = decodeToTempFile(base64Data, filename);
+
+    if (fromPath.empty())
+    {
+        sendJsonRpcResponse(socket,
+                            McpResponseUtil::makeJsonRpcError(
+                                requestId, -32603, "Internal error: failed to obtain input file"));
+        return true;
+    }
+
+    Poco::URI uriPublic = RequestDetails::sanitizeLocalPath(fromPath);
+    const std::string docKey = RequestDetails::getDocKey(uriPublic);
+
+    std::unique_lock<std::mutex> docBrokersLock(DocBrokersMutex);
+
+    LOG_DBG("MCP: New DocumentBroker for docKey [" << docKey << "].");
+    auto docBroker =
+        getConvertToBrokerImplementation(requestType, fromPath, uriPublic, docKey, format, options,
+                                         lang, /*target=*/std::string(), filter, transformJSON);
+    if (!docBroker)
+    {
+        docBrokersLock.unlock();
+        StatelessBatchBroker::removeFile(fromPath);
+        sendJsonRpcResponse(
+            socket, McpResponseUtil::makeJsonRpcError(requestId, -32603,
+                                                      "Internal error: failed to create broker"));
+        return true;
+    }
+
+    COOLWSD::cleanupDocBrokers();
+
+    DocBrokers.emplace(docKey, docBroker);
+    LOG_TRC("MCP: Have " << DocBrokers.size() << " DocBrokers after inserting [" << docKey << "].");
+
+    // Set the MCP context on the broker before starting conversion.
+    // startConversion will create the ClientSession and forward it.
+    McpContext mcpCtx;
+    mcpCtx.jsonRpcId = requestId;
+    docBroker->setMcpContext(std::move(mcpCtx));
+
+    AdditionalFilePocoUris emptyUris;
+    if (!docBroker->startConversion(disposition, id, emptyUris))
+    {
+        LOG_WRN("MCP: Failed to create Client Session with id [" << id << "] on docKey [" << docKey
+                                                                 << "].");
+        StatelessBatchBroker::removeFile(fromPath);
+        COOLWSD::cleanupDocBrokers();
+        sendJsonRpcResponse(socket,
+                            McpResponseUtil::makeJsonRpcError(
+                                requestId, -32603, "Internal error: failed to start conversion"));
+        return true;
+    }
+
+    // Response will come asynchronously through the broker/session response handlers.
+    return false;
+}
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/McpHandler.hpp
+++ b/wsd/McpHandler.hpp
@@ -1,0 +1,62 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * MCP (Model Context Protocol) handler for JSON-RPC over HTTP.
+ * Exposes existing stateless batch APIs as MCP tools.
+ */
+
+#pragma once
+
+#include <Socket.hpp>
+
+#include <memory>
+#include <string>
+
+class SocketDisposition;
+
+/// Handles MCP JSON-RPC requests at the /cool/mcp endpoint.
+class McpHandler
+{
+public:
+    /// Handle a JSON-RPC request body. Returns true if the response was sent
+    /// synchronously (initialize, tools/list, errors). Returns false if the
+    /// request was dispatched to a broker and the response will come later.
+    /// @p uploadUrl is the absolute URL of the /cool/mcp/upload endpoint,
+    /// returned to clients by the prepare_upload tool.
+    static bool handleRequest(const std::string& body,
+                              const std::shared_ptr<StreamSocket>& socket,
+                              SocketDisposition& disposition,
+                              const std::string& id,
+                              const std::string& uploadUrl);
+
+    /// Build the JSON-RPC response for the "initialize" method.
+    static std::string handleInitialize(const std::string& requestId);
+
+    /// Build the JSON-RPC response for the "tools/list" method.
+    static std::string handleToolsList(const std::string& requestId);
+
+    /// Register an uploaded file and return a unique file ID.
+    static std::string registerUpload(std::string path);
+
+    /// Look up a previously uploaded file by ID. Returns the path, or empty if
+    /// the ID is unknown or expired.
+    static std::string lookupUpload(const std::string& fileId);
+
+    /// Generate and store a single-use upload token valid for a short time.
+    static std::string registerUploadToken();
+
+    /// Consume an upload token. Returns true if the token was valid and is
+    /// now burned. Returns false if the token is unknown or expired.
+    static bool consumeUploadToken(const std::string& token);
+};
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/McpResponseUtil.cpp
+++ b/wsd/McpResponseUtil.cpp
@@ -1,0 +1,135 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Implementation of MCP JSON-RPC response utility functions.
+ */
+
+#include <config.h>
+
+#include "McpResponseUtil.hpp"
+
+#include <common/base64.hpp>
+
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Array.h>
+
+#include <sstream>
+#include <string>
+
+namespace McpResponseUtil
+{
+
+std::string wrapJsonResult(const std::string& id, const std::string& jsonBody)
+{
+    Poco::JSON::Object::Ptr content = new Poco::JSON::Object;
+    content->set("type", "text");
+    content->set("text", jsonBody);
+
+    Poco::JSON::Array::Ptr contentArray = new Poco::JSON::Array;
+    contentArray->add(content);
+
+    Poco::JSON::Object::Ptr result = new Poco::JSON::Object;
+    result->set("content", contentArray);
+
+    Poco::JSON::Object::Ptr response = new Poco::JSON::Object;
+    response->set("jsonrpc", "2.0");
+    response->set("id", id);
+    response->set("result", result);
+
+    std::ostringstream oss;
+    response->stringify(oss);
+    return oss.str();
+}
+
+std::string wrapBinaryResult(const std::string& id, const char* data, std::size_t size,
+                             const std::string& mimeType)
+{
+    std::string encoded = macaron::Base64::Encode(std::string_view(data, size));
+
+    Poco::JSON::Object::Ptr resource = new Poco::JSON::Object;
+    // The uri is a data URI prefix for identification; actual data is in the blob field per MCP spec.
+    resource->set("uri", "data:" + mimeType + ";base64,");
+    resource->set("mimeType", mimeType);
+    resource->set("blob", encoded);
+
+    Poco::JSON::Object::Ptr content = new Poco::JSON::Object;
+    content->set("type", "resource");
+    content->set("resource", resource);
+
+    Poco::JSON::Array::Ptr contentArray = new Poco::JSON::Array;
+    contentArray->add(content);
+
+    Poco::JSON::Object::Ptr result = new Poco::JSON::Object;
+    result->set("content", contentArray);
+
+    Poco::JSON::Object::Ptr response = new Poco::JSON::Object;
+    response->set("jsonrpc", "2.0");
+    response->set("id", id);
+    response->set("result", result);
+
+    std::ostringstream oss;
+    response->stringify(oss);
+    return oss.str();
+}
+
+std::string makeJsonRpcError(const std::string& id, int code, const std::string& message)
+{
+    Poco::JSON::Object::Ptr error = new Poco::JSON::Object;
+    error->set("code", code);
+    error->set("message", message);
+
+    Poco::JSON::Object::Ptr response = new Poco::JSON::Object;
+    response->set("jsonrpc", "2.0");
+    response->set("id", id);
+    response->set("error", error);
+
+    std::ostringstream oss;
+    response->stringify(oss);
+    return oss.str();
+}
+
+std::string mimeTypeFromExtension(const std::string& ext)
+{
+    if (ext == "pdf")
+        return "application/pdf";
+    if (ext == "docx")
+        return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    if (ext == "xlsx")
+        return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    if (ext == "pptx")
+        return "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+    if (ext == "odt")
+        return "application/vnd.oasis.opendocument.text";
+    if (ext == "ods")
+        return "application/vnd.oasis.opendocument.spreadsheet";
+    if (ext == "odp")
+        return "application/vnd.oasis.opendocument.presentation";
+    if (ext == "odg")
+        return "application/vnd.oasis.opendocument.graphics";
+    if (ext == "rtf")
+        return "application/rtf";
+    if (ext == "html")
+        return "text/html";
+    if (ext == "txt")
+        return "text/plain";
+    if (ext == "csv")
+        return "text/csv";
+    if (ext == "png")
+        return "image/png";
+    if (ext == "svg")
+        return "image/svg+xml";
+    return "application/octet-stream";
+}
+
+} // namespace McpResponseUtil
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/McpResponseUtil.hpp
+++ b/wsd/McpResponseUtil.hpp
@@ -1,0 +1,40 @@
+/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+ * Utility functions for building MCP (Model Context Protocol) JSON-RPC responses.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace McpResponseUtil
+{
+
+/// Build a JSON-RPC result that wraps a JSON string as MCP text content.
+std::string wrapJsonResult(const std::string& id, const std::string& jsonBody);
+
+/// Build a JSON-RPC result that wraps binary data as a base64-encoded MCP resource.
+std::string wrapBinaryResult(const std::string& id, const char* data, std::size_t size,
+                             const std::string& mimeType);
+
+/// Build a JSON-RPC error response.
+std::string makeJsonRpcError(const std::string& id, int code, const std::string& message);
+
+/// Map a file extension to a MIME type for common document/image formats.
+/// Returns "application/octet-stream" for unrecognized extensions.
+std::string mimeTypeFromExtension(const std::string& ext);
+
+} // namespace McpResponseUtil
+
+/* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/SpecialBrokers.cpp
+++ b/wsd/SpecialBrokers.cpp
@@ -128,6 +128,10 @@ bool ConvertToBroker::startConversion(SocketDisposition& disposition, const std:
                                                      additionalFileUrisPublic);
     _clientSession->construct();
 
+    // Forward MCP context to the session if set.
+    if (_mcpContext)
+        _clientSession->setMcpContext(std::move(*_mcpContext));
+
     docBroker->setupTransfer(
         disposition,
         [docBroker](const std::shared_ptr<Socket>& moveSocket)

--- a/wsd/SpecialBrokers.hpp
+++ b/wsd/SpecialBrokers.hpp
@@ -20,6 +20,7 @@
 #error This file should be excluded from Mobile App builds
 #endif // MOBILEAPP
 
+#include <wsd/ClientSession.hpp>
 #include <wsd/DocumentBroker.hpp>
 
 #include <cstddef>
@@ -27,8 +28,6 @@
 #include <string>
 
 #include <Poco/URI.h>
-
-class ClientSession;
 
 class StatelessBatchBroker : public DocumentBroker
 {
@@ -55,6 +54,9 @@ class ConvertToBroker : public StatelessBatchBroker
     const std::string _inFilterOptions;
     const std::string _lang;
 
+    /// Optional MCP context to forward to the client session on conversion start.
+    std::optional<McpContext> _mcpContext;
+
 public:
     /// Construct DocumentBroker with URI and docKey
     ConvertToBroker(const std::string& uri, const Poco::URI& uriPublic, const std::string& docKey,
@@ -64,6 +66,9 @@ public:
 
     /// _lang accessors
     const std::string& getLang() { return _lang; }
+
+    /// Set MCP context to forward to the client session on conversion start.
+    void setMcpContext(McpContext ctx) { _mcpContext = std::move(ctx); }
 
     /// Move socket to this broker for response & do conversion
     bool startConversion(SocketDisposition& disposition, const std::string& id, const AdditionalFilePocoUris& additionalFileUrisPublic);
@@ -193,5 +198,13 @@ public:
     /// How many instances are running.
     static std::size_t getInstanceCount();
 };
+
+/// Construct a ConvertToBroker subclass based on the request type string.
+std::shared_ptr<ConvertToBroker>
+getConvertToBrokerImplementation(const std::string& requestType, const std::string& fromPath,
+                                 const Poco::URI& uriPublic, const std::string& docKey,
+                                 const std::string& format, const std::string& options,
+                                 const std::string& lang, const std::string& target,
+                                 const std::string& filter, const std::string& transformJSON);
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
JSON-RPC 2.0 interface exposing document tools: convert_document, extract_link_targets, extract_document_structure,
transform_document_structure, and prepare_upload.

The endpoint is gated by a Bearer token matched against the net.mcp.api_key config value. When no key is configured the endpoint is disabled and returns 404.

Input via base64 data or file_id. For files too large to pass inline, the prepare_upload tool returns a short-lived, single-use ephemeral token that authenticates one POST to /cool/mcp/upload; the upload response is a file_id usable by the other tools.

Includes unit tests for the handler and an integration test that exercises convert and extract end-to-end.


Change-Id: I7dafd56cb2c232031624ae266bc35f0e2fa95e14


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

