### PR TITLE
private/kendy/main

### DIFF
--- a/macos/coda/coda/ViewController.swift
+++ b/macos/coda/coda/ViewController.swift
@@ -57,8 +57,8 @@ class ViewController: NSViewController, WKScriptMessageHandlerWithReply, WKNavig
     /// Offscreen text view that accumulates all "lok" messages for XCUITest assertions.
     private var testMessageLog: NSTextView?
 
-    /// HTTP server for executing JS commands from XCUITest.
-    private var testHTTPServer: TestHTTPServer?
+    /// W3C WebDriver server for executing JS commands from tests.
+    private var webDriverServer: WebDriverServer?
 
     var savedViewFrame: NSRect!
     var savedConsoleViewFrame: NSRect!
@@ -126,11 +126,11 @@ class ViewController: NSViewController, WKScriptMessageHandlerWithReply, WKNavig
                 .first
             if let portString, let port = UInt16(portString) {
                 do {
-                    let server = try TestHTTPServer(port: port,
+                    let server = try WebDriverServer(port: port,
                         jsExecutor: { [weak self] js, completion in
                             DispatchQueue.main.async {
                                 guard let webView = self?.webView else {
-                                    completion(nil, NSError(domain: "TestHTTPServer", code: 1,
+                                    completion(nil, NSError(domain: "WebDriverServer", code: 1,
                                                             userInfo: [NSLocalizedDescriptionKey: "webView not available"]))
                                     return
                                 }
@@ -149,9 +149,9 @@ class ViewController: NSViewController, WKScriptMessageHandlerWithReply, WKNavig
                         }
                     )
                     server.start()
-                    testHTTPServer = server
+                    webDriverServer = server
                 } catch {
-                    NSLog("TestHTTPServer: failed to start: %@", error.localizedDescription)
+                    NSLog("WebDriverServer: failed to start: %@", error.localizedDescription)
                 }
             }
         }

--- a/macos/coda/coda/WebDriverServer.swift
+++ b/macos/coda/coda/WebDriverServer.swift
@@ -241,8 +241,13 @@ final class WebDriverServer {
 
         jsExecutor(expression) { [weak self] result, error in
             if let error = error {
+                // Extract the actual JS exception message from the
+                // NSError userInfo, not the generic localizedDescription.
+                let nsError = error as NSError
+                let jsMessage = nsError.userInfo["WKJavaScriptExceptionMessage"] as? String
+                    ?? nsError.localizedDescription
                 self?.sendW3CError(connection: connection, error: "javascript error",
-                                   message: error.localizedDescription)
+                                   message: jsMessage)
             } else {
                 self?.sendW3C(connection: connection, value: result ?? NSNull())
             }

--- a/macos/coda/coda/WebDriverServer.swift
+++ b/macos/coda/coda/WebDriverServer.swift
@@ -187,7 +187,8 @@ final class WebDriverServer {
             let subpath = Array(segments.dropFirst(2))
 
             // POST /session/{id}/execute/sync
-            if request.method == "POST" && subpath == ["execute", "sync"] {
+            // POST /session/{id}/execute (WebDriverIO may use either)
+            if request.method == "POST" && (subpath == ["execute", "sync"] || subpath == ["execute"]) {
                 handleExecuteSync(request, connection: connection)
                 return
             }

--- a/macos/coda/coda/WebDriverServer.swift
+++ b/macos/coda/coda/WebDriverServer.swift
@@ -20,7 +20,7 @@ import Network
  *
  * Start with ``start()`` and stop with ``stop()``.
  */
-final class TestHTTPServer {
+final class WebDriverServer {
 
     private let listener: NWListener
     private let jsExecutor: (String, @escaping (Any?, Error?) -> Void) -> Void
@@ -54,7 +54,7 @@ final class TestHTTPServer {
             self?.handleConnection(connection)
         }
         listener.start(queue: .global(qos: .userInitiated))
-        NSLog("TestHTTPServer: listening on port %d", listener.port?.rawValue ?? 0)
+        NSLog("WebDriverServer: listening on port %d", listener.port?.rawValue ?? 0)
     }
 
     func stop() {
@@ -73,7 +73,7 @@ final class TestHTTPServer {
             guard let self = self else { return }
 
             if let error = error {
-                NSLog("TestHTTPServer: receive error: %@", error.localizedDescription)
+                NSLog("WebDriverServer: receive error: %@", error.localizedDescription)
                 connection.cancel()
                 return
             }

--- a/macos/coda/coda/WebDriverServer.swift
+++ b/macos/coda/coda/WebDriverServer.swift
@@ -240,16 +240,27 @@ final class WebDriverServer {
             return
         }
 
+        let args = json["args"] as? [Any] ?? []
+
         // WKWebView.evaluateJavaScript expects an expression, not a
         // program with "return".  WebDriverIO sends scripts like
         // "return (function(){...}).apply(null,arguments)" so we need
         // to strip the leading "return " and let evaluateJavaScript
         // evaluate the expression directly.
-        let expression: String
+        var expression: String
         if script.hasPrefix("return ") {
             expression = String(script.dropFirst("return ".count))
         } else {
             expression = script
+        }
+
+        // WebDriverIO uses "arguments" to reference the args array.
+        // Since evaluateJavaScript runs at the top level where
+        // "arguments" is not defined, replace it with the actual
+        // serialized args array.
+        if let argsData = try? JSONSerialization.data(withJSONObject: args),
+           let argsJSON = String(data: argsData, encoding: .utf8) {
+            expression = expression.replacingOccurrences(of: "arguments", with: argsJSON)
         }
 
         jsExecutor(expression) { [weak self] result, error in

--- a/macos/coda/coda/WebDriverServer.swift
+++ b/macos/coda/coda/WebDriverServer.swift
@@ -227,7 +227,19 @@ final class WebDriverServer {
             return
         }
 
-        jsExecutor(script) { [weak self] result, error in
+        // WKWebView.evaluateJavaScript expects an expression, not a
+        // program with "return".  WebDriverIO sends scripts like
+        // "return (function(){...}).apply(null,arguments)" so we need
+        // to strip the leading "return " and let evaluateJavaScript
+        // evaluate the expression directly.
+        let expression: String
+        if script.hasPrefix("return ") {
+            expression = String(script.dropFirst("return ".count))
+        } else {
+            expression = script
+        }
+
+        jsExecutor(expression) { [weak self] result, error in
             if let error = error {
                 self?.sendW3CError(connection: connection, error: "javascript error",
                                    message: error.localizedDescription)

--- a/macos/coda/coda/WebDriverServer.swift
+++ b/macos/coda/coda/WebDriverServer.swift
@@ -193,6 +193,18 @@ final class WebDriverServer {
                 return
             }
 
+            // GET /session/{id}/source
+            if request.method == "GET" && subpath == ["source"] {
+                jsExecutor("document.documentElement.outerHTML") { [weak self] result, error in
+                    if let html = result as? String {
+                        self?.sendW3C(connection: connection, value: html)
+                    } else {
+                        self?.sendW3C(connection: connection, value: "")
+                    }
+                }
+                return
+            }
+
             // GET /session/{id}/window/handles
             if request.method == "GET" && subpath == ["window", "handles"] {
                 sendW3C(connection: connection, value: ["main"])

--- a/macos/coda/coda/WebDriverServer.swift
+++ b/macos/coda/coda/WebDriverServer.swift
@@ -12,13 +12,16 @@ import Foundation
 import Network
 
 /**
- * Minimal HTTP server for UI testing.
+ * W3C WebDriver protocol server for UI testing.
  *
- * Listens on localhost and accepts POST /execute requests with a JSON body
- * containing a "js" field.  The JavaScript is evaluated in a WKWebView via
- * a caller-supplied closure, and the result (or error) is returned as JSON.
+ * Listens on localhost and implements a subset of the W3C WebDriver
+ * protocol sufficient for WebDriverIO to execute JavaScript, manage
+ * sessions, and track window handles.  This allows the same test
+ * specs to run on macOS (this server), Linux (WebEngineDriver), and
+ * Windows (EdgeDriver).
  *
- * Start with ``start()`` and stop with ``stop()``.
+ * Additionally supports POST /focus as a custom extension to make
+ * the WKWebView the macOS first responder for XCUITest typing.
  */
 final class WebDriverServer {
 
@@ -26,8 +29,11 @@ final class WebDriverServer {
     private let jsExecutor: (String, @escaping (Any?, Error?) -> Void) -> Void
     private let focusHandler: (@escaping () -> Void) -> Void
 
+    /// The session ID, created on first POST /session.
+    private var sessionId: String?
+
     /**
-     * Create a test HTTP server.
+     * Create a WebDriver server.
      *
      * - Parameters:
      *   - port: TCP port to listen on.
@@ -83,14 +89,11 @@ final class WebDriverServer {
                 buffer.append(data)
             }
 
-            // Check if we have a complete HTTP request (headers + body)
             if let request = self.parseHTTPRequest(buffer) {
-                self.handleRequest(request, connection: connection)
+                self.routeRequest(request, connection: connection)
             } else if isComplete {
-                // Connection closed before we got a full request
                 connection.cancel()
             } else {
-                // Need more data
                 self.receiveRequest(connection: connection, accumulated: buffer)
             }
         }
@@ -126,7 +129,6 @@ final class WebDriverServer {
         let method = String(parts[0])
         let path = String(parts[1])
 
-        // Find Content-Length
         var contentLength = 0
         for line in lines.dropFirst() {
             if line.lowercased().hasPrefix("content-length:") {
@@ -138,64 +140,128 @@ final class WebDriverServer {
         let bodyStart = headerEnd.upperBound
         let available = data.count - data.distance(from: data.startIndex, to: bodyStart)
         if available < contentLength {
-            return nil // Need more data
+            return nil
         }
 
         let body = data[bodyStart..<data.index(bodyStart, offsetBy: contentLength)]
         return HTTPRequest(method: method, path: path, body: Data(body))
     }
 
-    // MARK: - Request handling
+    // MARK: - W3C WebDriver routing
 
-    private func handleRequest(_ request: HTTPRequest, connection: NWConnection) {
-        guard request.method == "POST" else {
-            sendResponse(connection: connection, status: "404 Not Found",
-                         body: #"{"error":"Not found"}"#)
+    private func routeRequest(_ request: HTTPRequest, connection: NWConnection) {
+        let segments = request.path.split(separator: "/").map(String.init)
+
+        // GET /status
+        if request.method == "GET" && request.path == "/status" {
+            sendW3C(connection: connection, value: ["ready": true, "message": "coda-macos"])
             return
         }
 
-        if request.path == "/focus" {
+        // POST /session
+        if request.method == "POST" && segments == ["session"] {
+            if sessionId == nil {
+                sessionId = UUID().uuidString.lowercased()
+            }
+            sendW3C(connection: connection, value: [
+                "sessionId": sessionId!,
+                "capabilities": [String: Any]()
+            ] as [String: Any])
+            return
+        }
+
+        // DELETE /session/{id}
+        if request.method == "DELETE" && segments.count == 2 && segments[0] == "session" {
+            sendW3C(connection: connection, value: NSNull())
+            return
+        }
+
+        // Routes that require a valid session: /session/{id}/...
+        if segments.count >= 3 && segments[0] == "session" {
+            guard segments[1] == sessionId else {
+                sendW3CError(connection: connection, error: "invalid session id",
+                             message: "No active session with id '\(segments[1])'")
+                return
+            }
+
+            let subpath = Array(segments.dropFirst(2))
+
+            // POST /session/{id}/execute/sync
+            if request.method == "POST" && subpath == ["execute", "sync"] {
+                handleExecuteSync(request, connection: connection)
+                return
+            }
+
+            // GET /session/{id}/window/handles
+            if request.method == "GET" && subpath == ["window", "handles"] {
+                sendW3C(connection: connection, value: ["main"])
+                return
+            }
+
+            // POST /session/{id}/window
+            if request.method == "POST" && subpath == ["window"] {
+                sendW3C(connection: connection, value: NSNull())
+                return
+            }
+        }
+
+        // POST /focus (custom extension for XCUITest)
+        if request.method == "POST" && request.path == "/focus" {
             focusHandler { [weak self] in
-                self?.sendResponse(connection: connection, status: "200 OK",
-                                   body: #"{"result":"ok"}"#)
+                self?.sendW3C(connection: connection, value: NSNull())
             }
             return
         }
 
-        guard request.path == "/execute" else {
-            sendResponse(connection: connection, status: "404 Not Found",
-                         body: #"{"error":"Not found"}"#)
-            return
-        }
+        sendW3CError(connection: connection, error: "unknown command",
+                     message: "\(request.method) \(request.path) not implemented")
+    }
 
+    // MARK: - Execute sync
+
+    private func handleExecuteSync(_ request: HTTPRequest, connection: NWConnection) {
         guard let json = try? JSONSerialization.jsonObject(with: request.body) as? [String: Any],
-              let js = json["js"] as? String else {
-            sendResponse(connection: connection, status: "400 Bad Request",
-                         body: #"{"error":"Missing 'js' field in JSON body"}"#)
+              let script = json["script"] as? String else {
+            sendW3CError(connection: connection, error: "invalid argument",
+                         message: "Missing 'script' field in request body")
             return
         }
 
-        jsExecutor(js) { [weak self] result, error in
+        jsExecutor(script) { [weak self] result, error in
             if let error = error {
-                let msg = error.localizedDescription.replacingOccurrences(of: "\\", with: "\\\\")
-                    .replacingOccurrences(of: "\"", with: "\\\"")
-                self?.sendResponse(connection: connection, status: "200 OK",
-                                   body: #"{"error":"\#(msg)"}"#)
+                self?.sendW3CError(connection: connection, error: "javascript error",
+                                   message: error.localizedDescription)
             } else {
-                let resultJSON: String
-                if let result = result {
-                    if let data = try? JSONSerialization.data(withJSONObject: result),
-                       let str = String(data: data, encoding: .utf8) {
-                        resultJSON = str
-                    } else {
-                        resultJSON = "\"\(result)\""
-                    }
-                } else {
-                    resultJSON = "null"
-                }
-                self?.sendResponse(connection: connection, status: "200 OK",
-                                   body: "{\"result\":\(resultJSON)}")
+                self?.sendW3C(connection: connection, value: result ?? NSNull())
             }
+        }
+    }
+
+    // MARK: - W3C response helpers
+
+    private func sendW3C(connection: NWConnection, value: Any) {
+        let wrapper: [String: Any] = ["value": value]
+        if let data = try? JSONSerialization.data(withJSONObject: wrapper),
+           let body = String(data: data, encoding: .utf8) {
+            sendResponse(connection: connection, status: "200 OK", body: body)
+        } else {
+            sendResponse(connection: connection, status: "200 OK",
+                         body: #"{"value":null}"#)
+        }
+    }
+
+    private func sendW3CError(connection: NWConnection, error: String, message: String) {
+        let wrapper: [String: Any] = [
+            "value": [
+                "error": error,
+                "message": message,
+                "stacktrace": ""
+            ]
+        ]
+        let status = error == "invalid session id" ? "404 Not Found" : "500 Internal Server Error"
+        if let data = try? JSONSerialization.data(withJSONObject: wrapper),
+           let body = String(data: data, encoding: .utf8) {
+            sendResponse(connection: connection, status: status, body: body)
         }
     }
 

--- a/macos/coda/coda/WebDriverServer.swift
+++ b/macos/coda/coda/WebDriverServer.swift
@@ -29,8 +29,8 @@ final class WebDriverServer {
     private let jsExecutor: (String, @escaping (Any?, Error?) -> Void) -> Void
     private let focusHandler: (@escaping () -> Void) -> Void
 
-    /// The session ID, created on first POST /session.
-    private var sessionId: String?
+    /// All session IDs created via POST /session.
+    private var sessionIds = Set<String>()
 
     /**
      * Create a WebDriver server.
@@ -160,11 +160,10 @@ final class WebDriverServer {
 
         // POST /session
         if request.method == "POST" && segments == ["session"] {
-            if sessionId == nil {
-                sessionId = UUID().uuidString.lowercased()
-            }
+            let newId = UUID().uuidString.lowercased()
+            sessionIds.insert(newId)
             sendW3C(connection: connection, value: [
-                "sessionId": sessionId!,
+                "sessionId": newId,
                 "capabilities": [String: Any]()
             ] as [String: Any])
             return
@@ -172,13 +171,14 @@ final class WebDriverServer {
 
         // DELETE /session/{id}
         if request.method == "DELETE" && segments.count == 2 && segments[0] == "session" {
+            sessionIds.remove(segments[1])
             sendW3C(connection: connection, value: NSNull())
             return
         }
 
         // Routes that require a valid session: /session/{id}/...
         if segments.count >= 3 && segments[0] == "session" {
-            guard segments[1] == sessionId else {
+            guard sessionIds.contains(segments[1]) else {
                 sendW3CError(connection: connection, error: "invalid session id",
                              message: "No active session with id '\(segments[1])'")
                 return

--- a/macos/coda/codaUITests/Lib/JSBridge.swift
+++ b/macos/coda/codaUITests/Lib/JSBridge.swift
@@ -41,7 +41,7 @@ final class JSBridge {
     @discardableResult
     static func execute(js: String) -> Any? {
         let body: [String: Any] = [
-            "script": "return (\(js))",
+            "script": js,
             "args": [] as [Any]
         ]
         guard let json = postJSON(path: "/session/\(sessionId)/execute/sync", body: body) else {

--- a/macos/coda/codaUITests/Lib/JSBridge.swift
+++ b/macos/coda/codaUITests/Lib/JSBridge.swift
@@ -12,14 +12,27 @@ import XCTest
 
 final class JSBridge {
 
-    /// Port for the embedded test HTTP server.
+    /// Port for the embedded WebDriver server.
     static let port: UInt16 = 4567
 
+    /// Base URL for the WebDriver server.
+    private static let baseURL = "http://localhost:4567"
+
+    /// Session ID, created lazily on first use.
+    private static var sessionId: String = {
+        guard let json = postJSON(path: "/session", body: [:]),
+              let value = json["value"] as? [String: Any],
+              let id = value["sessionId"] as? String else {
+            XCTFail("JSBridge: failed to create WebDriver session")
+            return "unknown"
+        }
+        return id
+    }()
+
     /**
-     * Execute JavaScript in the WKWebView via the embedded HTTP test driver.
+     * Execute JavaScript in the WKWebView via the W3C WebDriver protocol.
      *
-     * Sends a POST /execute request with the JS command and returns the
-     * parsed JSON result, or nil on error.
+     * Sends POST /session/{id}/execute/sync with the script.
      *
      * - Parameters:
      *   - js: The JavaScript to execute.
@@ -27,36 +40,22 @@ final class JSBridge {
      */
     @discardableResult
     static func execute(js: String) -> Any? {
-        let url = URL(string: "http://localhost:\(port)/execute")!
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try? JSONSerialization.data(withJSONObject: ["js": js])
-        request.timeoutInterval = 30
-
-        var result: Any?
-        let semaphore = DispatchSemaphore(value: 0)
-
-        let task = URLSession.shared.dataTask(with: request) { data, response, error in
-            defer { semaphore.signal() }
-            if let error = error {
-                XCTFail("JSBridge HTTP error: \(error.localizedDescription)")
-                return
-            }
-            guard let data = data,
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                return
-            }
-            if let errorMsg = json["error"] as? String {
-                XCTFail("JSBridge JS error: \(errorMsg)")
-                return
-            }
-            result = json["result"]
+        let body: [String: Any] = [
+            "script": "return (\(js))",
+            "args": [] as [Any]
+        ]
+        guard let json = postJSON(path: "/session/\(sessionId)/execute/sync", body: body) else {
+            return nil
         }
-        task.resume()
-        semaphore.wait()
 
-        return result
+        // W3C error response: {"value": {"error": "...", "message": "..."}}
+        if let value = json["value"] as? [String: Any], value["error"] != nil {
+            let msg = value["message"] as? String ?? "unknown error"
+            XCTFail("JSBridge JS error: \(msg)")
+            return nil
+        }
+
+        return json["value"]
     }
 
     /**
@@ -78,8 +77,8 @@ final class JSBridge {
      * Switch the document from Viewing mode to Editing mode.
      *
      * On CO Desktop, non-new documents start in read-only (Viewing) mode.
-     * This calls _proceedEditMode() via the HTTP bridge, which is the same
-     * function the Viewing/Editing dropdown invokes.
+     * This calls _proceedEditMode() via the WebDriver bridge, which is the
+     * same function the Viewing/Editing dropdown invokes.
      *
      * - Parameters:
      *   - app: The XCUIApplication instance.
@@ -101,16 +100,64 @@ final class JSBridge {
      * reach the WKWebView.
      */
     static func focusWebView() {
-        let url = URL(string: "http://localhost:\(port)/focus")!
+        _ = postJSON(path: "/focus", body: [:])
+    }
+
+    // MARK: - HTTP helpers
+
+    /**
+     * Send a POST request with a JSON body and return the parsed response.
+     */
+    private static func postJSON(path: String, body: [String: Any]) -> [String: Any]? {
+        let url = URL(string: "\(baseURL)\(path)")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.timeoutInterval = 10
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        request.timeoutInterval = 30
 
+        var result: [String: Any]?
         let semaphore = DispatchSemaphore(value: 0)
-        let task = URLSession.shared.dataTask(with: request) { _, _, _ in
-            semaphore.signal()
+
+        let task = URLSession.shared.dataTask(with: request) { data, _, error in
+            defer { semaphore.signal() }
+            if let error = error {
+                XCTFail("JSBridge HTTP error: \(error.localizedDescription)")
+                return
+            }
+            guard let data = data else { return }
+            result = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         }
         task.resume()
         semaphore.wait()
+
+        return result
+    }
+
+    /**
+     * Send a GET request and return the parsed response.
+     */
+    static func getJSON(path: String) -> [String: Any]? {
+        let url = URL(string: "\(baseURL)\(path)")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 30
+
+        var result: [String: Any]?
+        let semaphore = DispatchSemaphore(value: 0)
+
+        let task = URLSession.shared.dataTask(with: request) { data, _, error in
+            defer { semaphore.signal() }
+            if let error = error {
+                XCTFail("JSBridge HTTP error: \(error.localizedDescription)")
+                return
+            }
+            guard let data = data else { return }
+            result = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        }
+        task.resume()
+        semaphore.wait()
+
+        return result
     }
 }

--- a/macos/coda/codaUITests/Lib/JSBridge.swift
+++ b/macos/coda/codaUITests/Lib/JSBridge.swift
@@ -108,7 +108,7 @@ final class JSBridge {
     /**
      * Send a POST request with a JSON body and return the parsed response.
      */
-    private static func postJSON(path: String, body: [String: Any]) -> [String: Any]? {
+    static func postJSON(path: String, body: [String: Any]) -> [String: Any]? {
         let url = URL(string: "\(baseURL)\(path)")!
         var request = URLRequest(url: url)
         request.httpMethod = "POST"

--- a/macos/coda/codaUITests/Lib/JSBridge.swift
+++ b/macos/coda/codaUITests/Lib/JSBridge.swift
@@ -18,16 +18,25 @@ final class JSBridge {
     /// Base URL for the WebDriver server.
     private static let baseURL = "http://localhost:4567"
 
-    /// Session ID, created lazily on first use.
-    private static var sessionId: String = {
+    /// Session ID for the current app instance.  Reset by calling
+    /// createSession() after each app launch.
+    private static var sessionId: String?
+
+    /**
+     * Create a new WebDriver session.
+     *
+     * Must be called after each app launch since a new app instance
+     * has a new server with no session.
+     */
+    static func createSession() {
         guard let json = postJSON(path: "/session", body: [:]),
               let value = json["value"] as? [String: Any],
               let id = value["sessionId"] as? String else {
             XCTFail("JSBridge: failed to create WebDriver session")
-            return "unknown"
+            return
         }
-        return id
-    }()
+        sessionId = id
+    }
 
     /**
      * Execute JavaScript in the WKWebView via the W3C WebDriver protocol.
@@ -44,7 +53,11 @@ final class JSBridge {
             "script": js,
             "args": [] as [Any]
         ]
-        guard let json = postJSON(path: "/session/\(sessionId)/execute/sync", body: body) else {
+        guard let sid = sessionId else {
+            XCTFail("JSBridge: no active session - call createSession() first")
+            return nil
+        }
+        guard let json = postJSON(path: "/session/\(sid)/execute/sync", body: body) else {
             return nil
         }
 

--- a/macos/coda/codaUITests/Lib/Launch.swift
+++ b/macos/coda/codaUITests/Lib/Launch.swift
@@ -41,6 +41,7 @@ final class Launch {
             path,
         ]
         app.launch()
+        JSBridge.createSession()
     }
 
     /**

--- a/macos/coda/codaUITests/WebDriverServerTests.swift
+++ b/macos/coda/codaUITests/WebDriverServerTests.swift
@@ -1,0 +1,126 @@
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import XCTest
+
+/**
+ * Tests for the W3C WebDriver protocol implemented by WebDriverServer.
+ *
+ * These tests launch the app with a test document and exercise the
+ * WebDriver endpoints via HTTP to verify protocol correctness.
+ */
+final class WebDriverServerTests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        app = XCUIApplication()
+        Launch.openTestFile(app: app, filename: "hello.odt")
+        Launch.waitForDocumentLoad(app: app)
+    }
+
+    // MARK: - Status
+
+    @MainActor
+    func testStatus() throws {
+        let json = JSBridge.getJSON(path: "/status")
+        XCTAssertNotNil(json, "GET /status should return JSON")
+
+        let value = json!["value"] as? [String: Any]
+        XCTAssertNotNil(value, "Response should have 'value' object")
+        XCTAssertEqual(value!["ready"] as? Bool, true, "Server should be ready")
+    }
+
+    // MARK: - Session
+
+    @MainActor
+    func testCreateSession() throws {
+        let json = JSBridge.postJSON(path: "/session", body: [:])
+        XCTAssertNotNil(json, "POST /session should return JSON")
+
+        let value = json!["value"] as? [String: Any]
+        XCTAssertNotNil(value, "Response should have 'value' object")
+
+        let sessionId = value!["sessionId"] as? String
+        XCTAssertNotNil(sessionId, "Response should contain sessionId")
+        XCTAssertFalse(sessionId!.isEmpty, "sessionId should not be empty")
+    }
+
+    // MARK: - Execute sync
+
+    @MainActor
+    func testExecuteSyncSimple() throws {
+        let result = JSBridge.execute(js: "1 + 1")
+        XCTAssertEqual(result as? Int, 2, "1 + 1 should return 2")
+    }
+
+    @MainActor
+    func testExecuteSyncString() throws {
+        let result = JSBridge.execute(js: "'hello' + ' world'")
+        XCTAssertEqual(result as? String, "hello world")
+    }
+
+    @MainActor
+    func testExecuteSyncObject() throws {
+        let result = JSBridge.execute(js: "({a: 1, b: 'two'})")
+        let obj = result as? [String: Any]
+        XCTAssertNotNil(obj, "Should return an object")
+        XCTAssertEqual(obj?["a"] as? Int, 1)
+        XCTAssertEqual(obj?["b"] as? String, "two")
+    }
+
+    @MainActor
+    func testExecuteSyncNull() throws {
+        let result = JSBridge.execute(js: "null")
+        XCTAssertTrue(result is NSNull || result == nil,
+                      "null should return NSNull or nil")
+    }
+
+    @MainActor
+    func testExecuteSyncDOMAccess() throws {
+        let result = JSBridge.execute(js: "document.readyState")
+        XCTAssertEqual(result as? String, "complete",
+                       "Document should be fully loaded")
+    }
+
+    // MARK: - Window handles
+
+    @MainActor
+    func testWindowHandles() throws {
+        // Create a session first
+        _ = JSBridge.postJSON(path: "/session", body: [:])
+        let sessionJson = JSBridge.postJSON(path: "/session", body: [:])
+        let sessionId = (sessionJson?["value"] as? [String: Any])?["sessionId"] as? String ?? ""
+
+        let json = JSBridge.getJSON(path: "/session/\(sessionId)/window/handles")
+        XCTAssertNotNil(json, "GET window/handles should return JSON")
+
+        let handles = json!["value"] as? [String]
+        XCTAssertNotNil(handles, "Should return array of handles")
+        XCTAssertFalse(handles!.isEmpty, "Should have at least one handle")
+    }
+
+    // MARK: - Switch window
+
+    @MainActor
+    func testSwitchWindow() throws {
+        let sessionJson = JSBridge.postJSON(path: "/session", body: [:])
+        let sessionId = (sessionJson?["value"] as? [String: Any])?["sessionId"] as? String ?? ""
+
+        let json = JSBridge.postJSON(
+            path: "/session/\(sessionId)/window",
+            body: ["handle": "main"])
+        XCTAssertNotNil(json, "POST window should return JSON")
+        // Should not be an error
+        let value = json!["value"]
+        XCTAssertTrue(value is NSNull || value != nil, "Should return null (success)")
+    }
+}

--- a/macos/coda/wdio-test/.gitignore
+++ b/macos/coda/wdio-test/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+logs/

--- a/macos/coda/wdio-test/lib/coda-macos.service.ts
+++ b/macos/coda/wdio-test/lib/coda-macos.service.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { ChildProcess, spawn } from 'child_process';
+import { cpSync, mkdirSync, mkdtempSync, rmSync } from 'fs';
+import http from 'http';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { promisify } from 'util';
+
+const sleep = promisify(setTimeout);
+
+interface CodaMacOSServiceOptions {
+	appPath: string;
+	webDriverPort: number | string;
+	fixturesDir: string;
+}
+
+async function waitForHttp(
+	url: string,
+	label: string,
+	maxAttempts = 30,
+): Promise<void> {
+	for (let i = 0; i < maxAttempts; i++) {
+		try {
+			const ok = await new Promise((resolve, reject) => {
+				const req = http.get(url, (res) => resolve(res.statusCode === 200));
+				req.on('error', reject);
+				req.setTimeout(1000, () => req.destroy(new Error('timeout')));
+			});
+			if (ok) {
+				console.log(`${label} is ready`);
+				return;
+			}
+		} catch {
+			// Not ready yet
+		}
+		await sleep(1000);
+	}
+	throw new Error(
+		`${label} not available at ${url} after ${maxAttempts} attempts`,
+	);
+}
+
+export class CodaMacOSServiceLauncher {
+	#appProcess: ChildProcess | null = null;
+	#testDocDir: string | null = null;
+	#options: CodaMacOSServiceOptions;
+
+	constructor(options: CodaMacOSServiceOptions) {
+		this.#options = options;
+	}
+
+	async onPrepare(): Promise<void> {
+		const { appPath, webDriverPort, fixturesDir } = this.#options;
+
+		// Copy fixtures to a temp directory so the app can write to them
+		this.#testDocDir = mkdtempSync(join(tmpdir(), 'coda-macos-test-'));
+		mkdirSync(join(this.#testDocDir, 'Documents'));
+		cpSync(fixturesDir, join(this.#testDocDir, 'Documents'), {
+			recursive: true,
+		});
+		process.env.CODA_MACOS_TEST_DOCUMENTS_DIR = join(
+			this.#testDocDir,
+			'Documents',
+		);
+
+		// Pick a test file to open initially
+		const testFile = join(this.#testDocDir, 'Documents', 'hello.odt');
+
+		console.log('Starting coda-macos...');
+		this.#appProcess = spawn('open', [
+			'-a', appPath,
+			'--args',
+			'--uitesting',
+			`--testDriverPort=${webDriverPort}`,
+			'-ApplePersistenceIgnoreState', 'YES',
+			testFile,
+		], {
+			stdio: ['ignore', 'pipe', 'pipe'],
+		});
+
+		this.#appProcess.stdout?.on('data', (d: Buffer) =>
+			console.log(`[coda-macos]: ${d.toString().trim()}`),
+		);
+		this.#appProcess.stderr?.on('data', (d: Buffer) => {
+			const msg = d.toString().trim();
+			if (msg) console.log(`[coda-macos]: ${msg}`);
+		});
+
+		await waitForHttp(
+			`http://localhost:${webDriverPort}/status`,
+			'WebDriverServer',
+		);
+
+		console.log('coda-macos is ready, tests will now run');
+	}
+
+	async onComplete(): Promise<void> {
+		// Send quit via AppleScript since we launched with `open`
+		try {
+			const { execSync } = await import('child_process');
+			execSync('osascript -e \'tell application "Collabora Office" to quit\'', {
+				timeout: 5000,
+			});
+		} catch {
+			// App may already be gone
+		}
+
+		if (this.#testDocDir) {
+			try {
+				rmSync(this.#testDocDir, { recursive: true, force: true });
+				console.log(`Removed test doc dir: ${this.#testDocDir}`);
+			} catch (e) {
+				console.warn(
+					`Failed to clean up test doc dir: ${(e as Error).message}`,
+				);
+			}
+		}
+	}
+}

--- a/macos/coda/wdio-test/package.json
+++ b/macos/coda/wdio-test/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "coda-macos-tests",
+  "version": "1.0.0",
+  "description": "WebdriverIO tests for coda-macos (shared with coda-qt)",
+  "type": "module",
+  "scripts": {
+    "test": "wdio run wdio.conf.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@wdio/cli": "^8.40.0",
+    "@wdio/local-runner": "^8.40.0",
+    "@wdio/mocha-framework": "^8.40.0",
+    "@wdio/spec-reporter": "^8.40.0",
+    "ts-node": "^10.9.0",
+    "typescript": "^5.5.0",
+    "webdriverio": "^8.40.0"
+  }
+}

--- a/macos/coda/wdio-test/tsconfig.json
+++ b/macos/coda/wdio-test/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022", "DOM"],
+    "types": [
+      "node",
+      "@wdio/globals/types",
+      "@wdio/mocha-framework"
+    ],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "ts-node": {
+    "esm": true,
+    "transpileOnly": true
+  },
+  "include": [
+    "wdio.d.ts",
+    "wdio.conf.ts",
+    "../../../qt/test/lib/**/*.ts",
+    "../../../qt/test/specs/**/*.ts"
+  ]
+}

--- a/macos/coda/wdio-test/wdio.conf.ts
+++ b/macos/coda/wdio-test/wdio.conf.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+import { CodaMacOSServiceLauncher } from './lib/coda-macos.service.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const WEBDRIVER_PORT = Number(process.env.WEBDRIVER_PORT || 4567);
+
+// Default to the Xcode Debug build location
+const CODA_APP = process.env.CODA_APP
+	|| join(__dirname, '..', '..', '..', 'tmp', 'DerivedData',
+		'Build', 'Products', 'Debug', 'Collabora Office.app');
+
+// Test documents
+const FIXTURES_DIR = process.env.FIXTURES_DIR
+	|| join(__dirname, '..', 'codaUITests', 'TestDocuments');
+
+// Shared specs from the Qt test directory
+const QT_SPECS_DIR = join(__dirname, '..', '..', '..', 'qt', 'test', 'specs');
+
+export const config = {
+	runner: 'local',
+
+	// Run the harness spec - the most basic shared test
+	specs: [[join(QT_SPECS_DIR, 'harness.spec.ts')]],
+
+	exclude: [],
+
+	maxInstances: 1,
+
+	// Multiremote so the shared Qt specs can use browser.webEngine.
+	// The webEngine driver points directly at our WebDriverServer.
+	// The native driver also points at our server; native-only tests
+	// (AT-SPI) will fail but are in separate describe blocks.
+	capabilities: {
+		webEngine: {
+			port: WEBDRIVER_PORT,
+			capabilities: {
+				browserName: 'chrome',
+			},
+		},
+		native: {
+			port: WEBDRIVER_PORT,
+			capabilities: {
+				browserName: 'chrome',
+			},
+		},
+	},
+
+	logLevel: 'info',
+	outputDir: './logs',
+	bail: 1,
+	waitforTimeout: 10000,
+	waitforInterval: 500,
+	connectionRetryTimeout: 30000,
+	connectionRetryCount: 3,
+
+	services: [
+		[CodaMacOSServiceLauncher, {
+			appPath: CODA_APP,
+			webDriverPort: WEBDRIVER_PORT,
+			fixturesDir: FIXTURES_DIR,
+		}],
+	],
+
+	framework: 'mocha',
+	reporters: ['spec'],
+
+	mochaOpts: {
+		ui: 'bdd',
+		timeout: 150000,
+	},
+
+	before: async function () {
+		// Add the same waitForCondition command as the Qt tests
+		browser.webEngine.addCommand(
+			'waitForCondition',
+			async function (this: WebdriverIO.Browser, predicate: () => boolean, opts: { timeout?: number; interval?: number; timeoutMsg?: string } = {}) {
+				return this.waitUntil(() => this.execute(predicate), {
+					timeout: opts.timeout,
+					interval: opts.interval,
+					timeoutMsg: opts.timeoutMsg ?? 'waitForCondition: condition not met',
+				});
+			},
+		);
+	},
+};

--- a/macos/coda/wdio-test/wdio.d.ts
+++ b/macos/coda/wdio-test/wdio.d.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+// Augment WebdriverIO.Browser with the custom waitForCondition command.
+declare namespace WebdriverIO {
+    interface Browser {
+        waitForCondition(
+            predicate: () => boolean,
+            opts?: {
+                timeout?: number;
+                interval?: number;
+                timeoutMsg?: string;
+            },
+        ): Promise<boolean>;
+    }
+}
+
+// Globals available inside browser.execute() callbacks (browser-side).
+interface Window {
+    postMobileMessage(msg: string): void;
+}
+declare const app: {
+    map: {
+        _docLoaded: boolean;
+        getDocType(): string;
+        backstageView?: {
+            show(): void;
+            hide(): void;
+            toggle(): void;
+        };
+    };
+    dispatcher: {
+        dispatch(action: string): void;
+    };
+    activeDocument?: {
+        activeLayout?: {
+            type: string;
+            documentRectangles?: Array<unknown>;
+            viewedRectangle?: { pWidth: number; pHeight: number };
+        };
+    };
+    layoutingService: {
+        hasTasksPending(): boolean;
+    };
+};

--- a/qt/test/specs/harness.spec.ts
+++ b/qt/test/specs/harness.spec.ts
@@ -17,11 +17,12 @@ describe('Test harness', () => {
 			);
 		});
 
-		it('should report QtWebEngine user agent', async function () {
+		it('should report a known engine user agent', async function () {
 			const userAgent = await browser.webEngine.execute(
 				() => navigator.userAgent,
 			);
-			expect(userAgent).toContain('QtWebEngine');
+			const known = userAgent.includes('QtWebEngine') || userAgent.includes('AppleWebKit');
+			expect(known).toBe(true);
 		});
 
 		it('should report non-zero page dimensions', async function () {


### PR DESCRIPTION
- **macOS tests: Rename TestHTTPServer to WebDriverServer**
- **macOS tests: Implement W3C WebDriver protocol**
- **macOS tests: Update JSBridge to use W3C WebDriver URLs**
- **macOS tests: Add WebDriver protocol unit tests**
- **macOS tests: Fix JS execution in WebDriver execute/sync**
- **macOS tests: Report actual JS exception in WebDriver errors**
- **macOS tests: Create a new WebDriver session on each app launch**
- **macOS tests: Add WebDriverIO test runner for shared Qt specs**
- **macOS tests: Handle POST /session/{id}/execute endpoint**
- **macOS tests: Handle GET /session/{id}/source endpoint**
- **Qt/macOS tests: Accept WebKit user agent in harness spec**
- **macOS tests: Replace 'arguments' with actual args in execute**
- **macOS tests: Support multiple concurrent WebDriver sessions**
