### PR TITLE
scroll: run panBy sync from drawSections

### DIFF
--- a/browser/src/canvas/sections/ScrollSection.ts
+++ b/browser/src/canvas/sections/ScrollSection.ts
@@ -338,16 +338,14 @@ export class ScrollSection extends CanvasSectionObject {
 	private doMove() {
 		const scrollProps: ScrollProperties = (app.activeDocument as DocumentBase).activeLayout.scrollProperties;
 
-		app.layoutingService.appendLayoutingTask(() => {
-			this.map.panBy(new cool.Point(scrollProps.moveBy[0] / app.dpiScale, scrollProps.moveBy[1] / app.dpiScale));
-			scrollProps.moveBy = null;
-			this.onUpdateScrollOffset();
+		this.map.panBy(new cool.Point(scrollProps.moveBy[0] / app.dpiScale, scrollProps.moveBy[1] / app.dpiScale));
+		scrollProps.moveBy = null;
+		this.onUpdateScrollOffset();
 
-			if (app && app.file.fileBasedView === true)
-				app.map._docLayer._checkSelectedPart();
+		if (app && app.file.fileBasedView === true)
+			app.map._docLayer._checkSelectedPart();
 
-			app.activeDocument.activeLayout.refreshScrollProperties();
-		});
+		app.activeDocument.activeLayout.refreshScrollProperties();
 	}
 
 	public onDraw(frameCount: number, elapsedTime: number): void {


### PR DESCRIPTION
- reverted code from commit 623e2f5b686db82a0a73a7df1ff851dabea9ae59 "Scroll Section: Move move event into layouting tasks." It even mention: This will change in the future but for now, move event modifies map css prpoerty.
- fixes regression after commit 5a672a70fc8a3345ca0b1cea708d2c0cf838d04b "canvas: flush LayoutingService before canvas render"
- makes order of processing again good for current frame: Original order (draw -> flush):
  1. drawSections() - ScrollSection queues panBy
  2. flushLayoutingTasks() - runs panBy synchronously

  Currently we flush tasks first, then will execute doMove() in
  ScrollSection which appends new task

