### PR TITLE
Handle no-arg "insert comment" commands in browser

### DIFF
--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -501,6 +501,18 @@ window.L.Map.WOPI = window.L.Handler.extend({
 			return;
 		}
 		else if (msg.MessageId === 'Send_UNO_Command' && msg.Values && msg.Values.Command) {
+			// Commands to insert comments without args initiate interactive insertion,
+			// showing in-place editor, and in PDF, entering a click-to-place mode.
+			if (!msg.Values.Args) {
+				if (msg.Values.Command === '.uno:InsertAnnotation') {
+					this._map.insertComment();
+					return;
+				}
+				if (msg.Values.Command === '.uno:InsertThreadedComment') {
+					this._map.insertThreadedComment();
+					return;
+				}
+			}
 			this._map.sendUnoCommand(msg.Values.Command, msg.Values.Args || '');
 			return;
 		}

--- a/cypress_test/integration_tests/desktop/calc/threaded_comment_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/threaded_comment_spec.js
@@ -14,6 +14,25 @@ describe(['tagdesktop'], 'Threaded Comment', function() {
 		});
 	});
 
+	// A WOPI host can request a new threaded comment by posting Send_UNO_Command
+	// with .uno:InsertThreadedComment. That should enter the in-browser handling,
+	// instead of sending the command to engine.
+	it('Send_UNO_Command .uno:InsertThreadedComment opens a new comment editor', function() {
+		cy.getFrameWindow().then(function(win) {
+			const message = {
+				MessageId: 'Send_UNO_Command',
+				Values: { Command: '.uno:InsertThreadedComment' }
+			};
+			win.postMessage(JSON.stringify(message), '*');
+		});
+
+		// Same expectation as with the toolbar button: the new-comment editor
+		// placeholder appears so the user can type before the slot is dispatched.
+		cy.cGet('#comment-container-new').should('exist');
+		cy.cGet('.cool-annotation').last().find('#annotation-modify-textarea-new')
+			.should('exist');
+	});
+
 	it('Insert, resolve, unresolve, and remove threaded comment', function() {
 		// Click the "Insert Comment" button on the Insert tab.
 		cy.cGet('#Insert-tab-label').click();

--- a/cypress_test/integration_tests/desktop/draw/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/annotation_spec.js
@@ -319,6 +319,37 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 		});
 	});
 
+	// A WOPI host can request a new comment in PDF by posting Send_UNO_Command
+	// with .uno:InsertAnnotation. That should enter the in-browser handling,
+	// instead of sending the command to engine.
+	it('Send_UNO_Command .uno:InsertAnnotation enters click-to-place mode', { env: { 'pdf-view': true } }, function() {
+		let initialCount = 0;
+
+		cy.getFrameWindow().then(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			initialCount = section.sectionProperties.commentList.length;
+
+			const message = {
+				MessageId: 'Send_UNO_Command',
+				Values: { Command: '.uno:InsertAnnotation' }
+			};
+			win.postMessage(JSON.stringify(message), '*');
+		});
+
+		cy.getFrameWindow().should(function(win) {
+			expect(win.document.getElementById('document-canvas').style.cursor,
+				'placement mode must switch the canvas cursor to crosshair')
+				.to.equal('crosshair');
+
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			expect(section.sectionProperties.commentList.length,
+				'no comment should be created until the user picks a position')
+				.to.equal(initialCount);
+		});
+	});
+
 	// Negative path through placement mode: enter placement, miss the page
 	// (no comment), then click on the page (anchor visible at the click
 	// point), then cancel the editor before saving (no comment ends up in


### PR DESCRIPTION
Without that, the command either is a no-op (calc), or adds an empty
comment at 0,0 (draw/pdf).

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I266b0c10eb1531742afc09a245add4acddfe81eb
Reviewed-on: https://gerrit.collaboraoffice.com/c/online/+/2864
Tested-by: Jenkins CPCI <releng@collaboraoffice.com>
Reviewed-by: Miklos Vajna <vmiklos@collabora.com>
