### PR TITLE
jsdialog: fix treeview context menu position for rendered entries (backport)

### DIFF
--- a/browser/src/control/Control.JSDialog.js
+++ b/browser/src/control/Control.JSDialog.js
@@ -625,8 +625,16 @@ window.L.Control.JSDialog = window.L.Control.extend({
 				var matchingElements;
 				if ((matchingElements = parent.querySelectorAll('span.ui-treeview-cell-text')).length) {// treeview entry for context menu
 					parent = Array.from(matchingElements).find(
-						(value) => (value.innerText === instance.clickToCloseText) // text entry
-											|| (value.firstChild && value.firstChild.alt === instance.clickToCloseText)); // custom render
+						(value) => {
+							if (value.innerText === instance.clickToCloseText) // text entry
+								return true;
+							// custom render: the rendered <img> may sit either as
+							// firstChild of the cell span, or - once OnDemandRenderer
+							// has replaced the placeholder - as a sibling inside the
+							// outer cell span. Match either case.
+							const img = value.querySelector('img');
+							return img && img.alt === instance.clickToCloseText;
+						});
 				} else if ((matchingElements = parent.querySelectorAll('div.ui-iconview-entry > img')).length) {// iconview entry for context menu
 					parent = Array.from(matchingElements).find((img) => img.title === instance.clickToCloseText);
 				}


### PR DESCRIPTION
After OnDemandRenderer replaces the placeholder, the rendered <img> sits as a sibling of the inner cell span rather than its firstChild. The position match in setPosition only checked innerText or firstChild.alt, so it failed to find the entry and the popup landed at undefined coordinates - typically near the middle of the page.

Match any descendant <img> whose alt equals clickToCloseText, which covers all three DOM states: text placeholder, img-as-firstChild, and img-as-sibling.

Most visible on the Writer styles sidebar when right-clicking the current paragraph style (e.g. "Body Text"), since that entry is the first to be rendered and cached.

Change-Id: I0722eb5f5e1cafaac3fe5e81a96f82464bf525ec

Reviewed-on: https://gerrit.collaboraoffice.com/c/online/+/2110
Tested-by: Caolán McNamara <caolan.mcnamara@collabora.com>
Reviewed-by: Caolán McNamara <caolan.mcnamara@collabora.com>


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

