### PR TITLE
a11y: add visible label for custom color input in color picker dialog

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -210,7 +210,7 @@ div#autoFillPreviewTooltip .lokdialog.ui-dialog-content.ui-widget-content {
 	overflow: hidden;
 }
 
-.jsdialog.vertical label, .ui-frame-label, #ui-color-picker-recent-label {
+.jsdialog.vertical label, .ui-frame-label, #ui-color-picker-recent-label, #ui-color-picker-custom-label {
 	margin: auto 0px;
 	color: var(--color-main-text);
 	font-size: var(--default-font-size);

--- a/browser/src/control/jsdialog/Widget.ColorPicker.ts
+++ b/browser/src/control/jsdialog/Widget.ColorPicker.ts
@@ -329,9 +329,13 @@ function updatePalette(
 
 	customContainer.replaceChildren();
 
+	const customLabel = window.L.DomUtil.create('label', '', customContainer);
+	customLabel.id = 'ui-color-picker-custom-label';
+	customLabel.textContent = _('Custom') + ':';
+	customLabel.htmlFor = 'ui-color-picker-custom-input';
+
 	const customInput = window.L.DomUtil.create('input', '', customContainer);
 	customInput.id = 'ui-color-picker-custom-input';
-	customInput.setAttribute('aria-label', _('Enter custom color in hex format'));
 	customInput.placeholder = '#FFF000';
 	customInput.maxlength = 7;
 	customInput.type = 'text';


### PR DESCRIPTION
Change-Id: I8eba2c4363c23b51828693656102e4649ab013dc

After:
<img width="361" height="470" alt="image" src="https://github.com/user-attachments/assets/30c95052-c82e-4943-88f6-583420236149" />

<img width="361" height="464" alt="image" src="https://github.com/user-attachments/assets/c14e9e08-56cd-4210-b226-53c08ed314d1" />

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

