### PR TITLE
Calc a11y: keep focus on the current toolbar button when ArrowDown has no target

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -1000,8 +1000,10 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 								elementToFocus.focus();
 							else if (elementToFocus)
 								document.querySelector('.ui-tab.notebookbar.selected').focus();
-							else {
-								// Nothing found — cycle to first focusable
+							else if (isTab) {
+								// Tab wrap-around only. If the user actually pressed Tab,
+								// wrap to first/last. For arrow keys, leave focus alone so
+								// it stays on the current button when nothing is found.
 								let visibleContainer = Array.from(container[0].children).find(child =>
 									!child.classList.contains('hidden') && child.offsetParent !== null
 								);

--- a/cypress_test/integration_tests/desktop/calc/a11y_notebookbar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/a11y_notebookbar_spec.js
@@ -70,6 +70,64 @@ describe(['tagdesktop'], 'Accessibility Calc Notebookbar Tests', { testIsolation
 		helper.typeIntoDocument('{esc}');
 	});
 
+	it('Shape tab: ArrowDown on first toolbar button keeps focus', function () {
+		cy.then(function () {
+			win.app.map.sendUnoCommand('.uno:BasicShapes.octagon');
+		});
+
+		cy.cGet('#test-div-shapeHandlesSection').should('exist');
+
+		cy.cGet('#Shape-tab-label').should('be.visible').click();
+		cy.cGet('#Shape-tab-label').should('have.class', 'selected');
+		cy.then(function () { return helper.processToIdle(win); });
+
+		// Extend notebookbar, collapsed mode hides all tab pages.
+		cy.then(function () {
+			if (win.app.map.uiManager.isNotebookbarCollapsed())
+				win.app.map.uiManager.extendNotebookbar();
+		});
+		cy.then(function () { return helper.processToIdle(win); });
+
+		cy.cGet('[modelid="shape-transform-dialog"] > button')
+			.should('not.be.disabled');
+
+		// Listen for focus changes during dispatch; the clipboard-area
+		// steals focus back instantly and hides any wrong .focus() call.
+		cy.then(function () {
+			var positionAndSizeBtn = win.document.querySelector(
+				'[modelid="shape-transform-dialog"] > button');
+			expect(positionAndSizeBtn,
+				'Position and Size button must exist').to.not.be.null;
+
+			var stolenFocusOnto = [];
+			var listener = function (e) {
+				if (e.target.classList &&
+					e.target.classList.contains('unotoolbutton')) {
+					stolenFocusOnto.push(e.target.id || '<no id>');
+				}
+			};
+			win.document.addEventListener('focusin', listener, true);
+
+			var event = new win.KeyboardEvent('keydown', {
+				key: 'ArrowDown',
+				bubbles: true,
+				cancelable: true,
+			});
+			positionAndSizeBtn.dispatchEvent(event);
+
+			win.document.removeEventListener('focusin', listener, true);
+
+			// Regression: ArrowDown used to focus a wrapper div.
+			expect(stolenFocusOnto,
+				'ArrowDown must not focus a unotoolbutton wrapper, saw: ' +
+				JSON.stringify(stolenFocusOnto))
+				.to.be.empty;
+		});
+
+		// exit shape mode
+		helper.typeIntoDocument('{esc}');
+	});
+
 	it('Notebookbar tab: Picture (context)', function () {
 		cy.viewport(1920, 1080);
 


### PR DESCRIPTION
- The notebookbar keydown handler had a Tab wrap-around fallback that arrow keys were also falling into. Its [tabindex="-1"] selector matches the unotoolbutton wrapper divs, not the inner <button>s, so ArrowDown on "Position and Size" in the Shape tab moved focus to a wrapper div with no accessible name. The focus ring disappeared, the screen reader fell silent, and subsequent arrow keys did nothing.

- Restrict the fallback to isTab so only Tab and Shift+Tab still wrap, while arrow keys with no target leave focus on the current button.
- Add a cypress test.


Change-Id: I07b49512f04ab6a8898b723c53e713fba11ade4b


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

