### PR TITLE
Calc a11y: keep screen reader scoped to the dialog when opening from notebookbar

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -354,6 +354,15 @@ window.L.Control.JSDialog = window.L.Control.extend({
 
 		instance.form = window.L.DomUtil.create('form', 'jsdialog-container ui-dialog ui-widget-content lokdialog_container', instance.container);
 		instance.form.setAttribute('role', 'dialog');
+		// aria-modal tells screen readers to ignore everything outside this dialog while it is open.
+		// Apply to real modal dialogs only. Skip popup-style jsdialog instances that share this code path but aren't modal:
+		// dropdowns, snackbars, document-area popovers, autocomplete popups and autofill preview tooltips.
+		if (!instance.isDropdown
+			&& !instance.isSnackbar
+			&& !instance.isDocumentAreaPopup
+			&& !instance.isAutoCompletePopup
+			&& !instance.isAutoFillPreviewTooltip)
+			instance.form.setAttribute('aria-modal', 'true');
 		instance.form.setAttribute('autocomplete', 'off');
 		if (instance.title)
 			instance.form.setAttribute('aria-labelledby', instance.title);

--- a/browser/src/dom/NotebookbarAccessibility.js
+++ b/browser/src/dom/NotebookbarAccessibility.js
@@ -191,15 +191,19 @@ var NotebookbarAccessibility = function() {
 				}
 				else if (this.state === 1) {
 					itemWasClicked = true;
-					this.setTabItemDescription(element);
 					var selectTarget = element.tagName === 'SELECT' ? element : element.querySelector('select');
 					if (selectTarget) {
+						this.setTabItemDescription(element);
 						selectTarget.focus();
 						selectTarget.showPicker();
 					} else {
 						var clickTarget = element.querySelector('button.unobutton') || element;
+						const doFocusToMap = this.filteredItem && this.filteredItem.focusBack === true;
+						// Blur the offscreen role="tablist" input first so the screen reader doesn't enumerate the notebookbar tabs on focus-out.
+						// The blur handler (onInputBlur) clears aria-description with resetState(). So, no need to clear it again here.
+						this.accessibilityInputElement.blur();
 						clickTarget.click();
-						if (this.filteredItem && this.filteredItem.focusBack === true)
+						if (doFocusToMap)
 							this.focusToMap();
 					}
 				}


### PR DESCRIPTION
- Blur the notebookbar's offscreen role="tablist" input before firing the click, so screen readers don't enumerate its tab buttons on focus-out.
- Set aria-modal="true" on modal jsdialog forms, excluding popup-style instances that share the dialog code path but aren't modal (dropdowns, snackbars, document-area popovers, autocomplete popups, autofill preview tooltips).
- Set aria-description on the activated item only when it opens a select picker, so screen readers read its context while the picker is shown.

Change-Id: I18ff5f27c46a1f4ed985517b52ab5571c0f0d9a7


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

