### PR TITLE
slideshow: improve slidshow sharpness (backport)

### DIFF
--- a/browser/src/slideshow/LayerDrawing.ts
+++ b/browser/src/slideshow/LayerDrawing.ts
@@ -939,8 +939,12 @@ class LayerDrawing {
 	}
 
 	private computeInitialResolution() {
-		const viewWidth = window.screen.width;
-		const viewHeight = window.screen.height;
+		// window.screen dimensions are in CSS pixels; multiply by DPR so the
+		// tier selection matches the display's physical pixels and the canvas
+		// backing store isn't upscaled by CSS on HiDPI screens.
+		const dpr = window.devicePixelRatio || 1;
+		const viewWidth = window.screen.width * dpr;
+		const viewHeight = window.screen.height * dpr;
 		this.computeResolution(viewWidth, viewHeight);
 	}
 

--- a/browser/src/slideshow/LayerRenderer.ts
+++ b/browser/src/slideshow/LayerRenderer.ts
@@ -260,10 +260,12 @@ class LayerRendererGl implements LayerRenderer {
 			// app.console.debug(`LayerDrawing.drawBitmap: cache hit: key: ${textureKey}`);
 		} else {
 			if (imageInfo instanceof ImageBitmap) {
-				texture = this.glContext.loadTexture(imageInfo);
+				texture = this.glContext.loadTexture(imageInfo, false, true);
 			} else {
 				texture = this.glContext.loadTexture(
 					imageInfo.data as HTMLImageElement,
+					false,
+					true,
 				);
 			}
 			this.textureCache.set(textureKey, texture);

--- a/browser/src/slideshow/LayersCompositor.ts
+++ b/browser/src/slideshow/LayersCompositor.ts
@@ -133,7 +133,7 @@ class LayersCompositor extends SlideCompositor {
 		if (slideRatio > resolutionRatio) {
 			height = Math.trunc((width * slideHeight) / slideWidth);
 		} else if (slideRatio < resolutionRatio) {
-			width = Math.trunc((height * slideWidth) / slideHeight);
+			width = Math.ceil((height * slideWidth) / slideHeight);
 		}
 		return [width, height];
 	}

--- a/browser/src/slideshow/RenderContext.ts
+++ b/browser/src/slideshow/RenderContext.ts
@@ -67,6 +67,7 @@ abstract class RenderContext {
 	public abstract loadTexture(
 		image: HTMLImageElement,
 		isMipMapEnable?: boolean,
+		nearestFiltering?: boolean,
 	): WebGLTexture | ImageBitmap;
 
 	public abstract deleteTexture(texture: WebGLTexture | ImageBitmap): void;
@@ -109,6 +110,7 @@ class RenderContextGl extends RenderContext {
 	public loadTexture(
 		image: HTMLImageElement | ImageBitmap,
 		isMipMapEnable: boolean = false,
+		nearestFiltering: boolean = false,
 	): WebGLTexture | ImageBitmap {
 		if (this.isDisposed()) return null;
 
@@ -128,6 +130,7 @@ class RenderContextGl extends RenderContext {
 		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
 		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
 
+		const filter = nearestFiltering ? gl.NEAREST : gl.LINEAR;
 		if (isMipMapEnable) {
 			gl.generateMipmap(gl.TEXTURE_2D);
 			gl.texParameteri(
@@ -136,10 +139,10 @@ class RenderContextGl extends RenderContext {
 				gl.LINEAR_MIPMAP_LINEAR,
 			);
 		} else {
-			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, filter);
 		}
 
-		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+		gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, filter);
 
 		if (image instanceof HTMLImageElement)
 			app.console.debug(`Texture loaded successfully`);
@@ -277,6 +280,7 @@ class RenderContext2d extends RenderContext {
 	public loadTexture(
 		image: HTMLImageElement,
 		isMipMapEnable: boolean = false,
+		nearestFiltering: boolean = false,
 	): WebGLTexture | ImageBitmap {
 		return image;
 	}


### PR DESCRIPTION
Use device pixel ratio when selecting the resolution tier so the offscreen canvas matches the display's physical pixels on HiDPI screens. Switch layer texture filtering to NEAREST to preserve pixel-exact rendering, and use Math.ceil for the width computation in computeLayerSize so the client-server dimensions agree and no row duplication artifact appears.

For example, a standard 16:9 Impress page (25400x14288 twips) at the 3840x2160 tier: Math.trunc(2160 * 25400/14288) = 3839, which causes a 1-pixel height mismatch with the server (2159 vs 2160), producing a visible tear. Math.ceil gives 3840, so the server derives trunc(3840 * 14288/25400) = 2160 — an exact match.

test screenshots updated to sharper shots


Change-Id: I6902f39677b626df8a7da2f54fefb30c1cc7faf0
Reviewed-on: https://gerrit.collaboraoffice.com/c/online/+/1622


* Target version: main


### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

