### PR TITLE
set a better aria-label for logo when it is a link

### DIFF
--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -117,11 +117,28 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 			docLogo.setAttribute('type', 'action');
 			docLogo.setAttribute('target', '_blank');
 			docLogo.setAttribute('tabIndex', 0);
-			docLogo.setAttribute('aria-label', _('file type icon'));
 
 			if (iconTooltip) {
 				docLogo.setAttribute('data-cooltip', iconTooltip);
 			}
+			// Mirror data-cooltip onto aria-label so the accessible name
+			// matches the visible tooltip, even when branding overrides
+			// data-cooltip after load (e.g. to "Collabora Online"). When
+			// branding also sets an href, target="_blank" takes effect and
+			// the link opens a new tab, so announce that to screen readers.
+			const syncAriaLabel = () => {
+				const cooltip = docLogo.getAttribute('data-cooltip');
+				if (!cooltip) return;
+				const label = docLogo.getAttribute('href')
+					? _('{0} website, opens in new tab').replace('{0}', cooltip)
+					: cooltip;
+				docLogo.setAttribute('aria-label', label);
+			};
+			syncAriaLabel();
+			new MutationObserver(syncAriaLabel).observe(docLogo, {
+				attributes: true,
+				attributeFilter: ['data-cooltip', 'href'],
+			});
 			window.L.control.attachTooltipEventListener(docLogo, this.map);
 			$('.main-nav').prepend(docLogoHeader);
 


### PR DESCRIPTION
branding can override this and then the aria-label is out of sync, so listen for the branding change and set a suitable aria-label if a link is set

WCAG 3.2.5 asks that a change of context like opening a new tab be announced
  - "SOMETHING website, opens in new tab"


Change-Id: I8dfb117259bbe25357d3054f1857004a15e52efd


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

