### PR TITLE
test(cypress): remove 'only' from 'Redraw after undo' test

### DIFF
--- a/cypress_test/integration_tests/desktop/calc/cell_edit_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/cell_edit_spec.js
@@ -33,7 +33,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Test rendering of a cell o
 		cy.cGet('#document-container').compareSnapshot(expected, 0.02);
 	}
 
-	it.only('Redraw after undo', function() {
+	it('Redraw after undo', function() {
 		// setup initial state
 		desktopHelper.assertScrollbarPosition('horizontal', 325, 355);
 		desktopHelper.assertScrollbarPosition('vertical', 235, 300);


### PR DESCRIPTION
- 4ca8b00396a6e7869a64fb3b981c51601a0294c9 accidentally added 'only' which skips all other cypress test in cell_edit_spec.js
- this is follow-up of https://github.com/CollaboraOnline/online/pull/15163

Change-Id: Ie9566dac9707f15e0520639c5b7ae278cb063d1b

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

