### PR TITLE
notebookbar: avoid duplicated styles (backport)

### DIFF
--- a/browser/src/control/jsdialog/Util.OnDemandRenderer.ts
+++ b/browser/src/control/jsdialog/Util.OnDemandRenderer.ts
@@ -26,6 +26,9 @@ function onDemandRenderer(
 	entryText: string | undefined,
 ) {
 	const setupOnDemandRenderer = () => {
+		// avoid races, might be already updated
+		if (!parentContainer.contains(placeholder)) return;
+
 		const cachedComboboxEntries = builder.rendersCache[controlId];
 		let requestRender = true;
 


### PR DESCRIPTION
- this patch prevents race in on demand rendering
- when we scheduled update "on first tile received" but iconview become already updated with other message it might happen that placeholder is not there already
