### PR TITLE
Do not show preview for text selection

### DIFF
--- a/browser/src/canvas/sections/MouseControl.ts
+++ b/browser/src/canvas/sections/MouseControl.ts
@@ -377,6 +377,9 @@ class MouseControl extends CanvasSectionObject {
 
 	// Shows unselected shapes drag preview
 	private showShapeDragPreview(dragDistance: number[]): void {
+		// Do not show in edit mode of inner edit engine
+		if (app.file.textCursor.visible || TextSelections.isActive()) return;
+
 		const handles = GraphicSelection.handlesSection;
 		if (!handles?.sectionProperties?.svg) return;
 		if (!GraphicSelection.extraInfo?.isDraggable) return;


### PR DESCRIPTION
- fixes regression from commit 0cb0a322ebb0d49072107f16d2f0e94c49eede8a Show drag preview of unselected shapes
- steps to reproduce:
  1. Open Impress
  2. Have textbox with some text
  3. double click on a textbox to activate edit mode
  4. try to select some word Result: preview of the same textbox appears duplicated on top Expected: no additional preview