### PR TITLE
Writer: Starting selection from a commented portion of text is not po…

### DIFF
--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -1613,7 +1613,42 @@ export class Comment extends CanvasSectionObject {
 		}
 	}
 
+	// In Writer, a comment-highlighted region overlays the document. By default
+	// this section would swallow mouse events, so a text selection drag started
+	// on top of a commented passage never reaches core. Forward the drag
+	// lifecycle (down/move/up) to MouseControl while leaving click handling
+	// to the existing onClick path.
+	private forwardWriterMouseEventToCore(handler: 'onMouseDown' | 'onMouseMove' | 'onMouseUp', point: cool.SimplePoint, dragDistance: Array<number>, e: MouseEvent): void {
+		const mousePoint = point.clone();
+		mousePoint.pX += this.myTopLeft[0];
+		mousePoint.pY += this.myTopLeft[1];
+		const mouseControl = app.activeDocument.mouseControl;
+		if (handler === 'onMouseMove')
+			mouseControl.onMouseMove(mousePoint, dragDistance, e);
+		else if (handler === 'onMouseDown')
+			mouseControl.onMouseDown(mousePoint, e);
+		else
+			mouseControl.onMouseUp(mousePoint, e);
+	}
+
+	public onMouseDown(point: cool.SimplePoint, e: MouseEvent): void {
+		if (app.map._docLayer._docType === 'text')
+			this.forwardWriterMouseEventToCore('onMouseDown', point, [0, 0], e);
+	}
+
+	public onMouseMove(point: cool.SimplePoint, dragDistance: Array<number>, e: MouseEvent): void {
+		if (app.map._docLayer._docType === 'text' && this.containerObject.isDraggingSomething())
+			this.forwardWriterMouseEventToCore('onMouseMove', point, dragDistance, e);
+	}
+
 	public onMouseUp (point: cool.SimplePoint, e: MouseEvent): void {
+		// A drag finishing on top of a commented region: let MouseControl
+		// send the matching buttonup so core completes the selection.
+		if (this.containerObject.isDraggingSomething() && app.map._docLayer._docType === 'text') {
+			this.forwardWriterMouseEventToCore('onMouseUp', point, [0, 0], e);
+			return;
+		}
+
 		// Hammer.js doesn't fire onClick event after touchEnd event.
 		// CanvasSectionContainer fires the onClick event. But since Hammer.js is used for map, it disables the onClick for SectionContainer.
 		// We will use this event as click event on touch devices, until we remove Hammer.js (then this code will be removed from here).

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -232,7 +232,7 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 		cy.cGet('#comment-container-1').should('be.visible');
 
 		/*
-			at this point, the space on the left of the document and the 
+			at this point, the space on the left of the document and the
 			space on the right of the document (without moving the document
 			to the left) is same, equal to half of the comment width;
 		*/
@@ -351,6 +351,99 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 			expect(textInput._lastSelectionStart).to.equal(20);
 			expect(textInput._lastSelectionEnd).to.equal(20);
 		});
+	});
+
+	it('Drag inside commented region forwards mouse events to core', function() {
+		// A Writer comment overlays the commented passage with a
+		// CommentSection that used to swallow mouse events. That blocked
+		// users from starting a text selection by mouse-dragging from
+		// inside the highlighted passage - core never saw the drag.
+		// CommentSection now delegates onMouseDown/Move/Up to MouseControl
+		// when a drag is active; this test exercises that path.
+
+		// 50% zoom (set in beforeEach) makes the highlight too small for a
+		// reliable drag, so switch to 100%.
+		desktopHelper.selectZoomLevel('100', false);
+		cy.getFrameWindow().then(function(win) {
+			return helper.processToIdle(win);
+		});
+
+		// Lay down a passage and select a slice of it so the comment is
+		// anchored to a real range and ends up with a meaningful
+		// highlight rectangle to drag inside.
+		helper.typeIntoDocument('Hello world from this test document for drag testing.{enter}');
+		helper.typeIntoDocument('{ctrl}{home}');
+		for (var i = 0; i < 17; ++i)
+			helper.typeIntoDocument('{shift}{rightArrow}');
+		helper.textSelectionShouldExist();
+
+		desktopHelper.insertComment('drag-test', true);
+		cy.cGet('.cool-annotation-content-wrapper').should('exist');
+
+		cy.getFrameWindow().then(function(win) {
+			return helper.processToIdle(win);
+		});
+
+		// Spy on MouseControl - if the new delegation works, the drag we
+		// dispatch below must reach these methods.
+		cy.getFrameWindow().then(function(win) {
+			cy.spy(win.app.activeDocument.mouseControl, 'onMouseDown').as('mcDown');
+			cy.spy(win.app.activeDocument.mouseControl, 'onMouseMove').as('mcMove');
+			cy.spy(win.app.activeDocument.mouseControl, 'onMouseUp').as('mcUp');
+		});
+
+		cy.getFrameWindow().then(function(win) {
+			var commentList = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			var comment = commentList.sectionProperties.commentList[0];
+			expect(comment, 'comment must exist').to.exist;
+			expect(comment.sectionProperties.data.rectangles,
+				'comment must own a highlight rectangle').to.exist;
+			var rects = comment.sectionProperties.data.rectangles;
+			expect(rects.length, 'at least one rectangle').to.be.greaterThan(0);
+			var rect = rects[0];
+
+			var canvas = win.document.getElementById('document-canvas');
+			var bounds = canvas.getBoundingClientRect();
+
+			// v1X/v1Y are view pixels inside the canvas (viewport offset
+			// baked in); /dpiScale -> CSS pixels.
+			var cssCenterX = ((rect.v1X + rect.v2X) / 2) / win.app.dpiScale;
+			var cssCenterY = ((rect.v1Y + rect.v4Y) / 2) / win.app.dpiScale;
+			var startX = bounds.left + cssCenterX - 10;
+			var startY = bounds.top + cssCenterY;
+			var endX = startX + 30;
+			var endY = startY;
+
+			// mouseenter primes mouseIsInside; the container's mousedown
+			// short-circuits otherwise.
+			canvas.dispatchEvent(new win.MouseEvent('mouseenter', {
+				clientX: startX, clientY: startY, button: 0, bubbles: true,
+			}));
+			canvas.dispatchEvent(new win.MouseEvent('mousedown', {
+				clientX: startX, clientY: startY, button: 0, bubbles: true,
+			}));
+			// mousemove and mouseup are wired on document, not canvas.
+			win.document.dispatchEvent(new win.MouseEvent('mousemove', {
+				clientX: endX, clientY: endY, button: 0, buttons: 1, bubbles: true,
+			}));
+			win.document.dispatchEvent(new win.MouseEvent('mouseup', {
+				clientX: endX, clientY: endY, button: 0, bubbles: true,
+			}));
+		});
+
+		// Each phase must have flowed through MouseControl. Without the
+		// CommentSection delegation, the spies stay silent because the
+		// section consumed the events.
+		cy.get('@mcDown').should('have.been.called');
+		cy.get('@mcMove').should('have.been.called');
+		cy.get('@mcUp').should('have.been.called');
+
+		// And core must have responded with a real text selection.
+		cy.getFrameWindow().then(function(win) {
+			return helper.processToIdle(win);
+		});
+		helper.textSelectionShouldExist();
 	});
 
 	it('Action_GoToComment postMessage returns error for invalid comment', function() {


### PR DESCRIPTION
…ssible.

Issue: Because comment section handles the events.

Fix: Redirect the dragging actions to mouse controller. It doesn't interfere with other comment section actions because it doesn't handle dragging currently.

Also a test is added and fix is confirmed.

Backport of: https://gerrit.collaboraoffice.com/c/online/+/2360


Change-Id: Ic51cf14ed84a5af4683219fef1a9ddff069824d9


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

