### PR TITLE
slide tab: use PageDown key to move focus into slide previews (backport)

### DIFF
--- a/browser/src/control/jsdialog/Util.KeyboardTabNavigation.ts
+++ b/browser/src/control/jsdialog/Util.KeyboardTabNavigation.ts
@@ -108,6 +108,7 @@ function handleTabKeydown(
 			break;
 
 		case 'ArrowDown':
+		case 'PageDown':
 			moveFocusIntoTabPage(contentDivs, currentTab);
 			break;
 


### PR DESCRIPTION
problem:
when switching between outline and slide tab,
we could get focus to slides preview with arrow down but not with page down

fixed #12101


Change-Id: I7e4d051ad0521f026ed3e785bb43bdf517ec0fe2


* Resolves: # <!-- related github issue -->
* Target version: 25.04

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

