### PR TITLE
name document title/name label appear beside editbox

### DIFF
--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -45,7 +45,6 @@
 	align-items: baseline;
 	justify-content: center;
 	flex-direction: row;
-	flex-wrap: wrap;
 	flex: 1 1 auto;
 	gap: 4px;
 	position: relative;
@@ -65,7 +64,19 @@
 	overflow: visible;
 	position: static;
 	width: auto;
+	flex: 0 0 auto;
+	font-size: var(--default-font-size);
 	color: var(--color-text-lighter);
+}
+
+.main-nav.hasnotebookbar .document-title:focus-within > label[for='document-name-input'] {
+	font-size: clamp(var(--tb-min-fs), var(--tb-fs-s), var(--tb-max-fs));
+}
+
+.document-title:focus-within > #document-name-input.editable {
+	width: auto !important;
+	min-width: 0;
+	flex: 1 1 auto;
 }
 
 .readonly .document-title {


### PR DESCRIPTION
and tweak the font to use the same shrink behaviour as the tab labels do for narrower window sizes

<img width="1630" height="108" alt="image" src="https://github.com/user-attachments/assets/633b7cef-7d4d-4324-bea4-54a2d1aa038e" />

Change-Id: I1ad1b6883625f889ed4859ce2d6a1eb1371736aa


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

