### PR TITLE
notebookbar a11y: keep arrow keys inside text inputs only

### DIFF
--- a/browser/src/control/Control.JSDialogBuilder.js
+++ b/browser/src/control/Control.JSDialogBuilder.js
@@ -947,7 +947,13 @@ window.L.Control.JSDialogBuilder = window.L.Control.extend({
 					}
 					if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(key)) {
 						var currentElement = e.srcElement;
-						if (!(currentElement.tagName === 'INPUT' || currentElement.tagName === 'TEXTAREA') || isTab) {
+						// Inside a text-entry widget arrow keys move the cursor, so
+						// don't intercept. Checkbox/radio/button inputs don't use
+						// arrows internally, so let arrow keys move focus off them.
+						var tag = currentElement.tagName;
+						var arrowsConsumed = tag === 'TEXTAREA' ||
+							(tag === 'INPUT' && !['checkbox', 'radio', 'button', 'submit', 'reset'].includes(currentElement.type));
+						if (!arrowsConsumed || isTab) {
 							if (isTab)
 								e.preventDefault();
 							let container = document.getElementsByClassName('ui-tabs-content notebookbar');


### PR DESCRIPTION
The handler at the notebookbar tabpage intercepts arrow keys to move focus between widgets, but skipped that for INPUT/TEXTAREA so the browser could handle cursor movement instead. Because checkboxes are <input type="checkbox">, arrow keys on a focused checkbox were also passed through and went nowhere, leaving focus stuck on the Status Bar / Ruler checkboxes.

Test the input type as well: only treat TEXTAREA and text-entry INPUTs as arrow-consumers, so arrow keys move focus off checkbox, radio and button inputs while still moving the cursor inside spinfield and color-picker text fields.

Change-Id: I21811b8785cf9a5ec24fe73b5dbfb71fe9ae7c12


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

