### PR TITLE
Writer: add Multi Page View entry to notebookbar and compact view

### DIFF
--- a/browser/images/lc_multipageview.svg
+++ b/browser/images/lc_multipageview.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 27 16" width="27" xmlns="http://www.w3.org/2000/svg"><g fill="#232629"><path d="m0 0v16h13v-11l-5-5zm1 1h6v5h5v9h-11z"/><path d="m14 0v16h13v-11l-5-5zm1 1h6v5h5v9h-11z"/></g></svg>
+<svg viewBox="0 0 27 16" xmlns="http://www.w3.org/2000/svg"><g fill="#232629"><path d="m0 0v16h13v-11l-5-5zm1 1h6v5h5v9h-11z"/><path d="m14 0v16h13v-11l-5-5zm1 1h6v5h5v9h-11z"/></g></svg>

--- a/browser/src/control/Control.Menubar.ts
+++ b/browser/src/control/Control.Menubar.ts
@@ -169,6 +169,7 @@ class Menubar extends window.L.Control {
 				] as MenuItem[]).concat([
 					{type: 'separator'},
 					{name: _('Toggle UI Mode'), id: 'toggleuimode', type: 'action'},
+					{name: _('Multi Page View'), id: 'multipageview', type: 'action'},
 					{name: _('Show Ruler'), id: 'showruler', type: 'action'},
 					{name: _('Show Status Bar'), id: 'showstatusbar', type: 'action'},
 					{name: _('Hide Menu Bar'), id: 'togglemenubar', type: 'action'},
@@ -2423,6 +2424,8 @@ class Menubar extends window.L.Control {
 			app.dispatcher.dispatch('columnrowhighlight');
 		} else if (id === 'comparechanges') {
 			app.dispatcher.dispatch('comparechanges');
+		} else if (id === 'multipageview') {
+			app.dispatcher.dispatch('multipageview');
 		} else {
 			// not found
 			app.console.warn('Menubar: unknown action for id: ' + id);

--- a/browser/src/control/Control.NotebookbarWriter.js
+++ b/browser/src/control/Control.NotebookbarWriter.js
@@ -1731,6 +1731,13 @@ window.L.Control.NotebookbarWriter = window.L.Control.Notebookbar.extend({
 				'accessibility': { focusBack: false, combination: 'UI', de: null }
 			},
 			{
+				'id': 'multipageview',
+				'type': 'bigcustomtoolitem',
+				'command': 'multipageview',
+				'text': _('Multi Page View'),
+				'accessibility': { focusBack: true, combination: 'MV', de: null }
+			},
+			{
 				'type': 'container',
 				'children': [
 					{


### PR DESCRIPTION
Change-Id: Ib4bf934a970ddec517e444b7d0a238960f926d35


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary
 -  Added multipageview to View tab in notebookbar and View menu in compact mode
 -  Removed width and height from multipage view icon so as to rely on viewbox for proper scaling of icon across different screens

### PREVIEW

#### Notebookbar
<img width="1413" height="115" alt="2026-04-22_02-11" src="https://github.com/user-attachments/assets/8f162563-f47b-44be-ae4f-0cf8fe185d49" />

#### Compact view
<img width="469" height="504" alt="2026-04-22_02-12" src="https://github.com/user-attachments/assets/6fb52eb3-19a5-477f-a506-5d4aee7d9cf8" />


- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

