### PR TITLE
comments: unresolve thread only if all is resolved

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -1526,29 +1526,22 @@ export class CommentSection extends CanvasSectionObject {
 		return (index === undefined) ? -1 : index;
 	}
 
-	public isThreadResolved (annotation: any): boolean {
-		// If comment has children.
-		if (annotation.sectionProperties.children.length > 0) {
-			for (var i = 0; i < annotation.sectionProperties.children.length; i++) {
-				if (annotation.sectionProperties.children[i].sectionProperties.data.resolved !== 'true')
-					return false;
-			}
-			return true;
-		}
-		// If it has a parent.
-		else if (annotation.sectionProperties.data.parent !== '0') {
-			var index = this.getSubRootIndexOf(annotation.sectionProperties.data.parent);
-			var comment = this.sectionProperties.commentList[index];
-			if (comment.sectionProperties.data.resolved !== 'true')
+	private isSubThreadResolved(annotation: Comment): boolean {
+		if (annotation.sectionProperties.data.resolved !== 'true')
+			return false;
+		for (let i = 0; i < annotation.sectionProperties.children.length; i++) {
+			if (!this.isSubThreadResolved(annotation.sectionProperties.children[i]))
 				return false;
-			else if (comment.sectionProperties.children.length > 0) {
-				for (var i = 0; i < comment.sectionProperties.children.length; i++) {
-					if (comment.sectionProperties.children[i].sectionProperties.data.resolved !== 'true')
-						return false;
-				}
-				return true;
-			}
 		}
+		return true;
+	}
+
+	public isThreadResolved(annotation: Comment): boolean {
+		if (annotation.isRootComment())
+			return this.isSubThreadResolved(annotation);
+		const index = this.getRootIndexOf(annotation.sectionProperties.data.parent);
+		const top_comment = this.sectionProperties.commentList[index];
+		return this.isSubThreadResolved(top_comment);
 	}
 
 	private initializeContextMenus (): void {
@@ -2606,26 +2599,6 @@ export class CommentSection extends CanvasSectionObject {
 				index--;
 			else
 				break;
-		}
-
-		return index;
-	}
-
-	// Returns the sub-root comment index of given id
-	private getSubRootIndexOf (id: any): number {
-		var index = this.getIndexOf(id);
-
-		if (index !== -1)
-		{
-			var comment = this.sectionProperties.commentList[index];
-			var parentId = comment.sectionProperties.data.parent;
-
-			while (index >= 0) {
-				if (this.sectionProperties.commentList[index].sectionProperties.data.id !== parentId && this.sectionProperties.commentList[index].sectionProperties.data.parent !== '0')
-					index--;
-				else
-					break;
-			}
 		}
 
 		return index;

--- a/cypress_test/integration_tests/desktop/writer/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/annotation_spec.js
@@ -427,6 +427,42 @@ describe(['tagdesktop'], 'Annotation Tests', function() {
 		});
 	});
 
+	it('Resolve/Unresolve Thread on partially resolved thread', function () {
+		desktopHelper.insertComment();
+		cy.cGet('#comment-container-1').should('exist');
+
+		// Reply to create a thread (root id 1, reply id 2).
+		cy.cGet('#comment-annotation-menu-1').click();
+		cy.cGet('body').contains('.context-menu-item', 'Reply').click();
+		cy.cGet('#annotation-reply-textarea-1').type('reply text');
+		cy.cGet('#annotation-reply-1').click();
+		cy.cGet('#annotation-content-area-2').should('contain', 'reply text');
+
+		// Resolve only the reply, leaving the root unresolved.
+		cy.cGet('#comment-annotation-menu-2').click();
+		cy.cGet('body').contains('.context-menu-item', 'Resolve').click();
+		cy.cGet('#comment-container-2 .cool-annotation-content-resolved').should('have.text', 'Resolved');
+		cy.cGet('#comment-container-1 .cool-annotation-content-resolved').should('have.text', '');
+
+		// Root menu must offer 'Resolve Thread' since the thread is not fully resolved.
+		cy.cGet('#comment-annotation-menu-1').click();
+		cy.cGet('body').contains('.context-menu-item', 'Resolve Thread').should('be.visible');
+		cy.cGet('body').contains('.context-menu-item', 'Unresolve Thread').should('not.exist');
+		cy.cGet('body').contains('.context-menu-item', 'Resolve Thread').click();
+
+		// All comments in the thread are now resolved.
+		cy.cGet('#comment-container-1 .cool-annotation-content-resolved').should('have.text', 'Resolved');
+		cy.cGet('#comment-container-2 .cool-annotation-content-resolved').should('have.text', 'Resolved');
+
+		// Root menu now offers 'Unresolve Thread'.
+		cy.cGet('#comment-annotation-menu-1').click();
+		cy.cGet('body').contains('.context-menu-item', 'Unresolve Thread').should('be.visible');
+		cy.cGet('body').contains('.context-menu-item', 'Unresolve Thread').click();
+
+		// All comments in the thread are unresolved again.
+		cy.cGet('#comment-container-1 .cool-annotation-content-resolved').should('have.text', '');
+		cy.cGet('#comment-container-2 .cool-annotation-content-resolved').should('have.text', '');
+	});
 });
 
 describe(['tagdesktop'], 'Collapsed Annotation Tests', function() {


### PR DESCRIPTION
Right now the "Unresolve Thread" option appears even if only some
comments in a thread are resolved, but the internal UNO call resolves
the thread (as it should). This change fixes the label so that it
corresponds to the correct action. A cypress test is also added.

Signed-off-by: Jaume Pujantell <jaume.pujantell@collabora.com>
Change-Id: I4867d44b76357d5c1af66efec3973c455abb77bf
(cherry picked from commit 4b4b1bac99853415f5b367197b6fba827f0a958b)
