### PR TITLE
Writer: Fix double issuing of paste command.

### DIFF
--- a/browser/src/map/Clipboard.js
+++ b/browser/src/map/Clipboard.js
@@ -717,6 +717,15 @@ window.L.Clipboard = window.L.Class.extend({
 			return;
 		}
 
+		// execCommand('paste') may fire the paste event synchronously and
+		// return false; in that case paste() has already dispatched a
+		// .uno:Paste, so a second async navigator-clipboard read would
+		// duplicate the content.
+		if (operation == 'paste' && serial !== this._clipboardSerial) {
+			this._unoCommandForCopyCutPaste = null;
+			return;
+		}
+
 		if (operation == 'paste' && this._navigatorClipboardRead(false)) {
 			// execCommand(paste) failed, the new clipboard API is available, tried that
 			// way.

--- a/cypress_test/integration_tests/desktop/writer/copy_paste_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/copy_paste_spec.js
@@ -66,6 +66,51 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Clipboard operations.', fu
 		});
 	});
 
+	it('Right-click Paste does not duplicate when execCommand fires paste event synchronously but returns false.', function() {
+		helper.setupAndLoadDocument('writer/copy_paste.odt');
+
+		cy.getFrameWindow().then(function(win) {
+			const app = win.app;
+			const clip = app.map._clip;
+
+			// Spy on the async navigator-clipboard read path. With the
+			// bug it gets called even after execCommand has already
+			// synchronously dispatched a paste, producing a second
+			// .uno:Paste socket message and visually duplicating the
+			// pasted content.
+			cy.spy(clip, '_navigatorClipboardRead').as('navClipRead');
+
+			// Force the buggy browser behaviour: execCommand('paste')
+			// fires the paste event synchronously (so paste() runs and
+			// _clipboardSerial is incremented) but the call itself
+			// returns false. Real-world Chromium/Firefox can do this
+			// when the focused element is read-only or in certain
+			// permission states.
+			cy.stub(win.document, 'execCommand').callsFake(function(operation) {
+				if (operation !== 'paste') {
+					return false;
+				}
+				const html = clip._originWrapBody('<p>test</p>');
+				clip.paste({
+					clipboardData: {
+						getData: function(t) {
+							return t === 'text/html' ? html : '';
+						},
+						types: ['text/html'],
+					},
+					preventDefault: function() {},
+				});
+				return false;
+			});
+
+			// Drive the same entry point used by the right-click
+			// "Paste" context-menu item.
+			clip.filterExecCopyPaste('.uno:Paste');
+		});
+
+		cy.get('@navClipRead').should('not.have.been.called');
+	});
+
 	it('Copy and Paste text with DisableCopy', function () {
 		helper.setupAndLoadDocument('writer/copy_paste.odt', /* isMultiUser */ false, /* copy .wopi.json */ true);
 		// Select some text


### PR DESCRIPTION
Issue: Right click paste option triggers 2 different paths. A guards is added.

Added a test and also confirmed the test.

Backport of: https://gerrit.collaboraoffice.com/c/online/+/2370


Change-Id: I51638dba9e8d48200eb0420536286a40a992d229


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

