### PR TITLE
Cursor background color: Fetch it from variable.

### DIFF
--- a/browser/css/leaflet.css
+++ b/browser/css/leaflet.css
@@ -611,7 +611,7 @@ a.leaflet-control-buttons:hover:first-child {
 }
 
 .leaflet-cursor {
-	background: black;
+	background: var(--color-cursor-blink-background);
 	width: 2px;
 	pointer-events: none;
 }


### PR DESCRIPTION
Issue: Cursor doesn't blink while scrolling the document or moving the cursor rapidly. This is a feature. But in dark mode, constant color was black. This makes cursor hidden instead of making it always visible.

Fix: Make the background dynamic like the blink CSS class uses it.


Change-Id: I92d089eee0c290e8a87a4a188b266015c3927370


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

