### PR TITLE
common: kit: test: wsd: make isKitInProcess constexpr

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -331,6 +331,7 @@ coolwsd_inproc_SOURCES = $(coolwsd_sources) \
                          $(coolforkit_sources) \
                          wsd/coolwsd-inproc.cpp
 
+coolwsd_inproc_CPPFLAGS = $(AM_CPPFLAGS) -DENABLE_INPROC=1
 coolwsd_inproc_LDADD = libsimd.a libkitwsdglobals.a
 
 if !ENABLE_SSL

--- a/common/Log-poco.cpp
+++ b/common/Log-poco.cpp
@@ -594,7 +594,8 @@ namespace Log
     {
         if constexpr (Util::isMobileApp())
             return;
-        if (!Util::isKitInProcess())
+
+        if constexpr (!Util::isKitInProcess())
         {
             // Allow other threads time to exit.
             for (int i = 0; i < 10 && ThreadLocalBufferCount > 1; ++i)

--- a/common/Util.cpp
+++ b/common/Util.cpp
@@ -185,10 +185,6 @@ namespace Util
         return std::getenv("DISPLAY") != nullptr;
     }
 
-    bool kitInProcess = false;
-    void setKitInProcess(bool value) { kitInProcess = value; }
-    bool isKitInProcess() { return isFuzzing() || isMobileApp() || kitInProcess; }
-
     std::string replace(std::string result, const std::string_view from, const std::string_view to)
     {
         const std::size_t fromSize = from.size();

--- a/common/Util.hpp
+++ b/common/Util.hpp
@@ -1108,8 +1108,14 @@ int main(int argc, char**argv)
 #endif
     }
 
-    void setKitInProcess(bool value);
-    bool isKitInProcess();
+    constexpr bool isKitInProcess()
+    {
+#if defined(ENABLE_INPROC) && ENABLE_INPROC
+        return true;
+#else
+        return isFuzzing() || isMobileApp();
+#endif // ENABLE_INPROC
+    }
 
     /**
      * Splits string into vector<string>. Does not accept referenced variables for easy

--- a/kit/ForKit.cpp
+++ b/kit/ForKit.cpp
@@ -309,7 +309,7 @@ bool haveCorrectCapabilities()
 /// Check if some previously forked kids have died.
 void cleanupChildren(const std::string& childRoot)
 {
-    if (Util::isKitInProcess())
+    if constexpr (Util::isKitInProcess())
         return;
 
     pid_t exitedChildPid;
@@ -550,7 +550,7 @@ int createCOKit(const std::string& childRoot, const std::string& sysTemplate,
     const auto startForkingTime = std::chrono::steady_clock::now();
 
     pid_t childPid = 0;
-    if (Util::isKitInProcess())
+    if constexpr (Util::isKitInProcess())
     {
         std::thread([childRoot, jailId = std::move(jailId), configId, sysTemplate,
                      loTemplate, queryVersion
@@ -829,7 +829,7 @@ int forkit_main(int argc, char** argv)
 
     Util::sleepFromEnvIfSet("Forkit", "SLEEPFORDEBUGGER");
 
-    if (!Util::isKitInProcess())
+    if constexpr (!Util::isKitInProcess())
     {
         // Already set by COOLWSD.cpp in kit in process
         SigUtil::setFatalSignals("forkit startup of " + Util::getCoolVersion() + ' ' +
@@ -848,7 +848,7 @@ int forkit_main(int argc, char** argv)
     if (simd::init())
         simd_deltaInit();
 
-    if (!Util::isKitInProcess())
+    if constexpr (!Util::isKitInProcess())
         Util::setApplicationPath(Poco::Path(argv[0]).parent().toString());
 
     // Initialization
@@ -1042,7 +1042,7 @@ int forkit_main(int argc, char** argv)
     JailUtil::SysTemplate::setupRandomDeviceLinks(sysTemplate);
 #endif
 
-    if (!Util::isKitInProcess())
+    if constexpr (!Util::isKitInProcess())
     {
         // Parse the configuration.
         char* const conf = std::getenv("COOL_CONFIG");

--- a/kit/Kit.cpp
+++ b/kit/Kit.cpp
@@ -2772,7 +2772,7 @@ void Document::flushAndExit(int code)
 {
     flushTraceEventRecordings();
     _deltaPool.stop();
-    if (!Util::isKitInProcess())
+    if constexpr (!Util::isKitInProcess())
         Util::forcedExit(code);
     else
         SigUtil::setTerminationFlag();
@@ -3442,7 +3442,7 @@ void lokit_main(
 {
 #if !MOBILEAPP
 
-    if (!Util::isKitInProcess())
+    if constexpr (!Util::isKitInProcess())
     {
         // Already set by COOLWSD.cpp
         SigUtil::setFatalSignals("kit startup of " + Util::getCoolVersion() + ' ' +
@@ -3925,7 +3925,7 @@ void lokit_main(
             if (!initFunction)
                 initFunction = cok_init_2;
 
-            if (!Util::isKitInProcess())
+            if constexpr (!Util::isKitInProcess())
                 kit = UnitKit::get().cok_init(instdir, userdir, initFunction);
             if (!kit)
                 kit = initFunction(instdir, userdir);
@@ -4183,7 +4183,7 @@ void lokit_main(
 
     LOG_INF("Kit process for Jail [" << jailId << "] finished.");
     flushTraceEventRecordings();
-    if (!Util::isKitInProcess())
+    if constexpr (!Util::isKitInProcess())
         Util::forcedExit(EX_OK);
 
 #endif

--- a/kit/KitWebSocket.cpp
+++ b/kit/KitWebSocket.cpp
@@ -126,7 +126,7 @@ void KitWebSocketHandler::handleMessage(const std::vector<char>& data)
             if (_document)
                 _document->joinThreads();
             _document.reset();
-            if (!Util::isKitInProcess())
+            if constexpr (!Util::isKitInProcess())
                 Util::forcedExit(EX_OK);
             else
                 SigUtil::setTerminationFlag();

--- a/test/ClientTestStubs.cpp
+++ b/test/ClientTestStubs.cpp
@@ -23,8 +23,6 @@
 #include <wsd/RequestDetails.hpp>
 
 // ----- Kit stubs -----
-void setKitInProcess() {}
-
 #include <kit/ChildSession.hpp>
 bool ChildSession::NoCapsForKit = true;
 

--- a/wsd/Admin.cpp
+++ b/wsd/Admin.cpp
@@ -1107,7 +1107,7 @@ void Admin::cleanupResourceConsumingDocs()
 
 void Admin::cleanupLostKits()
 {
-    if (Util::isKitInProcess())
+    if constexpr (Util::isKitInProcess())
         return; // we might look lost ourselves.
 
     static std::map<pid_t, std::time_t> mapKitsLost;

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -4515,7 +4515,6 @@ int main(int argc, char** argv)
 {
     SigUtil::setUserSignals();
     SigUtil::setFatalSignals("wsd " + Util::getCoolVersion() + ' ' + Util::getCoolVersionHash());
-    setKitInProcess();
 
     try
     {

--- a/wsd/COOLWSD.cpp
+++ b/wsd/COOLWSD.cpp
@@ -546,7 +546,7 @@ void COOLWSD::cleanupDocBrokers()
 /// Forks as many children as requested.
 static void forkChildren(const std::string& configId, const int number)
 {
-    if (Util::isKitInProcess())
+    if constexpr (Util::isKitInProcess())
         return;
 
     LOG_TRC("Request forkit to spawn " << number << " new child(ren)");
@@ -572,7 +572,7 @@ static bool queueMessageToForKit(const std::string& message);
 
 bool COOLWSD::ensureSubForKit(const std::string& configId)
 {
-    if (Util::isKitInProcess())
+    if constexpr (Util::isKitInProcess())
         return false;
 
     LOG_TRC("Request forkit to spawn subForKit " << configId);
@@ -594,7 +594,7 @@ bool COOLWSD::ensureSubForKit(const std::string& configId)
 /// Cleans up dead children.
 static void cleanupChildren()
 {
-    if (Util::isKitInProcess())
+    if constexpr (Util::isKitInProcess())
         return;
 
     Util::assertIsLocked(NewChildrenMutex);
@@ -2087,7 +2087,7 @@ void COOLWSD::innerInitialize(Poco::Util::Application& self)
         ConfigUtil::getConfigValue("indirection_endpoint.geolocation_setup.enable", false);
 
 #if ENABLE_DEBUG
-    if (Util::isKitInProcess())
+    if constexpr (Util::isKitInProcess())
         SingleKit = true;
 #endif
 #endif
@@ -2650,7 +2650,7 @@ bool COOLWSD::checkAndRestoreForKit()
         }
     }
 
-    if (Util::isKitInProcess())
+    if constexpr (Util::isKitInProcess())
         return true;
 
     int status;
@@ -2937,7 +2937,7 @@ bool COOLWSD::createForKit()
     // Always reap first, in case we haven't done so yet.
     if (ForKitProcId != -1)
     {
-        if (Util::isKitInProcess())
+        if constexpr (Util::isKitInProcess())
             return true;
         int status;
         waitpid(ForKitProcId, &status, WUNTRACED | WNOHANG);
@@ -3796,7 +3796,7 @@ void COOLWSD::innerMain()
 // No need to "have at least one child" beforehand on mobile
 #if !MOBILEAPP
 
-    if (!Util::isKitInProcess())
+    if constexpr (!Util::isKitInProcess())
     {
         // Make sure we have at least one child before moving forward.
         std::unique_lock<std::mutex> lock(NewChildrenMutex);
@@ -4143,7 +4143,7 @@ void COOLWSD::innerMain()
     }
 
 #if !MOBILEAPP
-    if (!Util::isKitInProcess())
+    if constexpr (!Util::isKitInProcess())
     {
         // Terminate child processes
         LOG_INF("Requesting forkit process " << ForKitProcId << " to terminate.");
@@ -4188,7 +4188,7 @@ void COOLWSD::innerMain()
     SigUtil::addActivity("terminated unused children");
 
 #if !MOBILEAPP
-    if (!Util::isKitInProcess())
+    if constexpr (!Util::isKitInProcess())
     {
         SigUtil::addActivity("waiting for forkit to exit");
 
@@ -4463,7 +4463,7 @@ void forwardSigUsr2()
 #if !MOBILEAPP
     LOG_TRC("forwardSigUsr2");
 
-    if (Util::isKitInProcess())
+    if constexpr (Util::isKitInProcess())
         return;
 
     Util::assertIsLocked(DocBrokersMutex);

--- a/wsd/COOLWSD.hpp
+++ b/wsd/COOLWSD.hpp
@@ -319,8 +319,6 @@ private:
     std::unordered_map<std::string, std::string> _overrideSettings;
 };
 
-void setKitInProcess();
-
 int createForkit(const std::string& forKitPath, const StringVector& args);
 
 /* vim:set shiftwidth=4 softtabstop=4 expandtab: */

--- a/wsd/coolwsd-fork.cpp
+++ b/wsd/coolwsd-fork.cpp
@@ -21,8 +21,6 @@
 #include <common/Util.hpp>
 #include <wsd/COOLWSD.hpp>
 
-void setKitInProcess() { Util::setKitInProcess(false); }
-
 int createForkit(const std::string& forKitPath, const StringVector& args)
 {
     // create forkit in a process

--- a/wsd/coolwsd-inproc.cpp
+++ b/wsd/coolwsd-inproc.cpp
@@ -21,8 +21,6 @@
 #include <COOLWSD.hpp>
 #include <Kit.hpp>
 
-void setKitInProcess() { Util::setKitInProcess(true); }
-
 int createForkit(const std::string& forKitPath, const StringVector& args)
 {
     // create forkit in a thread


### PR DESCRIPTION
### Summary
The `setKitInProcess` function was only called with the true argument
in `coolwsd-inproc.cpp`, which is only compiled when `ENABLE_DEBUG` is true.
Similarly, `setKitInProcess` was always called with false argument from
`coolwsd-fork.cpp`.

Since these are compile time invariants, create `ENABLE_INPROC` compiler
directive when `ENABLE_DEBUG` is true in `Makefile.am`, and convert `isKitInProcess`
into a constexpr function that returns true if `ENABLE_INPROC`, and simplify its
implementation. 

Also, remove `setKitInProcess` and `kitInProcess`, and convert all conditionals 
on `isKitInProcess` constexpr where applicable.


### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay