### PR TITLE
[Backport] Apply clone formatting to a cell using the Enter key

### DIFF
--- a/browser/src/map/handler/Map.Keyboard.js
+++ b/browser/src/map/handler/Map.Keyboard.js
@@ -585,6 +585,11 @@ window.L.Map.Keyboard = window.L.Handler.extend({
 				// key ignored
 			}
 			else if (ev.type === 'keydown') {
+				if (window.mode.isDesktop()
+					&& keyCode === this.keyCodes.enter
+					&& this._isFormatPaintbrushActiveOnCalcCell()) {
+					this._clickCellCursor();
+				}
 				if (this.handleOnKeyDownKeys[keyCode] && charCode === 0) {
 					if (keyEventFn) {
 						keyEventFn('input', charCode, unoKeyCode);
@@ -656,6 +661,25 @@ window.L.Map.Keyboard = window.L.Handler.extend({
 			return e.metaKey;
 		else
 			return e.ctrlKey;
+	},
+
+	_isFormatPaintbrushActiveOnCalcCell: function () {
+		if (this._map.getDocType() !== 'spreadsheet')
+			return false;
+		if (this._map._docLayer.insertMode)
+			return false;
+		return this._map.stateChangeHandler.getItemValue('.uno:FormatPaintbrush') === 'true';
+	},
+
+	// Simulates a click on the cell cursor, which is needed to apply
+	// the format paintbrush in calc when pressing enter on a cell
+	// with the paintbrush active.
+	_clickCellCursor: function () {
+		var center = app.calc.cellCursorRectangle.center;
+		var x = Math.round(center[0]);
+		var y = Math.round(center[1]);
+		this._map._docLayer._postMouseEvent('buttondown', x, y, 1, 1, 0);
+		this._map._docLayer._postMouseEvent('buttonup', x, y, 1, 1, 0);
 	},
 
 	// Keys that should still be sent to core with modifiers in read-only mode.


### PR DESCRIPTION
Previously, applying clone formatting required a mouse, blocking keyboard-only and screen reader users. Now, when the paintbrush tool is active, pressing Enter on a cell triggers a synthetic click at the cell cursor’s center, applying the formatting to the target cell.


Change-Id: I3ea06fddc3c44153ad18ee56abff7afc3a2b51f7


* Resolves: # <!-- related github issue -->
* Target version: distro/collabora/co-25.04
Backport for https://gerrit.collaboraoffice.com/c/online/+/1900