### PR TITLE
fix(calc): Make dropdows work with different zooms (backport 25.04)

### DIFF
--- a/browser/src/app/A11yValidator.ts
+++ b/browser/src/app/A11yValidator.ts
@@ -263,6 +263,21 @@ class A11yValidator {
 		);
 	}
 
+	private checkInitialFocusNotCloseButton(dialogElement: HTMLElement): number {
+		const active = document.activeElement;
+		if (!active || !dialogElement.contains(active)) return 0;
+
+		if (active.classList.contains('ui-dialog-titlebar-close')) {
+			console.error(
+				new A11yValidatorException(
+					`In '${this.getDialogTitle(active as HTMLElement)}': initial keyboard focus is on the close (X) button in the titlebar. Focus should be on a control inside the dialog body.`,
+				),
+			);
+			return 1;
+		}
+		return 0;
+	}
+
 	private checkDuplicateButtonLabels(container: HTMLElement): number {
 		const buttons = container.querySelectorAll('button[aria-labelledby]');
 		const labelMap = new Map<string, HTMLElement[]>();
@@ -378,10 +393,11 @@ class A11yValidator {
 	validateDialog(dialogElement: HTMLElement): void {
 		const content = dialogElement.querySelector('.ui-dialog-content');
 
-		const errorCount = this.validateContainer(
-			dialogElement,
-			content instanceof HTMLElement ? content : undefined,
-		);
+		const errorCount =
+			this.validateContainer(
+				dialogElement,
+				content instanceof HTMLElement ? content : undefined,
+			) + this.checkInitialFocusNotCloseButton(dialogElement);
 
 		if (errorCount === 0) {
 			console.error('A11yValidator: dialog passed all checks');

--- a/browser/src/app/A11yValidator.ts
+++ b/browser/src/app/A11yValidator.ts
@@ -35,6 +35,85 @@ class A11yValidator {
 		this.checks.push(this.checkElementHasLabel.bind(this));
 		this.checks.push(this.checkAriaControls.bind(this));
 		this.checks.push(this.checkFrameOnlyDecorativeImages.bind(this));
+		this.checks.push(this.checkNoSpatialReferences.bind(this));
+	}
+
+	// Spatial words in accessible text are useless to blind users who
+	// cannot perceive layout (see commit 1f1bafcbfd9), unless they sit
+	// next to a document-structure noun ("Insert Rows Above") where
+	// they describe the action's effect on content rather than the
+	// on-screen position of a UI element.
+	private static readonly SPATIAL_RE =
+		/\b(below|above|to the (?:left|right)(?: of)?)\b/gi;
+	private static readonly CONTENT_NOUNS: Set<string> = new Set([
+		'row',
+		'rows',
+		'paragraph',
+		'paragraphs',
+		'column',
+		'columns',
+		'cell',
+		'cells',
+		'page',
+		'pages',
+		'line',
+		'lines',
+		'section',
+		'sections',
+		'heading',
+		'headings',
+		'sheet',
+		'sheets',
+		'slide',
+		'slides',
+	]);
+
+	private findSpatialMatch(text: string | null | undefined): string | null {
+		if (!text) return null;
+		const re = A11yValidator.SPATIAL_RE;
+		re.lastIndex = 0;
+		let m: RegExpExecArray | null;
+		while ((m = re.exec(text)) !== null) {
+			const before = text.slice(0, m.index).match(/(\w+)\W*$/)?.[1];
+			const after = text.slice(m.index + m[0].length).match(/^\W*(\w+)/)?.[1];
+			const neighbours = [before, after]
+				.filter((w): w is string => !!w)
+				.map((w) => w.toLowerCase());
+			if (!neighbours.some((w) => A11yValidator.CONTENT_NOUNS.has(w)))
+				return m[0];
+		}
+		return null;
+	}
+
+	private checkNoSpatialReferences(type: string, element: HTMLElement): void {
+		const sources: Array<[string, string | null]> = [
+			['aria-label', element.getAttribute('aria-label')],
+			['aria-description', element.getAttribute('aria-description')],
+			['alt', element.tagName === 'IMG' ? element.getAttribute('alt') : null],
+		];
+		const describedBy = element.getAttribute('aria-describedby') || '';
+		for (const id of describedBy.trim().split(/\s+/).filter(Boolean)) {
+			const ref = document.getElementById(id);
+			if (!ref) continue;
+			sources.push([
+				`aria-describedby="${id}"`,
+				(ref.textContent || '').trim(),
+			]);
+		}
+
+		for (const [source, text] of sources) {
+			const match = this.findSpatialMatch(text);
+			if (match)
+				throw new A11yValidatorException(
+					`In '${this.getDialogTitle(element)}' at '${this.getElementPath(element)}': widget of type '${type}' has spatial reference '${match}' in ${source} ('${(text as string).trim()}'). Spatial words like "above"/"below" are useless to screen-reader users; refer to widgets by name instead.`,
+				);
+		}
+
+		for (let i = 0; i < element.children.length; i++) {
+			const child = element.children[i];
+			if (this.shouldCheckChild(child))
+				this.checkNoSpatialReferences(type, child as HTMLElement);
+		}
 	}
 
 	checkWidget(type: string, element: HTMLElement): void {

--- a/browser/src/app/A11yValidator.ts
+++ b/browser/src/app/A11yValidator.ts
@@ -34,6 +34,7 @@ class A11yValidator {
 		this.checks.push(this.checkLabelElement.bind(this));
 		this.checks.push(this.checkElementHasLabel.bind(this));
 		this.checks.push(this.checkAriaControls.bind(this));
+		this.checks.push(this.checkFrameOnlyDecorativeImages.bind(this));
 	}
 
 	checkWidget(type: string, element: HTMLElement): void {
@@ -226,6 +227,40 @@ class A11yValidator {
 				this.checkAriaControls(type, child as HTMLElement);
 			}
 		}
+	}
+
+	private checkFrameOnlyDecorativeImages(
+		type: string,
+		element: HTMLElement,
+	): void {
+		if (
+			!element.classList.contains('ui-frame-container') ||
+			!element.classList.contains('ui-fieldset')
+		) {
+			return;
+		}
+
+		const content = element.querySelector('.ui-expander-content');
+		if (!content) return;
+
+		const decorativeImages = content.querySelectorAll(
+			'img.ui-decorative-image',
+		);
+		if (decorativeImages.length === 0) return;
+
+		// If there is any focusable element, the frame has accessible content
+		if (JSDialog.FindFocusableWithin(content, 'next')) return;
+
+		// If there are any form controls (even disabled), the frame has
+		// real content rather than only decorative images
+		const formControlTags = JSDialog.GetFormControlTypesInCO();
+		for (const tag of formControlTags) {
+			if (content.querySelector(tag)) return;
+		}
+
+		throw new A11yValidatorException(
+			`In '${this.getDialogTitle(element)}' at '${this.getElementPath(element)}': frame '${type}' contains only decorative images with no accessible content. Remove the frame so its label does not mislead users into expecting meaningful content.`,
+		);
 	}
 
 	private checkDuplicateButtonLabels(container: HTMLElement): number {

--- a/browser/src/canvas/sections/CalcValidityDropDownSection.ts
+++ b/browser/src/canvas/sections/CalcValidityDropDownSection.ts
@@ -33,11 +33,9 @@ class CalcValidityDropDown extends HTMLObjectSection {
 		e.preventDefault();
 		this.stopPropagating();
 
-		// Calculate the center position of the section. We will send this to core side.
-		point.pX = this.position[0] + this.size[0] / 2;
-		point.pY = this.position[1] + this.size[1] / 2;
-
-		app.map._docLayer._postMouseEvent('buttondown', point.x, point.y, 1, 1, 0);
-		app.map._docLayer._postMouseEvent('buttonup', point.x, point.y, 1, 1, 0);
+		const _validatedCellAddress = (app.map._docLayer as { _validatedCellAddress?: null | cool.SimplePoint })._validatedCellAddress;
+		if (_validatedCellAddress && app.calc.cellCursorVisible && _validatedCellAddress.equals(app.calc.cellAddress?.toArray() ?? [])) {
+			app.map.sendUnoCommand('.uno:DataSelect');
+		}
 	}
 }

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -123,6 +123,7 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.acceptButton = null;
 		this.sectionProperties.rejectButton = null;
 		this.sectionProperties.menu = null;
+		this.sectionProperties.menuBarCell = null;
 		this.sectionProperties.captionNode = null;
 		this.sectionProperties.captionText = null;
 
@@ -228,7 +229,11 @@ export class Comment extends CanvasSectionObject {
 			this.createTrackChangeButtons();
 		}
 
-		if (this.sectionProperties.noMenu !== true && app.isCommentEditingAllowed()) {
+		// Always create the menu if allowed; its visibility is kept in sync with
+		// the current edit permission by updateEditability() so the Viewing/
+		// Editing toggle can show or hide the Edit/Reply/Delete affordances
+		// without re-rendering the comment.
+		if (this.sectionProperties.noMenu !== true) {
 			this.createMenu();
 		}
 
@@ -273,6 +278,35 @@ export class Comment extends CanvasSectionObject {
 
 		if (!(<any>window).mode.isMobile())
 			document.getElementById('document-container').appendChild(this.sectionProperties.container);
+
+		this.updateEditability();
+		this.sectionProperties.onUpdatePermissionBound = this.updateEditability.bind(this);
+		app.events.on('updatepermission', this.sectionProperties.onUpdatePermissionBound);
+	}
+
+	// Syncs visible edit affordances with the current comment-editing
+	// permission. The editable=true branch only re-shows the menubar
+	// cell: nodeModify/nodeReply remain hidden until the user explicitly
+	// triggers edit()/reply(), so we deliberately do NOT auto-reopen a
+	// previously open edit/reply pane when permission is restored.
+	private makeEditable (editable: boolean): void {
+		const props = this.sectionProperties;
+		if (props.menuBarCell?.style)
+			props.menuBarCell.style.display = editable ? '' : 'none';
+		if (editable) return;
+		if (props.nodeModify?.style) props.nodeModify.style.display = 'none';
+		if (props.nodeReply?.style) props.nodeReply.style.display = 'none';
+		if (props.contentNode?.style) props.contentNode.style.display = '';
+		props.container.classList.remove('modify-annotation-container');
+		props.container.classList.remove('reply-annotation-container');
+		this.cachedIsEdit = false;
+	}
+
+	// Invoked at init and on every updatepermission event, so toggling
+	// between Viewing and Editing mode immediately hides or restores the
+	// per-comment controls.
+	private updateEditability (): void {
+		this.makeEditable(app.isCommentEditingAllowed());
 	}
 
 	private createContainerAndWrapper (): void {
@@ -331,6 +365,7 @@ export class Comment extends CanvasSectionObject {
 
 	private createMenu (): void {
 		var tdMenu = window.L.DomUtil.create('td', 'cool-annotation-menubar', this.sectionProperties.authorRow);
+		this.sectionProperties.menuBarCell = tdMenu;
 		const edit = window.L.DomUtil.create('div', 'cool-annotation-menu-edit', tdMenu);
 		edit.id = 'comment-annotation-menu-edit-' + this.sectionProperties.data.id;
 		edit.tabIndex = 0;
@@ -1702,6 +1737,11 @@ export class Comment extends CanvasSectionObject {
 
 	public onRemove (): void {
 		this.sectionProperties.commentContainerRemoved = true;
+
+		if (this.sectionProperties.onUpdatePermissionBound) {
+			app.events.off('updatepermission', this.sectionProperties.onUpdatePermissionBound);
+			this.sectionProperties.onUpdatePermissionBound = null;
+		}
 
 		if (this.sectionProperties.commentListSection.sectionProperties.selectedComment === this)
 			this.sectionProperties.commentListSection.sectionProperties.selectedComment = null;

--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -529,9 +529,18 @@ window.L.Control.JSDialog = window.L.Control.extend({
 		}
 	},
 
+	// Focusables with the titlebar close (X) button demoted to the lowest
+	// priority - used only when nothing else in the dialog is focusable.
+	_getFocusablesForInitialFocus: function(container) {
+		const focusables = JSDialog.GetFocusableElements(container);
+		if (!focusables) return focusables;
+		const isClose = el => el.classList.contains('ui-dialog-titlebar-close');
+		return focusables.sort((a, b) => isClose(a) - isClose(b));
+	},
+
 	setupInitialFocus: function(instance) {
 		// setup initial focus and helper elements for closing popup
-		var initialFocusElement = JSDialog.GetFocusableElements(instance.container);
+		var initialFocusElement = this._getFocusablesForInitialFocus(instance.container);
 
 		if (instance.canHaveFocus && initialFocusElement && initialFocusElement.length)
 			initialFocusElement[0].focus();
@@ -552,13 +561,17 @@ window.L.Control.JSDialog = window.L.Control.extend({
 			// If init_id is not defined, select the first focusable element from the container
 			firstFocusableElement = instance.init_focus_id ? instance.container.querySelector('[id=\'' + instance.init_focus_id + '\']') : null;
 
-			if (!firstFocusableElement) {
-				const focusables = JSDialog.GetFocusableElements(instance.container);
-				if (focusables && focusables.length) firstFocusableElement = focusables[0];
-			}
-
+			// If the candidate from init_focus_id can't itself take focus
+			// (e.g. a container div), descend into it for a focusable child.
 			if (firstFocusableElement && !JSDialog.IsFocusable(firstFocusableElement)) {
 				firstFocusableElement = JSDialog.FindFocusableWithin(firstFocusableElement, 'next');
+			}
+
+			// Still no target (no init_focus_id, or it resolved to a dead end):
+			// pick the first element in the dialog that can take focus.
+			if (!firstFocusableElement) {
+				const focusables = this._getFocusablesForInitialFocus(instance.container);
+				if (focusables && focusables.length) firstFocusableElement = focusables[0];
 			}
 		}
 

--- a/browser/src/control/Control.NotebookbarBase.ts
+++ b/browser/src/control/Control.NotebookbarBase.ts
@@ -161,7 +161,7 @@ class NotebookbarBase extends JSDialogComponent {
 				selected: false,
 				ondemand: true,
 				width: 96,
-				height: 72,
+				height: 30, // adjust with expected image to not blink
 			});
 		});
 

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -509,6 +509,7 @@ class UIManager extends window.L.Control {
 			formulabarRow?.classList?.remove('hidden');
 			this.map.formulabar = JSDialog.FormulaBar(this.map);
 			this.map.addressInputField = JSDialog.AddressInputField(this.map);
+			JSDialog.MessageRouter.flushPending('addressinputfield');
 			$('#toolbar-wrapper').addClass('spreadsheet');
 
 			// remove unused elements
@@ -776,6 +777,7 @@ class UIManager extends window.L.Control {
 		}
 
 		this.notebookbar = JSDialog.NotebookbarBase(this.map, notebookbar);
+		JSDialog.MessageRouter.flushPending('notebookbar');
 		if (showUI)
 			this.showNotebookbarControl();
 	}

--- a/browser/src/control/Permission.js
+++ b/browser/src/control/Permission.js
@@ -210,6 +210,22 @@ window.L.Map.include({
 		}
 	},
 
+	// Tell core whether this view is read-only, and flip the client-side
+	// comment/redline gates the UI checks via isCommentEditingAllowed()/
+	// isRedlineManagementAllowed(). Only meaningful for users that actually
+	// have WOPI write permission: users without write permission already
+	// get read-only set up server-side at session start, and their
+	// app.file.editComment / allowManageRedlines flags already reflect the
+	// real doc state (e.g. comment-only PDFs) and must not be touched.
+	_applyViewReadOnly: function (readOnly) {
+		if (!this['wopi'] || !this['wopi'].UserCanWrite)
+			return;
+		if (app.socket)
+			app.socket.sendMessage('setviewreadonly value=' + readOnly);
+		app.file.editComment = !readOnly;
+		app.file.allowManageRedlines = !readOnly;
+	},
+
 	_enterEditMode: function (perm) {
 		this._permission = perm;
 
@@ -219,6 +235,11 @@ window.L.Map.include({
 
 		if (app.map['stateChangeHandler'].getItemValue('EditDoc') === 'false')
 			app.map.sendUnoCommand('.uno:EditDoc?Editable:bool=true');
+
+		// Re-enable direct-canvas interactions (shape drag, arrow-key
+		// shape move) that the matching _enterReadOnlyMode branch
+		// disabled.
+		this._applyViewReadOnly(false);
 
 		app.events.fire('updatepermission', {perm : perm});
 
@@ -241,6 +262,12 @@ window.L.Map.include({
 			this._docLayer._onUpdateCursor();
 			this._docLayer._clearSelections();
 		}
+
+		// Block direct-canvas interactions (shape drag, arrow-key shape
+		// move) server-side and hide per-comment edit/redline controls
+		// in the UI.
+		this._applyViewReadOnly(true);
+
 		app.events.fire('updatepermission', {perm : perm});
 		this.fire('closemobilewizard');
 		this.fire('closealldialogs');

--- a/browser/src/control/jsdialog/Util.MessageRouter.ts
+++ b/browser/src/control/jsdialog/Util.MessageRouter.ts
@@ -16,6 +16,9 @@
 declare var JSDialog: any;
 
 class JSDialogMessageRouter {
+	// Per-jsontype queues for messages with target component not yet ready
+	private pendingByJsontype: Map<string, Array<() => void>> = new Map();
+
 	// show labels instead of editable fields in message boxes
 	private _preProcessMessageDialog(msgData: WidgetJSON) {
 		if (!msgData.children) return;
@@ -25,6 +28,23 @@ class JSDialogMessageRouter {
 			if (child.type === 'multilineedit') child.type = 'fixedtext';
 			else if (child.children) this._preProcessMessageDialog(child);
 		}
+	}
+
+	private isReady(jsontype: string): boolean {
+		if (jsontype === 'notebookbar')
+			return !!(
+				app.socket._map.uiManager && app.socket._map.uiManager.notebookbar
+			);
+		if (jsontype === 'addressinputfield')
+			return !!app.socket._map.addressInputField;
+		return true;
+	}
+
+	public flushPending(jsontype: string): void {
+		const queue = this.pendingByJsontype.get(jsontype);
+		if (!queue) return;
+		this.pendingByJsontype.delete(jsontype);
+		for (const fire of queue) fire();
 	}
 
 	public processMessage(msgData: JSDialogJSON, callbackFn: JSDialogCallback) {
@@ -44,14 +64,14 @@ class JSDialogMessageRouter {
 				return false;
 			};
 
-			var isNotebookbarInitialized =
-				app.socket._map.uiManager && app.socket._map.uiManager.notebookbar;
-			if (
-				(msgData.jsontype === 'notebookbar' && !isNotebookbarInitialized) ||
-				(msgData.jsontype === 'addressinputfield' &&
-					!app.socket._map.addressInputField)
-			) {
-				setTimeout(fireJSDialogEvent, 1000);
+			const jsontype = msgData.jsontype;
+			const queue = this.pendingByJsontype.get(jsontype);
+			if (queue || !this.isReady(jsontype)) {
+				// target is not initialized yet or earlier messages
+				// of the same jsontype are still queued.
+				const q = queue || [];
+				q.push(fireJSDialogEvent);
+				if (!queue) this.pendingByJsontype.set(jsontype, q);
 				return;
 			} else if (fireJSDialogEvent() === true) {
 				return;

--- a/browser/src/dom/NotebookbarAccessibilityDefinitions.js
+++ b/browser/src/dom/NotebookbarAccessibilityDefinitions.js
@@ -29,6 +29,19 @@ var NotebookbarAccessibilityDefinitions = function() {
 					var arrow = document.querySelector('#' + id + ' .arrowbackground');
 					var element = document.getElementById(id + '-button');
 
+					// If standard lookups failed and item has a UNO command, try
+					// finding by modelid. This handles WeldedToolbar items where
+					// core assigns command-based ids (e.g. NumberFormatCurrency)
+					// instead of the JS definition ids (e.g. home-number-format-currency).
+					if (!overflow && !arrow && !element && rawList[i].command) {
+						var commandId = rawList[i].command.replace('.uno:', '');
+						var byModelId = document.querySelector('[modelid="' + commandId + '"]');
+						if (byModelId) {
+							id = commandId;
+							arrow = byModelId.querySelector('.arrowbackground');
+						}
+					}
+
 					if (overflow) {
 						// overflow button
 						if (typeof overflow.isCollapsed === 'function' && overflow.isCollapsed()) {

--- a/cypress_test/integration_tests/common/desktop_helper.js
+++ b/cypress_test/integration_tests/common/desktop_helper.js
@@ -49,6 +49,26 @@ function sidebarToggle() {
 	cy.cGet('#optionscontainer [id^="SidebarDeck.PropertyDeck"] button').click();
 }
 
+// Wait for the sidebar to reshow and grab focus to its first focusable
+// element via the 'sidebarstealfocus' timer scheduled in
+// Control.Sidebar.ts.
+function assertSidebarStealsFocus(win) {
+	cy.log('>> assertSidebarStealsFocus - start');
+
+	cy.cGet('#sidebar-dock-wrapper').should('be.visible').then(function(sidebar) {
+		// This first waitUntilLayoutingIsIdle ensures the sidebar
+		// update task has run and registered the timer.
+		helper.waitUntilLayoutingIsIdle(win);
+		// Wait for that timer to complete
+		helper.waitForTimers(win, 'sidebarstealfocus');
+		// Wait until dispatched tasks get done
+		helper.waitUntilLayoutingIsIdle(win);
+		helper.containsFocusElement(sidebar[0], true);
+	});
+
+	cy.log('<< assertSidebarStealsFocus - end');
+}
+
 // Make the status bar visible if it's hidden at the moment.
 // We use the menu option under 'View' menu to make it visible.
 function showStatusBarIfHidden() {
@@ -627,6 +647,7 @@ module.exports.updateFollowingUsers = updateFollowingUsers;
 module.exports.assertVisiblePage = assertVisiblePage;
 module.exports.closeNavigatorSidebar = closeNavigatorSidebar;
 module.exports.sidebarToggle = sidebarToggle;
+module.exports.assertSidebarStealsFocus = assertSidebarStealsFocus;
 module.exports.getCompactIcon = getCompactIcon;
 module.exports.getNbIcon = getNbIcon;
 module.exports.getCompactIconArrow = getCompactIconArrow;

--- a/cypress_test/integration_tests/desktop/calc/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/a11y_dialog_spec.js
@@ -212,7 +212,7 @@ describe(['tagdesktop'], 'Accessibility Calc Dialog Tests', { testIsolation: fal
         a11yHelper.handleDialog(win, 1);
     });
 
-    it.skip('Text Import Dialog (Buggy)', function () {
+    it('Text Import Dialog', function () {
         helper.setDummyClipboardForCopy('text/plain');
         // Select some text
         helper.selectAllText();

--- a/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_dialog_spec.js
@@ -487,11 +487,7 @@ describe(['tagdesktop'], 'Accessibility Writer Dialog Tests', { testIsolation: f
         helper.processToIdle(win);
 
         // sidebar starts again, and grabs focus to itself
-        cy.cGet('#sidebar-dock-wrapper').should('be.visible').then(function(sidebar) {
-                helper.waitForTimers(win, 'sidebarstealfocus');
-                helper.waitUntilLayoutingIsIdle(win);
-                helper.containsFocusElement(sidebar[0], true);
-       });
+        desktopHelper.assertSidebarStealsFocus(win);
 
        // esc to send focus back to main document
        escLevel(win, 1);

--- a/cypress_test/integration_tests/desktop/writer/a11y_sidebar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/a11y_sidebar_spec.js
@@ -113,11 +113,7 @@ describe(['tagdesktop'], 'Accessibility Writer Sidebar Tests', { testIsolation: 
 		helper.processToIdle(win);
 
 		// sidebar starts again, and grabs focus to itself
-		cy.cGet('#sidebar-dock-wrapper').should('be.visible').then(function(sidebar) {
-			helper.waitForTimers(win, 'sidebarstealfocus');
-			helper.waitUntilLayoutingIsIdle(win);
-			helper.containsFocusElement(sidebar[0], true);
-		});
+		desktopHelper.assertSidebarStealsFocus(win);
 
 		// esc to send focus back to main document
 		escLevel(win, 1);

--- a/cypress_test/integration_tests/desktop/writer/presets_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/presets_spec.js
@@ -36,8 +36,10 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Preset tests.', function()
 
                 cy.cGet('.notebookbar > .unoSpellingAndGrammarDialog > button').first().click();
 
-		// we should end up with the "there are no misspelling information dialog"
-		cy.cGet('.ui-dialog-title').should('have.text', 'Spelling: Information');
+		// we should end up with the "there are no misspelling" Information messagebox.
+		// Scope to its own #Information; the underlying SpellingDialog stays visible
+		// behind it and a bare .ui-dialog-title would match both and concatenate.
+		cy.cGet('#Information.ui-dialog-title').should('have.text', 'Information');
 
 		cy.cGet('body').type('{esc}');
 		cy.cGet('body').type('{esc}');
@@ -65,8 +67,10 @@ describe(['tagdesktop', 'tagnextcloud', 'tagproxy'], 'Preset tests.', function()
 
                 cy.cGet('.notebookbar > .unoSpellingAndGrammarDialog > button').first().click();
 
-		// we should end up with the "there are no misspelling information dialog"
-		cy.cGet('.ui-dialog-title').should('have.text', 'Spelling: Information');
+		// we should end up with the "there are no misspelling" Information messagebox.
+		// Scope to its own #Information; the underlying SpellingDialog stays visible
+		// behind it and a bare .ui-dialog-title would match both and concatenate.
+		cy.cGet('#Information.ui-dialog-title').should('have.text', 'Information');
 
 		cy.cGet('body').type('{esc}');
 		cy.cGet('body').type('{esc}');

--- a/cypress_test/integration_tests/desktop/writer/spinfield_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/spinfield_spec.js
@@ -1,6 +1,7 @@
 /* global describe it cy require beforeEach expect */
 
 var helper = require('../../common/helper');
+var desktopHelper = require('../../common/desktop_helper');
 
 describe(['tagdesktop'], 'Spinfield unit and button tests', function () {
 	var win;
@@ -126,6 +127,33 @@ describe(['tagdesktop'], 'Spinfield unit and button tests', function () {
 				expect(parseFloat($el.val())).to.be.lessThan(num);
 			});
 		});
+	});
+
+	it('Kerning spinfield is labelled by Custom Value label', function () {
+		desktopHelper.switchUIToNotebookbar();
+		cy.cGet('#sidebar-dock-wrapper').should('be.visible');
+
+		// Click the dropdown arrow on the Spacing toolbar button
+		// in the sidebar to open the TextCharacterSpacingControl popover
+		cy.cGet('#sidebar-dock-wrapper .unoSpacing .arrowbackground').click();
+
+		cy.cGet('.jsdialog-window.modalpopup').should('exist');
+		cy.then(function () {
+			return helper.processToIdle(win);
+		});
+
+		// The kerning spinfield should be labeled by a <label> element
+		// with text "Custom Value", not have a stale aria-label
+		// containing the current numeric value.
+		cy.cGet('label[for="kerning-input"]').should('exist')
+			.should('contain.text', 'Custom Value');
+		cy.cGet('#kerning-input').should('not.have.attr', 'aria-label');
+
+		// Change the value and verify the label still says "Custom Value"
+		// and no aria-label with the old value reappears.
+		cy.cGet('#kerning-input').clear().type('1.5');
+		cy.cGet('#kerning-input').should('not.have.attr', 'aria-label');
+		cy.cGet('label[for="kerning-input"]').should('contain.text', 'Custom Value');
 	});
 
 	it('Buttons enabled after re-enabling spinfield in columns dialog', function () {

--- a/cypress_test/integration_tests/desktop/writer/stylesview_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/stylesview_spec.js
@@ -13,11 +13,11 @@ describe(['tagdesktop'], 'Stylesview Iconview Tests', function() {
 	}
 
 	beforeEach(function() {
-		cy.viewport(1920, 1080);
+		cy.viewport(1280, 720);
 		helper.setupAndLoadDocument('writer/styles.odt');
 		desktopHelper.switchUIToNotebookbar();
 		desktopHelper.sidebarToggle();
-		cy.cGet('.notebookbar #stylesview').should('exist').should('be.visible');
+		cy.cGet('.notebookbar #stylesview').should('exist').should('be.visible').should('not.be.empty');
 	});
 
 	it('Scroll Up/Down Buttons', function() {
@@ -32,9 +32,9 @@ describe(['tagdesktop'], 'Stylesview Iconview Tests', function() {
 	});
 
 	it('Expander Button', function() {
+		cy.cGet('.jsdialog #stylesview_9').should('not.exist');
 		openExpander();
-		cy.cGet('.jsdialog #stylesview_59').should('exist').should('be.visible'); // Contents 9
-		cy.cGet('.jsdialog #stylesview_60').should('exist').should('not.be.visible');
+		cy.cGet('.jsdialog #stylesview_9').should('exist').should('be.visible');
 	});
 
 	it('Open Styles Sidebar Button', function() {
@@ -50,28 +50,22 @@ describe(['tagdesktop'], 'Stylesview Iconview Tests', function() {
 		cy.cGet('#StyleListDeck').should('exist').should('be.visible');
 	});
 
-	it.only('Resize', function() {
+	it('Resize', function() {
 		// the dropdown should close on resize
 		openExpander();
 		cy.cGet('#stylesview-iconview-list-dropdown').should('exist').should('be.visible');
 		cy.viewport(650, 1080);
 		cy.cGet('#stylesview-iconview-list-dropdown').should('not.exist');
 
-		// with reduced width, only one column should be visible
+		// re-open after resize
 		openExpander();
-		cy.cGet('.jsdialog #stylesview_11').should('exist').should('be.visible'); // Standardstyckeformatmall
-		cy.cGet('.jsdialog #stylesview_12').should('exist').should('not.be.visible');
-
-		// NOTE: changes to the height don't trigger the resize observer,
-		// thus the dropdown doesn't disappear. so no need to call
-		// `openExpander` again.
 
 		// with reduced height:
 		// - only a few rows should be visible.
 		// - the open styles sidebar button should be visible.
 		cy.viewport(650, 454);
-		cy.cGet('.jsdialog #stylesview_4').should('exist').should('be.visible'); // Title
-		cy.cGet('.jsdialog #stylesview_5').should('exist').should('not.be.visible'); // Subtitle
+		cy.cGet('.jsdialog #stylesview_4').should('exist').should('be.visible');
+		cy.cGet('.jsdialog #stylesview_5').should('exist').should('not.be.visible');
 		cy.cGet('#format-style-list-dialog-button').should('exist').should('be.visible');
 	});
 });

--- a/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
+++ b/cypress_test/integration_tests/desktop/writer/top_toolbar_spec.js
@@ -59,8 +59,8 @@ describe(['tagdesktop'], 'Top toolbar tests.', function() {
 
 	it('Apply style.', function() {
 		helper.setDummyClipboardForCopy();
-		cy.cGet('#stylesview').scrollTo('bottom') ;
-		cy.cGet('#stylesview .notebookbar.ui-iconview-entry img[title=Title]').click();
+		cy.cGet('#stylesview').scrollTo('bottom');
+		cy.cGet('#stylesview .notebookbar.ui-iconview-entry img[title=Title]').first().scrollIntoView().should('be.visible').click();
 		refreshCopyPasteContainer();
 		helper.copy();
 		cy.cGet('#copy-paste-container p font font').should('have.attr', 'style', 'font-size: 28pt');

--- a/kit/ChildSession.cpp
+++ b/kit/ChildSession.cpp
@@ -578,6 +578,7 @@ bool ChildSession::_handleInput(const char *buffer, int length)
                tokens.equals(0, "formfieldevent") ||
                tokens.equals(0, "traceeventrecording") ||
                tokens.equals(0, "sallogoverride") ||
+               tokens.equals(0, "setviewreadonly") ||
                tokens.equals(0, "rendersearchresult") ||
                tokens.equals(0, "contentcontrolevent") ||
                tokens.equals(0, "a11ystate") ||
@@ -846,6 +847,33 @@ bool ChildSession::_handleInput(const char *buffer, int length)
             else if (tokens.size() > 0)
             {
                 getLOKit()->setOption("sallogoverride", tokens[1].c_str());
+            }
+        }
+        else if (tokens.equals(0, "setviewreadonly"))
+        {
+            // Propagate the browser-side Viewing/Editing toggle to core so it can
+            // block direct-canvas interactions (shape drag, arrow-key move) and
+            // gate comment/redline commands via the dispatch filter.
+            bool readOnly = false;
+            std::string value;
+            if (tokens.size() > 1 && getTokenString(tokens[1], "value", value))
+                readOnly = (value == "true");
+
+            if (getLOKitDocument())
+            {
+                getLOKitDocument()->setView(_viewId);
+                getLOKitDocument()->setViewReadOnly(_viewId, readOnly);
+
+                // Browser only sends setviewreadonly when the user has WOPI
+                // write permission, so this path is the Viewing/Editing toggle
+                // on a fully editable doc. Block comments and redline management
+                // in Viewing mode too - comment-only docs (e.g. PDFs) are set
+                // up separately at session start and never reach this branch.
+                getLOKitDocument()->setAllowChangeComments(_viewId, !readOnly);
+                getLOKitDocument()->setAllowManageRedlines(_viewId, !readOnly);
+
+                LOG_DBG("setviewreadonly: viewId=" << _viewId
+                        << " readOnly=" << readOnly);
             }
         }
         else if (tokens.equals(0, "rendersearchresult"))

--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1234,6 +1234,7 @@ bool ClientSession::_handleInput(const char *buffer, int length)
     }
     else if (tokens.equals(0, "formfieldevent") ||
              tokens.equals(0, "sallogoverride") ||
+             tokens.equals(0, "setviewreadonly") ||
              tokens.equals(0, "contentcontrolevent"))
     {
         return forwardToChild(firstLine, docBroker);


### PR DESCRIPTION
Backport of: https://github.com/CollaboraOnline/online/pull/15459

In I4cab2546f6828ab3c76ba8a4e06601904a06502e, DropDownSection was moved into its own file. During this move, some stuff was broken so the dropdown was only active on part of the dropdown arrow.

In I6a5b26b42e4cf77a070452042d5f7a242e874bc0, we then stopped using the uno command to send the dropdown to core, and instead relied on the core position of the dropdown arrow.

Finally, Ib48f7266f7b0d147761eaccd647caf39df0d6550 made it so we would click in the center of the dropdown arrow.

Unfortunately, Ib48f7266f7b0d147761eaccd647caf39df0d6550 made the problem worse on certain zooms/high DPI screens. The dropdown would then either be activeateable across the whole arrow or not be activateable at all.

I think the problems caused by I4cab2546f6828ab3c76ba8a4e06601904a06502e are not still around today, however they did mask problems caused by  I6a5b26b42e4cf77a070452042d5f7a242e874bc0 which made the dropdown break when the core position didn't line up.

To fix this, we can revert to using the original uno-command-based approach to handling dropdowns. I've chatted to Gokay and he has OKed this as an approach...




