### PR TITLE
Calc Issue: After mouse up event, cell selection continues.

### DIFF
--- a/browser/src/canvas/CanvasSectionContainer.ts
+++ b/browser/src/canvas/CanvasSectionContainer.ts
@@ -1459,7 +1459,9 @@ class CanvasSectionContainer {
 			return;
 		}
 
-		this.clearMousePositions();
+		if (!this.draggingSomething)
+			this.clearMousePositions();
+
 		this.width = newWidth;
 		this.height = newHeight;
 		this.needsResize = true;


### PR DESCRIPTION
Root cause: In some themes, notebookbar size is slightly modified. This triggers canvas element's onResize handler. onResize handler clears mouse positions, because it assumes that size wouldn't change during a dragging operation.

Fix: Don't clear positions if dragging is active. This will cause slighlty off coordinates but acceptable for small unnoticable differences like few pixels. Because intentional resize while dragging is not expected.


Change-Id: I4c9672b4f5a1a1ced7263fd5b86ca5d05b1a35ef


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

