### PR TITLE
11754 jsdepend: replace jQuery ID selectors with getElementById (batch 1)

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -914,7 +914,12 @@ export class CommentSection extends CanvasSectionObject {
 	/// returns canvas top and bottom position in core pixels
 	public getScreenTopBottom(): Array<number> {
 		const screenTop = app.activeDocument.activeView.viewedRectangle.pY1;
-		const screenBottom = screenTop + this.cssToCorePixels($('#map').height());
+		const mapEl = document.getElementById('map');
+		if (!mapEl) {
+			console.warn("HTML element with ID map doesn't exist.");
+			return [screenTop, screenTop];
+		}
+		const screenBottom = screenTop + this.cssToCorePixels(mapEl.getBoundingClientRect().height);
 
 		return [screenTop, screenBottom];
 	}

--- a/browser/src/canvas/sections/ContentControlDropdownSubSection.ts
+++ b/browser/src/canvas/sections/ContentControlDropdownSubSection.ts
@@ -57,14 +57,18 @@ class ContentControlDropdownSubSection extends HTMLObjectSection {
 	}
 
 	private showDatePicker(): void {
-		if ($('#datepicker').is(':visible')) {
-			$('#datepicker').hide();
+		const datePicker = document.getElementById('datepicker');
+		if (!datePicker) {
+			console.warn("HTML element with ID datepicker doesn't exist.");
+			return;
+		}
+		if (getComputedStyle(datePicker).display !== 'none') {
+			datePicker.style.display = 'none';
 		} else {
-			var datePicker = document.getElementById('datepicker');
 			datePicker.style.left = String(this.myTopLeft[0] / app.dpiScale) + 'px';
 			datePicker.style.top =
 				String((this.myTopLeft[1] + this.size[1]) / app.dpiScale) + 'px';
-			$('#datepicker').show();
+			datePicker.style.display = '';
 		}
 	}
 

--- a/browser/src/canvas/sections/ContentControlSection.ts
+++ b/browser/src/canvas/sections/ContentControlSection.ts
@@ -70,7 +70,8 @@ export class ContentControlSection extends CanvasSectionObject {
 					}
 				}
 			});
-			$('#datepicker').hide();
+			const datepickerEl = document.getElementById('datepicker');
+			if (datepickerEl) datepickerEl.style.display = 'none';
 		} else
 			$('#datepicker').datepicker('destroy');
 

--- a/browser/src/control/Control.DocumentNameInput.js
+++ b/browser/src/control/Control.DocumentNameInput.js
@@ -12,7 +12,7 @@
  * L.Control.DocumentNameInput
  */
 
-/* global _ */
+/* global $ _ */
 L.Control.DocumentNameInput = L.Control.extend({
 
 	onAdd: function (map) {

--- a/browser/src/control/Control.DocumentNameInput.js
+++ b/browser/src/control/Control.DocumentNameInput.js
@@ -12,7 +12,7 @@
  * L.Control.DocumentNameInput
  */
 
-/* global $ _ */
+/* global _ */
 L.Control.DocumentNameInput = L.Control.extend({
 
 	onAdd: function (map) {
@@ -59,28 +59,50 @@ L.Control.DocumentNameInput = L.Control.extend({
 		if (this._renaming)
 			return;
 
-		$('#document-name-input').val(this.map['wopi'].BreadcrumbDocName);
+		const nameInput = document.getElementById('document-name-input');
+		if (!nameInput) {
+			console.warn("HTML element with ID document-name-input doesn't exist.");
+			return;
+		}
+		nameInput.value = this.map['wopi'].BreadcrumbDocName;
 		this.map._onGotFocus();
 	},
 
 	disableDocumentNameInput : function() {
-		$('#document-name-input').prop('disabled', true);
-		$('#document-name-input').removeClass('editable');
-		$('#document-name-input').off('keypress', this.onDocumentNameKeyPress);
+		const nameInput = document.getElementById('document-name-input');
+		if (!nameInput) {
+			console.warn("HTML element with ID document-name-input doesn't exist.");
+			return;
+		}
+		nameInput.disabled = true;
+		nameInput.classList.remove('editable');
+		nameInput.removeEventListener('keypress', this.onDocumentNameKeyPress);
 	},
 
 	enableDocumentNameInput : function() {
-		$('#document-name-input').prop('disabled', false);
-		$('#document-name-input').addClass('editable');
-		$('#document-name-input').off('keypress', this.onDocumentNameKeyPress).on('keypress', this.onDocumentNameKeyPress.bind(this));
-		$('#document-name-input').off('focus', this.onDocumentNameFocus).on('focus', this.onDocumentNameFocus.bind(this));
-		$('#document-name-input').off('blur', this.documentNameCancel).on('blur', this.documentNameCancel.bind(this));
+		const nameInput = document.getElementById('document-name-input');
+		if (!nameInput) {
+			console.warn("HTML element with ID document-name-input doesn't exist.");
+			return;
+		}
+		nameInput.disabled = false;
+		nameInput.classList.add('editable');
+		nameInput.removeEventListener('keypress', this.onDocumentNameKeyPress);
+		nameInput.addEventListener('keypress', this.onDocumentNameKeyPress.bind(this));
+		nameInput.removeEventListener('focus', this.onDocumentNameFocus);
+		nameInput.addEventListener('focus', this.onDocumentNameFocus.bind(this));
+		nameInput.removeEventListener('blur', this.documentNameCancel);
+		nameInput.addEventListener('blur', this.documentNameCancel.bind(this));
 	},
 
 	onDocumentNameKeyPress: function(e) {
 		if (e.keyCode === 13) { // Enter key
-			var value = $('#document-name-input').val();
-			this.documentNameConfirm(value);
+			const nameInput = document.getElementById('document-name-input');
+			if (!nameInput) {
+				console.warn("HTML element with ID document-name-input doesn't exist.");
+				return;
+			}
+			this.documentNameConfirm(nameInput.value);
 		} else if (e.keyCode === 27) { // Escape key
 			this.documentNameCancel();
 		}
@@ -94,13 +116,22 @@ L.Control.DocumentNameInput = L.Control.extend({
 		var extn = name.lastIndexOf('.');
 		if (extn < 0)
 			extn = name.length;
-		$('#document-name-input').val(name);
-		$('#document-name-input')[0].setSelectionRange(0, extn);
+		const nameInput = document.getElementById('document-name-input');
+		if (!nameInput) {
+			console.warn("HTML element with ID document-name-input doesn't exist.");
+			return;
+		}
+		nameInput.value = name;
+		nameInput.setSelectionRange(0, extn);
 	},
 
 	onDocLayerInit: function() {
 
-		var el = $('#document-name-input');
+		const el = document.getElementById('document-name-input');
+		if (!el) {
+			console.warn("HTML element with ID document-name-input doesn't exist.");
+			return;
+		}
 
 		try {
 			var fileNameFullPath = new URL(
@@ -112,30 +143,30 @@ L.Control.DocumentNameInput = L.Control.extend({
 			var basePath = fileNameFullPath.replace(this.map['wopi'].BaseFileName , '').replace(/\/$/, '');
 			var title = this.map['wopi'].BaseFileName + '\n' + _('Path') + ': ' + basePath;
 
-			el.prop('title', title);
+			el.title = title;
 		} catch (e) {
 			// purposely ignore the error for legacy browsers
 		}
 
 		// FIXME: Android app would display a temporary filename, not the actual filename
 		if (window.ThisIsTheAndroidApp) {
-			el.hide();
+			el.style.display = 'none';
 		} else {
-			el.show();
+			el.style.display = '';
 		}
 
 		if (window.ThisIsAMobileApp) {
 			// We can now set the document name in the menu bar
-			el.prop('disabled', false);
-			el.removeClass('editable');
-			el.focus(function() { $(this).blur(); });
+			el.disabled = false;
+			el.classList.remove('editable');
+			el.addEventListener('focus', function() { this.blur(); });
 			// Call decodeURIComponent twice: Reverse both our encoding and the encoding of
 			// the name in the file system.
-			el.val(decodeURIComponent(decodeURIComponent(this.map.options.doc.replace(/.*\//, '')))
+			el.value = decodeURIComponent(decodeURIComponent(this.map.options.doc.replace(/.*\//, '')))
 							  // To conveniently see the initial visualViewport scale and size, un-comment the following line.
 							  // + ' (' + window.visualViewport.scale + '*' + window.visualViewport.width + 'x' + window.visualViewport.height + ')'
 							  // TODO: Yes, it would be better to see it change as you rotate the device or invoke Split View.
-							 );
+							 ;
 		}
 
 		if (this.map.isReadOnlyMode()) {
@@ -146,8 +177,12 @@ L.Control.DocumentNameInput = L.Control.extend({
 	onWopiProps: function(e) {
 		if (e.BaseFileName !== null) {
 			// set the document name into the name field
-			$('#document-name-input').val(e.BreadcrumbDocName !== undefined ? e.BreadcrumbDocName : e.BaseFileName);
 			var input = L.DomUtil.get('document-name-input');
+			if (!input) {
+				console.warn("HTML element with ID document-name-input doesn't exist.");
+				return;
+			}
+			input.value = e.BreadcrumbDocName !== undefined ? e.BreadcrumbDocName : e.BaseFileName;
 			input.setAttribute('data-cooltip', input.value);
 			L.control.attachTooltipEventListener(input, this.map);
 		}
@@ -175,16 +210,32 @@ L.Control.DocumentNameInput = L.Control.extend({
 
 	showLoadingAnimation : function() {
 		this.disableDocumentNameInput();
-		$('#document-name-input-loading-bar').css('display', 'block');
+		const loadingBar = document.getElementById('document-name-input-loading-bar');
+		if (!loadingBar) {
+			console.warn("HTML element with ID document-name-input-loading-bar doesn't exist.");
+			return;
+		}
+		loadingBar.style.display = 'block';
 	},
 
 	hideLoadingAnimation : function() {
 		this.enableDocumentNameInput();
-		$('#document-name-input-loading-bar').css('display', 'none');
+		const loadingBar = document.getElementById('document-name-input-loading-bar');
+		if (!loadingBar) {
+			console.warn("HTML element with ID document-name-input-loading-bar doesn't exist.");
+			return;
+		}
+		loadingBar.style.display = 'none';
 	},
 
 	_getMaxAvailableWidth: function() {
-		var x = $('#document-titlebar').prop('offsetLeft') + $('.document-title').prop('offsetLeft') + $('#document-name-input').prop('offsetLeft');
+		const titlebar = document.getElementById('document-titlebar');
+		const nameInput = document.getElementById('document-name-input');
+		if (!titlebar || !nameInput) {
+			console.warn("HTML element with ID document-titlebar or document-name-input doesn't exist.");
+			return 300;
+		}
+		var x = titlebar.offsetLeft + $('.document-title').prop('offsetLeft') + nameInput.offsetLeft;
 		var containerWidth = parseInt($('.main-nav').css('width'));
 		var maxWidth = Math.max(containerWidth - x - 30, 0);
 		maxWidth = Math.max(maxWidth, 300); // input field at least 300px

--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -217,11 +217,21 @@ L.Control.DownloadProgress = L.Control.extend({
 	},
 
 	_setProgressCursor: function() {
-		$('#map').css('cursor', 'progress');
+		const mapEl = document.getElementById('map');
+		if (!mapEl) {
+			console.warn('HTML element with ID map doesn\'t exist.');
+			return;
+		}
+		mapEl.style.cursor = 'progress';
 	},
 
 	_setNormalCursor: function() {
-		$('#map').css('cursor', 'default');
+		const mapEl = document.getElementById('map');
+		if (!mapEl) {
+			console.warn('HTML element with ID map doesn\'t exist.');
+			return;
+		}
+		mapEl.style.cursor = 'default';
 	},
 
 	startProgressMode: function() {

--- a/browser/src/control/Control.DownloadProgress.js
+++ b/browser/src/control/Control.DownloadProgress.js
@@ -11,7 +11,7 @@
 /*
  * L.Control.DownloadProgress.
  */
-/* global _ $ JSDialog app */
+/* global _ JSDialog app */
 L.Control.DownloadProgress = L.Control.extend({
 	options: {
 		snackbarTimeout: 20000,

--- a/browser/src/control/Control.MobileTopBar.ts
+++ b/browser/src/control/Control.MobileTopBar.ts
@@ -96,7 +96,8 @@ class MobileTopBar extends JSDialog.Toolbar {
 				this.showItem(id, false);
 			});
 			this.showItem('comment_wizard', true);
-			if ($('#mobile-edit-button').is(':hidden')) {
+			const mobileEditButton = document.getElementById('mobile-edit-button');
+			if (!mobileEditButton || getComputedStyle(mobileEditButton).display === 'none') {
 				this.showItem('PermissionMode', true);
 			}
 		}

--- a/browser/src/control/Control.Tabs.js
+++ b/browser/src/control/Control.Tabs.js
@@ -392,7 +392,12 @@ L.Control.Tabs = L.Control.extend({
 
 	_deleteSheet: function() {
 		var nPos = this._tabForContextMenu;
-		var message = _('Are you sure you want to delete sheet, {sheet}?').replace('{sheet}', $('#spreadsheet-tab' + this._tabForContextMenu).text());
+		const tabEl = document.getElementById('spreadsheet-tab' + this._tabForContextMenu);
+		if (!tabEl) {
+			console.warn("HTML element with ID spreadsheet-tab" + this._tabForContextMenu + " doesn't exist.");
+			return;
+		}
+		var message = _('Are you sure you want to delete sheet, {sheet}?').replace('{sheet}', tabEl.textContent);
 
 		this._map.uiManager.showInfoModal('delete-sheet-modal', '', message, '', _('OK'), function() {
 			this._map.deletePage(nPos);
@@ -402,7 +407,12 @@ L.Control.Tabs = L.Control.extend({
 	_renameSheet: function() {
 		var map = this._map;
 		var nPos = this._tabForContextMenu;
-		var tabName = $('#spreadsheet-tab' + this._tabForContextMenu).text();
+		const renameTabEl = document.getElementById('spreadsheet-tab' + this._tabForContextMenu);
+		if (!renameTabEl) {
+			console.warn("HTML element with ID spreadsheet-tab" + this._tabForContextMenu + " doesn't exist.");
+			return;
+		}
+		var tabName = renameTabEl.textContent;
 		this._map.uiManager.showInputModal('rename-calc-sheet', _('Rename sheet'), _('Enter new sheet name'), tabName, _('OK'),
 			function (value) {
 				map.renamePage(value, nPos);

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -278,8 +278,12 @@ var sendInsertTableFunction = function(event) {
 	var col = $(event.target).index() + 1;
 	var row = $(event.target).parent().index() + 1;
 	$('.col').removeClass('bright');
-	var status = $('#inserttable-status')
-	status.html('<br/>');
+	const status = document.getElementById('inserttable-status');
+	if (!status) {
+		console.warn("HTML element with ID inserttable-status doesn't exist.");
+	} else {
+		status.innerHTML = '<br/>';
+	}
 	var msg = 'uno .uno:InsertTable {' +
 		' "Columns": { "type": "long","value": '
 		+ col +
@@ -1064,21 +1068,28 @@ function onUpdatePermission(e) {
 				if (!keepDisabled || alwaysEnable)
 					toolbar.enableItem(items[idx].id, true);
 				$('.main-nav').removeClass('readonly');
-				$('#toolbar-down').removeClass('readonly');
+				const toolbarDown1 = document.getElementById('toolbar-down');
+				if (toolbarDown1) toolbarDown1.classList.remove('readonly');
 			} else if (!alwaysEnable) {
 				$('.main-nav').addClass('readonly');
-				$('#toolbar-down').addClass('readonly');
+				const toolbarDown2 = document.getElementById('toolbar-down');
+				if (toolbarDown2) toolbarDown2.classList.add('readonly');
 				toolbar.enableItem(items[idx].id, false);
 			}
 		}
 
+		const toolbarMobileBack = document.getElementById('toolbar-mobile-back');
 		if (e.detail.perm === 'edit') {
-			$('#toolbar-mobile-back').removeClass('editmode-off');
-			$('#toolbar-mobile-back').addClass('editmode-on');
+			if (toolbarMobileBack) {
+				toolbarMobileBack.classList.remove('editmode-off');
+				toolbarMobileBack.classList.add('editmode-on');
+			}
 			toolbar.updateItem({id: 'closemobile', type: 'customtoolitem', w2icon: 'editmode'});
 		} else {
-			$('#toolbar-mobile-back').removeClass('editmode-on');
-			$('#toolbar-mobile-back').addClass('editmode-off');
+			if (toolbarMobileBack) {
+				toolbarMobileBack.classList.remove('editmode-on');
+				toolbarMobileBack.classList.add('editmode-off');
+			}
 			toolbar.updateItem({id: 'closemobile', type: 'customtoolitem', w2icon: 'closemobile'});
 		}
 	}
@@ -1101,11 +1112,14 @@ function editorUpdate(e) { // eslint-disable-line no-unused-vars
 
 global.editorUpdate = editorUpdate;
 
-$(document).ready(function() {
+document.addEventListener('DOMContentLoaded', function() {
 	// Attach insert file action
-	$('#insertgraphic').on('change', onInsertGraphic);
-	$('#insertmultimedia').on('change', onInsertMultimedia);
-	$('#selectbackground').on('change', onInsertBackground);
+	const insertGraphic = document.getElementById('insertgraphic');
+	if (insertGraphic) insertGraphic.addEventListener('change', onInsertGraphic);
+	const insertMultimedia = document.getElementById('insertmultimedia');
+	if (insertMultimedia) insertMultimedia.addEventListener('change', onInsertMultimedia);
+	const selectBackground = document.getElementById('selectbackground');
+	if (selectBackground) selectBackground.addEventListener('change', onInsertBackground);
 });
 
 function setupToolbar(e) {
@@ -1123,10 +1137,15 @@ function setupToolbar(e) {
 			toolbar.enableItem('searchnext', false);
 			toolbar.showItem('cancelsearch', false);
 			L.DomUtil.addClass(searchInput, 'search-not-found');
-			$('#findthis').addClass('search-not-found');
+			const findThis = document.getElementById('findthis');
+			if (!findThis) {
+				console.warn("HTML element with ID findthis doesn't exist.");
+			} else {
+				findThis.classList.add('search-not-found');
+			}
 			app.searchService.resetSelection();
 			setTimeout(function () {
-				$('#findthis').removeClass('search-not-found');
+				if (findThis) findThis.classList.remove('search-not-found');
 				L.DomUtil.removeClass(searchInput, 'search-not-found');
 			}, 800);
 		}
@@ -1154,8 +1173,13 @@ function setupToolbar(e) {
 	map.on('commandresult', onCommandResult);
 	map.on('updateparts pagenumberchanged', onUpdateParts);
 
+	const closebuttonwrapper = document.getElementById('closebuttonwrapper');
 	if (map.options.wopi && L.Params.closeButtonEnabled && !window.mode.isMobile()) {
-		$('#closebuttonwrapper').css('display', 'flex');
+		if (!closebuttonwrapper) {
+			console.warn("HTML element with ID closebuttonwrapper doesn't exist.");
+		} else {
+			closebuttonwrapper.style.display = 'flex';
+		}
 		var button = L.DomUtil.get('closebutton');
 		if (button) {
 			const closeButtonText = _('Close document');
@@ -1164,19 +1188,25 @@ function setupToolbar(e) {
 			L.control.attachTooltipEventListener(button, map);
 		}
 	} else if (!L.Params.closeButtonEnabled) {
-		$('#closebuttonwrapper').hide();
-		$('#closebuttonwrapperseparator').hide();
+		if (closebuttonwrapper) closebuttonwrapper.style.display = 'none';
+		const closebuttonwrapperseparator = document.getElementById('closebuttonwrapperseparator');
+		if (closebuttonwrapperseparator) closebuttonwrapperseparator.style.display = 'none';
 	} else if (L.Params.closeButtonEnabled && !window.mode.isMobile()) {
-		$('#closebuttonwrapper').css('display', 'flex');
+		if (closebuttonwrapper) closebuttonwrapper.style.display = 'flex';
 	}
 
-	$('#closebutton').click(function () {
-		let dispatcher = global.app.dispatcher;
-		if (!dispatcher)
-			dispatcher = new app.definitions['dispatcher']('global');
+	const closebutton = document.getElementById('closebutton');
+	if (!closebutton) {
+		console.warn("HTML element with ID closebutton doesn't exist.");
+	} else {
+		closebutton.addEventListener('click', function () {
+			let dispatcher = global.app.dispatcher;
+			if (!dispatcher)
+				dispatcher = new app.definitions['dispatcher']('global');
 
-		dispatcher.dispatch('closeapp');
-	});
+			dispatcher.dispatch('closeapp');
+		});
+	}
 }
 
 global.setupToolbar = setupToolbar;

--- a/browser/src/control/Permission.js
+++ b/browser/src/control/Permission.js
@@ -11,7 +11,7 @@
 /*
  * Document permission handler
  */
-/* global app $ _ */
+/* global app _ */
 L.Map.include({
 	readonlyStartingFormats: {
 		'txt': { canEdit: true, odfFormat: 'odt' },
@@ -20,12 +20,19 @@ L.Map.include({
 	},
 
 	setPermission: function (perm) {
-		var button = $('#mobile-edit-button');
-		button.off('click');
-		button.attr('tabindex', 0);
-		button.attr('role', 'button');
-		button.attr('title', _('Edit document'));
-		button.attr('aria-label', _('Edit document'));
+		const button = document.getElementById('mobile-edit-button');
+		if (!button) {
+			console.warn("HTML element with ID mobile-edit-button doesn't exist.");
+			return;
+		}
+		if (button._clickHandler) {
+			button.removeEventListener('click', button._clickHandler);
+			button._clickHandler = null;
+		}
+		button.tabIndex = 0;
+		button.setAttribute('role', 'button');
+		button.title = _('Edit document');
+		button.setAttribute('aria-label', _('Edit document'));
 		// app.file.fileBasedView is new view that has continuous scrolling
 		// used for PDF and we don't permit editing for PDFs
 		// this._shouldStartReadOnly() is a check for files that should start in readonly mode and even on desktop browser
@@ -36,16 +43,17 @@ L.Map.include({
 		// we offer save-as to another place where the user can edit the document
 		var isPDF = app.file.fileBasedView && app.file.editComment;
 		if (!isPDF && (this._shouldStartReadOnly() || window.mode.isMobile() || window.mode.isTablet())) {
-			button.css('display', 'flex');
+			button.style.display = 'flex';
 		} else {
-			button.hide();
+			button.style.display = 'none';
 		}
 		var that = this;
 		if (perm === 'edit') {
 			if (this._shouldStartReadOnly() || window.mode.isMobile() || window.mode.isTablet()) {
-				button.on('click', function () {
+				button._clickHandler = function () {
 					that._switchToEditMode();
-				});
+				};
+				button.addEventListener('click', button._clickHandler);
 
 				// temporarily, before the user touches the floating action button
 				this._enterReadOnlyMode('readonly');
@@ -60,16 +68,18 @@ L.Map.include({
 		}
 		else if (perm === 'view' || perm === 'readonly') {
 			if (this.isLockedReadOnlyUser()) {
-				button.on('click', function () {
+				button._clickHandler = function () {
 					that.openUnlockPopup();
-				});
+				};
+				button.addEventListener('click', button._clickHandler);
 			}
 			else if (window.ThisIsTheAndroidApp) {
-				button.on('click', function () {
+				button._clickHandler = function () {
 					that._requestFileCopy();
-				});
+				};
+				button.addEventListener('click', button._clickHandler);
 			} else if ((!window.ThisIsAMobileApp && !this['wopi'].UserCanWrite) || (!this.options.canTryLock && (window.mode.isMobile() || window.mode.isTablet()))) {
-				$('#mobile-edit-button').hide();
+				button.style.display = 'none';
 			}
 
 			this._enterReadOnlyMode(perm);
@@ -126,7 +136,12 @@ L.Map.include({
 				return;
 		}
 		this.options.canTryLock = false; // don't respond to lockfailed anymore
-		$('#mobile-edit-button').hide();
+		const editButton = document.getElementById('mobile-edit-button');
+		if (!editButton) {
+			console.warn("HTML element with ID mobile-edit-button doesn't exist.");
+		} else {
+			editButton.style.display = 'none';
+		}
 		this._enterEditMode('edit');
 		if (window.mode.isMobile() || window.mode.isTablet()) {
 			this.fire('editorgotfocus');

--- a/browser/src/docdispatcher.ts
+++ b/browser/src/docdispatcher.ts
@@ -258,17 +258,26 @@ class Dispatcher {
 			app.map.cancelSearch();
 		};
 		this.actionsMap['showsearchbar'] = () => {
-			$('#toolbar-down').hide();
-			$('#showsearchbar').removeClass('over');
-			$('#toolbar-search').show();
+			const toolbarDown = document.getElementById('toolbar-down');
+			if (toolbarDown) toolbarDown.style.display = 'none';
+			const showsearchbar = document.getElementById('showsearchbar');
+			if (showsearchbar) showsearchbar.classList.remove('over');
+			const toolbarSearch = document.getElementById('toolbar-search');
+			if (toolbarSearch) toolbarSearch.style.display = '';
 			L.DomUtil.get('search-input').focus();
 		};
 		this.actionsMap['hidesearchbar'] = () => {
-			$('#toolbar-search').hide();
-			if (app.map.isEditMode()) $('#toolbar-down').show();
+			const toolbarSearch = document.getElementById('toolbar-search');
+			if (toolbarSearch) toolbarSearch.style.display = 'none';
+			if (app.map.isEditMode()) {
+				const toolbarDown = document.getElementById('toolbar-down');
+				if (toolbarDown) toolbarDown.style.display = '';
+			}
 			/** show edit button if only we are able to edit but in readonly mode */
-			if (!app.isReadOnly() && app.map.isReadOnlyMode())
-				$('#mobile-edit-button').css('display', 'flex');
+			if (!app.isReadOnly() && app.map.isReadOnlyMode()) {
+				const mobileEditButton = document.getElementById('mobile-edit-button');
+				if (mobileEditButton) mobileEditButton.style.display = 'flex';
+			}
 		};
 
 		this.actionsMap['prev'] = () => {
@@ -448,23 +457,29 @@ class Dispatcher {
 
 		// sheets toolbar
 		this.actionsMap['insertsheet'] = function () {
-			var nPos = $('#spreadsheet-tab-scroll')[0].childElementCount;
+			const tabScroll = document.getElementById('spreadsheet-tab-scroll');
+			if (!tabScroll) {
+				console.warn(
+					"HTML element with ID spreadsheet-tab-scroll doesn't exist.",
+				);
+				return;
+			}
+			var nPos = tabScroll.childElementCount;
 			app.map.insertPage(nPos);
 			app.map.insertPage.scrollToEnd = true;
 		};
 		this.actionsMap['firstrecord'] = function () {
-			$('#spreadsheet-tab-scroll').scrollLeft(0);
+			const tabScroll = document.getElementById('spreadsheet-tab-scroll');
+			if (tabScroll) tabScroll.scrollLeft = 0;
 		};
 		this.actionsMap['nextrecord'] = function () {
 			// TODO: We should get visible tab's width instead of 60px
-			$('#spreadsheet-tab-scroll').scrollLeft(
-				$('#spreadsheet-tab-scroll').scrollLeft() + 60,
-			);
+			const tabScroll = document.getElementById('spreadsheet-tab-scroll');
+			if (tabScroll) tabScroll.scrollLeft = tabScroll.scrollLeft + 60;
 		};
 		this.actionsMap['prevrecord'] = function () {
-			$('#spreadsheet-tab-scroll').scrollLeft(
-				$('#spreadsheet-tab-scroll').scrollLeft() - 30,
-			);
+			const tabScroll = document.getElementById('spreadsheet-tab-scroll');
+			if (tabScroll) tabScroll.scrollLeft = tabScroll.scrollLeft - 30;
 		};
 		this.actionsMap['lastrecord'] = function () {
 			// Set a very high value, so that scroll is set to the maximum possible value internally.

--- a/browser/src/map/handler/Map.StateChanges.js
+++ b/browser/src/map/handler/Map.StateChanges.js
@@ -95,15 +95,20 @@ L.Map.StateChangeHandler = L.Handler.extend({
 			this._items[commandName] = links;
 		}
 
-		$('#document-container').removeClass('slide-master-mode');
-		$('#document-container').addClass('slide-normal-mode');
+		const docContainer = document.getElementById('document-container');
+		if (!docContainer) {
+			console.warn('HTML element with ID document-container doesn\'t exist.');
+			return;
+		}
+		docContainer.classList.remove('slide-master-mode');
+		docContainer.classList.add('slide-normal-mode');
 		if (slideMasterPageItem) {
-			$('#document-container').removeClass('slide-normal-mode');
-			$('#document-container').addClass('slide-master-mode');
+			docContainer.classList.remove('slide-normal-mode');
+			docContainer.classList.add('slide-master-mode');
 		}
 		if (!slideMasterPageItem || slideMasterPageItem == 'false' || slideMasterPageItem == 'undefined') {
-			$('#document-container').removeClass('slide-master-mode');
-			$('#document-container').addClass('slide-normal-mode');
+			docContainer.classList.remove('slide-master-mode');
+			docContainer.classList.add('slide-normal-mode');
 		}
 	},
 


### PR DESCRIPTION
* Resolves: #11754 
* Target version: main
* Change-Id: I0a6fc0cd9f2b851bb39ecf2a4c502fd58aa5dd8f

### Summary

Part of gh#11754 — Remove jQuery dependency

This is the first batch of changes replacing jQuery ID selectors ($('#element-id')) with native document.getElementById('element-id') across the codebase.

What was changed

Replaced all $('#id') jQuery selectors with document.getElementById('id')
Converted chained jQuery methods (.hide(), .show(), .addClass(), .removeClass(), .css(), .val(), .on(), .off(), .prop(), .scrollLeft()) to their native equivalents
Added null-guards with console.warn for elements that should always be present, mimicking jQuery's silent-fail behaviour while alerting developers when an element is missing
Files changed (one commit per file)

- Map.StateChanges.js
- Control.DownloadProgress.js
- Control.DocumentNameInput.js
- Permission.js
- Control.Tabs.js
- Control.MobileTopBar.ts
- Control.Toolbar.js
- docdispatcher.ts
- CommentListSection.ts
- ContentControlDropdownSubSection.ts
- ContentControlSection.ts

**Note: j**Query UI .datepicker() plugin calls in ContentControlSection.ts were intentionally left unchanged as they require a separate full widget replacement.



### Checklist

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [ ] I have run tests with `make check`
- [x] I have issued `make run` and manually verified that everything looks okay
- [x] Documentation (manuals or wiki) has been updated or is not required

