### PR TITLE
Show drag preview of charts in Writer

### DIFF
--- a/browser/src/app/GraphicSelectionMiddleware.ts
+++ b/browser/src/app/GraphicSelectionMiddleware.ts
@@ -390,16 +390,10 @@ class GraphicSelection {
 			// Workaround for tdf#123874. For some reason the handling of the
 			// shapeselectioncontent messages that we get back causes the WebKit process
 			// to crash on iOS.
-
-			// Note2: scroll to frame in writer would result an error:
-			//   svgexport.cxx:810: ...UnknownPropertyException message: "Background
-			var isFrame = extraInfo.type == 601 && !extraInfo.isWriterGraphic;
-
 			if (
 				!window.ThisIsTheiOSApp &&
 				this.extraInfo.isDraggable &&
-				!this.extraInfo.svg &&
-				!isFrame
+				!this.extraInfo.svg
 			) {
 				app.socket.sendMessage('rendershapeselection mimetype=image/svg+xml');
 			}


### PR DESCRIPTION
  Until now MouseControl / ShapeHandlesSection's semi-transparent drag
  preview worked for charts in Calc and Impress but not in Writer:
  charts there are wrapped in a Writer fly (type 601) without an
  isWriterGraphic flag, so the type == 601 && !isWriterGraphic
  "isFrame" guard suppressed the rendershapeselection request and the
  preview never had an SVG to show.

  Drop the guard.  Together with the writer_svg_Export change that
  makes selected charts render as SVG, and the sfxbasemodel guard that
  keeps an internal render failure from popping up as a user-facing
  "Document cannot be exported" dialog, charts in Writer now show the
  same drag preview as in Calc / Impress.  Plain Writer text frames
  (the case the workaround was originally added for, tdf#123874) still
  behave the same way for the user: the kit returns 0 bytes, no
  shapeselectioncontent message is sent, no preview, no dialog.


Change-Id: I2952c6d96c91b49e8fc0f3800cdd02a1fe514dd5


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

