### PR TITLE
restore focus to column header on dialog rebuild

### DIFF
--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -320,7 +320,12 @@ class TreeViewControl {
 		return false;
 	}
 
-	fillHeader(header: TreeHeaderJSON, builder: JSBuilder) {
+	fillHeader(
+		header: TreeHeaderJSON,
+		builder: JSBuilder,
+		data?: TreeWidgetJSON,
+		columnIndex?: number,
+	) {
 		if (!header) return;
 
 		const th = window.L.DomUtil.create(
@@ -336,6 +341,9 @@ class TreeViewControl {
 				builder.options.cssClass + ' ui-treeview-header-button',
 				th,
 			);
+			if (data && columnIndex !== undefined) {
+				button.id = data.id + '-header-' + columnIndex + '-button';
+			}
 			button.textContent = header.text;
 			if (header.arrow) {
 				th.setAttribute(
@@ -1811,7 +1819,7 @@ class TreeViewControl {
 		}
 
 		for (const index in headers) {
-			this.fillHeader(headers[index], builder);
+			this.fillHeader(headers[index], builder, data, parseInt(index));
 
 			if (headers[index].sortable === false) continue;
 

--- a/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
@@ -250,6 +250,33 @@ describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: f
             });
     });
 
+    it('Sorting via Enter on column header keeps focus on the header', function () {
+        helper.clearAllText();
+        helper.typeIntoDocument('bookmark');
+        helper.selectAllText();
+        cy.then(() => {
+            win.app.map.sendUnoCommand('.uno:InsertBookmark?Bookmark:string=bookmark1');
+            win.app.map.sendUnoCommand('.uno:InsertBookmark?Bookmark:string=bookmark2');
+            win.app.map.sendUnoCommand('.uno:InsertBookmark');
+        });
+
+        a11yHelper.getActiveDialog(1)
+            .then(() => helper.processToIdle(win))
+            .then(() => {
+                cy.cGet('.ui-treeview-header-button').first().focus();
+                cy.cGet('.ui-treeview-header-button').first().should('have.focus');
+
+                helper.realPressInDialog('Enter');
+                return helper.processToIdle(win);
+            })
+            .then(() => {
+                cy.cGet('.ui-treeview-header[role="columnheader"]').first()
+                    .should('have.attr', 'aria-sort');
+                cy.cGet('.ui-treeview-header-button').first().should('have.focus');
+                a11yHelper.closeActiveDialog(1);
+            });
+    });
+
     it('Treeview Enter key keeps focus in dialog', function () {
         cy.then(function () {
             win.app.map.sendUnoCommand('.uno:ChapterNumberingDialog');


### PR DESCRIPTION
When users use the keyboard to select a column header in the table within the “Bookmark” dialog and press Enter, the table column is sorted.

However, the keyboard focus does not remain on the column header afterwards; instead, it disappears. This should not happen. The keyboard focus should remain on the column header.

The widget needs a unique id so focus can be restored back to it after a jsdialog rebuild


Change-Id: If794d717c48fc8a39d1a8e23bdf3035d24763e08


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

