### PR TITLE
check wopi isWritable

### DIFF
--- a/wsd/ClientSession.cpp
+++ b/wsd/ClientSession.cpp
@@ -1232,9 +1232,15 @@ bool ClientSession::_handleInput(const char *buffer, int length)
 
         return forwardToChild(firstLine, docBroker);
     }
+    else if (tokens.equals(0, "setviewreadonly"))
+    {
+        // only if the session has WOPI write permission
+        if (!isWritable())
+            return false;
+        return forwardToChild(firstLine, docBroker);
+    }
     else if (tokens.equals(0, "formfieldevent") ||
              tokens.equals(0, "sallogoverride") ||
-             tokens.equals(0, "setviewreadonly") ||
              tokens.equals(0, "contentcontrolevent"))
     {
         return forwardToChild(firstLine, docBroker);


### PR DESCRIPTION
for editing toggle

commit 4dd2d8ac761d571b6bafbc3b0540c2dea5f8f535
Date:   Tue Apr 21 19:54:33 2026 +0530

    wsd, kit, browser: honour the Viewing/Editing toggle across the session


Change-Id: I8314fb0419e4b3634136ac46f52cb265418e29cb
Reviewed-on: https://gerrit.collaboraoffice.com/c/online/+/2642
Tested-by: Jenkins CPCI <releng@collaboraoffice.com>
Reviewed-by: Szymon Kłos <szymon.klos@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

