### PR TITLE
PDF comments: drag a rectangle to anchor a comment over an area

### DIFF
--- a/browser/Makefile.am
+++ b/browser/Makefile.am
@@ -315,6 +315,7 @@ COOL_JS_LST =\
 	src/canvas/sections/RulerSpacerSection.ts \
 	src/canvas/sections/CompareChangesLabelSection.ts \
 	src/canvas/sections/CommentMarkerSubSection.ts \
+	src/canvas/sections/CommentAnchorAreaSubSection.ts \
 	src/canvas/sections/CommentSection.ts \
 	src/canvas/sections/CommentListSection.ts \
 	src/canvas/sections/CalcGridSection.ts \

--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -523,6 +523,14 @@ body {
 	outline: none;
 }
 
+.annotation-anchor-area {
+	margin-left: 0px;
+	margin-top: 0px;
+	border: 1px solid var(--color-primary, #0078d4);
+	background: rgba(0, 120, 212, 0.08);
+	box-sizing: border-box;
+}
+
 .cool-scrolled {
 	overflow: auto;
 }
@@ -596,6 +604,14 @@ body {
 	z-index: 12;
 	width: 250px;
 	transition: left .25s;
+}
+
+.comment-placement-overlay {
+	position: absolute;
+	pointer-events: none;
+	border: 1px dashed var(--color-primary, #0078d4);
+	background: rgba(0, 120, 212, 0.10);
+	z-index: 11;
 }
 
 .cool-annotation.annotation-pop-up {

--- a/browser/src/canvas/sections/CommentAnchorAreaSubSection.ts
+++ b/browser/src/canvas/sections/CommentAnchorAreaSubSection.ts
@@ -1,0 +1,80 @@
+/* -*- js-indent-level: 8 -*- */
+/*
+ * Copyright the Collabora Online contributors.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/*
+	Outlined "anchor area" rectangle drawn underneath a Draw/Impress comment
+	when the comment carries an explicit area (PDF /Rect or the user's
+	drag-to-area selection in fileBasedView). The small CommentMarkerSubSection
+	icon stays at the rectangle's top-left; this section adds a clickable
+	box covering the whole area so the user can activate the comment by
+	clicking anywhere on it, not only on the icon.
+*/
+
+class CommentAnchorAreaSubSection extends HTMLObjectSection {
+	constructor(
+		sectionName: string,
+		objectWidth: number,
+		objectHeight: number,
+		documentPosition: cool.SimplePoint,
+		showSection: boolean,
+		parentSection: any,
+		data: any,
+	) {
+		super(
+			sectionName,
+			objectWidth,
+			objectHeight,
+			documentPosition,
+			'annotation-anchor-area',
+			showSection,
+		);
+		this.sectionProperties.parentSection = parentSection;
+		this.sectionProperties.data = data;
+
+		// Take pointer events directly. The default HTMLObjectSection
+		// passes them through to the canvas so the section container can
+		// hit-test by section bounds; that path lost clicks here
+		// intermittently (likely because the marker icon is added to the
+		// same documentObject layer and its hit area shadowed the
+		// area's). Listening on the div is simpler and the area is
+		// purpose-built to "clicking activates the comment."
+		this.sectionProperties.objectDiv.style.pointerEvents = 'auto';
+		this.sectionProperties.objectDiv.style.cursor = 'pointer';
+		this.sectionProperties.objectDiv.addEventListener(
+			'click',
+			(e: MouseEvent) => {
+				e.stopPropagation();
+				this.sectionProperties.parentSection.sectionProperties.commentListSection.selectById(
+					this.sectionProperties.data.id,
+				);
+			},
+		);
+		// Swallow mousedown so the underlying canvas sections (e.g.
+		// MouseControl forwarding to core) don't see the click as a
+		// page interaction.
+		this.sectionProperties.objectDiv.addEventListener(
+			'mousedown',
+			(e: MouseEvent) => {
+				e.stopPropagation();
+			},
+		);
+	}
+
+	public resize(widthPx: number, heightPx: number): void {
+		this.size = [widthPx * app.dpiScale, heightPx * app.dpiScale];
+		this.sectionProperties.objectWidth = widthPx;
+		this.sectionProperties.objectHeight = heightPx;
+		this.sectionProperties.objectDiv.style.width = widthPx + 'px';
+		this.sectionProperties.objectDiv.style.height = heightPx + 'px';
+	}
+}
+
+app.definitions.commentAnchorAreaSubSection = CommentAnchorAreaSubSection;

--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -166,9 +166,14 @@ export class CommentSection extends CanvasSectionObject {
 
 	// Active "click anywhere on the page to place a new comment" mode for PDF.
 	// When non-null, the next document mousedown is consumed to position a new
-	// comment at that point instead of being forwarded to core.
+	// comment at that point instead of being forwarded to core. A click+drag
+	// instead of a plain click captures an anchor area; if the drag stays
+	// below DRAG_THRESHOLD_PX the click is treated as a point placement.
 	private placementCommentData: any = null;
 	private placementSavedCursor: string | null = null;
+	private placementStart: { cX: number; cY: number } | null = null;
+	private placementOverlay: HTMLDivElement | null = null;
+	private static readonly DRAG_THRESHOLD_PX = 5;
 
 	constructor () {
 		super(app.CSections.CommentList.name);
@@ -208,6 +213,8 @@ export class CommentSection extends CanvasSectionObject {
 		// addEventListener/removeEventListener; bind once here so the same
 		// reference is used for both calls.
 		this.onPlacementMouseDown = this.onPlacementMouseDown.bind(this);
+		this.onPlacementMouseMove = this.onPlacementMouseMove.bind(this);
+		this.onPlacementMouseUp = this.onPlacementMouseUp.bind(this);
 		this.onPlacementKeyDown = this.onPlacementKeyDown.bind(this);
 	}
 
@@ -827,19 +834,84 @@ export class CommentSection extends CanvasSectionObject {
 		const canvas = document.getElementById('document-canvas') as HTMLCanvasElement | null;
 		if (canvas) {
 			canvas.removeEventListener('mousedown', this.onPlacementMouseDown, true);
+			canvas.removeEventListener('mousemove', this.onPlacementMouseMove, true);
+			canvas.removeEventListener('mouseup', this.onPlacementMouseUp, true);
 			if (this.placementSavedCursor !== null)
 				canvas.style.cursor = this.placementSavedCursor;
 		}
 		document.removeEventListener('keydown', this.onPlacementKeyDown, true);
+		this.removePlacementOverlay();
 		this.placementCommentData = null;
 		this.placementSavedCursor = null;
+		this.placementStart = null;
 	}
 
 	private onPlacementMouseDown(e: MouseEvent): void {
 		if (e.button !== 0) return; // ignore right/middle clicks
 		e.stopImmediatePropagation();
 		e.preventDefault();
-		this.finishCommentPlacement(e, e.currentTarget as HTMLCanvasElement);
+		const canvas = e.currentTarget as HTMLCanvasElement;
+		const rect = canvas.getBoundingClientRect();
+		this.placementStart = {
+			cX: e.clientX - rect.left,
+			cY: e.clientY - rect.top,
+		};
+		// Track move/up on the canvas so a click-and-drag draws a rectangle.
+		// A plain click without movement is handled by mouseup with the same
+		// start/end point and falls through to point placement.
+		canvas.addEventListener('mousemove', this.onPlacementMouseMove, true);
+		canvas.addEventListener('mouseup', this.onPlacementMouseUp, true);
+	}
+
+	private onPlacementMouseMove(e: MouseEvent): void {
+		if (!this.placementStart) return;
+		e.stopImmediatePropagation();
+		e.preventDefault();
+		const canvas = e.currentTarget as HTMLCanvasElement;
+		const rect = canvas.getBoundingClientRect();
+		const cur = { cX: e.clientX - rect.left, cY: e.clientY - rect.top };
+		const dx = cur.cX - this.placementStart.cX;
+		const dy = cur.cY - this.placementStart.cY;
+		if (!this.placementOverlay
+			&& Math.hypot(dx, dy) < CommentSection.DRAG_THRESHOLD_PX)
+			return;
+		this.updatePlacementOverlay(canvas, rect, cur);
+	}
+
+	private onPlacementMouseUp(e: MouseEvent): void {
+		if (e.button !== 0 || !this.placementStart) return;
+		e.stopImmediatePropagation();
+		e.preventDefault();
+		const canvas = e.currentTarget as HTMLCanvasElement;
+		const rect = canvas.getBoundingClientRect();
+		const end = { cX: e.clientX - rect.left, cY: e.clientY - rect.top };
+		this.finishCommentPlacement(canvas, end);
+	}
+
+	private updatePlacementOverlay(canvas: HTMLCanvasElement, rect: DOMRect,
+		cur: { cX: number; cY: number }): void {
+		if (!this.placementOverlay) {
+			this.placementOverlay = document.createElement('div');
+			this.placementOverlay.className = 'comment-placement-overlay';
+			canvas.parentElement.appendChild(this.placementOverlay);
+		}
+		const x1 = Math.min(this.placementStart.cX, cur.cX);
+		const y1 = Math.min(this.placementStart.cY, cur.cY);
+		const w = Math.abs(cur.cX - this.placementStart.cX);
+		const h = Math.abs(cur.cY - this.placementStart.cY);
+		// rect.left/top are viewport-relative; the overlay is parented to the
+		// canvas's parent, which uses the same offset, so add canvas.offsetLeft
+		// /Top to align with the canvas position inside that parent.
+		this.placementOverlay.style.left = (canvas.offsetLeft + x1) + 'px';
+		this.placementOverlay.style.top = (canvas.offsetTop + y1) + 'px';
+		this.placementOverlay.style.width = w + 'px';
+		this.placementOverlay.style.height = h + 'px';
+	}
+
+	private removePlacementOverlay(): void {
+		if (this.placementOverlay && this.placementOverlay.parentNode)
+			this.placementOverlay.parentNode.removeChild(this.placementOverlay);
+		this.placementOverlay = null;
 	}
 
 	private onPlacementKeyDown(e: KeyboardEvent): void {
@@ -849,33 +921,58 @@ export class CommentSection extends CanvasSectionObject {
 		this.exitCommentPlacement();
 	}
 
-	private finishCommentPlacement(e: MouseEvent, canvas: HTMLCanvasElement): void {
+	private finishCommentPlacement(canvas: HTMLCanvasElement,
+		end: { cX: number; cY: number }): void {
 		const commentData = this.placementCommentData;
+		const start = this.placementStart;
+		// Treat the gesture as a drag-to-area when the user moved past the
+		// threshold; otherwise it's a plain click and we anchor a 5x5 mm
+		// marker at the click point (current behaviour, preserved by the
+		// engine when no Width/Height args reach .uno:InsertAnnotation).
+		const isDrag = Math.hypot(end.cX - start.cX, end.cY - start.cY)
+			>= CommentSection.DRAG_THRESHOLD_PX;
 		// canvasToDocumentPoint expects coordinates relative to the canvas DOM
-		// element.
-		const rect = canvas.getBoundingClientRect();
-		const point = new cool.SimplePoint(0, 0);
-		point.cX = e.clientX - rect.left;
-		point.cY = e.clientY - rect.top;
-
+		// element. Use the top-left corner of the dragged box as the anchor;
+		// cap the bottom-right at the canvas in case the drag escaped it.
 		const layout = app.activeDocument.activeLayout;
-		const docPoint = layout.canvasToDocumentPoint(point);
-		if (Number.isNaN(docPoint.x) || Number.isNaN(docPoint.y))
+		const tlPoint = new cool.SimplePoint(0, 0);
+		tlPoint.cX = isDrag ? Math.min(start.cX, end.cX) : end.cX;
+		tlPoint.cY = isDrag ? Math.min(start.cY, end.cY) : end.cY;
+		const docTL = layout.canvasToDocumentPoint(tlPoint);
+		if (Number.isNaN(docTL.x) || Number.isNaN(docTL.y))
 			return;
 
-		// docPoint.x/.y are stacked-document twips. fileBasedView lays pages
+		let docBR = null;
+		if (isDrag) {
+			const brPoint = new cool.SimplePoint(0, 0);
+			brPoint.cX = Math.max(start.cX, end.cX);
+			brPoint.cY = Math.max(start.cY, end.cY);
+			docBR = layout.canvasToDocumentPoint(brPoint);
+			if (Number.isNaN(docBR.x) || Number.isNaN(docBR.y))
+				return;
+		}
+
+		// docTL.x/.y are stacked-document twips. fileBasedView lays pages
 		// out vertically with a fixed _spaceBetweenParts gap. Compute the
 		// containing page and reject clicks that fell in a horizontal margin,
 		// in an inter-page gap, or past the last page - the user should stay
 		// in placement mode and try again on a real page.
 		const docLayer = app.map._docLayer;
 		const additionPerPart = docLayer._partHeightTwips + docLayer._spaceBetweenParts;
-		const partIndex = Math.floor(docPoint.y / additionPerPart);
-		const yInPart = docPoint.y - partIndex * additionPerPart;
+		const partIndex = Math.floor(docTL.y / additionPerPart);
+		const yInPart = docTL.y - partIndex * additionPerPart;
 		if (partIndex < 0 || partIndex >= docLayer._parts
-			|| docPoint.x < 0 || docPoint.x > docLayer._partWidthTwips
+			|| docTL.x < 0 || docTL.x > docLayer._partWidthTwips
 			|| yInPart > docLayer._partHeightTwips)
 			return;
+
+		// For a drag, clamp the bottom-right to the same page so a comment
+		// that overshot the page boundary still produces a valid in-page area.
+		if (docBR) {
+			const partTop = partIndex * additionPerPart;
+			docBR.x = Math.min(docBR.x, docLayer._partWidthTwips);
+			docBR.y = Math.min(docBR.y, partTop + docLayer._partHeightTwips);
+		}
 
 		// Switching the active part keeps save()'s setPart wrapper consistent
 		// and lets newAnnotation pick up the correct parthash; yAddition lets
@@ -883,7 +980,9 @@ export class CommentSection extends CanvasSectionObject {
 		commentData.yAddition = partIndex * additionPerPart;
 		this.map.setPart(partIndex, false);
 
-		commentData.position = [docPoint.x, docPoint.y];
+		commentData.position = [docTL.x, docTL.y];
+		if (docBR)
+			commentData.size = [docBR.x - docTL.x, docBR.y - docTL.y];
 		this.exitCommentPlacement();
 		this.sectionProperties.docLayer.newAnnotation(commentData);
 	}
@@ -903,6 +1002,8 @@ export class CommentSection extends CanvasSectionObject {
 			// opening the editor, ship it as twips so core can place the
 			// annotation there instead of (0, 0). Mirrors the EditAnnotation
 			// pattern in CommentMarkerSubSection.sendAnnotationPositionChange.
+			// PDF drag-to-area: when the user dragged out a rectangle,
+			// also ship Width/Height so core stores the area as the PDF /Rect.
 			let positionArgs: any = {};
 			if (annotation.sectionProperties.data.position) {
 				const pos = annotation.sectionProperties.data.position;
@@ -913,6 +1014,11 @@ export class CommentSection extends CanvasSectionObject {
 					PositionX: { type: 'int32', value: pos[0] },
 					PositionY: { type: 'int32', value: py },
 				};
+				const size = annotation.sectionProperties.data.size;
+				if (size) {
+					positionArgs.Width = { type: 'int32', value: size[0] };
+					positionArgs.Height = { type: 'int32', value: size[1] };
+				}
 			}
 			comment = {
 				Author: {

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -155,6 +155,7 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.childLines = [];
 		this.sectionProperties.childCommentOffset = 8;
 		this.sectionProperties.commentMarkerSubSection = null; // For Impress and Draw documents.
+		this.sectionProperties.commentAnchorAreaSubSection = null; // For comments with an explicit anchor area (PDF /Rect, drag-to-area).
 		this.sectionProperties.calcCommentAreaWidth = 40; // Calc comment area doesn't cover the whole cell, in order to allow multi-cell selections.
 
 		app.map.on('sheetgeometrychanged', this.setPositionAndSize.bind(this));
@@ -795,6 +796,21 @@ export class Comment extends CanvasSectionObject {
 					this.sectionProperties.data.anchorPos[1] * app.twipsToPixels
 				);
 			}
+			if (this.sectionProperties.commentAnchorAreaSubSection !== null) {
+				const data = this.sectionProperties.data;
+				this.sectionProperties.commentAnchorAreaSubSection.sectionProperties.data = data;
+				this.sectionProperties.commentAnchorAreaSubSection.setPosition(
+					data.anchorPos[0] * app.twipsToPixels,
+					data.anchorPos[1] * app.twipsToPixels
+				);
+				// rectangle = [x, y, width, height] in twips (ImpressTileLayer.newAnnotation
+				// builds it from the data; the JSON form coming back from core uses the
+				// same shape via tools::Rectangle::toString()).
+				this.sectionProperties.commentAnchorAreaSubSection.resize(
+					data.rectangle[2] * app.twipsToPixels / app.dpiScale,
+					data.rectangle[3] * app.twipsToPixels / app.dpiScale
+				);
+			}
 		}
 	}
 
@@ -804,6 +820,30 @@ export class Comment extends CanvasSectionObject {
 
 		const showMarker = app.impress.partList[app.map._docLayer._selectedPart].hash === this.sectionProperties.data.parthash ||
 							app.file.fileBasedView;
+
+		// Anchor-area outline: only when the comment carries an explicit
+		// area (set by core via the hasArea JSON field for PDF /Rect or
+		// the Width/Height args of .uno:InsertAnnotation). Added before
+		// the marker sub-section so findSectionContainingPoint, which
+		// iterates last-to-first, lets the smaller marker icon take a
+		// click at the rectangle's top-left while the area catches
+		// clicks elsewhere inside the rectangle.
+		if (this.sectionProperties.data.hasArea) {
+			const widthCssPx = this.sectionProperties.data.rectangle[2]
+				* app.twipsToPixels / app.dpiScale;
+			const heightCssPx = this.sectionProperties.data.rectangle[3]
+				* app.twipsToPixels / app.dpiScale;
+			this.sectionProperties.commentAnchorAreaSubSection = new CommentAnchorAreaSubSection(
+				this.name + this.sectionProperties.data.id + '-area' + String(Math.random()),
+				widthCssPx,
+				heightCssPx,
+				new SimplePoint(this.sectionProperties.data.anchorPos[0], this.sectionProperties.data.anchorPos[1]),
+				showMarker,
+				this,
+				this.sectionProperties.data
+			);
+			app.sectionContainer.addSection(this.sectionProperties.commentAnchorAreaSubSection);
+		}
 
 		this.sectionProperties.commentMarkerSubSection = new CommentMarkerSubSection(
 			this.name + this.sectionProperties.data.id + String(Math.random()), // Section name - only as a placeholder.
@@ -838,12 +878,20 @@ export class Comment extends CanvasSectionObject {
 			this.sectionProperties.commentMarkerSubSection.showSection = true;
 			this.sectionProperties.commentMarkerSubSection.onSectionShowStatusChange();
 		}
+		if (this.sectionProperties.commentAnchorAreaSubSection != null) {
+			this.sectionProperties.commentAnchorAreaSubSection.showSection = true;
+			this.sectionProperties.commentAnchorAreaSubSection.onSectionShowStatusChange();
+		}
 	}
 
 	private hideMarker (): void {
 		if (this.sectionProperties.commentMarkerSubSection != null) {
 			this.sectionProperties.commentMarkerSubSection.showSection = false;
 			this.sectionProperties.commentMarkerSubSection.onSectionShowStatusChange();
+		}
+		if (this.sectionProperties.commentAnchorAreaSubSection != null) {
+			this.sectionProperties.commentAnchorAreaSubSection.showSection = false;
+			this.sectionProperties.commentAnchorAreaSubSection.onSectionShowStatusChange();
 		}
 	}
 
@@ -1668,6 +1716,9 @@ export class Comment extends CanvasSectionObject {
 
 		if (this.sectionProperties.commentMarkerSubSection !== null)
 			app.sectionContainer.removeSection(this.sectionProperties.commentMarkerSubSection.name);
+
+		if (this.sectionProperties.commentAnchorAreaSubSection !== null)
+			app.sectionContainer.removeSection(this.sectionProperties.commentAnchorAreaSubSection.name);
 
 		if (container && container.parentElement) {
 			var c: number = 0;

--- a/browser/src/layer/tile/ImpressTileLayer.js
+++ b/browser/src/layer/tile/ImpressTileLayer.js
@@ -128,14 +128,19 @@ window.L.ImpressTileLayer = window.L.CanvasTileLayer.extend({
 		// commentData.position (twips, top-left) lets the caller pin the new
 		// comment to a specific document point; used by the PDF click-to-place
 		// flow. Without it the marker lands at the current viewport top-left.
+		// commentData.size (twips, [w,h]) further pins the marker rectangle
+		// to a user-dragged area; without it the marker stays at the default
+		// 566x566 twips placeholder.
 		const anchorX = commentData.position
 			? commentData.position[0]
 			: app.activeDocument.activeLayout.viewedRectangle.x1;
 		const anchorY = commentData.position
 			? commentData.position[1]
 			: app.activeDocument.activeLayout.viewedRectangle.y1;
+		const w = commentData.size ? commentData.size[0] : 566;
+		const h = commentData.size ? commentData.size[1] : 566;
 		commentData.anchorPos = [anchorX, anchorY];
-		commentData.rectangle = [anchorX, anchorY, 566, 566];
+		commentData.rectangle = [anchorX, anchorY, w, h];
 
 		commentData.parthash = app.impress.partList[this._selectedPart].hash;
 

--- a/cypress_test/integration_tests/desktop/draw/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/annotation_spec.js
@@ -237,15 +237,25 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 			expectedX = docPoint.x;
 			expectedY = docPoint.y;
 
-			// Capture-phase mousedown listener inside startCommentPlacement
-			// consumes this; bubbles:true is needed so the capture path runs.
-			const ev = new win.MouseEvent('mousedown', {
+			// Capture-phase listeners inside startCommentPlacement consume
+			// these; bubbles:true is needed so the capture path runs. A
+			// mouseup at the same point with no mousemove between keeps the
+			// gesture below DRAG_THRESHOLD_PX, so finishCommentPlacement
+			// treats it as a point placement (no Width/Height arg).
+			const downEv = new win.MouseEvent('mousedown', {
 				clientX: rect.left + canvasClickX,
 				clientY: rect.top + canvasClickY,
 				button: 0,
 				bubbles: true,
 			});
-			canvas.dispatchEvent(ev);
+			canvas.dispatchEvent(downEv);
+			const upEv = new win.MouseEvent('mouseup', {
+				clientX: rect.left + canvasClickX,
+				clientY: rect.top + canvasClickY,
+				button: 0,
+				bubbles: true,
+			});
+			canvas.dispatchEvent(upEv);
 		});
 
 		// Local 'new' comment exists with the expected on-screen anchor.
@@ -330,20 +340,29 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 
 		// Off-page click. Compute an X past the page's right edge from
 		// _partWidthTwips so it's guaranteed off-page regardless of zoom or
-		// scroll.
+		// scroll. mousedown+mouseup at the same point keeps the gesture
+		// below DRAG_THRESHOLD_PX so finishCommentPlacement runs and
+		// rejects the off-page point.
 		cy.getFrameWindow().then(function(win) {
 			const canvas = win.document.getElementById('document-canvas');
 			const rect = canvas.getBoundingClientRect();
 			const docLayer = win.app.map._docLayer;
 			const offPageCssX = (docLayer._partWidthTwips
 				* win.app.twipsToPixels) / win.app.dpiScale + 50;
-			const ev = new win.MouseEvent('mousedown', {
+			const downEv = new win.MouseEvent('mousedown', {
 				clientX: rect.left + offPageCssX,
 				clientY: rect.top + 200,
 				button: 0,
 				bubbles: true,
 			});
-			canvas.dispatchEvent(ev);
+			canvas.dispatchEvent(downEv);
+			const upEv = new win.MouseEvent('mouseup', {
+				clientX: rect.left + offPageCssX,
+				clientY: rect.top + 200,
+				button: 0,
+				bubbles: true,
+			});
+			canvas.dispatchEvent(upEv);
 		});
 
 		cy.getFrameWindow().then(function(win) { return helper.processToIdle(win); });
@@ -381,13 +400,20 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 			expectedX = docPoint.x;
 			expectedY = docPoint.y;
 
-			const ev = new win.MouseEvent('mousedown', {
+			const downEv = new win.MouseEvent('mousedown', {
 				clientX: rect.left + canvasClickX,
 				clientY: rect.top + canvasClickY,
 				button: 0,
 				bubbles: true,
 			});
-			canvas.dispatchEvent(ev);
+			canvas.dispatchEvent(downEv);
+			const upEv = new win.MouseEvent('mouseup', {
+				clientX: rect.left + canvasClickX,
+				clientY: rect.top + canvasClickY,
+				button: 0,
+				bubbles: true,
+			});
+			canvas.dispatchEvent(upEv);
 		});
 
 		cy.getFrameWindow().should(function(win) {
@@ -421,6 +447,194 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 			expect(section.sectionProperties.commentList.length,
 				'no comment should remain after cancelling the editor')
 				.to.equal(initialCount);
+		});
+	});
+
+	// Drag-to-area placement: while in placement mode, the user clicks and
+	// drags a rectangle on the page. The anchor lands at the top-left of the
+	// rectangle and the dragged Width/Height reach core, so the new comment's
+	// marker spans the dragged area instead of the default 5x5 mm marker.
+	it('Insert Comment in PDF supports drag-to-area selection', { env: { 'pdf-view': true } }, function() {
+		const commentText = 'drag-to-area-test ' + Date.now();
+		let initialCount = 0;
+
+		cy.getFrameWindow().then(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			initialCount = section.sectionProperties.commentList.length;
+			win.app.map.insertComment();
+		});
+
+		cy.getFrameWindow().should(function(win) {
+			expect(win.document.getElementById('document-canvas').style.cursor,
+				'placement mode must switch the canvas cursor to crosshair')
+				.to.equal('crosshair');
+		});
+
+		// Drag a rectangle from ~25%/25% to ~50%/40% of page 1. Compute the
+		// CSS-pixel positions from twips so the test is zoom-independent.
+		let expectedTLX = 0, expectedTLY = 0;
+		let expectedW = 0, expectedH = 0;
+		cy.getFrameWindow().then(function(win) {
+			const canvas = win.document.getElementById('document-canvas');
+			const rect = canvas.getBoundingClientRect();
+			const docLayer = win.app.map._docLayer;
+
+			const startTwipsX = docLayer._partWidthTwips / 4;
+			const startTwipsY = docLayer._partHeightTwips / 4;
+			const endTwipsX = docLayer._partWidthTwips / 2;
+			const endTwipsY = docLayer._partHeightTwips * 0.4;
+
+			const startCssX = (startTwipsX * win.app.twipsToPixels) / win.app.dpiScale;
+			const startCssY = (startTwipsY * win.app.twipsToPixels) / win.app.dpiScale;
+			const endCssX = (endTwipsX * win.app.twipsToPixels) / win.app.dpiScale;
+			const endCssY = (endTwipsY * win.app.twipsToPixels) / win.app.dpiScale;
+
+			// Top-left of the dragged rectangle (= the anchor).
+			const tlPoint = new win.cool.SimplePoint(0, 0);
+			tlPoint.cX = Math.min(startCssX, endCssX);
+			tlPoint.cY = Math.min(startCssY, endCssY);
+			const docTL = win.app.activeDocument.activeLayout.canvasToDocumentPoint(tlPoint);
+			expectedTLX = docTL.x;
+			expectedTLY = docTL.y;
+			// Bottom-right; canvasToDocumentPoint mutates so build a fresh point.
+			const brPoint = new win.cool.SimplePoint(0, 0);
+			brPoint.cX = Math.max(startCssX, endCssX);
+			brPoint.cY = Math.max(startCssY, endCssY);
+			const docBR = win.app.activeDocument.activeLayout.canvasToDocumentPoint(brPoint);
+			expectedW = docBR.x - expectedTLX;
+			expectedH = docBR.y - expectedTLY;
+
+			const downEv = new win.MouseEvent('mousedown', {
+				clientX: rect.left + startCssX,
+				clientY: rect.top + startCssY,
+				button: 0,
+				bubbles: true,
+			});
+			canvas.dispatchEvent(downEv);
+			const moveEv = new win.MouseEvent('mousemove', {
+				clientX: rect.left + endCssX,
+				clientY: rect.top + endCssY,
+				button: 0,
+				bubbles: true,
+			});
+			canvas.dispatchEvent(moveEv);
+			const upEv = new win.MouseEvent('mouseup', {
+				clientX: rect.left + endCssX,
+				clientY: rect.top + endCssY,
+				button: 0,
+				bubbles: true,
+			});
+			canvas.dispatchEvent(upEv);
+		});
+
+		// Local 'new' comment exists with anchor at the rectangle's top-left
+		// and a marker rectangle that reflects the dragged size.
+		cy.getFrameWindow().should(function(win) {
+			expect(win.document.getElementById('document-canvas').style.cursor,
+				'cursor must be restored after placement finishes')
+				.to.not.equal('crosshair');
+
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			const newComment = section.sectionProperties.commentList.find(
+				function(c) { return c.sectionProperties.data.id === 'new'; });
+			expect(newComment, 'new comment was not created after drag').to.exist;
+			const data = newComment.sectionProperties.data;
+			expect(data.size, 'drag must capture a size').to.exist;
+			expect(data.size[0], 'captured width must match dragged width')
+				.to.be.closeTo(expectedW, 1);
+			expect(data.size[1], 'captured height must match dragged height')
+				.to.be.closeTo(expectedH, 1);
+			expect(data.anchorPos[0],
+				'anchor X must be the rectangle top-left').to.be.closeTo(expectedTLX, 1);
+			expect(data.anchorPos[1],
+				'anchor Y must be the rectangle top-left').to.be.closeTo(expectedTLY, 1);
+			// rectangle = [x, y, width, height] in twips; width/height come from data.size.
+			expect(data.rectangle[2], 'marker rectangle width must reflect drag')
+				.to.be.closeTo(expectedW, 1);
+			expect(data.rectangle[3], 'marker rectangle height must reflect drag')
+				.to.be.closeTo(expectedH, 1);
+		});
+
+		// Type and save - core stores the area as PDF /Rect.
+		cy.cGet('.cool-annotation').last({log: false})
+			.find('#annotation-modify-textarea-new').should('exist');
+		cy.getFrameWindow().then(function(win) { return helper.processToIdle(win); });
+		cy.cGet('.cool-annotation').last({log: false})
+			.find('.modify-annotation .cool-annotation-textarea')
+			.should('not.have.attr', 'disabled');
+		cy.cGet('.cool-annotation').last({log: false})
+			.find('.modify-annotation .cool-annotation-textarea')
+			.type(commentText);
+		cy.cGet('.cool-annotation').last({log: false})
+			.find('[value="Save"]').click();
+
+		// After core's acknowledgement: the area survived twips -> mm/100 -> twips.
+		cy.getFrameWindow().should(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			expect(section.sectionProperties.commentList.length,
+				'commentList must have one more entry after save')
+				.to.equal(initialCount + 1);
+
+			const acked = section.sectionProperties.commentList.find(function(c) {
+				return c.sectionProperties.data.text === commentText;
+			});
+			expect(acked, 'a comment with the typed text must be present').to.exist;
+			expect(acked.sectionProperties.data.id,
+				'core must assign a real (non-\'new\') id').to.not.equal('new');
+
+			const ackRect = acked.sectionProperties.data.rectangle;
+			// Round-trip goes twips -> mm/100 (core) -> twips, so allow a few
+			// twips of rounding slack.
+			expect(ackRect[2],
+				'round-tripped marker width must match the dragged area').to.be.closeTo(expectedW, 5);
+			expect(ackRect[3],
+				'round-tripped marker height must match the dragged area').to.be.closeTo(expectedH, 5);
+			// Core flagged the size as explicit, so Online creates the
+			// anchor-area sub-section underneath the comment marker.
+			expect(acked.sectionProperties.data.hasArea,
+				'core must report hasArea for an explicit-size comment').to.equal('true');
+			expect(acked.sectionProperties.commentAnchorAreaSubSection,
+				'comment must own an anchor-area sub-section').to.exist;
+		});
+
+		// Click on the anchor-area div and verify the comment becomes
+		// the selected one - the area's div has pointer-events:auto and
+		// listens for click directly, no canvas section routing involved.
+		cy.getFrameWindow().then(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			const acked = section.sectionProperties.commentList.find(function(c) {
+				return c.sectionProperties.data.text === commentText;
+			});
+			// Deselect first so the click below has something observable to
+			// flip; selectedComment may already point at our comment after
+			// save.
+			if (section.sectionProperties.selectedComment === acked)
+				acked.onCancelClick(null);
+			const div = acked.sectionProperties.commentAnchorAreaSubSection
+				.sectionProperties.objectDiv;
+			const rect = div.getBoundingClientRect();
+			const cx = rect.left + rect.width / 2;
+			const cy = rect.top + rect.height / 2;
+			['mousedown', 'mouseup', 'click'].forEach(function(t) {
+				div.dispatchEvent(new win.MouseEvent(t, {
+					clientX: cx, clientY: cy, button: 0, bubbles: true,
+				}));
+			});
+		});
+
+		cy.getFrameWindow().should(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			const acked = section.sectionProperties.commentList.find(function(c) {
+				return c.sectionProperties.data.text === commentText;
+			});
+			expect(section.sectionProperties.selectedComment,
+				'clicking on the anchor-area must select the comment')
+				.to.equal(acked);
 		});
 	});
 });


### PR DESCRIPTION
Extend the PDF click-to-place flow with a drag-to-area gesture: while
in placement mode, the user can press, drag, and release to mark out
a rectangle on the page instead of clicking a single point. The
captured rectangle reaches core via the new Width/Height args of
.uno:InsertAnnotation, and core stores it as the comment's anchor
area, exporting it back as the PDF /Rect on save.

Visual feedback during placement: a translucent dashed overlay tracks
the drag, mirroring the rectangle the user is selecting. Below
DRAG_THRESHOLD_PX of movement the gesture falls back to point
placement, so a plain click still works as before.

Once core acknowledges the new comment with hasArea: "true", a new
CommentAnchorAreaSubSection is added underneath the small marker
icon. It renders a 1px-bordered, faintly tinted rectangle that
matches the dragged area, and listens for clicks directly so the
user can activate the comment by clicking anywhere inside the area
rather than only on the small marker icon.

ImpressTileLayer.newAnnotation now sizes the marker rectangle from
commentData.size when present, so the local 'new' marker reflects
the dragged area immediately.

Pairs with engine commit I1c2ded2ecf23415123ee4cc9dad7d0a264a105ad
that adds the Width/Height args to .uno:InsertAnnotation.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: Ie727862b6f915f60e068f5045d5bd1376db0dfcd
Reviewed-on: https://gerrit.collaboraoffice.com/c/online/+/1787
Tested-by: Jenkins CPCI <releng@collaboraoffice.com>
Reviewed-by: Miklos Vajna <vmiklos@collabora.com>
