### PR TITLE
cypress: improve a11y_sidebar_spec.js Chart (LinePropertyPanel) stabi…

### DIFF
--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -49,6 +49,26 @@ function sidebarToggle() {
 	cy.cGet('#optionscontainer [id^="SidebarDeck.PropertyDeck"] button').click();
 }
 
+// Wait for the sidebar to reshow and grab focus to its first focusable
+// element via the 'sidebarstealfocus' timer scheduled in
+// Control.Sidebar.ts.
+function assertSidebarStealsFocus(win) {
+	cy.log('>> assertSidebarStealsFocus - start');
+
+	cy.cGet('#sidebar-dock-wrapper').should('be.visible').then(function(sidebar) {
+		// This first waitUntilLayoutingIsIdle ensures the sidebar
+		// update task has run and registered the timer.
+		helper.waitUntilLayoutingIsIdle(win);
+		// Wait for that timer to complete
+		helper.waitForTimers(win, 'sidebarstealfocus');
+		// Wait until dispatched tasks get done
+		helper.waitUntilLayoutingIsIdle(win);
+		helper.containsFocusElement(sidebar[0], true);
+	});
+
+	cy.log('<< assertSidebarStealsFocus - end');
+}
+
 // Make the status bar visible if it's hidden at the moment.
 // We use the menu option under 'View' menu to make it visible.
 function showStatusBarIfHidden() {
@@ -627,6 +647,7 @@ module.exports.updateFollowingUsers = updateFollowingUsers;
 module.exports.assertVisiblePage = assertVisiblePage;
 module.exports.closeNavigatorSidebar = closeNavigatorSidebar;
 module.exports.sidebarToggle = sidebarToggle;
+module.exports.assertSidebarStealsFocus = assertSidebarStealsFocus;
 module.exports.getCompactIcon = getCompactIcon;
 module.exports.getNbIcon = getNbIcon;
 module.exports.getCompactIconArrow = getCompactIconArrow;

--- a/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
@@ -487,11 +487,7 @@ describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: f
         helper.processToIdle(win);
 
         // sidebar starts again, and grabs focus to itself
-        cy.cGet('#sidebar-dock-wrapper').should('be.visible').then(function(sidebar) {
-                helper.waitForTimers(win, 'sidebarstealfocus');
-                helper.waitUntilLayoutingIsIdle(win);
-                helper.containsFocusElement(sidebar[0], true);
-       });
+        desktopHelper.assertSidebarStealsFocus(win);
 
        // esc to send focus back to main document
        escLevel(win, 1);

--- a/cypress_test/integration_tests/desktop/writer/a11y_sidebar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_sidebar_spec.js
@@ -113,11 +113,7 @@ describe(['tagdesktop'], 'Accessibility Writer Sidebar Tests', { testIsolation: 
 		helper.processToIdle(win);
 
 		// sidebar starts again, and grabs focus to itself
-		cy.cGet('#sidebar-dock-wrapper').should('be.visible').then(function(sidebar) {
-			helper.waitForTimers(win, 'sidebarstealfocus');
-			helper.waitUntilLayoutingIsIdle(win);
-			helper.containsFocusElement(sidebar[0], true);
-		});
+		desktopHelper.assertSidebarStealsFocus(win);
 
 		// esc to send focus back to main document
 		escLevel(win, 1);


### PR DESCRIPTION
…lity

Drain layouting first so the sidebar update task has run and the timer is registered, then waitForTimers properly waits for it to fire, and the second waitUntilLayoutingIsIdle drains the focus task.

Extract the assertion into desktopHelper.assertSidebarStealsFocus and reuse it.

Failure context for 'Chart (LinePropertyPanel)':
      cy:command ✔  wrap    null, {timeout: 20000}
      cy:command ✔  assert    .uno:ReportWhenIdle result with idleID 17: expected **{ Object (proxy, thisValue, ...) }** to be an object
      cy:command ✔  waitUntil    Object{3}
      cy:command ✔  waitUntil    true
      cy:command ✔  wrap    null, {timeout: 20000}
      cy:command ✔  assert    .uno:ReportWhenIdle result with idleID 18: expected **{ Object (proxy, thisValue, ...) }** to be an object
      cy:command ✔  waitUntil    Object{3}
      cy:command ✔  waitUntil    true
      cy:command ✔  cGet    #sidebar-dock-wrapper
      cy:command ✔  assert    expected **<div#sidebar-dock-wrapper.visible.coreBased>** to be **visible**
      cy:command ✔  waitUntil    Object{3}
      cy:command ✔  waitUntil    true
      cy:command ✔  getFrameWindow    #coolframe
      cy:command ✘  assert    expected **false** to equal **true**
      cy:command ✔  fail:
                    expected false to equal true
                    /home/collabora/jenkins/workspace/gerrit_cypress_main/cypress_test/integration_tests/common/helper.js:1064:70
                      1062 | function containsFocusElement(container, doesContain) {
                      1063 |     cy.getFrameWindow().then(function (win) {
                    > 1064 |         cy.expect(container.contains(win.document.activeElement)).to.equal(doesContain);
                           |                                                                      ^
                      1065 |     });
                      1066 | }
                      1067 | function getMenuEntry(index) {
          cy:log ✱  >> undoAll - start


Change-Id: Ia10aa567b59b08d4bb089985efcec2b401ed9335 Reviewed-on: https://gerrit.collaboraoffice.com/c/online/+/2129
Reviewed-by: Mohit Marathe <mohit.marathe@collabora.com>
(cherry picked from commit 549cf9d6425b557f3efd919b3b29ac07b6db7337)


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

