### PR TITLE
Fix dark mode issue of the Position and Size dialog of shapes

### DIFF
--- a/browser/css/jsdialogs.css
+++ b/browser/css/jsdialogs.css
@@ -2389,6 +2389,16 @@ button.has-img img {
 	filter: invert(.9)
 }
 
+/* Position and Size dialog - drawing area images */
+[data-theme='dark'] #CTL_POSRECT img.ui-drawing-area,
+[data-theme='dark'] #CTL_SIZERECT img.ui-drawing-area,
+[data-theme='dark'] #CTL_RECT img.ui-drawing-area,
+[data-theme='dark'] #CTL_ANGLE img.ui-drawing-area,
+[data-theme='dark'] #daRatioTop img.ui-drawing-area,
+[data-theme='dark'] #daRatioBottom img.ui-drawing-area {
+	filter: invert(.95)
+}
+
 /* scrollable content */
 .ui-scrollable-content {
 	overflow-x: scroll;


### PR DESCRIPTION
Base point, connector lines and rotation angle was white in dark mode. The commit fix the dark mode issue of this elements.


Change-Id: I918419547ea92fcb255da89add6e5644d0b2c41b


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

