### PR TITLE
backport: notebookbar previews / fix CI (25.04)

### DIFF
--- a/browser/src/control/Control.NotebookbarBase.ts
+++ b/browser/src/control/Control.NotebookbarBase.ts
@@ -161,7 +161,7 @@ class NotebookbarBase extends JSDialogComponent {
 				selected: false,
 				ondemand: true,
 				width: 96,
-				height: 72,
+				height: 30, // adjust with expected image to not blink
 			});
 		});
 

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -509,6 +509,7 @@ class UIManager extends window.L.Control {
 			formulabarRow?.classList?.remove('hidden');
 			this.map.formulabar = JSDialog.FormulaBar(this.map);
 			this.map.addressInputField = JSDialog.AddressInputField(this.map);
+			JSDialog.MessageRouter.flushPending('addressinputfield');
 			$('#toolbar-wrapper').addClass('spreadsheet');
 
 			// remove unused elements
@@ -776,6 +777,7 @@ class UIManager extends window.L.Control {
 		}
 
 		this.notebookbar = JSDialog.NotebookbarBase(this.map, notebookbar);
+		JSDialog.MessageRouter.flushPending('notebookbar');
 		if (showUI)
 			this.showNotebookbarControl();
 	}

--- a/browser/src/control/jsdialog/Util.MessageRouter.ts
+++ b/browser/src/control/jsdialog/Util.MessageRouter.ts
@@ -16,6 +16,9 @@
 declare var JSDialog: any;
 
 class JSDialogMessageRouter {
+	// Per-jsontype queues for messages with target component not yet ready
+	private pendingByJsontype: Map<string, Array<() => void>> = new Map();
+
 	// show labels instead of editable fields in message boxes
 	private _preProcessMessageDialog(msgData: WidgetJSON) {
 		if (!msgData.children) return;
@@ -25,6 +28,23 @@ class JSDialogMessageRouter {
 			if (child.type === 'multilineedit') child.type = 'fixedtext';
 			else if (child.children) this._preProcessMessageDialog(child);
 		}
+	}
+
+	private isReady(jsontype: string): boolean {
+		if (jsontype === 'notebookbar')
+			return !!(
+				app.socket._map.uiManager && app.socket._map.uiManager.notebookbar
+			);
+		if (jsontype === 'addressinputfield')
+			return !!app.socket._map.addressInputField;
+		return true;
+	}
+
+	public flushPending(jsontype: string): void {
+		const queue = this.pendingByJsontype.get(jsontype);
+		if (!queue) return;
+		this.pendingByJsontype.delete(jsontype);
+		for (const fire of queue) fire();
 	}
 
 	public processMessage(msgData: JSDialogJSON, callbackFn: JSDialogCallback) {
@@ -44,14 +64,14 @@ class JSDialogMessageRouter {
 				return false;
 			};
 
-			var isNotebookbarInitialized =
-				app.socket._map.uiManager && app.socket._map.uiManager.notebookbar;
-			if (
-				(msgData.jsontype === 'notebookbar' && !isNotebookbarInitialized) ||
-				(msgData.jsontype === 'addressinputfield' &&
-					!app.socket._map.addressInputField)
-			) {
-				setTimeout(fireJSDialogEvent, 1000);
+			const jsontype = msgData.jsontype;
+			const queue = this.pendingByJsontype.get(jsontype);
+			if (queue || !this.isReady(jsontype)) {
+				// target is not initialized yet or earlier messages
+				// of the same jsontype are still queued.
+				const q = queue || [];
+				q.push(fireJSDialogEvent);
+				if (!queue) this.pendingByJsontype.set(jsontype, q);
 				return;
 			} else if (fireJSDialogEvent() === true) {
 				return;

--- a/cypress_test/integration_tests/desktop/writer/presets_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/presets_spec.js
@@ -36,8 +36,10 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Preset tests.', function()
 
                 cy.cGet('.notebookbar > .unoSpellingAndGrammarDialog > button').first().click();
 
-		// we should end up with the "there are no misspelling information dialog"
-		cy.cGet('.ui-dialog-title').should('have.text', 'Spelling: Information');
+		// we should end up with the "there are no misspelling" Information messagebox.
+		// Scope to its own #Information; the underlying SpellingDialog stays visible
+		// behind it and a bare .ui-dialog-title would match both and concatenate.
+		cy.cGet('#Information.ui-dialog-title').should('have.text', 'Information');
 
 		cy.cGet('body').type('{esc}');
 		cy.cGet('body').type('{esc}');
@@ -65,8 +67,10 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Preset tests.', function()
 
                 cy.cGet('.notebookbar > .unoSpellingAndGrammarDialog > button').first().click();
 
-		// we should end up with the "there are no misspelling information dialog"
-		cy.cGet('.ui-dialog-title').should('have.text', 'Spelling: Information');
+		// we should end up with the "there are no misspelling" Information messagebox.
+		// Scope to its own #Information; the underlying SpellingDialog stays visible
+		// behind it and a bare .ui-dialog-title would match both and concatenate.
+		cy.cGet('#Information.ui-dialog-title').should('have.text', 'Information');
 
 		cy.cGet('body').type('{esc}');
 		cy.cGet('body').type('{esc}');

--- a/cypress_test/integration_tests/desktop/writer/stylesview_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/stylesview_spec.js
@@ -13,11 +13,11 @@ describe(['tagdesktop'], 'Stylesview Iconview Tests', function() {
 	}
 
 	beforeEach(function() {
-		cy.viewport(1920, 1080);
+		cy.viewport(1280, 720);
 		helper.setupAndLoadDocument('writer/styles.odt');
 		desktopHelper.switchUIToNotebookbar();
 		desktopHelper.sidebarToggle();
-		cy.cGet('.notebookbar #stylesview').should('exist').should('be.visible');
+		cy.cGet('.notebookbar #stylesview').should('exist').should('be.visible').should('not.be.empty');
 	});
 
 	it('Scroll Up/Down Buttons', function() {
@@ -32,9 +32,9 @@ describe(['tagdesktop'], 'Stylesview Iconview Tests', function() {
 	});
 
 	it('Expander Button', function() {
+		cy.cGet('.jsdialog #stylesview_9').should('not.exist');
 		openExpander();
-		cy.cGet('.jsdialog #stylesview_59').should('exist').should('be.visible'); // Contents 9
-		cy.cGet('.jsdialog #stylesview_60').should('exist').should('not.be.visible');
+		cy.cGet('.jsdialog #stylesview_9').should('exist').should('be.visible');
 	});
 
 	it('Open Styles Sidebar Button', function() {
@@ -50,28 +50,22 @@ describe(['tagdesktop'], 'Stylesview Iconview Tests', function() {
 		cy.cGet('#StyleListDeck').should('exist').should('be.visible');
 	});
 
-	it.only('Resize', function() {
+	it('Resize', function() {
 		// the dropdown should close on resize
 		openExpander();
 		cy.cGet('#stylesview-iconview-list-dropdown').should('exist').should('be.visible');
 		cy.viewport(650, 1080);
 		cy.cGet('#stylesview-iconview-list-dropdown').should('not.exist');
 
-		// with reduced width, only one column should be visible
+		// re-open after resize
 		openExpander();
-		cy.cGet('.jsdialog #stylesview_11').should('exist').should('be.visible'); // Standardstyckeformatmall
-		cy.cGet('.jsdialog #stylesview_12').should('exist').should('not.be.visible');
-
-		// NOTE: changes to the height don't trigger the resize observer,
-		// thus the dropdown doesn't disappear. so no need to call
-		// `openExpander` again.
 
 		// with reduced height:
 		// - only a few rows should be visible.
 		// - the open styles sidebar button should be visible.
 		cy.viewport(650, 454);
-		cy.cGet('.jsdialog #stylesview_4').should('exist').should('be.visible'); // Title
-		cy.cGet('.jsdialog #stylesview_5').should('exist').should('not.be.visible'); // Subtitle
+		cy.cGet('.jsdialog #stylesview_4').should('exist').should('be.visible');
+		cy.cGet('.jsdialog #stylesview_5').should('exist').should('not.be.visible');
 		cy.cGet('#format-style-list-dialog-button').should('exist').should('be.visible');
 	});
 });

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -59,8 +59,8 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 
 	it('Apply style.', function() {
 		helper.setDummyClipboardForCopy();
-		cy.cGet('#stylesview').scrollTo('bottom') ;
-		cy.cGet('#stylesview .notebookbar.ui-iconview-entry img[title=Title]').click();
+		cy.cGet('#stylesview').scrollTo('bottom');
+		cy.cGet('#stylesview .notebookbar.ui-iconview-entry img[title=Title]').first().scrollIntoView().should('be.visible').click();
 		refreshCopyPasteContainer();
 		helper.copy();
 		cy.cGet('#copy-paste-container p font font').should('have.attr', 'style', 'font-size: 28pt');


### PR DESCRIPTION
- fixes initial overlapping style previews
- protects us from race on initialization
- should prevent form duplicated styles

Backport of:
https://gerrit.collaboraoffice.com/c/online/+/2457
https://gerrit.collaboraoffice.com/c/online/+/2109

===========================

Backport of cypress fixes:
- unify stylesview_spec.js with main
- https://gerrit.collaboraoffice.com/c/online/+/2570 (presets_spec.js)