### PR TITLE
kit: harden documentStatus() against unchecked JSON parsing

### DIFF
--- a/kit/KitHelper.hpp
+++ b/kit/KitHelper.hpp
@@ -71,12 +71,21 @@ namespace LOKitHelper
 
     inline int getMode(const std::string &partData)
     {
-        Poco::JSON::Parser parser;
-        Poco::Dynamic::Var partJsonVar = parser.parse(partData);
-        const Poco::SharedPtr<Poco::JSON::Object>& partObject = partJsonVar.extract<Poco::JSON::Object::Ptr>();
+        if (partData.empty())
+            return 0;
 
-        if (partObject->has("mode"))
-            return std::atoi(partObject->get("mode").toString().c_str());
+        try
+        {
+            Poco::JSON::Parser parser;
+            Poco::Dynamic::Var partJsonVar = parser.parse(partData);
+            const Poco::SharedPtr<Poco::JSON::Object>& partObject = partJsonVar.extract<Poco::JSON::Object::Ptr>();
+
+            if (partObject && partObject->has("mode"))
+                return std::atoi(partObject->get("mode").toString().c_str());
+        }
+        catch (const std::exception&)
+        {
+        }
         return 0;
     }
 
@@ -180,17 +189,23 @@ namespace LOKitHelper
         }
 
         ScopedString values(loKitDocument->pClass->getCommandValues(loKitDocument, ".uno:AllPageSize"));
-        if (values)
+        if (values && values.get() && *values.get())
         {
-            Poco::JSON::Parser parser;
-            const auto var = parser.parse(values.get());
-            const auto& obj = var.extract<Poco::JSON::Object::Ptr>();
-            if (obj && obj->has("parts"))
+            try
             {
-                const auto parts = obj->getArray("parts");
-                std::ostringstream os;
-                parts->stringify(os);
-                resultInfo["partdimensions"] = os.str();
+                Poco::JSON::Parser parser;
+                const auto var = parser.parse(values.get());
+                const auto& obj = var.extract<Poco::JSON::Object::Ptr>();
+                if (obj && obj->has("parts"))
+                {
+                    const auto parts = obj->getArray("parts");
+                    std::ostringstream os;
+                    parts->stringify(os);
+                    resultInfo["partdimensions"] = os.str();
+                }
+            }
+            catch (const std::exception&)
+            {
             }
         }
 


### PR DESCRIPTION
## Summary

`documentStatus()` (in `kit/KitHelper.hpp`) calls `Poco::JSON::Parser::parse()` in two places without any error handling. When the underlying `LibreOfficeKit` call returns an empty C-string for an edge-case document, Poco throws `JSON Exception: unexpected end of text`, the exception escapes `documentStatus()`, is caught by `Session::handleMessage`, and the `status: ...` reply to the client is silently dropped.

This PR adds minimal defensive guards (zero behavior change on the happy path).

## How it manifests

Discovered while debugging the Android app. Sequence in logcat:

\`\`\`
INF Document url [...] for session [001] loaded view [0]. Have 1 view.
INF ToMaster-001: Created new view with viewid: [0]
DBG ToMaster-001: Sending status after loading view 0
ERR Exception while handling [load url=...] in ToMaster-001:
    JSON Exception: unexpected end of text
\`\`\`

The document loads, the view is created, but the client never receives the \`status:\` frame, so it never enters edit mode → **blank screen**. Once the user backgrounds the app and returns, the auto-save fires and produces the misleading \`cmd=save kind=nodocloaded\` error, because \`_isDocLoaded\` was never set to \`true\`.

This was likely never reported on the desktop / web Collabora because users there never trigger the affected edge case (they always open existing documents). The Android app produced documents that did, exposing the latent issue.

## Changes

- \`getMode(\"\")\` returns \`0\` instead of throwing.
- \`.uno:AllPageSize\` parsing wrapped in \`try/catch\` and skipped when the returned C-string is empty.

Both sites already had fallbacks for when the field is absent — this just extends the same robustness to malformed/empty values.

## Test plan

- [x] Reproduced on Android (OnePlus 13T, arm64-v8a) prior to fix: opening external \`.doc\` / \`.odt\` produced blank screen and \`nodocloaded\` errors.
- [x] After fix, same documents open correctly into editable view.
- [ ] No automated test added (hard to mock LOK returning empty string from these specific endpoints; happy to add one if reviewers can suggest the right harness).

Made with [Cursor](https://cursor.com)