### PR TITLE
browser: drop redundant scroll from Comment.highlight() for Draw/Impress

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -708,11 +708,6 @@ export class Comment extends CanvasSectionObject {
 			var y: number = Math.round(this.position[1] / app.dpiScale);
 			(this.containerObject.getSectionWithName(app.CSections.Scroll.name) as any as cool.ScrollSection).onScrollTo({x: x, y: y});
 		}
-		else if (app.map._docLayer._docType === 'presentation' || app.map._docLayer._docType === 'drawing') {
-			var x: number = Math.round(this.position[0] / app.dpiScale);
-			var y: number = Math.round(this.position[1] / app.dpiScale);
-			(this.containerObject.getSectionWithName(app.CSections.Scroll.name) as any as cool.ScrollSection).onScrollTo({x: x, y: y});
-		}
 
 		this.containerObject.requestReDraw();
 		this.sectionProperties.isHighlighted = true;

--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -1266,7 +1266,7 @@ function waitUntilCoreIsIdle(win) {
 		win.app.socket.sendMessage('uno .uno:ReportWhenIdle ' + JSON.stringify(idleArgs));
 	});
 
-	cy.wrap(null).should(function() {
+	cy.wrap(null, { timeout: Cypress.config('defaultCommandTimeout') * 2.0 }).should(function() {
 		var matchingCall = spy.getCalls().find(function(call) {
 			var evt = call.args && call.args[0];
 			var textMsg = evt && evt.textMsg;


### PR DESCRIPTION
- https://github.com/CollaboraOnline/online/commit/0adef6df44d650a2165035731e315f21287154ce fixes `draw/annotation_spec.js` flakiness