### PR TITLE
Comments Section: Ensure comment heights are calculated and up to date.

### DIFF
--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -1323,7 +1323,7 @@ export class CommentSection extends CanvasSectionObject {
 				this.setThreadPopup(this.sectionProperties.selectedComment, false);
 				this.sectionProperties.showSelectedBigger = false;
 			}
-			
+
 			const previouslySelectedComment = this.sectionProperties.selectedComment;
 			this.sectionProperties.selectedComment = null;
 			if (app.map._docLayer._docType !== 'spreadsheet') {
@@ -2539,7 +2539,8 @@ export class CommentSection extends CanvasSectionObject {
 	}
 
 	private update (reLayout: boolean = true): void {
-		this.sectionProperties.reLayout = reLayout;
+		if (reLayout)
+			this.sectionProperties.reLayout = true;
 		this.updateDOM();
 	}
 
@@ -2547,10 +2548,13 @@ export class CommentSection extends CanvasSectionObject {
 		if (!this.sectionProperties.firstImport) return;
 
 		app.layoutingService.appendLayoutingTask(() => {
-			if (this.sectionProperties.reLayout && app.map._docLayer._docType === 'text')
+			const reLayout = this.sectionProperties.reLayout;
+			this.sectionProperties.reLayout = false;
+
+			if (reLayout && app.map._docLayer._docType === 'text')
 				this.updateThreadInfoIndicator();
 
-			this.layout(this.sectionProperties.reLayout);
+			this.layout(reLayout);
 		});
 
 		app.sectionContainer.requestReDraw();
@@ -2733,8 +2737,19 @@ export class CommentSection extends CanvasSectionObject {
 								maxSize += moveUp;
 							}
 						}
-						if (maxSize > minMaxHeight)
-							this.sectionProperties.commentList[i].sectionProperties.contentNode.style.maxHeight = Math.round(maxSize) + 'px';
+						if (maxSize > minMaxHeight) {
+							const comment = this.sectionProperties.commentList[i];
+							const contentNode = comment.sectionProperties.contentNode;
+							const oldMaxHeight = parseFloat(contentNode.style.maxHeight) || minMaxHeight;
+							contentNode.style.maxHeight = Math.round(maxSize) + 'px';
+
+							// Without this, a later layout(false) would reuse a stale value.
+							if (comment.cachedCommentHeight !== null) {
+								const oldContent = Math.min(actHeight, oldMaxHeight);
+								const newContent = Math.min(actHeight, maxSize);
+								comment.cachedCommentHeight += newContent - oldContent;
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Issue: cachedCommentHeight may hold old value.

Fix (2 steps):
* Ensure that a relayout action is proessed even if there are consecutive calls to update with differnet "reLayout" boolean values.
* Update the cached height of the comment to make sure that the correct height is read while layouting.


Change-Id: I191dd539fdf8288284f0664adb7dbc7ab2a5be65


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

