### PR TITLE
CSC: Prevent cancelling of mouseup event.

### DIFF
--- a/browser/css/helpdialog.css
+++ b/browser/css/helpdialog.css
@@ -80,6 +80,17 @@
 		/* Adjust margin bottom */
 	}
 
+	/* Strip default browser styling from the TOC list */
+	.toc-list {
+		list-style: none;
+		padding-left: 0;
+		margin: 0;
+	}
+
+	.toc-list .toc-list {
+		padding-left: 1.5em;
+	}
+
 	.screenshot {
 		text-align: center;
 		margin: 0.1in;

--- a/browser/css/helpdialog.css
+++ b/browser/css/helpdialog.css
@@ -3,7 +3,8 @@
 
 #online-help-content-box,
 #keyboard-shortcuts-content-box {
-	h1 {
+	h1,
+	.help-dialog-header {
 		text-align: center;
 	}
 

--- a/browser/css/helpdialog.css
+++ b/browser/css/helpdialog.css
@@ -88,10 +88,6 @@
 		margin: 0;
 	}
 
-	.toc-list .toc-list {
-		padding-left: 1.5em;
-	}
-
 	.screenshot {
 		text-align: center;
 		margin: 0.1in;

--- a/browser/css/helpdialog.css
+++ b/browser/css/helpdialog.css
@@ -67,11 +67,11 @@
 		/* Darker text color when clicked */
 	}
 
-	/* Style for toc-h2 and toc-h3 button text when focused */
+	/* Visible keyboard focus indicator for TOC jump links */
 	.toc-h2 a:focus,
 	.toc-h3 a:focus {
-		outline: none;
-		/* Remove outline when focused */
+		outline: 2px solid var(--color-primary);
+		outline-offset: 2px;
 	}
 
 	/* Add margin to the paragraph to separate each item */

--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -45,6 +45,7 @@
 	align-items: baseline;
 	justify-content: center;
 	flex-direction: row;
+	flex-wrap: wrap;
 	flex: 1 1 auto;
 	gap: 4px;
 	position: relative;

--- a/browser/css/menubar.css
+++ b/browser/css/menubar.css
@@ -45,7 +45,6 @@
 	align-items: baseline;
 	justify-content: center;
 	flex-direction: row;
-	flex-wrap: wrap;
 	flex: 1 1 auto;
 	gap: 4px;
 	position: relative;
@@ -65,7 +64,19 @@
 	overflow: visible;
 	position: static;
 	width: auto;
+	flex: 0 0 auto;
+	font-size: var(--default-font-size);
 	color: var(--color-text-lighter);
+}
+
+.main-nav.hasnotebookbar .document-title:focus-within > label[for='document-name-input'] {
+	font-size: clamp(var(--tb-min-fs), var(--tb-fs-s), var(--tb-max-fs));
+}
+
+.document-title:focus-within > #document-name-input.editable {
+	width: auto !important;
+	min-width: 0;
+	flex: 1 1 auto;
 }
 
 .readonly .document-title {

--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -331,35 +331,27 @@
             <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1335">Opening, closing, saving, printing and downloading documents</a></li>
             <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1337">Editing documents</a></li>
             <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1338">Advanced features</a></li>
-            <li class="spreadsheet link-section hide">
-                <ul class="toc-list">
-                    <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1359"><span class="productname">{productname}</span> spreadsheets</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1361">Editing spreadsheets</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1363">Formulas</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1367">Formatting spreadsheets</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1371">Advanced features</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1409">Spreadsheets</a></li>
-                </ul>
-            </li>
-            <li class="text link-section hide">
-                <ul class="toc-list">
-                    <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1373"><span class="productname">{productname}</span> text documents</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1375">Editing text documents</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1377">Context menus</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1383">Advanced text document editor features</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1407">Text documents</a></li>
-                </ul>
-            </li>
-            <li class="presentation link-section hide">
-                <ul class="toc-list">
-                    <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1391"><span class="productname">{productname}</span> presentations</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1393">Editing presentations</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1395">Slide show</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1397">Slide pane</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1401">Advanced features</a></li>
-                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1411">Presentations</a></li>
-                </ul>
-            </li>
+
+            <li class="toc-h2 m-v-0 spreadsheet hide"><a class="border-0 scroll-button" href="#1359"><span class="productname">{productname}</span> spreadsheets</a></li>
+            <li class="toc-h3 m-v-0 spreadsheet hide"><a class="border-0 scroll-button" href="#1361">Editing spreadsheets</a></li>
+            <li class="toc-h3 m-v-0 spreadsheet hide"><a class="border-0 scroll-button" href="#1363">Formulas</a></li>
+            <li class="toc-h3 m-v-0 spreadsheet hide"><a class="border-0 scroll-button" href="#1367">Formatting spreadsheets</a></li>
+            <li class="toc-h3 m-v-0 spreadsheet hide"><a class="border-0 scroll-button" href="#1371">Advanced features</a></li>
+            <li class="toc-h3 m-v-0 spreadsheet hide"><a class="border-0 scroll-button" href="#1409">Spreadsheets</a></li>
+
+            <li class="toc-h2 m-v-0 text hide"><a class="border-0 scroll-button" href="#1373"><span class="productname">{productname}</span> text documents</a></li>
+            <li class="toc-h3 m-v-0 text hide"><a class="border-0 scroll-button" href="#1375">Editing text documents</a></li>
+            <li class="toc-h3 m-v-0 text hide"><a class="border-0 scroll-button" href="#1377">Context menus</a></li>
+            <li class="toc-h3 m-v-0 text hide"><a class="border-0 scroll-button" href="#1383">Advanced text document editor features</a></li>
+            <li class="toc-h3 m-v-0 text hide"><a class="border-0 scroll-button" href="#1407">Text documents</a></li>
+
+            <li class="toc-h2 m-v-0 presentation hide"><a class="border-0 scroll-button" href="#1391"><span class="productname">{productname}</span> presentations</a></li>
+            <li class="toc-h3 m-v-0 presentation hide"><a class="border-0 scroll-button" href="#1393">Editing presentations</a></li>
+            <li class="toc-h3 m-v-0 presentation hide"><a class="border-0 scroll-button" href="#1395">Slide show</a></li>
+            <li class="toc-h3 m-v-0 presentation hide"><a class="border-0 scroll-button" href="#1397">Slide pane</a></li>
+            <li class="toc-h3 m-v-0 presentation hide"><a class="border-0 scroll-button" href="#1401">Advanced features</a></li>
+            <li class="toc-h3 m-v-0 presentation hide"><a class="border-0 scroll-button" href="#1411">Presentations</a></li>
+
             <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1403">Frequently Asked Questions</a></li>
         </ul>
     </nav>

--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -324,35 +324,45 @@
 </div>
 <div id="online-help-content">
     <h1 class="help-dialog-header"><span class="productname">{productname}</span> Help</h1>
-    <h2 class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1327">Collaborative editing</a></h2>
-    <h2 class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1333"><span class="productname">{productname}</span> user interface</a></h2>
-    <h2 class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1335">Opening, closing, saving, printing and downloading documents</a></h2>
-    <h2 class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1337">Editing documents</a></h2>
-    <h2 class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1338">Advanced features</a></h2>
-    <div class="spreadsheet link-section hide">
-        <h2 class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1359"><span class="productname">{productname}</span> spreadsheets</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1361">Editing spreadsheets</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1363">Formulas</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1367">Formatting spreadsheets</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1371">Advanced features</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1409">Spreadsheets</a></h2>
-    </div>
-    <div class="text link-section hide">
-        <h2 class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1373"><span class="productname">{productname}</span> text documents</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1375">Editing text documents</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1377">Context menus</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1383">Advanced text document editor features</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1407">Text documents</a></h2>
-    </div>
-    <div class="presentation link-section hide">
-        <h2 class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1391"><span class="productname">{productname}</span> presentations</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1393">Editing presentations</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1395">Slide show</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1397">Slide pane</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1401">Advanced features</a></h2>
-        <h2 class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1411">Presentations</a></h2>
-    </div>
-    <h2 class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1403">Frequently Asked Questions</a></h2>
+    <nav class="help-toc" aria-label="Help table of contents">
+        <ul class="toc-list">
+            <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1327">Collaborative editing</a></li>
+            <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1333"><span class="productname">{productname}</span> user interface</a></li>
+            <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1335">Opening, closing, saving, printing and downloading documents</a></li>
+            <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1337">Editing documents</a></li>
+            <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1338">Advanced features</a></li>
+            <li class="spreadsheet link-section hide">
+                <ul class="toc-list">
+                    <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1359"><span class="productname">{productname}</span> spreadsheets</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1361">Editing spreadsheets</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1363">Formulas</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1367">Formatting spreadsheets</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1371">Advanced features</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1409">Spreadsheets</a></li>
+                </ul>
+            </li>
+            <li class="text link-section hide">
+                <ul class="toc-list">
+                    <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1373"><span class="productname">{productname}</span> text documents</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1375">Editing text documents</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1377">Context menus</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1383">Advanced text document editor features</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1407">Text documents</a></li>
+                </ul>
+            </li>
+            <li class="presentation link-section hide">
+                <ul class="toc-list">
+                    <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1391"><span class="productname">{productname}</span> presentations</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1393">Editing presentations</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1395">Slide show</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1397">Slide pane</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1401">Advanced features</a></li>
+                    <li class="toc-h3 m-v-0"><a class="border-0 scroll-button" href="#1411">Presentations</a></li>
+                </ul>
+            </li>
+            <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1403">Frequently Asked Questions</a></li>
+        </ul>
+    </nav>
 
     <div class="section">
     <p class="section-header"><span class="productname">{productname}</span> allows you to create and edit office documents text documents, spreadsheets and presentations directly in your browser, in a simple and straight-forward way. You can work alone on a document, or collaboratively as part of a team.</p>

--- a/browser/html/cool-help.html
+++ b/browser/html/cool-help.html
@@ -323,7 +323,7 @@
     </div>
 </div>
 <div id="online-help-content">
-    <h1 class="help-dialog-header"><span class="productname">{productname}</span> Help</h1>
+    <h2 class="help-dialog-header"><span class="productname">{productname}</span> Help</h2>
     <nav class="help-toc" aria-label="Help table of contents">
         <ul class="toc-list">
             <li class="toc-h2 m-v-0"><a class="border-0 scroll-button" href="#1327">Collaborative editing</a></li>

--- a/browser/src/app/ViewLayoutCompareChanges.ts
+++ b/browser/src/app/ViewLayoutCompareChanges.ts
@@ -45,8 +45,12 @@ class ViewLayoutCompareChanges extends ViewLayoutNewBase {
 	}
 
 	private onResize(): void {
-		this.adjustViewZoomLevel();
-		this.refreshView();
+		// Defer so that the document anchor section picks up its new size
+		// first.
+		app.layoutingService.appendLayoutingTask(() => {
+			this.adjustViewZoomLevel();
+			this.refreshView();
+		});
 	}
 
 	private onZoomEnd(): void {

--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -224,6 +224,12 @@ class CanvasSectionContainer {
 		// listener above, recover from the resulting stuck drag. Deferred via
 		// microtask so the normal flow runs first when nothing intercepts.
 		window.addEventListener('mouseup', this.onMouseUpFallback.bind(this), true);
+
+		// Sometimes another event other than mouseup is fired for ending a drag.
+		// Try not to miss it or we get stuck in dragging state.
+		window.addEventListener('pointerup', this.onPointerUpFallback.bind(this), true);
+		window.addEventListener('pointercancel', this.onPointerUpFallback.bind(this), true);
+
 		this.canvas.onclick = this.onClick.bind(this);
 		this.canvas.ondblclick = this.onDoubleClick.bind(this);
 		this.canvas.oncontextmenu = this.onContextMenu.bind(this);
@@ -1148,6 +1154,18 @@ class CanvasSectionContainer {
 	}
 
 	private onMouseMove (e: MouseEvent) {
+		// If a drag is in progress but the OS reports no buttons are pressed,
+		// the mouseup was lost. Fix it.
+		if (this.draggingSomething && e.buttons === 0) {
+			var recoveryEvent = new MouseEvent('mouseup', {
+				button: 0,
+				buttons: 0,
+				clientX: e.clientX,
+				clientY: e.clientY,
+			});
+			this.onMouseUp(recoveryEvent);
+		}
+
 		// Early exit. If mouse is outside and "draggingSomething = false", then there is no reason to check further.
 		// Add an exception for leaflet, check after removing it.
 		if (!this.mouseIsInside && !this.draggingSomething && !this.isLongPressActive())
@@ -1228,6 +1246,23 @@ class CanvasSectionContainer {
 				return;
 			this.onMouseUp(e);
 		});
+	}
+
+	// Recovers when no mouseup reaches at all.
+	private onPointerUpFallback (e: PointerEvent) {
+		if (e.pointerType === 'touch')
+			return;
+		setTimeout(() => {
+			if (!this.draggingSomething)
+				return;
+			var synthetic = new MouseEvent('mouseup', {
+				button: 0,
+				buttons: 0,
+				clientX: e.clientX,
+				clientY: e.clientY,
+			});
+			this.onMouseUp(synthetic);
+		}, 0);
 	}
 
 	private onMouseUp (e: MouseEvent) { // Should be ignored unless this.draggingSomething = true.

--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -218,6 +218,12 @@ class CanvasSectionContainer {
 		document.addEventListener('mousemove', this.onMouseMove.bind(this));
 		this.canvas.onmousedown = this.onMouseDown.bind(this);
 		document.addEventListener('mouseup', this.onMouseUp.bind(this));
+
+		// Capture-phase fallback: if a downstream bubble-phase stopPropagation
+		// (e.g. from branding scripts) hides the mouseup from the document
+		// listener above, recover from the resulting stuck drag. Deferred via
+		// microtask so the normal flow runs first when nothing intercepts.
+		window.addEventListener('mouseup', this.onMouseUpFallback.bind(this), true);
 		this.canvas.onclick = this.onClick.bind(this);
 		this.canvas.ondblclick = this.onDoubleClick.bind(this);
 		this.canvas.oncontextmenu = this.onContextMenu.bind(this);
@@ -1210,7 +1216,23 @@ class CanvasSectionContainer {
 		}
 	}
 
+	// Capture-phase fallback: schedules a deferred check so the normal
+	// document-bubble path runs first. If that path was blocked upstream
+	// (stopPropagation by a branding script or similar) and we are stuck
+	// in a drag, run the recovery here.
+	private onMouseUpFallback (e: MouseEvent) {
+		queueMicrotask(() => {
+			if ((e as any).__cscMouseUpHandled)
+				return;
+			if (!this.draggingSomething)
+				return;
+			this.onMouseUp(e);
+		});
+	}
+
 	private onMouseUp (e: MouseEvent) { // Should be ignored unless this.draggingSomething = true.
+		(e as any).__cscMouseUpHandled = true;
+
 		// Early exit. If mouse down position is not inside the canvas area, we have nothing to check further.
 		if (!this.positionOnMouseDown) {
 			this.clearMousePositions();

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -564,7 +564,8 @@ window.L.Control.JSDialog = window.L.Control.extend({
 
 		if (firstFocusableElement && document.activeElement !== firstFocusableElement && !instance.isAutoCompletePopup) {
 			// for tab control case we have more then 1 element that can be focusable so select the first tab for the list
-			firstFocusableElement = firstFocusableElement.length > 0 ? firstFocusableElement[0] : firstFocusableElement;
+			if (Array.isArray(firstFocusableElement))
+				firstFocusableElement = firstFocusableElement[0];
 			firstFocusableElement.focus();
 		}
 		else if (instance.canHaveFocus !== false && instance.init_focus_id)

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -117,11 +117,28 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 			docLogo.setAttribute('type', 'action');
 			docLogo.setAttribute('target', '_blank');
 			docLogo.setAttribute('tabIndex', 0);
-			docLogo.setAttribute('aria-label', _('file type icon'));
 
 			if (iconTooltip) {
 				docLogo.setAttribute('data-cooltip', iconTooltip);
 			}
+			// Mirror data-cooltip onto aria-label so the accessible name
+			// matches the visible tooltip, even when branding overrides
+			// data-cooltip after load (e.g. to "Collabora Online"). When
+			// branding also sets an href, target="_blank" takes effect and
+			// the link opens a new tab, so announce that to screen readers.
+			const syncAriaLabel = () => {
+				const cooltip = docLogo.getAttribute('data-cooltip');
+				if (!cooltip) return;
+				const label = docLogo.getAttribute('href')
+					? _('{0} website, opens in new tab').replace('{0}', cooltip)
+					: cooltip;
+				docLogo.setAttribute('aria-label', label);
+			};
+			syncAriaLabel();
+			new MutationObserver(syncAriaLabel).observe(docLogo, {
+				attributes: true,
+				attributeFilter: ['data-cooltip', 'href'],
+			});
 			window.L.control.attachTooltipEventListener(docLogo, this.map);
 			$('.main-nav').prepend(docLogoHeader);
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -759,7 +759,8 @@ window.L.Map.include({
 		}.bind(this));
 
 		// select all event scroll elements, main-header elements, product header elements and make visible to user if search term is empty
-		document.querySelectorAll('.m-v-0, .product-header, .help-dialog-header, .help-toc').forEach(function(element) {
+		// Exclude doctype-tagged TOC entries so non-current-doctype items stay hidden after search clear
+		document.querySelectorAll('.m-v-0:not(.text):not(.spreadsheet):not(.presentation), .product-header, .help-dialog-header, .help-toc').forEach(function(element) {
 			this.show(element);
 			element.style.backgroundColor = '';
 		}.bind(this));

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -750,7 +750,7 @@ window.L.Map.include({
 		}.bind(this));
 
 		// select all event scroll elements, main-header elements, product header elements and make visible to user if search term is empty
-		document.querySelectorAll('.m-v-0, .product-header, .help-dialog-header').forEach(function(element) {
+		document.querySelectorAll('.m-v-0, .product-header, .help-dialog-header, .help-toc').forEach(function(element) {
 			this.show(element);
 			element.style.backgroundColor = '';
 		}.bind(this));

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -633,13 +633,22 @@ window.L.Map.include({
 		const buttons = onlineHelpContent.querySelectorAll('.scroll-button');
 
 		buttons.forEach((button) => {
-			button.addEventListener('click', () => {
-				const targetId = button.dataset.target;
-				if (targetId) {
-					const targetElement = document.getElementById(`${targetId}`);
-					if (targetElement) {
-						targetElement.scrollIntoView();
-					}
+			button.addEventListener('click', (e) => {
+				const href = button.getAttribute('href');
+				if (!href || !href.startsWith('#')) return;
+				const targetElement = document.getElementById(href.substring(1));
+				if (!targetElement) return;
+				// Scroll only the help content area. The browser's default anchor
+				// navigation can scroll the modal popup itself, pushing the
+				// titlebar (and its close button) out of view.
+				e.preventDefault();
+				const scrollContainer = targetElement.closest('.ui-dialog-content');
+				if (scrollContainer) {
+					const containerRect = scrollContainer.getBoundingClientRect();
+					const targetRect = targetElement.getBoundingClientRect();
+					scrollContainer.scrollTop += targetRect.top - containerRect.top;
+				} else {
+					targetElement.scrollIntoView({ block: 'start' });
 				}
 			});
 		});

--- a/browser/src/control/jsdialog/Widget.PageMarginEntry.ts
+++ b/browser/src/control/jsdialog/Widget.PageMarginEntry.ts
@@ -187,7 +187,9 @@ JSDialog.PageMarginEntry = function (
 	custom.setAttribute('tabindex', '-1');
 
 	const customClickEventHdl = () => {
-		map.sendUnoCommand(isCalc ? '.uno:PageFormatDialog' : '.uno:PageDialog');
+		map.sendUnoCommand(
+			isCalc ? '.uno:PageFormatDialog' : '.uno:PageSettingDialog',
+		);
 		builder.callback('dialog', 'close', { id: data.id }, null);
 	};
 

--- a/browser/src/control/jsdialog/Widget.TreeView.ts
+++ b/browser/src/control/jsdialog/Widget.TreeView.ts
@@ -320,7 +320,12 @@ class TreeViewControl {
 		return false;
 	}
 
-	fillHeader(header: TreeHeaderJSON, builder: JSBuilder) {
+	fillHeader(
+		header: TreeHeaderJSON,
+		builder: JSBuilder,
+		data?: TreeWidgetJSON,
+		columnIndex?: number,
+	) {
 		if (!header) return;
 
 		const th = window.L.DomUtil.create(
@@ -336,6 +341,9 @@ class TreeViewControl {
 				builder.options.cssClass + ' ui-treeview-header-button',
 				th,
 			);
+			if (data && columnIndex !== undefined) {
+				button.id = data.id + '-header-' + columnIndex + '-button';
+			}
 			button.textContent = header.text;
 			if (header.arrow) {
 				th.setAttribute(
@@ -1811,7 +1819,7 @@ class TreeViewControl {
 		}
 
 		for (const index in headers) {
-			this.fillHeader(headers[index], builder);
+			this.fillHeader(headers[index], builder, data, parseInt(index));
 
 			if (headers[index].sortable === false) continue;
 

--- a/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
@@ -250,6 +250,33 @@ describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: f
             });
     });
 
+    it('Sorting via Enter on column header keeps focus on the header', function () {
+        helper.clearAllText();
+        helper.typeIntoDocument('bookmark');
+        helper.selectAllText();
+        cy.then(() => {
+            win.app.map.sendUnoCommand('.uno:InsertBookmark?Bookmark:string=bookmark1');
+            win.app.map.sendUnoCommand('.uno:InsertBookmark?Bookmark:string=bookmark2');
+            win.app.map.sendUnoCommand('.uno:InsertBookmark');
+        });
+
+        a11yHelper.getActiveDialog(1)
+            .then(() => helper.processToIdle(win))
+            .then(() => {
+                cy.cGet('.ui-treeview-header-button').first().focus();
+                cy.cGet('.ui-treeview-header-button').first().should('have.focus');
+
+                helper.realPressInDialog('Enter');
+                return helper.processToIdle(win);
+            })
+            .then(() => {
+                cy.cGet('.ui-treeview-header[role="columnheader"]').first()
+                    .should('have.attr', 'aria-sort');
+                cy.cGet('.ui-treeview-header-button').first().should('have.focus');
+                a11yHelper.closeActiveDialog(1);
+            });
+    });
+
     it('Treeview Enter key keeps focus in dialog', function () {
         cy.then(function () {
             win.app.map.sendUnoCommand('.uno:ChapterNumberingDialog');

--- a/cypress_test/integration_tests/desktop/writer/compare_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/compare_changes_spec.js
@@ -231,4 +231,45 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Compare Changes view.', fu
 			});
 		});
 	});
+
+	it('Comment does not overlap when sidebar is enabled in compare mode.', function() {
+		// Given a document with a comment, sidebar hidden, in doc compare mode:
+		loadDocument('track_changes_comment.docx');
+		desktopHelper.sidebarToggle();
+		cy.cGet('#sidebar-dock-wrapper').should('not.be.visible');
+		enterCompareChangesMode();
+		cy.getFrameWindow().then(function(win) {
+			helper.processToIdle(win);
+		});
+		cy.cGet('#comment-container-1').should('exist');
+
+		// And then turning the sidebar on:
+		desktopHelper.sidebarToggle();
+		cy.cGet('#sidebar-dock-wrapper').should('be.visible');
+		cy.getFrameWindow().then(function(win) {
+			helper.processToIdle(win);
+		});
+
+		// Then make sure that pages, comment and sidebar don't overlap:
+		cy.getFrameWindow().then(function(win) {
+			var layout = win.app.activeDocument.activeLayout;
+			var rightEdgePoint = new win.cool.SimplePoint(win.app.activeDocument.fileSize.pX, 0);
+			rightEdgePoint.mode = 2; // TileMode.RightSide
+			var rightPageEdge = layout.documentToViewX(rightEdgePoint) / win.app.dpiScale;
+
+			cy.cGet('#comment-container-1').should(function($el) {
+				expect($el.position().left, 'comment left vs right page edge').to.be.at.least(rightPageEdge);
+			});
+		});
+		cy.cGet('#sidebar-dock-wrapper').then(function($sidebar) {
+			var sidebarLeft = $sidebar[0].getBoundingClientRect().left;
+
+			cy.cGet('#comment-container-1').should(function($el) {
+				var commentRight = $el[0].getBoundingClientRect().right;
+				// Without the accompanying fix in place, this test would have failed with:
+				// comment right vs sidebar left: expected 1335 to be at most 1174.8583984375
+				expect(commentRight, 'comment right vs sidebar left').to.be.at.most(sidebarLeft);
+			});
+		});
+	});
 });

--- a/cypress_test/integration_tests/desktop/writer/compare_changes_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/compare_changes_spec.js
@@ -1,9 +1,16 @@
-/* global describe it cy require expect */
+/* global describe it cy require expect Cypress */
 
 var helper = require('../../common/helper');
 var desktopHelper = require('../../common/desktop_helper');
 
-describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Compare Changes view with comments.', function() {
+describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Compare Changes view.', function() {
+
+	function loadDocument(fileName) {
+		cy.viewport(1400, 600);
+		helper.setupAndLoadDocument('writer/' + fileName);
+		desktopHelper.switchUIToNotebookbar();
+		cy.cGet('#Review-tab-label').click();
+	}
 
 	function enterCompareChangesMode() {
 		desktopHelper.getNbIconArrow('TrackChanges', 'Review').click();
@@ -13,10 +20,7 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Compare Changes view with 
 
 	it('Comment does not overlap with page or sidebar.', function() {
 		// Given a document with a comment, sidebar is visible:
-		cy.viewport(1400, 600);
-		helper.setupAndLoadDocument('writer/track_changes_comment.docx');
-		desktopHelper.switchUIToNotebookbar();
-		cy.cGet('#Review-tab-label').click();
+		loadDocument('track_changes_comment.docx');
 		cy.cGet('#sidebar-dock-wrapper').should('be.visible');
 
 		// When changing to doc compare mode:
@@ -47,6 +51,183 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Compare Changes view with 
 				// - comment right vs sidebar left: expected 1290 to be at most 1071
 				// while normally it's around 1015.
 				expect(commentRight, 'comment right vs sidebar left').to.be.at.most(sidebarLeft);
+			});
+		});
+	});
+
+	// Regression test for: compare changes view: fix "scroll by pressing scrollbar" feature.
+	// Bug: In CompareChanges view, viewedRectangle.pY1 can be negative (due to
+	// yStart offset) even when scrolling is possible, so the scrollbar click was
+	// blocked. The fix uses canScrollVertical/canScrollHorizontal instead.
+	it('Scrollbar vertical scroll works in compare changes mode.', function() {
+		loadDocument('track_changes.odt');
+		enterCompareChangesMode();
+
+		cy.getFrameWindow().then(function(win) {
+			helper.processToIdle(win);
+		});
+
+		// Record initial viewY.
+		var initialViewY;
+		cy.getFrameWindow().then(function(win) {
+			var layout = win.app.activeDocument.activeLayout;
+			expect(layout.type).to.equal('ViewLayoutCompareChanges');
+			initialViewY = layout.scrollProperties.viewY;
+		});
+
+		// Scroll down using the scroll section offset API (simulates scrollbar drag).
+		cy.getFrameWindow().then(function(win) {
+			win.app.sectionContainer.getSectionWithName('scroll').scrollVerticalWithOffset(200);
+		});
+
+		// viewY should increase even though viewedRectangle.pY1 might be negative.
+		cy.getFrameWindow().then(function(win) {
+			cy.wrap(null).should(function() {
+				var layout = win.app.activeDocument.activeLayout;
+				expect(layout.scrollProperties.viewY, 'viewY after vertical scroll').to.be.greaterThan(initialViewY);
+			});
+		});
+	});
+
+	// Verify that canScrollVertical returns true in compare changes mode
+	// even when viewedRectangle.pY1 is negative (due to yStart offset).
+	it('canScrollVertical is true in compare changes mode.', function() {
+		loadDocument('track_changes.odt');
+		enterCompareChangesMode();
+
+		cy.getFrameWindow().then(function(win) {
+			helper.processToIdle(win);
+		});
+
+		cy.getFrameWindow().then(function(win) {
+			var layout = win.app.activeDocument.activeLayout;
+			var documentAnchor = win.app.sectionContainer.getSectionWithName(win.app.CSections.Tiles.name);
+
+			// canScrollVertical should be true (the document is taller than the viewport).
+			expect(layout.canScrollVertical(documentAnchor), 'canScrollVertical').to.be.true;
+		});
+	});
+
+	// Regression test for: comparechanges view: fix onresize and vertical scroll.
+	// Bug: When the browser window was resized, the compare changes layout was not
+	// refreshed, so the two side-by-side views were not repositioned correctly.
+	// The fix adds a resize handler that updates halfWidth and refreshes the view.
+	it('Resize updates compare changes layout.', function() {
+		loadDocument('track_changes.odt');
+		enterCompareChangesMode();
+
+		cy.getFrameWindow().then(function(win) {
+			helper.processToIdle(win);
+		});
+
+		// Ensure sidebar is closed so we start from a known state.
+		cy.cGet('#sidebar-dock-wrapper').then(function($el) {
+			if (Cypress.dom.isVisible($el[0])) {
+				desktopHelper.sidebarToggle();
+				cy.cGet('#sidebar-dock-wrapper').should('not.be.visible');
+			}
+		});
+
+		cy.getFrameWindow().then(function(win) {
+			helper.processToIdle(win);
+		});
+
+		// Record halfWidth with sidebar closed (full canvas width).
+		cy.getFrameWindow().then(function(win) {
+			var layout = win.app.activeDocument.activeLayout;
+			expect(layout.halfWidth, 'initial halfWidth').to.be.greaterThan(0);
+			cy.wrap(layout.halfWidth).as('initialHalfWidth');
+		});
+
+		// Open sidebar to reduce canvas width, which fires the resize event.
+		desktopHelper.sidebarToggle();
+		cy.cGet('#sidebar-dock-wrapper').should('be.visible');
+
+		// After sidebar opens, halfWidth should decrease since the
+		// document anchor section is narrower.
+		cy.get('@initialHalfWidth').then(function(initialHalfWidth) {
+			cy.getFrameWindow().then(function(win) {
+				cy.wrap(null, {timeout: 10000}).should(function() {
+					var newHalfWidth = win.app.activeDocument.activeLayout.halfWidth;
+					expect(newHalfWidth, 'halfWidth after sidebar toggle').to.not.equal(initialHalfWidth);
+				});
+			});
+		});
+	});
+
+	// Verify that viewSize covers both left and right document pages.
+	// Bug: viewSize.pX was calculated using halfWidth instead of full canvas width,
+	// so the horizontal extent did not account for both pages.
+	it('View size covers both pages in compare changes mode.', function() {
+		loadDocument('track_changes.odt');
+		enterCompareChangesMode();
+
+		cy.getFrameWindow().then(function(win) {
+			helper.processToIdle(win);
+		});
+
+		cy.getFrameWindow().then(function(win) {
+			var layout = win.app.activeDocument.activeLayout;
+			var documentAnchor = win.app.sectionContainer.getSectionWithName(win.app.CSections.Tiles.name);
+
+			// viewSize.pX should be at least as wide as the canvas (both pages fit).
+			expect(layout.viewSize.pX, 'viewSize.pX').to.be.at.least(documentAnchor.size[0]);
+		});
+	});
+
+	// Regression test for: compare changes view: tile rendering issue.
+	// Bug: The visible area rectangle (viewedRectangle) was too narrow, so tiles
+	// for the left page were not requested. The fix widens it to cover the full
+	// document width so that both left-side and right-side tiles are rendered.
+	it('Visible area covers full document width for tile rendering.', function() {
+		loadDocument('track_changes.odt');
+		enterCompareChangesMode();
+
+		cy.getFrameWindow().then(function(win) {
+			helper.processToIdle(win);
+		});
+
+		// The viewedRectangle should be wide enough to cover the full document.
+		cy.getFrameWindow().then(function(win) {
+			cy.wrap(null).should(function() {
+				var layout = win.app.activeDocument.activeLayout;
+				var docWidth = win.app.activeDocument.fileSize.pX;
+
+				// viewedRectangle width must cover the full document width (both pages
+				// need tiles from the same X range). The fix added margin, so the
+				// rectangle width should be >= document width.
+				expect(layout.viewedRectangle.width, 'viewedRectangle covers document width').to.be.at.least(docWidth);
+			});
+		});
+	});
+
+	// Verify both tile modes (LeftSide and RightSide) have content after the
+	// tile rendering fix. This complements the existing "View Changes mode has
+	// tiles for both modes" test by checking specifically after the visible area fix.
+	it('Both left and right side tiles have content after visible area fix.', function() {
+		loadDocument('track_changes.odt');
+		enterCompareChangesMode();
+
+		// Wait for tiles to be rendered.
+		cy.getFrameWindow().then(function(win) {
+			helper.processToIdle(win);
+		});
+
+		cy.getFrameWindow().then(function(win) {
+			cy.wrap(null).should(function() {
+				var tiles = win.TileManager.getTiles();
+				var hasMode1 = false;
+				var hasMode2 = false;
+				tiles.forEach(function(tile) {
+					if (tile.coords.mode === 1 && tile.hasContent() && tile.distanceFromView < Number.MAX_SAFE_INTEGER) {
+						hasMode1 = true;
+					}
+					if (tile.coords.mode === 2 && tile.hasContent() && tile.distanceFromView < Number.MAX_SAFE_INTEGER) {
+						hasMode2 = true;
+					}
+				});
+				expect(hasMode1, 'mode=1 (LeftSide) tiles with content').to.be.true;
+				expect(hasMode2, 'mode=2 (RightSide) tiles with content').to.be.true;
 			});
 		});
 	});


### PR DESCRIPTION
Worst case scenario:
* User presses mouse button left.
* Moves mouse (initiates a drag).
* Release left mouse button but another unexpected integrator defined layer prevents the mouseup event.

result: dragging continues.

To prevent such scenrior, this commit ensures that a mouseup event can not go unnoticed.


Change-Id: Iff537b79c68f3ef0b302c9531ea7b9e2c6c06d2c


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

