### PR TITLE
Backport: Fix overlapping popups when opening Styles dialog

### DIFF
--- a/browser/src/control/jsdialog/Util.Dropdown.ts
+++ b/browser/src/control/jsdialog/Util.Dropdown.ts
@@ -296,6 +296,8 @@ JSDialog.CloseDropdown = function (id: string, focusHandled?: boolean) {
 
 JSDialog.CloseAllDropdowns = function () {
 	window.L.Map.THIS.jsdialog.closeAllDropdowns();
+	if (window.L.Map.THIS.contextToolbar)
+		window.L.Map.THIS.contextToolbar.hideContextToolbar();
 };
 
 JSDialog.GetDropdown = function (id: string) {

--- a/browser/src/control/jsdialog/Widget.NotebookbarIconView.ts
+++ b/browser/src/control/jsdialog/Widget.NotebookbarIconView.ts
@@ -184,6 +184,8 @@ JSDialog.notebookbarIconViewList = function (
 	};
 
 	const expanderCallback = () => {
+		JSDialog.CloseAllDropdowns();
+
 		JSDialog.OpenDropdown(
 			data.id,
 			rootNode,


### PR DESCRIPTION
Backport: https://github.com/CollaboraOnline/online/pull/15134

* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

