### PR TITLE
css: use a text color variable for the 'Open Styles Sidebar' button

### DIFF
--- a/browser/css/notebookbar.css
+++ b/browser/css/notebookbar.css
@@ -663,6 +663,7 @@ label.notebookbar.ui-checkbox-label {
 	width: 100%;
 	position: relative;
 	justify-content: start;
+	color: var(--color-main-text);
 }
 
 #stylesview-dropdown hr {


### PR DESCRIPTION
Change-Id: Ib0d363902fc165cd6dff7a18a6b882a580af43a6


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

