### PR TITLE
[backport] Calc a11y: focus on prev/next element in the dialog

### DIFF
--- a/browser/src/control/jsdialog/Util.StateChange.ts
+++ b/browser/src/control/jsdialog/Util.StateChange.ts
@@ -32,6 +32,25 @@ function onStateChange(element: Element, callback: StateChangeCallback) {
 	enableObserver.observe(element, { attributeFilter: ['disabled'], attributeOldValue: true });
 }
 
+function moveFocusFromDisabledElement(widget: Element) {
+	const dialog = widget.closest('.jsdialog-window');
+	if (!dialog) return;
+	const next = JSDialog.FindFocusableElement(widget.nextElementSibling, 'next');
+	if (next) {
+		next.focus();
+		return;
+	}
+	const prev = JSDialog.FindFocusableElement(widget.previousElementSibling, 'prev');
+	if (prev) {
+		prev.focus();
+		return;
+	}
+	const focusable = JSDialog.GetFocusableElements(dialog);
+	if (focusable && focusable.length) {
+		focusable[0].focus();
+	}
+}
+
 function synchronizeDisabledState(source: Element, targets: Array<Element>) {
 	const enabledCallback = function (enable: boolean) {
 		app.layoutingService.appendLayoutingTask(() => {
@@ -40,8 +59,11 @@ function synchronizeDisabledState(source: Element, targets: Array<Element>) {
 					targets[i].removeAttribute('disabled');
 					targets[i].removeAttribute('aria-disabled');
 				} else {
+					const hadFocus = targets[i].contains(document.activeElement);
 					targets[i].setAttribute('disabled', 'true');
 					targets[i].setAttribute('aria-disabled', 'true');
+					if (hadFocus)
+						moveFocusFromDisabledElement(source);
 				}
 			}
 		});

--- a/cypress_test/data/desktop/calc/manage_names.fods
+++ b/cypress_test/data/desktop/calc/manage_names.fods
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<office:document xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+ xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+ xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+ xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"
+ xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"
+ office:version="1.4" office:mimetype="application/vnd.oasis.opendocument.spreadsheet">
+ <office:body>
+  <office:spreadsheet>
+   <table:table table:name="Sheet1">
+    <table:table-column/>
+    <table:table-row>
+     <table:table-cell office:value-type="string"><text:p>hello</text:p></table:table-cell>
+    </table:table-row>
+   </table:table>
+   <table:named-expressions>
+    <table:named-range table:name="TestRange" table:base-cell-address="$Sheet1.$A$1" table:cell-range-address="$Sheet1.$A$1"/>
+   </table:named-expressions>
+  </office:spreadsheet>
+ </office:body>
+</office:document>

--- a/cypress_test/integration_tests/desktop/calc/manage_names_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/manage_names_spec.js
@@ -1,0 +1,45 @@
+/* global describe it cy require beforeEach expect */
+
+var helper = require('../../common/helper');
+
+describe(['tagdesktop'], 'Manage Names dialog focus', function() {
+
+	beforeEach(function() {
+		helper.setupAndLoadDocument('calc/manage_names.fods');
+		cy.viewport(1920, 1080);
+	});
+
+	it('Focus moves to another dialog control when delete button becomes disabled', function() {
+		var win;
+
+		cy.getFrameWindow().then(function(frameWindow) {
+			win = frameWindow;
+			win.app.map.sendUnoCommand('.uno:DefineName');
+		});
+
+		cy.cGet('.ui-dialog[role="dialog"]').should('have.length', 1);
+		cy.then(function() {
+			return helper.processToIdle(win);
+		});
+
+		cy.cGet('#delete-button').should('not.be.disabled');
+
+		cy.cGet('#delete-button').focus();
+		cy.cGet('#delete-button').should('have.focus');
+
+		cy.cGet('#delete-button').click();
+
+		cy.then(function() {
+			return helper.processToIdle(win);
+		});
+
+		cy.cGet('#delete-button').should('be.disabled');
+
+		cy.then(function() {
+			var active = win.document.activeElement;
+			var dialog = win.document.querySelector('.ui-dialog[role="dialog"]');
+			var contains = dialog ? dialog.contains(active) : false;
+			expect(contains).to.be.true;
+		});
+	});
+});


### PR DESCRIPTION
if an element has disabled.


Change-Id: Ibab18302356865a46f19f3f5c9575ead9e9a7005
Reviewed-on: https://gerrit.collaboraoffice.com/c/online/+/1437
Reviewed-by: Caolán McNamara <caolan.mcnamara@collabora.com>
Tested-by: Caolán McNamara <caolan.mcnamara@collabora.com>
Tested-by: Jenkins CPCI <releng@collaboraoffice.com>


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

