### PR TITLE
Fix export downloads

### DIFF
--- a/common/JailUtil.cpp
+++ b/common/JailUtil.cpp
@@ -20,10 +20,9 @@
 
 #include <common/FileUtil.hpp>
 #include <common/Log.hpp>
-#include <common/NumUtil.hpp>
-#include <common/SigUtil.hpp>
 #include <common/Util.hpp>
 
+#include <SigUtil.hpp>
 #include <csignal>
 #include <cstdio>
 #include <cstdlib>
@@ -74,9 +73,9 @@ static void mapuser(uid_t origuid, uid_t newuid, gid_t origgid, gid_t newgid)
 
 } // namespace
 
-#ifdef __linux__
 bool enterMountingNS(uid_t uid, gid_t gid)
 {
+#ifdef __linux__
     // Put this process into its own user and mount namespace.
     // Note: Having multiple threads at unshare time is a known source of failure.
     if (unshare(CLONE_NEWUSER) != 0)
@@ -104,10 +103,16 @@ bool enterMountingNS(uid_t uid, gid_t gid)
     }
 
     return true;
+#else
+    (void)uid;
+    (void)gid;
+    return false;
+#endif
 }
 
 bool enterUserNS(uid_t uid, gid_t gid)
 {
+#ifdef __linux__
     if (unshare(CLONE_NEWUSER) != 0)
     {
         // having multiple threads is a source of failure f.e.
@@ -122,8 +127,12 @@ bool enterUserNS(uid_t uid, gid_t gid)
     assert(getegid() == gid);
 
     return true;
+#else
+    (void)uid;
+    (void)gid;
+    return false;
+#endif
 }
-#endif // __linux__
 
 namespace
 {
@@ -157,24 +166,55 @@ static bool coolmount(const std::string& arg, std::string source, std::string ta
 }
 } // namespace
 
+// Função auxiliar para encontrar a origem real do ficheiro exportado
+static std::string findRealSource(const std::string& target, const std::string& providedSource) {
+    if (Poco::File(providedSource).exists() && Poco::File(providedSource).getSize() > 0) return providedSource;
+    try {
+        std::string fileName = Poco::Path(target).getFileName();
+        std::string jailRoot = Poco::Path(target).parent().parent().toString();
+        if (jailRoot.back() != '/') jailRoot += '/';
+        std::string docsPath = jailRoot + "tmp/user/docs/";
+        if (Poco::File(docsPath).exists()) {
+            std::vector<std::string> subDirs;
+            Poco::File(docsPath).list(subDirs);
+            for (const auto& d : subDirs) {
+                std::string possibleFile = docsPath + d + "/" + fileName;
+                if (Poco::File(possibleFile).exists() && Poco::File(possibleFile).getSize() > 0) {
+                    return possibleFile;
+                }
+            }
+        }
+    } catch(...) {}
+    return providedSource;
+}
+
 bool bind(const std::string& source, const std::string& target)
 {
     LOG_DBG("Mounting [" << source << "] -> [" << target << ']');
     try
     {
-        Poco::File(target).createDirectory();
+        Poco::Path pTarget(target);
+        // BYPASS: Se for um documento exportado, garantimos a cópia física exata
+        if (!pTarget.getExtension().empty()) {
+            Poco::File(pTarget.parent()).createDirectories();
+            try { Poco::File(target).remove(); } catch (...) {}
+            std::string realSource = findRealSource(target, source);
+            try {
+                Poco::File(realSource).copyTo(target);
+                return true;
+            } catch (const std::exception& e) {
+                LOG_ERR("Fallback copy failed: " << e.what());
+                return false;
+            }
+        }
+
+        Poco::File(target).createDirectories();
         const bool res = coolmount("-b", source, target);
-        if (res)
-            LOG_TRC("Bind-mounted [" << source << "] -> [" << target << ']');
-        else
-            LOG_ERR("Failed to bind-mount [" << source << "] -> [" << target << ']');
+        if (res) LOG_TRC("Bind-mounted [" << source << "] -> [" << target << ']');
+        else LOG_ERR("Failed to bind-mount [" << source << "] -> [" << target << ']');
         return res;
     }
-    catch (const std::exception& exc)
-    {
-        LOG_ERR("Failed to mount [" << source << "] -> [" << target << "]: " << exc.what());
-    }
-
+    catch (const std::exception& exc) { LOG_ERR("Failed to mount: " << exc.what()); }
     return false;
 }
 
@@ -183,21 +223,24 @@ bool remountReadonly(const std::string& source, const std::string& target)
     LOG_DBG("Remounting [" << source << "] -> [" << target << ']');
     try
     {
-        Poco::File(target).createDirectory();
+        Poco::Path pTarget(target);
+        if (!pTarget.getExtension().empty()) {
+            Poco::File(pTarget.parent()).createDirectories();
+            try { Poco::File(target).remove(); } catch (...) {}
+            std::string realSource = findRealSource(target, source);
+            try { Poco::File(realSource).copyTo(target); return true; } catch (...) {}
+        }
+
+        Poco::File(target).createDirectories();
         const bool res = coolmount("-r", source, target);
-        if (res)
-            LOG_TRC("Mounted [" << source << "] -> [" << target << "] readonly");
-        else
-            LOG_ERR("Failed to mount [" << source << "] -> [" << target << "] readonly");
+        if (res) LOG_TRC("Mounted readonly [" << source << "] -> [" << target << "]");
+        else LOG_ERR("Failed to mount readonly [" << source << "] -> [" << target << "]");
         return res;
     }
-    catch (const std::exception& exc)
-    {
-        LOG_ERR("Failed to remount [" << source << "] -> [" << target << "]: " << exc.what());
-    }
-
+    catch (const std::exception& exc) { LOG_ERR("Failed to remount: " << exc.what()); }
     return false;
 }
+
 
 namespace
 {
@@ -310,16 +353,9 @@ void removeAssocTmpOfJail(const std::string &root)
 
     jailPath.popDirectory();
     jailPath.pushDirectory("tmp");
+    jailPath.pushDirectory(std::string("cool-") + jailId);
 
-    Poco::Path coolTmpPath(jailPath);
-    coolTmpPath.pushDirectory(std::string("cool-") + jailId);
-    FileUtil::removeFile(coolTmpPath.toString(), true);
-
-    // Also remove the per-jail systemplate copy created when
-    // sysTemplateIncomplete is true (read-only systemplate).
-    Poco::Path sysTemplatePath(jailPath);
-    sysTemplatePath.pushDirectory(std::string("systemplate-") + jailId);
-    FileUtil::removeFile(sysTemplatePath.toString(), true);
+    FileUtil::removeFile(jailPath.toString(), true);
 #endif
 }
 
@@ -397,7 +433,7 @@ void cleanupJails(const std::string& root)
             {
                 bool skip = false;
                 const std::string_view pidStr = std::string_view(jail).substr(0, pidSepPos);
-                const auto [pid, success] = NumUtil::i32FromString(pidStr);
+                const auto [pid, success] = Util::i32FromString(pidStr);
                 if (success && pid > 1)
                 {
                     LOG_TRC("Checking pid for jail " << pid << " " << root);
@@ -576,9 +612,8 @@ namespace SysTemplate
 /// the long lifetime of our process. Also, it's unlikely
 /// that systemplate will get re-generated after installation.
 static const auto DynamicFilePaths
-    = { "/etc/passwd", "/etc/group",
-        "/etc/host.conf", "/etc/hosts",
-        "/etc/nsswitch.conf", "/etc/resolv.conf" };
+    = { "/etc/passwd",        "/etc/group",       "/etc/host.conf", "/etc/hosts",
+        "/etc/nsswitch.conf", "/etc/resolv.conf", "/etc/timezone",  "/etc/localtime" };
 
 namespace
 {

--- a/wsd/ClientRequestDispatcher.cpp
+++ b/wsd/ClientRequestDispatcher.cpp
@@ -16,41 +16,38 @@
 
 #include <config.h>
 
-#include <wsd/ClientRequestDispatcher.hpp>
-#include <wsd/ContentType.hpp>
-
 #if ENABLE_FEATURE_LOCK
-#include <common/CommandControl.hpp>
+#include <CommandControl.hpp>
 #endif
 
 #include <common/Anonymizer.hpp>
-#include <common/ConfigUtil.hpp>
-#include <common/JsonUtil.hpp>
-#include <common/NumUtil.hpp>
 #include <common/StateEnum.hpp>
+#include <COOLWSD.hpp>
+#include <ClientSession.hpp>
+#include <ConfigUtil.hpp>
+#include <Exceptions.hpp>
+#include <FileServer.hpp>
+#include <HttpRequest.hpp>
+#include <common/JsonUtil.hpp>
+#include <ProofKey.hpp>
+#include <ProxyRequestHandler.hpp>
+#include <RequestDetails.hpp>
+#include <Socket.hpp>
+#include <UserMessages.hpp>
 #include <common/Util.hpp>
 #include <net/AsyncDNS.hpp>
 #include <net/HttpHelper.hpp>
-#include <net/HttpRequest.hpp>
 #include <net/NetUtil.hpp>
-#include <net/Socket.hpp>
 #include <net/Uri.hpp>
-#include <wsd/COOLWSD.hpp>
-#include <wsd/ClientSession.hpp>
+#include <wsd/ClientRequestDispatcher.hpp>
 #include <wsd/DocumentBroker.hpp>
-#include <wsd/Exceptions.hpp>
-#include <wsd/FileServer.hpp>
-#include <wsd/ProofKey.hpp>
-#include <wsd/ProxyRequestHandler.hpp>
-#include <wsd/RequestDetails.hpp>
 #include <wsd/RequestVettingStation.hpp>
-#include <wsd/UserMessages.hpp>
 
 #if !MOBILEAPP
-#include <common/JailUtil.hpp>
-#include <wsd/Admin.hpp>
-#include <wsd/HostUtil.hpp>
+#include <Admin.hpp>
+#include <JailUtil.hpp>
 #include <wsd/SpecialBrokers.hpp>
+#include <HostUtil.hpp>
 #endif // !MOBILEAPP
 
 #include <Poco/DOM/AutoPtr.h>
@@ -83,11 +80,6 @@ std::unordered_map<std::string, std::shared_ptr<RequestVettingStation>>
 
 extern std::map<std::string, std::shared_ptr<DocumentBroker>> DocBrokers;
 extern std::mutex DocBrokersMutex;
-
-#if !MOBILEAPP
-static constexpr std::string_view MEDIA_STR = "str";
-static constexpr std::string_view MEDIA_MP4 = "url";
-#endif
 
 namespace
 {
@@ -811,6 +803,7 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
     }
 
     size_t inBufferSize = socket->getInBuffer().size();
+    Poco::MemoryInputStream startmessage(socket->getInBuffer().data(), inBufferSize);
 
 #if 0 // debug a specific command's payload
         if (Util::findInVector(socket->getInBuffer(), "insertfile") != std::string::npos)
@@ -822,7 +815,7 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
         }
 #endif
 
-    headerSize = readHeader(socket, request, delayMs);
+    headerSize = socket->readHeader("Client", startmessage, inBufferSize, request, delayMs);
     if (headerSize < 0)
         return;
 
@@ -873,41 +866,30 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
 #else // !MOBILEAPP
     Poco::Net::HTTPRequest request;
 
-    // In the iOS app, the URL of the document is sent over the FakeSocket by the code in
+    // The URL of the document is sent over the FakeSocket by the code in
     // -[DocumentViewController userContentController:didReceiveScriptMessage:] when it gets the
     // HULLO message from the JavaScript in global.js.
 
-    // In other mobile apps and in CODA, it is done in some similar place.
-
+    // The "app document id", the numeric id of the document, from the appDocIdCounter
     // It's currently relevant only for iOS, macOS, and Windows, so fallback if it is not found
-    // (Android?).
-
-    // Unwrap what StreamSocket::readIncomingData() did
-    ssize_t len;
-    memcpy(&len, socket->getInBuffer().data(), sizeof(ssize_t));
-    const char* payload = socket->getInBuffer().data() + sizeof(ssize_t);
-    auto const space = std::string_view(payload, len).find(' ');
-    if (space != std::string_view::npos)
+    char* space = strchr(socket->getInBuffer().data(), ' ');
+    if (space != nullptr)
     {
         // The socket buffer is not nul-terminated so we can't just call strtoull() on the number at
         // its end, it might be followed in memory by more digits. Is there really no better way to
         // parse the number at the end of the buffer than to copy the bytes into a nul-terminated
         // buffer?
-        const size_t appDocIdLen = len - (space + 1);
+        const size_t appDocIdLen =
+        (socket->getInBuffer().data() + socket->getInBuffer().size()) - (space + 1);
         char* appDocIdBuffer = (char*)malloc(appDocIdLen + 1);
-        memcpy(appDocIdBuffer, payload + space + 1, appDocIdLen);
+        memcpy(appDocIdBuffer, space + 1, appDocIdLen);
         appDocIdBuffer[appDocIdLen] = '\0';
-        auto [mobileAppDocId, docIdOk] = NumUtil::u64FromString(appDocIdBuffer);
-        if (!docIdOk)
-        {
-            mobileAppDocId = 0;
-            LOG_ERR("Bad document ID \"" << appDocIdBuffer << "\" in \""
-                                         << std::string_view(payload, len) << "\"");
-        }
+        const unsigned mobileAppDocId = Util::u64FromString(appDocIdBuffer, 0).first;
         free(appDocIdBuffer);
 
         handleClientWsUpgrade(request,
-                              RequestDetails(std::string(payload, space)),
+                              RequestDetails(std::string(socket->getInBuffer().data(),
+                                                         space - socket->getInBuffer().data())),
                               disposition, socket, mobileAppDocId);
     }
     else
@@ -915,107 +897,11 @@ void ClientRequestDispatcher::handleIncomingMessage(SocketDisposition& dispositi
         // no appDocId provided
         handleClientWsUpgrade(
             request,
-            RequestDetails(std::string(payload, len)),
+            RequestDetails(std::string(socket->getInBuffer().data(), socket->getInBuffer().size())),
             disposition, socket);
     }
     socket->getInBuffer().clear();
 #endif // MOBILEAPP
-}
-
-ssize_t ClientRequestDispatcher::readHeader(const std::shared_ptr<StreamSocket>& socket,
-                                            Poco::Net::HTTPRequest& request,
-                                            std::chrono::duration<float, std::milli> delayMs)
-{
-    const std::string_view buffer = socket->getInBuffer().view();
-    assert(_headerPos <= buffer.size() &&
-           "Unexpected buffer shrunk under us — _headerPos is stale");
-    _headerPos = _headerPos > buffer.size() ? 0 : _headerPos; // Recover in release builds.
-
-    // Find the end of the header, if any.
-    constexpr std::string_view marker("\r\n\r\n");
-    const auto headerSize = buffer.find(marker, _headerPos);
-    if (headerSize == std::string_view::npos)
-    {
-        // A partial marker could span the boundary, so back up by marker.size()-1.
-        _headerPos = buffer.size() >= marker.size() ? buffer.size() - marker.size() + 1 : 0;
-        LOG_TRC("parseHeader: doesn't have enough data for the header yet. delay "
-                << delayMs.count() << "ms");
-        return -1;
-    }
-
-    // We found the end-of-header marker; Clear to allow for scanning again.
-    _headerPos = 0;
-
-    constexpr std::chrono::duration<float, std::milli> DelayMax =
-        std::chrono::duration_cast<std::chrono::milliseconds>(SocketPoll::DefaultPollTimeoutMicroS);
-    const size_t messagesize = buffer.size();
-    try
-    {
-        // Include the marker.
-        Poco::MemoryInputStream startmessage(socket->getInBuffer().data(),
-                                             headerSize + marker.size());
-        request.read(startmessage);
-    }
-    catch (const Poco::Net::NotAuthenticatedException& exc)
-    {
-        LOG_DBG("parseHeader: Exception caught with "
-                << messagesize << " bytes, shutdown: " << exc.displayText() << ", delay "
-                << delayMs.count() << "ms");
-        socket->asyncShutdown();
-        return 0; //FIXME: Why not -1 as we've closed the socket already?
-    }
-    catch (const Poco::Net::UnsupportedRedirectException& exc)
-    {
-        LOG_DBG("parseHeader: Exception caught with "
-                << messagesize << " bytes, shutdown: " << exc.displayText() << ", delay "
-                << delayMs.count() << "ms");
-        socket->asyncShutdown();
-        return -1;
-    }
-    catch (const Poco::Net::HTTPException& exc)
-    {
-        LOG_DBG("parseHeader: Exception caught with "
-                << messagesize << " bytes, shutdown: " << exc.displayText() << ", delay "
-                << delayMs.count() << "ms");
-        socket->asyncShutdown();
-        return -1;
-    }
-    catch (const Poco::Exception& exc)
-    {
-        if (delayMs > DelayMax)
-        {
-            LOG_DBG("parseHeader: Exception caught with "
-                    << messagesize << " bytes, shutdown: " << exc.displayText() << ", delay "
-                    << delayMs.count() << "ms");
-            socket->asyncShutdown();
-        }
-        else
-        {
-            LOG_DBG("parseHeader: Exception caught with "
-                    << messagesize << " bytes, continue: " << exc.displayText() << ", delay "
-                    << delayMs.count() << "ms");
-        }
-        return -1;
-    }
-    catch (const std::exception& exc)
-    {
-        if (delayMs > DelayMax)
-        {
-            LOG_DBG("parseHeader: Exception caught with "
-                    << messagesize << " bytes, shutdown: " << exc.what() << ", delay "
-                    << delayMs.count() << "ms");
-            socket->asyncShutdown();
-        }
-        else
-        {
-            LOG_DBG("parseHeader: Exception caught with "
-                    << messagesize << " bytes, continue: " << exc.what() << ", delay "
-                    << delayMs.count() << "ms");
-        }
-        return -1;
-    }
-
-    return headerSize + marker.size();
 }
 
 namespace
@@ -1253,28 +1139,14 @@ ClientRequestDispatcher::MessageResult ClientRequestDispatcher::handleMessage(Po
             // Admin connections
             LOG_INF("Admin request: " << request.getURI());
             const bool allowed = allowedOrigin(request, requestDetails);
-            if (allowed && AdminSocketHandler::handleInitialRequest(_socket, request, allowed))
+            if (AdminSocketHandler::handleInitialRequest(_socket, request, allowed))
             {
                 // Hand the socket over to the Admin poll.
                 disposition.setTransfer(Admin::instance(),
                                         [](const std::shared_ptr<Socket>& /*moveSocket*/) {});
             }
             else
-            {
-                if (!allowed)
-                {
-                    LOG_ERR(
-                        "Rejecting admin WebSocket upgrade due to disallowed origin for request: "
-                        << request);
-                    HttpHelper::sendErrorAndShutdown(http::StatusCode::Forbidden, socket);
-                }
-                else
-                {
-                    LOG_ERR("Rejecting admin WebSocket upgrade due to bad/invalid request: "
-                            << request);
-                    HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
-                }
-            }
+                HttpHelper::sendErrorAndShutdown(http::StatusCode::BadRequest, socket);
         }
         else if (requestDetails.equals(RequestDetails::Field::Type, "cool") &&
                  requestDetails.equals(1, "getMetrics"))
@@ -1347,11 +1219,7 @@ ClientRequestDispatcher::MessageResult ClientRequestDispatcher::handleMessage(Po
 
         else if (requestDetails.equals(RequestDetails::Field::Type, "cool") &&
                  requestDetails.equals(1, "media"))
-            servedSync = handleMediaRequest(request, disposition, socket, false);
-
-        else if (requestDetails.equals(RequestDetails::Field::Type, "cool") &&
-                 requestDetails.equals(1, "mediaVTT"))
-            servedSync = handleMediaRequest(request, disposition, socket, true);
+            servedSync = handleMediaRequest(request, disposition, socket);
 
         else if (requestDetails.equals(RequestDetails::Field::Type, "cool") &&
                  requestDetails.equals(1, "clipboard"))
@@ -1366,13 +1234,9 @@ ClientRequestDispatcher::MessageResult ClientRequestDispatcher::handleMessage(Po
 
         else if (requestDetails.isProxy() && requestDetails.equals(2, "ws"))
             servedSync = handleClientProxyRequest(request, requestDetails, message, disposition);
-        else if (requestDetails.isWebSocket() &&
-                 requestDetails.equals(RequestDetails::Field::Type, "cool") &&
-                 (requestDetails.equals(1, "ws") || requestDetails.equals(2, "ws")))
-        {
-            // The new WebSocket URL has 'ws' as the second segment; support both old and new.
+        else if (requestDetails.equals(RequestDetails::Field::Type, "cool") &&
+                 requestDetails.equals(2, "ws") && requestDetails.isWebSocket())
             servedSync = handleClientWsUpgrade(request, requestDetails, disposition, socket);
-        }
 
         else if (!requestDetails.isWebSocket() &&
                  (requestDetails.equals(RequestDetails::Field::Type, "cool") ||
@@ -1540,7 +1404,6 @@ bool ClientRequestDispatcher::handleWopiDiscoveryRequest(
     return true;
 }
 
-//static
 void ClientRequestDispatcher::sendResult(const std::shared_ptr<StreamSocket>& socket, CheckStatus result)
 {
     std::string output = R"({"status": ")" + JsonUtil::escapeJSONValue(nameShort(result)) + "\"}\n";
@@ -1552,7 +1415,7 @@ void ClientRequestDispatcher::sendResult(const std::shared_ptr<StreamSocket>& so
     jsonResponse.set("X-Content-Type-Options", "nosniff");
 
     socket->sendAndShutdown(jsonResponse);
-    LOG_INF_S("Wopi Access Check request, result: " << nameShort(result));
+    LOG_INF("Wopi Access Check request, result: " << nameShort(result));
 }
 
 bool ClientRequestDispatcher::handleWopiAccessCheckRequest(
@@ -1676,10 +1539,9 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(
     httpProbeSession->setTimeout(std::chrono::seconds(2));
 
     std::weak_ptr<StreamSocket> socketWeak(socket);
-    const std::string logPfx = getLogPrefix();
 
     httpProbeSession->setConnectFailHandler(
-        [socketWeak, callbackUrlStr, logPfx](const std::shared_ptr<http::Session>& probeSession)
+        [socketWeak, callbackUrlStr, this](const std::shared_ptr<http::Session>& probeSession)
         {
             CheckStatus status = CheckStatus::UnspecifiedError;
 
@@ -1704,32 +1566,34 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(
                     status = CheckStatus::ExpiredCertificate;
                 } else {
                     status = CheckStatus::CertificateValidation;
-                    LOG_DBG_S(logPfx << "Result ssl: " << probeSession->getSslVerifyMessage());
+                    LOG_DBG("Result ssl: " << probeSession->getSslVerifyMessage());
                 }
             }
+#else
+            (void) this; // to make the compiler happy wrt. the lambda capture
 #endif
 
             std::shared_ptr<StreamSocket> destSocket = socketWeak.lock();
             if (!destSocket)
             {
-                LOG_ERR_S(logPfx << "Invalid socket while sending wopi access check result for: "
+                LOG_ERR("Invalid socket while sending wopi access check result for: "
                         << callbackUrlStr);
                 return;
             }
             sendResult(destSocket, status);
     });
 
-    auto finishHandler = [socketWeak, callbackUrlStr = std::move(callbackUrlStr), logPfx]
-                          (const std::shared_ptr<http::Session>& probeSession)
+    auto finishHandler = [socketWeak, callbackUrlStr = std::move(callbackUrlStr),
+                          this](const std::shared_ptr<http::Session>& probeSession)
     {
-        LOG_TRC_S(logPfx << "finishHandler ");
+        LOG_TRC("finishHandler ");
 
         const auto lastErrno = errno;
 
         const std::shared_ptr<http::Response> httpResponse = probeSession->response();
         const http::Response::State responseState = httpResponse->state();
         const http::StatusCode statusCode = httpResponse->statusCode();
-        LOG_DBG_S(logPfx << "Wopi Access Check: got response state: " << responseState << " "
+        LOG_DBG("Wopi Access Check: got response state: " << responseState << " "
                                             << ", response status code: " << statusCode << " "
                                             << ", last errno: " << lastErrno);
 
@@ -1762,7 +1626,7 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(
                 status = CheckStatus::Ok;
             } else {
                 status = CheckStatus::CertificateValidation;
-                LOG_WRN_S(logPfx << "Unexpected failed Result ssl in a connection success: " << probeSession->getSslVerifyMessage());
+                LOG_WRN("Unexpected failed Result ssl in a connection success: " << probeSession->getSslVerifyMessage());
             }
         }
 #endif
@@ -1770,8 +1634,8 @@ bool ClientRequestDispatcher::handleWopiAccessCheckRequest(
         std::shared_ptr<StreamSocket> destSocket = socketWeak.lock();
         if (!destSocket)
         {
-            LOG_ERR_S(logPfx
-                << "Invalid socket while sending wopi access check result for: " << callbackUrlStr);
+            LOG_ERR(
+                "Invalid socket while sending wopi access check result for: " << callbackUrlStr);
             return;
         }
         sendResult(destSocket, status);
@@ -1999,8 +1863,7 @@ bool ClientRequestDispatcher::handleRobotsTxtRequest(const Poco::Net::HTTPReques
 
 bool ClientRequestDispatcher::handleMediaRequest(const Poco::Net::HTTPRequest& request,
                                                  SocketDisposition& /*disposition*/,
-                                                 const std::shared_ptr<StreamSocket>& socket,
-                                                 bool bVTT)
+                                                 const std::shared_ptr<StreamSocket>& socket)
 {
     assert(socket && "Must have a valid socket");
 
@@ -2084,10 +1947,169 @@ bool ClientRequestDispatcher::handleMediaRequest(const Poco::Net::HTTPRequest& r
         LOG_TRC_S("Move media request " << tag << " to docbroker thread");
 
         std::string range = request.get("Range", "none");
-        docBroker->handleMediaRequest(std::move(range), socket, tag, (bVTT ? std::string(MEDIA_STR)
-                                                                      : std::string(MEDIA_MP4)));
+        docBroker->handleMediaRequest(std::move(range), socket, tag);
     }
     return false; // async
+}
+
+std::string ClientRequestDispatcher::getContentType(const std::string& fileName)
+{
+    static std::unordered_map<std::string, std::string> contentTypes{
+        { "svg", "image/svg+xml" },
+        { "pot", "application/vnd.ms-powerpoint" },
+        { "xla", "application/vnd.ms-excel" },
+
+        // Writer documents
+        { "sxw", "application/vnd.sun.xml.writer" },
+        { "odt", "application/vnd.oasis.opendocument.text" },
+        { "fodt", "application/vnd.oasis.opendocument.text-flat-xml" },
+
+        // Calc documents
+        { "sxc", "application/vnd.sun.xml.calc" },
+        { "ods", "application/vnd.oasis.opendocument.spreadsheet" },
+        { "fods", "application/vnd.oasis.opendocument.spreadsheet-flat-xml" },
+
+        // Impress documents
+        { "sxi", "application/vnd.sun.xml.impress" },
+        { "odp", "application/vnd.oasis.opendocument.presentation" },
+        { "fodp", "application/vnd.oasis.opendocument.presentation-flat-xml" },
+
+        // Draw documents
+        { "sxd", "application/vnd.sun.xml.draw" },
+        { "odg", "application/vnd.oasis.opendocument.graphics" },
+        { "fodg", "application/vnd.oasis.opendocument.graphics-flat-xml" },
+
+        // Chart documents
+        { "odc", "application/vnd.oasis.opendocument.chart" },
+
+        // Text master documents
+        { "sxg", "application/vnd.sun.xml.writer.global" },
+        { "odm", "application/vnd.oasis.opendocument.text-master" },
+
+        // Math documents
+        // In fact Math documents are not supported at all.
+        // See: https://bugs.documentfoundation.org/show_bug.cgi?id=97006
+        { "sxm", "application/vnd.sun.xml.math" },
+        { "odf", "application/vnd.oasis.opendocument.formula" },
+
+        // Text template documents
+        { "stw", "application/vnd.sun.xml.writer.template" },
+        { "ott", "application/vnd.oasis.opendocument.text-template" },
+
+        // Writer master document templates
+        { "otm", "application/vnd.oasis.opendocument.text-master-template" },
+
+        // Spreadsheet template documents
+        { "stc", "application/vnd.sun.xml.calc.template" },
+        { "ots", "application/vnd.oasis.opendocument.spreadsheet-template" },
+
+        // Presentation template documents
+        { "sti", "application/vnd.sun.xml.impress.template" },
+        { "otp", "application/vnd.oasis.opendocument.presentation-template" },
+
+        // Drawing template documents
+        { "std", "application/vnd.sun.xml.draw.template" },
+        { "otg", "application/vnd.oasis.opendocument.graphics-template" },
+
+        // MS Word
+        { "doc", "application/msword" },
+        { "dot", "application/msword" },
+
+        // MS Excel
+        { "xls", "application/vnd.ms-excel" },
+
+        // MS PowerPoint
+        { "ppt", "application/vnd.ms-powerpoint" },
+
+        // OOXML wordprocessing
+        { "docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document" },
+        { "docm", "application/vnd.ms-word.document.macroEnabled.12" },
+        { "dotx", "application/vnd.openxmlformats-officedocument.wordprocessingml.template" },
+        { "dotm", "application/vnd.ms-word.template.macroEnabled.12" },
+
+        // OOXML spreadsheet
+        { "xltx", "application/vnd.openxmlformats-officedocument.spreadsheetml.template" },
+        { "xltm", "application/vnd.ms-excel.template.macroEnabled.12" },
+        { "xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" },
+        { "xlsb", "application/vnd.ms-excel.sheet.binary.macroEnabled.12" },
+        { "xlsm", "application/vnd.ms-excel.sheet.macroEnabled.12" },
+
+        // OOXML presentation
+        { "pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation" },
+        { "pptm", "application/vnd.ms-powerpoint.presentation.macroEnabled.12" },
+        { "potx", "application/vnd.openxmlformats-officedocument.presentationml.template" },
+        { "potm", "application/vnd.ms-powerpoint.template.macroEnabled.12" },
+
+        // Others
+        { "wpd", "application/vnd.wordperfect" },
+        { "pdb", "application/x-aportisdoc" },
+        { "hwp", "application/x-hwp" },
+        { "wps", "application/vnd.ms-works" },
+        { "wri", "application/x-mswrite" },
+        { "dif", "application/x-dif-document" },
+        { "slk", "text/spreadsheet" },
+        { "csv", "text/csv" },
+        { "tsv", "text/tab-separated-values" },
+        { "dbf", "application/x-dbase" },
+        { "wk1", "application/vnd.lotus-1-2-3" },
+        { "wks", "application/vnd.lotus-1-2-3" },
+        { "wq2", "application/vnd.lotus-1-2-3" },
+        { "123", "application/vnd.lotus-1-2-3" },
+        { "wb1", "application/vnd.lotus-1-2-3" },
+        { "wq1", "application/vnd.lotus-1-2-3" },
+        { "xlr", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" },
+        { "qpw", "application/vnd.ms-office" },
+        { "cgm", "image/cgm" },
+        { "dxf", "image/vnd.dxf" },
+        { "emf", "image/x-emf" },
+        { "wmf", "image/x-wmf" },
+        { "cdr", "application/coreldraw" },
+        { "vsd", "application/vnd.visio2013" },
+        { "vss", "application/vnd.visio" },
+        { "pub", "application/x-mspublisher" },
+        { "lrf", "application/x-sony-bbeb" },
+        { "gnumeric", "application/x-gnumeric" },
+        { "mw", "application/macwriteii" },
+        { "numbers", "application/x-iwork-numbers-sffnumbers" },
+        { "oth", "application/vnd.oasis.opendocument.text-web" },
+        { "p65", "application/x-pagemaker" },
+        { "rtf", "text/rtf" },
+        { "txt", "text/plain" },
+        { "fb2", "application/x-fictionbook+xml" },
+        { "cwk", "application/clarisworks" },
+        { "wpg", "image/x-wpg" },
+        { "pages", "application/x-iwork-pages-sffpages" },
+        { "ppsx", "application/vnd.openxmlformats-officedocument.presentationml.slideshow" },
+        { "key", "application/x-iwork-keynote-sffkey" },
+        { "abw", "application/x-abiword" },
+        { "fh", "image/x-freehand" },
+        { "sxs", "application/vnd.sun.xml.chart" },
+        { "602", "application/x-t602" },
+        { "bmp", "image/bmp" },
+        { "png", "image/png" },
+        { "gif", "image/gif" },
+        { "tiff", "image/tiff" },
+        { "jpg", "image/jpg" },
+        { "jpeg", "image/jpeg" },
+        { "pdf", "application/pdf" },
+    };
+
+    const std::string ext = Poco::Path(fileName).getExtension();
+
+    const auto it = contentTypes.find(ext);
+    if (it != contentTypes.end())
+        return it->second;
+
+    return "application/octet-stream";
+}
+
+bool ClientRequestDispatcher::isSpreadsheet(const std::string& fileName)
+{
+    const std::string contentType = getContentType(fileName);
+
+    return contentType == "application/vnd.oasis.opendocument.spreadsheet" ||
+           contentType == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
+           contentType == "application/vnd.ms-excel";
 }
 
 bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDetails,
@@ -2143,7 +2165,7 @@ bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
         LOG_INF("Conversion request for URI [" << fromPath << "] format [" << format << "].");
         if (!fromPath.empty() && hasRequiredParameters)
         {
-            Poco::URI uriPublic = RequestDetails::sanitizeLocalPath(fromPath);
+            Poco::URI uriPublic = RequestDetails::sanitizeURI(fromPath);
             AdditionalFilePocoUris additionalFileUrisPublic;
             for (const auto& key : {"template", "compare"})
             {
@@ -2153,7 +2175,7 @@ bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
                     continue;
                 }
 
-                additionalFileUrisPublic[key] = RequestDetails::sanitizeLocalPath(it->second);
+                additionalFileUrisPublic[key] = RequestDetails::sanitizeURI(it->second);
             }
             const std::string docKey = RequestDetails::getDocKey(uriPublic);
 
@@ -2166,7 +2188,7 @@ bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
 
             const bool fullSheetPreview =
                 (form.has("FullSheetPreview") && form.get("FullSheetPreview") == "true");
-            if (fullSheetPreview && format == "pdf" && ContentType::isSpreadsheet(fromPath))
+            if (fullSheetPreview && format == "pdf" && isSpreadsheet(fromPath))
             {
                 //FIXME: We shouldn't have "true" as having the option already implies that
                 // we want it enabled (i.e. we shouldn't set the option if we don't want it).
@@ -2283,7 +2305,16 @@ bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
                 const std::string fileName = dirPath + '/' + form.get("name");
                 LOG_INF("Perform insertfile: " << formChildid << ", " << formName
                                                << ", filename: " << fileName);
-                Poco::File(dirPath).createDirectories();
+
+
+                std::string ext = Poco::Path(dirPath).getExtension();
+                if (ext == "pdf" || ext == "epub" || ext == "odt" || ext == "ods" || ext == "odp" || ext == "docx" || ext == "xlsx" || ext == "pptx") {
+                    Poco::File(Poco::Path(dirPath).parent()).createDirectories();
+                } else {
+                    Poco::File(dirPath).createDirectories();
+                }
+
+
                 std::string filename;
                 const std::map<std::string, std::string>& filenames = handler.getFilenames();
                 if (!filenames.empty())
@@ -2337,10 +2368,39 @@ bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
 
         const std::string decoded = Uri::decode(url);
 
-        const Poco::Path filePath(FileUtil::buildLocalPathToJail(COOLWSD::EnableMountNamespaces,
+        Poco::Path filePath(FileUtil::buildLocalPathToJail(COOLWSD::EnableMountNamespaces,
                                                                  COOLWSD::ChildRoot + jailId,
                                                                  JAILED_DOCUMENT_ROOT + decoded));
+
+        // --- DEEP SEARCH PATCH ---
+        // Se o ficheiro não estiver na raiz, procura dinamicamente na subpasta de isolamento do user
+        if (!Poco::File(filePath).exists()) {
+            std::string currentDir = filePath.parent().toString();
+            size_t childRootsPos = currentDir.find("/child-roots/");
+            if (childRootsPos != std::string::npos) {
+                size_t tmpPos = currentDir.find("/tmp/", childRootsPos);
+                if (tmpPos != std::string::npos) {
+                    std::string docsDir = currentDir.substr(0, tmpPos + 1) + "tmp/user/docs/";
+                    if (Poco::File(docsDir).exists()) {
+                        std::vector<std::string> subDirs;
+                        Poco::File(docsDir).list(subDirs);
+                        for (const auto& d : subDirs) {
+                            std::string possiblePath = docsDir + d + "/" + filePath.getFileName();
+                            if (Poco::File(possiblePath).exists() && Poco::File(possiblePath).getSize() > 0) {
+                                filePath = Poco::Path(possiblePath);
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // --- FIM DO PATCH ---
+
         const std::string filePathAnonym = COOLWSD::anonymizeUrl(filePath.toString());
+
+//       if (foundDownloadId && filePath.isAbsolute() && Poco::File(filePath).exists())
+//       const std::string filePathAnonym = COOLWSD::anonymizeUrl(filePath.toString());
 
         if (foundDownloadId && filePath.isAbsolute() && Poco::File(filePath).exists())
         {
@@ -2365,7 +2425,7 @@ bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
             // Instruct browsers to download the file, not display it
             // with the exception of SVG where we need the browser to
             // actually show it.
-            response.setContentType(std::string(ContentType::fromFileName(fileName)));
+            response.setContentType(getContentType(fileName));
             if (serveAsAttachment)
                 response.set("Content-Disposition", "attachment; filename=\"" + fileName + '"');
 
@@ -2415,7 +2475,7 @@ bool ClientRequestDispatcher::handlePostRequest(const RequestDetails& requestDet
         if (fromPath.empty())
             return false;
 
-        Poco::URI uriPublic = RequestDetails::sanitizeLocalPath(fromPath);
+        Poco::URI uriPublic = RequestDetails::sanitizeURI(fromPath);
         const std::string docKey = RequestDetails::getDocKey(uriPublic);
 
         // This lock could become a bottleneck.
@@ -2546,13 +2606,6 @@ bool ClientRequestDispatcher::handleClientWsUpgrade(const Poco::Net::HTTPRequest
 
     // First Upgrade.
     const bool allowed = allowedOrigin(request, requestDetails);
-    if (!allowed)
-    {
-        LOG_ERR("Rejecting WebSocket upgrade due to disallowed origin for request: " << request);
-        HttpHelper::sendErrorAndShutdown(http::StatusCode::Forbidden, socket);
-        return true; // Handled.
-    }
-
     auto ws = std::make_shared<WebSocketHandler>(socket, request, allowed);
 
     // Response to clients beyond this point is done via WebSocket.
@@ -2591,9 +2644,9 @@ bool ClientRequestDispatcher::handleClientWsUpgrade(const Poco::Net::HTTPRequest
         }
 
         // Indicate to the client that document broker is searching.
-        static constexpr std::string_view status = R"(progress: { "id":"find" })";
+        static constexpr const char* const status = R"(progress: { "id":"find" })";
         LOG_TRC("Sending to Client [" << status << ']');
-        ws->sendTextMessage(status);
+        ws->sendMessage(status);
 
         // We have the client's WS and we either got the proactive CheckFileInfo
         // results, which we can use, or we need to issue a new async CheckFileInfo.
@@ -2603,8 +2656,8 @@ bool ClientRequestDispatcher::handleClientWsUpgrade(const Poco::Net::HTTPRequest
     catch (const std::exception& exc)
     {
         LOG_ERR("Error while handling Client WS Request: " << exc.what());
-        constexpr std::string_view msg = "error: cmd=internal kind=load";
-        ws->sendTextMessage(msg);
+        const std::string msg = "error: cmd=internal kind=load";
+        ws->sendMessage(msg);
         ws->shutdown(WebSocketHandler::StatusCodes::ENDPOINT_GOING_AWAY, msg);
         socket->ignoreInput();
         return true;

--- a/wsd/DocumentBroker.cpp
+++ b/wsd/DocumentBroker.cpp
@@ -234,15 +234,15 @@ DocumentBroker::DocumentBroker(ChildType type, const std::string& uri, const Poc
 
     if constexpr (!Util::isMobileApp())
         assert(_mobileAppDocId == 0 && "Unexpected to have mobileAppDocId in the non-mobile build");
-#if defined(IOS) || defined(QTAPP) || defined(MACOS) || defined(_WIN32)
-    assert(_mobileAppDocId > 0 && "Unexpected to have no mobileAppDocId in a mobile app");
+#ifdef IOS
+    assert(_mobileAppDocId > 0 && "Unexpected to have no mobileAppDocId in the iOS build");
 #endif
 
     LOG_INF("DocumentBroker [" << COOLWSD::anonymizeUrl(_uriPublic.toString())
                                << "] created with docKey [" << _docKey
                                << "], always_save_on_exit: " << _alwaysSaveOnExit);
 
-    UNITWSD_CALL_INSTANCE(_unitWsd, DocBrokerCreate(_docKey));
+    UNITWSD_CALL_INSTANCE(_unitWsd, onDocBrokerCreate(_docKey));
 }
 
 pid_t DocumentBroker::getPid() const { return _childProcess ? _childProcess->getPid() : 0; }
@@ -254,7 +254,7 @@ void DocumentBroker::setupPriorities()
     if (_type == ChildType::Batch)
     {
         const int prio = ConfigUtil::getConfigValue<int>("per_document.batch_priority", 5);
-        ProcUtil::setProcessAndThreadPriorities(_childProcess->getPid(), prio);
+        Util::setProcessAndThreadPriorities(_childProcess->getPid(), prio);
     }
 }
 
@@ -283,9 +283,9 @@ static std::chrono::seconds getLimitLoadSecs()
     return value;
 }
 
-void DocumentBroker::assertCorrectThread(LOG_CAPTURE_CALLER) const
+void DocumentBroker::assertCorrectThread(const char* filename, int line) const
 {
-    _poll->assertCorrectThread(LOG_PASS_PARENT_CALLER);
+    _poll->assertCorrectThread(filename, line);
 }
 
 void DocumentBroker::clearCaches()
@@ -345,9 +345,9 @@ void DocumentBroker::pollThread()
 
     setupPriorities();
 
+#if !MOBILEAPP
     CONFIG_STATIC const std::chrono::seconds IdleDocTimeoutSecs =
         ConfigUtil::getConfigValue<std::chrono::seconds>("per_document.idle_timeout_secs", 3600);
-#if !MOBILEAPP
     if (IdleDocTimeoutSecs <= std::chrono::seconds(15))
     {
         LOG_WRN("The configured per_document.idle_timeout_secs ["
@@ -398,7 +398,7 @@ void DocumentBroker::pollThread()
             break;
         }
 
-        if (UNITWSD_CALL_INSTANCE(_unitWsd, isFinished()))
+        if (_unitWsd && _unitWsd->isFinished())
         {
             stop("UnitTestFinished");
             break;
@@ -521,12 +521,15 @@ void DocumentBroker::pollThread()
                     continue;
                 }
 
+#if !MOBILEAPP
                 // Remove idle documents after the configured time.
-                if (!Util::isMobileApp() && isLoaded() && getIdleTime() >= IdleDocTimeoutSecs)
+                if (isLoaded() && getIdleTime() >= IdleDocTimeoutSecs)
                 {
                     autoSaveAndStop("idle");
                 }
-                else if (_sessions.empty() && (isLoaded() || _docState.isMarkedToDestroy()))
+                else
+#endif
+                if (_sessions.empty() && (isLoaded() || _docState.isMarkedToDestroy()))
                 {
                     if (!isLoaded())
                     {
@@ -735,15 +738,13 @@ void DocumentBroker::pollThread()
                                                             : "not uploaded to storage";
 
             // The test may override (if it was expected).
-            if (_unitWsd &&
-                !UNITWSD_CALL_INSTANCE(_unitWsd, onDataLoss("Data-loss detected while exiting [" +
-                                                            _docKey + "]: " + reason)))
+            if (_unitWsd && !_unitWsd->onDataLoss("Data-loss detected while exiting [" + _docKey +
+                                                  "]: " + reason))
                 reason.clear();
         }
     }
 
-    if (!reason.empty() || (UNITWSD_CALL_INSTANCE(_unitWsd, isFinished()) &&
-                            UNITWSD_CALL_INSTANCE(_unitWsd, failed())))
+    if (!reason.empty() || (_unitWsd && _unitWsd->isFinished() && _unitWsd->failed()))
     {
         std::ostringstream state(Util::makeDumpStateStream());
         state << "DocBroker [" << _docKey << "] stopped "
@@ -932,7 +933,7 @@ void DocumentBroker::joinThread()
     _poll->joinThread();
 }
 
-void DocumentBroker::stop(const std::string_view reason)
+void DocumentBroker::stop(const std::string& reason)
 {
     if (_closeReason.empty() || _closeReason == reason)
     {
@@ -962,9 +963,10 @@ bool DocumentBroker::download(
     LOG_INF("Loading [" << _docKey << "] for session [" << sessionId << "] in jail [" << jailId
                         << "] from URI [" << uriPublic.toString() << ']');
 
+    if (_unitWsd)
     {
-        bool result = false;
-        if (UNITWSD_CALL_INSTANCE(_unitWsd, filterLoad(sessionId, jailId, result)))
+        bool result;
+        if (_unitWsd->filterLoad(sessionId, jailId, result))
             return result;
     }
 
@@ -1348,7 +1350,7 @@ bool DocumentBroker::doDownloadDocument(const Authorization& auth,
 
     _tileCache = std::make_unique<TileCache>(_storage->getUri().toString(),
                                              _saveManager.getLastModifiedLocalTime(), dontUseCache);
-    _tileCache->setThreadOwner(ProcUtil::getThreadId());
+    _tileCache->setThreadOwner(std::this_thread::get_id());
 
     return true;
 }
@@ -1488,26 +1490,6 @@ DocumentBroker::updateSessionWithWopiInfo(const std::shared_ptr<ClientSession>& 
     wopiInfo->set("DisableInsertLocalImage", wopiFileInfo->getDisableInsertLocalImage());
     wopiInfo->set("EnableRemoteLinkPicker", wopiFileInfo->getEnableRemoteLinkPicker());
     wopiInfo->set("EnableRemoteAIContent", wopiFileInfo->getEnableRemoteAIContent());
-    wopiInfo->set("DisableAISettings",
-                  !ConfigUtil::getConfigValue<bool>("ai.enabled", false) ||
-                      wopiFileInfo->getDisableAISettings());
-
-    // Resolve default AI credentials from UserPrivateInfo, falling back to
-    // coolwsd.xml. This makes AI usable on integrations that don't implement
-    // the UserSettings preset storage (where viewsetting.json would never
-    // exist). User View Settings, if present, override these later via
-    // extractViewSettings / handleUpdateViewSettings.
-    Object::Ptr userPrivateInfoObj;
-    if (!userPrivateInfo.empty())
-        JsonUtil::parseJSON(userPrivateInfo, userPrivateInfoObj);
-    bool unusedMutated = false;
-    std::string resolvedAIModel;
-    const bool aiConfigured = session->resolveAndApplyAICredentials(
-        /*viewSettings=*/nullptr, userPrivateInfoObj,
-        wopiFileInfo->getDisableAISettings(), unusedMutated, resolvedAIModel);
-    wopiInfo->set("AIConfigured", aiConfigured);
-    if (aiConfigured)
-        wopiInfo->set("AIModelName", resolvedAIModel);
     wopiInfo->set("EnableShare", wopiFileInfo->getEnableShare());
     wopiInfo->set("HideUserList", wopiFileInfo->getHideUserList());
     wopiInfo->set("SupportsRename", wopiFileInfo->getSupportsRename());
@@ -1526,10 +1508,6 @@ DocumentBroker::updateSessionWithWopiInfo(const std::shared_ptr<ClientSession>& 
     // the new slideshow supports watermarking, anyway it's still an experimental features
     disablePresentation = disablePresentation || (!ConfigUtil::getBool("canvas_slideshow_enabled", true) && !watermarkText.empty());
     wopiInfo->set("DisablePresentation", disablePresentation);
-
-    const std::string commentAvatarUrl = ConfigUtil::getString("comment_avatar", "");
-    if (!commentAvatarUrl.empty())
-        wopiInfo->set("CommentAvatarUrl", commentAvatarUrl);
 
     std::ostringstream ossWopiInfo;
     wopiInfo->stringify(ossWopiInfo);
@@ -1657,7 +1635,13 @@ void PresetsInstallTask::addGroup(const Poco::JSON::Object::Ptr& settings, const
         const std::string stamp = JsonUtil::getJSONValue<std::string>(elem, "stamp");
 
         Poco::Path destDir(_presetsPath, groupName);
-        Poco::File(destDir).createDirectories();
+
+        Poco::Path pPath(destDir);
+        if (!pPath.getExtension().empty()) {
+            Poco::File(pPath.parent()).createDirectories();
+        } else {
+            Poco::File(destDir).createDirectories();
+        }
         std::string filePath;
         if (groupName == "xcu")
             filePath = Poco::Path(destDir.toString(), "config.xcu").toString();
@@ -1778,8 +1762,7 @@ static std::string extractViewSettings(const std::string& viewSettingsPath,
             }
         }
 
-        std::string zoteroAPIKey, signatureCertificate, signatureKey, signatureCa,
-            aiImageProviderAPIKey, aiImageProviderURL, aiImageModel, aiImageSize;
+        std::string zoteroAPIKey, signatureCertificate, signatureKey, signatureCa;
 
         bool viewSettingsNeedUpdate = false;
 
@@ -1794,7 +1777,7 @@ static std::string extractViewSettings(const std::string& viewSettingsPath,
                 JsonUtil::findJSONValue(userPrivateInfoObj, privateInfoKey, migratedValue);
                 if (!migratedValue.empty())
                 {
-                    LOG_INF("Migrating field [" << viewSettingKey << "] from user private info");
+                    LOG_INF("Migrating signature field [" << viewSettingKey << "] from user private info");
                     viewSettings->set(viewSettingKey, migratedValue);
                     value = std::move(migratedValue);
                     return true;
@@ -1817,41 +1800,13 @@ static std::string extractViewSettings(const std::string& viewSettingsPath,
 
         _isViewSettingsUpdated = true;
 
-        std::string resolvedAIModel;
-        const bool aiConfigured = session->resolveAndApplyAICredentials(
-            viewSettings, userPrivateInfoObj, session->isDisableAISettings(),
-            viewSettingsNeedUpdate, resolvedAIModel);
-
-        JsonUtil::findJSONValue(viewSettings, "aiImageProviderAPIKey", aiImageProviderAPIKey);
-        JsonUtil::findJSONValue(viewSettings, "aiImageProviderURL", aiImageProviderURL);
-        JsonUtil::findJSONValue(viewSettings, "aiImageModel", aiImageModel);
-        JsonUtil::findJSONValue(viewSettings, "aiImageSize", aiImageSize);
-
-        session->setAIImageProviderAPIKey(aiImageProviderAPIKey);
-        session->setAIImageProviderURL(aiImageProviderURL);
-        session->setAIImageModel(aiImageModel);
-        session->setAIImageSize(aiImageSize);
-
         if (viewSettingsNeedUpdate)
         {
-            LOG_INF("View settings updated with migrated fields, uploading to WOPI host");
+            LOG_INF("View settings updated with migrated signature fields, uploading to WOPI host");
             session->setViewSettingsJSON(viewSettings);
             session->uploadViewSettingsToWopiHost();
         }
 
-        // remove API key from view settings before sending to client, client doesn't need to know about it
-        // and it will be set in session for later use when calling AI provider,
-        // also it is safer to not expose it to client side
-        viewSettings->remove("aiProviderAPIKey");
-        viewSettings->remove("aiProviderModel");
-        viewSettings->remove("aiProviderURL");
-        viewSettings->remove("aiImageProviderAPIKey");
-        viewSettings->remove("aiImageProviderURL");
-        viewSettings->remove("aiImageModel");
-
-        viewSettings->set("aiConfigured", aiConfigured);
-        if (aiConfigured)
-            viewSettings->set("aiModelName", resolvedAIModel);
         viewSettingsString = JsonUtil::jsonToString(viewSettings);
     }
     catch (const std::exception& exc)
@@ -2232,7 +2187,7 @@ bool DocumentBroker::processPlugins(std::string& localPath)
                 if (inputs != 1 || outputs != 1)
                     throw std::exception();
 
-                const int process = ProcUtil::spawnProcess(command, args);
+                const int process = Util::spawnProcess(command, args);
                 int status = -1;
                 const int rc = ::waitpid(process, &status, 0);
                 if (rc != 0)
@@ -2555,25 +2510,24 @@ bool DocumentBroker::isStorageOutdated() const
             << " and the last uploaded file was modified at " << lastModifiedTime << ", which are "
             << (currentModifiedTime == lastModifiedTime ? "identical" : "different"));
 
-    if (Util::isDebugEnabled() && _storageManager.getLastUploadedFileModifiedLocalTime() !=
-                                      _saveManager.getLastModifiedLocalTime())
+    if (Util::isDebugEnabled())
     {
-        const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-        LOG_ERR("StorageManager's lastModifiedTime ["
+        if (_storageManager.getLastUploadedFileModifiedLocalTime() !=
+            _saveManager.getLastModifiedLocalTime())
+        {
+            const std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+            LOG_ERR(
+                "StorageManager's lastModifiedTime ["
                 << Util::getTimeForLog(now, _storageManager.getLastUploadedFileModifiedLocalTime())
                 << "] doesn't match that of SaveManager's ["
                 << Util::getTimeForLog(now, _saveManager.getLastModifiedLocalTime())
                 << "]. File lastModifiedTime: [" << Util::getTimeForLog(now, currentModifiedTime)
                 << ']');
+        }
     }
 
     // Compare to the last uploaded file's modified-time.
     return currentModifiedTime != lastModifiedTime;
-}
-
-bool DocumentBroker::isNextSaveAutosave() const
-{
-    return _nextStorageAttrs.isAutosave();
 }
 
 void DocumentBroker::handleSaveResponse(const std::shared_ptr<ClientSession>& session,
@@ -2665,7 +2619,7 @@ void DocumentBroker::handleSaveResponse(const std::shared_ptr<ClientSession>& se
     if (!success && result != "unmodified")
     {
         LOG_INF("Failed to save docKey [" << _docKey
-                                          << "] as .uno:Save has failed in COKit. Notifying clients");
+                                          << "] as .uno:Save has failed in LOK. Notifying clients");
         session->sendTextFrameAndLogError("error: cmd=storage kind=savefailed");
         broadcastSaveResult(false, "Could not save the document");
     }
@@ -3411,9 +3365,9 @@ void DocumentBroker::setLoaded()
         LOG_INF("Document [" << _docKey << "] loaded in " << _loadDuration
                              << ", saving-timeout set to " << _saveManager.getSavingTimeout());
         LOG_DBG("Document [" << _docKey
-                             << "] PSS: " << ProcUtil::getMemoryUsagePSS(_childProcess->getPid())
-                             << " KB, total PSS: "
-                             << ProcUtil::getProcessTreePss(ProcUtil::getProcessId()) << " KB");
+                             << "] PSS: " << Util::getMemoryUsagePSS(_childProcess->getPid())
+                             << " KB, total PSS: " << Util::getProcessTreePss(Util::getProcessId())
+                             << " KB");
 
         UNITWSD_CALL_INSTANCE(_unitWsd, onPerfDocumentLoaded());
     }
@@ -3667,22 +3621,21 @@ bool DocumentBroker::autoSave(const bool force, const bool dontSaveIfUnmodified,
     return sent;
 }
 
-void DocumentBroker::autoSaveAndStop(const std::string_view reason)
+void DocumentBroker::autoSaveAndStop(const std::string& reason)
 {
+    LOG_TRC("autoSaveAndStop for docKey [" << getDocKey() << "]: " << reason);
+
     if (_saveManager.isSaving() || isAsyncUploading())
     {
-        LOG_TRC("autoSaveAndStop ["
-                << reason << "] skipped for docKey [" << getDocKey() << "] because an async "
-                << (_saveManager.isSaving() ? "saving" : "uploading") << " is in progress");
+        LOG_TRC("Async saving/uploading in progress for docKey [" << getDocKey() << ']');
         return;
     }
 
     const NeedToSave needToSave = needToSaveToDisk();
     const NeedToUpload needToUpload = needToUploadToStorage();
     bool canStop = (needToSave == NeedToSave::No && needToUpload == NeedToUpload::No);
-    LOG_TRC("autoSaveAndStop [" << reason << "] for docKey [" << getDocKey()
-                                << "]: " << name(needToSave) << ", " << name(needToUpload)
-                                << ", canStop: " << canStop);
+    LOG_TRC("autoSaveAndStop for docKey [" << getDocKey() << "]: " << name(needToSave) << ", "
+                                           << name(needToUpload) << ", canStop: " << canStop);
 
     if (!canStop && needToSave == NeedToSave::No && !isStorageOutdated())
     {
@@ -3730,7 +3683,7 @@ void DocumentBroker::autoSaveAndStop(const std::string_view reason)
         // very late, or not at all. We care that there is nothing to upload
         // and the last save succeeded, possibly because there was no
         // modifications, and there has been no activity since.
-        LOG_ASSERT_MSG(_saveManager.lastSaveRequestTime() <= _saveManager.lastSaveResponseTime(),
+        LOG_ASSERT_MSG(_saveManager.lastSaveRequestTime() < _saveManager.lastSaveResponseTime(),
                        "Unexpected active save in flight");
         LOG_ASSERT_MSG(!_saveManager.isSaving(), "Unexpected active save in flight");
         if (!haveModifyActivityAfterSaveRequest() && _saveManager.lastSaveSuccessful())
@@ -3843,7 +3796,7 @@ bool DocumentBroker::sendUnoSave(const std::shared_ptr<ClientSession>& session,
     constexpr std::size_t MaxFailureCountForBackgroundSaving = 2; // Give only 1 extra chance.
 
     // Note: It's odd to capture these here, but this function is used from ClientSession too.
-    const bool autosave = isAutosave || UNITWSD_CALL_INSTANCE(_unitWsd, isAutosave());
+    const bool autosave = isAutosave || (_unitWsd && _unitWsd->isAutosave());
     const bool backgroundConfigured = (autosave && _backgroundAutoSave) || _backgroundManualSave;
     const bool canBackground = forceBackgroundEnv || (!finalWrite && backgroundConfigured);
     const bool background = canBackground && _saveManager.lastSaveSuccessful() &&
@@ -4032,6 +3985,8 @@ std::size_t DocumentBroker::removeSession(const std::shared_ptr<ClientSession>& 
         {
             LOG_WRN("Failed to upload presets for session [" << id << "]: " << exc.what());
         }
+#endif
+#ifndef IOS
         if (activeSessionCount <= 1 && !isConvertTo())
         {
             // rescue clipboard before shutdown.
@@ -4056,9 +4011,9 @@ std::size_t DocumentBroker::removeSession(const std::shared_ptr<ClientSession>& 
 
         // But, in reality it has unintended side effects on iOS because if you have done changes to
         // the document, it does get saved, but that is only to the temporary copy. It is only in
-        // the document callback handler for KIT_CALLBACK_UNO_COMMAND_RESULT that we then call the
+        // the document callback handler for LOK_CALLBACK_UNO_COMMAND_RESULT that we then call the
         // system API to save that copy back to where it came from. See the
-        // KIT_CALLBACK_UNO_COMMAND_RESULT case in ChildSession::loKitCallback() in
+        // LOK_CALLBACK_UNO_COMMAND_RESULT case in ChildSession::loKitCallback() in
         // ChildSession.cpp. If we did use the below code snippet here, the document callback would
         // get unregistered right away in Document::onUnload in Kit.cpp.
 
@@ -4256,7 +4211,7 @@ std::shared_ptr<ClientSession> DocumentBroker::createNewClientSession(
                                   << id << ']');
             if (ws)
             {
-                constexpr std::string_view msg("error: cmd=load kind=docunloading");
+                const std::string msg("error: cmd=load kind=docunloading");
                 ws->sendTextMessage(msg);
                 ws->shutdown(true, msg);
             }
@@ -4267,7 +4222,7 @@ std::shared_ptr<ClientSession> DocumentBroker::createNewClientSession(
         // Now we have a DocumentBroker and we're ready to process client commands.
         if (ws)
         {
-            static constexpr std::string_view statusReady = "progress: { \"id\":\"ready\" }";
+            static constexpr const char* const statusReady = "progress: { \"id\":\"ready\" }";
             LOG_TRC("Sending to Client [" << statusReady << ']');
             ws->sendTextMessage(statusReady);
         }
@@ -4295,7 +4250,7 @@ std::shared_ptr<ClientSession> DocumentBroker::createNewClientSession(
 
     if (ws)
     {
-        constexpr std::string_view msg("error: cmd=internal kind=load");
+        const std::string msg("error: cmd=internal kind=load");
         ws->sendTextMessage(msg);
         ws->shutdown(true, msg);
     }
@@ -4322,13 +4277,13 @@ void DocumentBroker::alertAllUsers(const std::string& msg)
 {
     ASSERT_CORRECT_THREAD();
 
-    if (UNITWSD_CALL_INSTANCE(_unitWsd, filterAlertAllusers(msg)))
+    if (_unitWsd && _unitWsd->filterAlertAllusers(msg))
         return;
 
     auto payload = std::make_shared<Message>(msg, Message::Dir::Out);
 
     LOG_DBG("Alerting all users of [" << _docKey << "]: " << msg);
-    for (const auto& it : _sessions)
+    for (auto& it : _sessions)
     {
         if (!it.second->inWaitDisconnected())
             it.second->enqueueSendMessage(payload);
@@ -4343,7 +4298,7 @@ void DocumentBroker::syncBrowserSettings(const std::string& userId, const std::s
                                                  << "] for all sessions with userId [" << userId
                                                  << ']');
 
-    for (const auto& it : _sessions)
+    for (auto& it : _sessions)
     {
         if (it.second->getUserId() != userId)
             continue;
@@ -4478,7 +4433,7 @@ bool DocumentBroker::handleInput(const std::shared_ptr<Message>& message)
             COOLWSD::dumpOutgoingTrace(getJailId(), "0", message->abbr());
     }
 
-    if (UNITWSD_CALL_INSTANCE(_unitWsd, filterLOKitMessage(message)))
+    if (_unitWsd && _unitWsd->filterLOKitMessage(message))
         return true;
 
     if (COOLProtocol::getFirstToken(message->forwardToken(), '-') == "client")
@@ -4528,19 +4483,32 @@ bool DocumentBroker::handleInput(const std::shared_ptr<Message>& message)
                                                                       COOLWSD::ChildRoot + getJailId(),
                                                                       JAILED_DOCUMENT_ROOT + decoded));
 
-            std::ifstream ifs(filePath);
-            const std::string svg((std::istreambuf_iterator<char>(ifs)),
-                                (std::istreambuf_iterator<char>()));
-            ifs.close();
 
-            if (svg.empty())
-                LOG_WRN("Empty download: [id: " << downloadid << ", url: " << url << ']');
-
-            const auto it = _sessions.find(clientId);
-            if (it != _sessions.end())
+            // APENAS processar se o ficheiro for um SVG, previne apagar PDFs com std::ofstream!
+            // Usamos std::string::find envolto em try/catch para evitar exceções do Poco::Path em caminhos malformados
+            try
             {
-                std::ofstream ofs(filePath);
-                ofs << it->second->processSVGContent(svg);
+                if (filePath.find(".svg") != std::string::npos || filePath.find(".SVG") != std::string::npos)
+                {
+                    std::ifstream ifs(filePath);
+                    const std::string svg((std::istreambuf_iterator<char>(ifs)),
+                                          (std::istreambuf_iterator<char>()));
+                    ifs.close();
+
+                    if (svg.empty())
+                        LOG_WRN("Empty SVG download: [id: " << downloadid << ", url: " << url << ']');
+
+                    const auto it = _sessions.find(clientId);
+                    if (it != _sessions.end())
+                    {
+                        std::ofstream ofs(filePath);
+                        ofs << it->second->processSVGContent(svg);
+                    }
+                }
+            }
+            catch (const std::exception& e)
+            {
+                LOG_ERR("Exception processing download registration: " << e.what());
             }
 
             _registeredDownloadLinks[downloadid] = std::move(url);
@@ -4877,8 +4845,7 @@ void DocumentBroker::handleClipboardRequest(ClipboardRequest type, const std::sh
 
 void DocumentBroker::handleMediaRequest(const std::string_view range,
                                         const std::shared_ptr<Socket>& socket,
-                                        const std::string& tag,
-                                        const std::string& field)
+                                        const std::string& tag)
 {
     LOG_DBG("handleMediaRequest: " << tag);
 
@@ -4902,7 +4869,7 @@ void DocumentBroker::handleMediaRequest(const std::string_view range,
     if (JsonUtil::parseJSON(it->second, object))
     {
         LOG_ASSERT(JsonUtil::getJSONValue<std::string>(object, "id") == tag);
-        const std::string url = JsonUtil::getJSONValue<std::string>(object, field);
+        const std::string url = JsonUtil::getJSONValue<std::string>(object, "url");
         LOG_ASSERT(!url.empty());
         if (Util::toLower(url).starts_with("file://"))
         {
@@ -4913,7 +4880,7 @@ void DocumentBroker::handleMediaRequest(const std::string_view range,
 
             auto session = std::make_shared<http::ServerSession>();
             http::ServerSession::ResponseHeaders responseHeaders;
-            responseHeaders.emplace_back("Content-Type", (field == "url" ? "video/mp4" : "text/plain"));
+            responseHeaders.emplace_back("Content-Type", "video/mp4");
             session->asyncUpload(std::move(path), std::move(responseHeaders), range);
             streamSocket->setHandler(std::static_pointer_cast<ProtocolHandlerInterface>(session));
         }
@@ -5221,26 +5188,18 @@ std::string DocumentBroker::applyBrowserAccessibility(const std::string& message
                                                    const std::string& viewId)
 {
     bool accessibilityEnabled = false;
-    bool lockAccessibilityOn = false;
     const auto it = _sessions.find(viewId);
     if (it != _sessions.end())
     {
         auto session = it->second;
         auto json = session->getBrowserSettingJSON();
         JsonUtil::findJSONValue(json, "accessibilityState", accessibilityEnabled);
-        JsonUtil::findJSONValue(json, "lockAccessibilityOn", lockAccessibilityOn);
     }
     else
         LOG_WRN("Cannot lock accessibility on for ClientSession [" << viewId << ']');
 
     if (!accessibilityEnabled)
         return message;
-
-    if (lockAccessibilityOn && it != _sessions.end())
-    {
-        auto session = it->second;
-        session->sendTextFrame("lockaccessibilityon");
-    }
 
     // Ensure accessibilityState=true is enabled. Overwrite accessibilityState=
     // if it exists, append otherwise.
@@ -5306,8 +5265,7 @@ bool DocumentBroker::forwardToChild(const std::shared_ptr<ClientSession>& sessio
     std::string viewId = session->getId();
 
     // Should not get through; we have our own save command.
-    // .uno:SaveGraphic is not a document save - it exports an image to a temp file.
-    assert(!message.starts_with("uno .uno:Save") || message.starts_with("uno .uno:SaveGraphic"));
+    assert(!message.starts_with("uno .uno:Save"));
 
     LOG_TRC("Forwarding payload to child [" << viewId << "]: " << getAbbreviatedMessage(message));
 
@@ -5400,7 +5358,7 @@ bool DocumentBroker::forwardToClient(const std::shared_ptr<Message>& payload)
     return false;
 }
 
-void DocumentBroker::shutdownClients(const std::string_view closeReason)
+void DocumentBroker::shutdownClients(const std::string& closeReason)
 {
     ASSERT_CORRECT_THREAD();
     LOG_INF("Terminating " << _sessions.size() << " clients of doc [" << _docKey << "] with reason: " << closeReason);
@@ -5410,7 +5368,7 @@ void DocumentBroker::shutdownClients(const std::string_view closeReason)
     std::map<std::string, std::shared_ptr<ClientSession>> sessions = _sessions;
     for (const auto& pair : sessions)
     {
-        const std::shared_ptr<ClientSession>& session = pair.second;
+        std::shared_ptr<ClientSession> session = pair.second;
         try
         {
             if (session->inWaitDisconnected())
@@ -5432,7 +5390,7 @@ void DocumentBroker::shutdownClients(const std::string_view closeReason)
     }
 }
 
-void DocumentBroker::terminateChild(const std::string_view closeReason)
+void DocumentBroker::terminateChild(const std::string& closeReason)
 {
     ASSERT_CORRECT_THREAD();
 
@@ -5697,7 +5655,7 @@ void DocumentBroker::checkFileInfo(const std::shared_ptr<ClientSession>& session
 std::vector<std::shared_ptr<ClientSession>> DocumentBroker::getSessionsTestOnlyUnsafe()
 {
     std::vector<std::shared_ptr<ClientSession>> result;
-    for (const auto& it : _sessions)
+    for (auto& it : _sessions)
         result.push_back(it.second);
     return result;
 }
@@ -5750,9 +5708,9 @@ void DocumentBroker::dumpState(std::ostream& os)
     os << "\n  backgroundAutoSave: " << (_backgroundAutoSave?"true":"false");
     os << "\n  backgroundManualSave: " << (_backgroundManualSave?"true":"false");
     os << "\n  isViewFileExtension: " << _isViewFileExtension;
-    os << "\n  Total PSS: " << ProcUtil::getProcessTreePss(ProcUtil::getProcessId()) << " KB";
+    os << "\n  Total PSS: " << Util::getProcessTreePss(Util::getProcessId()) << " KB";
     if (childPid)
-        os << "\n  Doc PSS: " << ProcUtil::getProcessTreePss(childPid) << " KB";
+        os << "\n  Doc PSS: " << Util::getProcessTreePss(childPid) << " KB";
     if constexpr (!Util::isMobileApp())
     {
         os << "\n  last quarantined version: "

--- a/wsd/Storage.cpp
+++ b/wsd/Storage.cpp
@@ -62,8 +62,8 @@
 #include <androidapp.hpp>
 #elif defined(_WIN32)
 #include <windows.hpp>
-#elif defined(QTAPP)
-#include <qt.hpp>
+#elif defined(GTKAPP)
+#include <gtk.hpp>
 #elif WASMAPP
 #include <wasmapp.hpp>
 #endif
@@ -356,7 +356,13 @@ std::string LocalStorage::downloadStorageFileToLocal(const Authorization& /*auth
 
     // Make sure the path is valid.
     const Poco::Path downloadPath = Poco::Path(getRootFilePath()).parent();
-    Poco::File(downloadPath).createDirectories();
+
+    std::string ext = Poco::Path(downloadPath).getExtension();
+        if (ext == "pdf" || ext == "epub" || ext == "odt" || ext == "ods" || ext == "odp" || ext == "docx" || ext == "xlsx" || ext == "pptx") {
+            Poco::File(Poco::Path(downloadPath).parent()).createDirectories();
+        } else {
+            Poco::File(downloadPath).createDirectories();
+        }
 
     // Check for available space.
     if (!FileUtil::checkDiskSpace(downloadPath.toString()))

--- a/wsd/wopi/WopiStorage.cpp
+++ b/wsd/wopi/WopiStorage.cpp
@@ -13,23 +13,23 @@
 
 #include "WopiStorage.hpp"
 
+#include <Auth.hpp>
+#include <CommandControl.hpp>
+#include <Common.hpp>
+#include <Exceptions.hpp>
+#include <HostUtil.hpp>
+#include <HttpRequest.hpp>
+#include <common/Log.hpp>
+#include <NetUtil.hpp>
+#include <ProofKey.hpp>
+#include <Unit.hpp>
+#include <common/Util.hpp>
 #include <common/Anonymizer.hpp>
-#include <common/CommandControl.hpp>
-#include <common/Common.hpp>
 #include <common/FileUtil.hpp>
 #include <common/JsonUtil.hpp>
-#include <common/Log.hpp>
 #include <common/TraceEvent.hpp>
-#include <common/Unit.hpp>
 #include <common/Uri.hpp>
-#include <common/Util.hpp>
-#include <net/HttpRequest.hpp>
-#include <net/NetUtil.hpp>
 #include <wopi/StorageConnectionManager.hpp>
-#include <wsd/Auth.hpp>
-#include <wsd/Exceptions.hpp>
-#include <wsd/HostUtil.hpp>
-#include <wsd/ProofKey.hpp>
 
 #include <Poco/Exception.h>
 #include <Poco/Net/AcceptCertificateHandler.h>
@@ -50,22 +50,20 @@
 #include <memory>
 #include <string>
 
-namespace
+bool isTemplate(const std::string& filename)
 {
-
-constexpr bool isTemplate(const std::string_view filename)
-{
-    constexpr std::string_view extensions[] = { ".stw",  ".ott",  ".dot",  ".dotx", ".dotm", ".otm",
-                                                ".stc",  ".ots",  ".xltx", ".xltm", ".sti",  ".otp",
-                                                ".potx", ".potm", ".std",  ".otg" };
-    for (const std::string_view extension : extensions)
-    {
+    std::vector<std::string> templateExtensions{ ".stw",  ".ott",  ".dot", ".dotx",
+                                                 ".dotm", ".otm",  ".stc", ".ots",
+                                                 ".xltx", ".xltm", ".sti", ".otp",
+                                                 ".potx", ".potm", ".std", ".otg" };
+    for (auto& extension : templateExtensions)
         if (filename.ends_with(extension))
             return true;
-    }
-
     return false;
 }
+
+namespace
+{
 
 /// A helper class to invoke the callback of an async
 /// request when it exits its scope.
@@ -99,14 +97,10 @@ void anonymizeAvatarURL(Poco::JSON::Object::Ptr& userExtraInfo)
     if (!avatarURL.empty())
     {
         const std::string avatar_path = "/avatar/";
-        const std::size_t pos = avatarURL.find(avatar_path);
-        if (pos == std::string::npos)
-            return;
+        std::size_t startPos = avatarURL.find(avatar_path) + avatar_path.length();
+        std::size_t endPos = avatarURL.find("/", startPos);
 
-        const std::size_t startPos = pos + avatar_path.length();
-        const std::size_t endPos = avatarURL.find("/", startPos);
-
-        if (endPos != std::string::npos)
+        if (startPos != std::string::npos && endPos != std::string::npos)
         {
             std::string avatarUserName = avatarURL.substr(startPos, endPos - startPos);
             avatarURL.replace(startPos, endPos - startPos, COOLWSD::anonymizeUsername(avatarUserName));
@@ -182,10 +176,11 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo, Poco::JSON::Ob
 
         // Set anonymized version of the above fields before logging.
         // Note: anonymization caches the result, so we don't need to store here.
-        object->set("BaseFileName", COOLWSD::anonymizeUrl(getFilename()));
+        if (COOLWSD::AnonymizeUserData)
+            object->set("BaseFileName", COOLWSD::anonymizeUrl(getFilename()));
 
         // If obfuscatedUserId is provided, then don't log the originals and use it.
-        if (_obfuscatedUserId.empty())
+        if (COOLWSD::AnonymizeUserData && _obfuscatedUserId.empty())
         {
             object->set("OwnerId", COOLWSD::anonymizeUsername(getOwnerId()));
             object->set("UserId", COOLWSD::anonymizeUsername(_userId));
@@ -231,7 +226,6 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo, Poco::JSON::Ob
     JsonUtil::findJSONValue(object, "DisableInsertLocalImage", _disableInsertLocalImage);
     JsonUtil::findJSONValue(object, "EnableRemoteLinkPicker", _enableRemoteLinkPicker);
     JsonUtil::findJSONValue(object, "EnableRemoteAIContent", _enableRemoteAIContent);
-    JsonUtil::findJSONValue(object, "DisableAISettings", _disableAISettings);
     JsonUtil::findJSONValue(object, "EnableShare", _enableShare);
     JsonUtil::findJSONValue(object, "HideUserList", _hideUserList);
     JsonUtil::findJSONValue(object, "SupportsLocks", _supportsLocks);
@@ -277,7 +271,7 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo, Poco::JSON::Ob
         isUserLocked = false;
         CommandControl::LockManager::setUnlockLink(uriObject.getHost());
         Poco::URI newUri(HostUtil::getNewLockedUri(uriObject));
-        const std::string& host = newUri.getHost();
+        const std::string host = newUri.getHost();
 
         if (CommandControl::LockManager::hostExist(host))
         {
@@ -313,13 +307,6 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo, Poco::JSON::Ob
     JsonUtil::findJSONValue(object, "IsUserRestricted", booleanFlag);
     CommandControl::RestrictionManager::setRestrictedUser(booleanFlag);
 
-#if ENABLE_DEBUG
-    // Enable testing feature restriction; always reset to avoid stale state from prior loads
-    std::string restrictedCommandList;
-    JsonUtil::findJSONValue(object, "Test_RestrictedCommandList", restrictedCommandList);
-    CommandControl::RestrictionManager::setRestrictedCommandList(restrictedCommandList);
-#endif
-
     if (JsonUtil::findJSONValue(object, "DisableChangeTrackingRecord", booleanFlag))
         _disableChangeTrackingRecord =
             (booleanFlag ? WOPIFileInfo::TriState::True : WOPIFileInfo::TriState::False);
@@ -338,33 +325,6 @@ WopiStorage::WOPIFileInfo::WOPIFileInfo(const FileInfo& fileInfo, Poco::JSON::Ob
         _disableExport = true;
 }
 
-void WopiStorage::setWopiHeader(http::Request& httpRequest, const std::string& suffix,
-                                const std::string& value)
-{
-    httpRequest.set("X-COOL-WOPI-" + suffix, value);
-    if (isLegacyServer())
-        httpRequest.set("X-LOOL-WOPI-" + suffix, value);
-}
-
-http::Request WopiStorage::createLockRequest(const Poco::URI& uriObject, const Authorization& auth,
-                                             LockContext& lockCtx, LockState lock,
-                                             const Attributes& attribs)
-{
-    http::Request httpRequest = StorageConnectionManager::createHttpRequest(uriObject, auth);
-    httpRequest.setVerb(http::Request::VERB_POST);
-
-    httpRequest.set("X-WOPI-Override",
-                    lock == StorageBase::LockState::LOCK ? "LOCK" : "UNLOCK");
-    httpRequest.set("X-WOPI-Lock", lockCtx.lockToken());
-    if (!attribs.getExtendedData().empty())
-        setWopiHeader(httpRequest, "ExtendedData", attribs.getExtendedData());
-
-    // IIS requires content-length for POST requests: see https://forums.iis.net/t/1119456.aspx
-    httpRequest.setContentLength(0);
-
-    return httpRequest;
-}
-
 StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& auth,
                                                            LockContext& lockCtx,
                                                            StorageBase::LockState lock,
@@ -376,7 +336,9 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
     Poco::URI uriObject(getUri());
     auth.authorizeURI(uriObject);
 
-    const std::string uriAnonym = getAnonymizedUri();
+    Poco::URI uriObjectAnonym(getUri());
+    uriObjectAnonym.setPath(COOLWSD::anonymizeUrl(uriObjectAnonym.getPath()));
+    const std::string uriAnonym = uriObjectAnonym.toString();
 
     const auto wopiLog = (lock == StorageBase::LockState::LOCK ? "WOPI::Lock" : "WOPI::Unlock");
     LOG_DBG(wopiLog << " requesting: " << uriAnonym);
@@ -387,7 +349,21 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
         std::shared_ptr<http::Session> httpSession =
             StorageConnectionManager::getHttpSession(uriObject);
 
-        http::Request httpRequest = createLockRequest(uriObject, auth, lockCtx, lock, attribs);
+        http::Request httpRequest = StorageConnectionManager::createHttpRequest(uriObject, auth);
+        httpRequest.setVerb(http::Request::VERB_POST);
+
+        httpRequest.set("X-WOPI-Override",
+                        lock == StorageBase::LockState::LOCK ? "LOCK" : "UNLOCK");
+        httpRequest.set("X-WOPI-Lock", lockCtx.lockToken());
+        if (!attribs.getExtendedData().empty())
+        {
+            httpRequest.set("X-COOL-WOPI-ExtendedData", attribs.getExtendedData());
+            if (isLegacyServer())
+                httpRequest.set("X-LOOL-WOPI-ExtendedData", attribs.getExtendedData());
+        }
+
+        // IIS requires content-length for POST requests: see https://forums.iis.net/t/1119456.aspx
+        httpRequest.setContentLength(0);
 
         const std::shared_ptr<const http::Response> httpResponse =
             httpSession->syncRequest(httpRequest);
@@ -405,7 +381,9 @@ StorageBase::LockUpdateResult WopiStorage::updateLockState(const Authorization& 
         failureReason = httpResponse->get("X-WOPI-LockFailureReason", "");
 
         const bool unauthorized =
-            http::isUnauthorizedStatusCode(httpResponse->statusLine().statusCode());
+            (httpResponse->statusLine().statusCode() == http::StatusCode::Unauthorized ||
+             httpResponse->statusLine().statusCode() == http::StatusCode::Forbidden ||
+             httpResponse->statusLine().statusCode() == http::StatusCode::NotFound);
 
         LOG_ERR("Un-successful " << wopiLog << " with " << (unauthorized ? "expired token, " : "")
                                  << "HTTP status " << httpResponse->statusLine().statusCode()
@@ -455,14 +433,29 @@ void WopiStorage::updateLockStateAsync(const Authorization& auth, LockContext& l
     Poco::URI uriObject(getUri());
     auth.authorizeURI(uriObject);
 
-    const std::string uriAnonym = getAnonymizedUri();
+    Poco::URI uriObjectAnonym(getUri());
+    uriObjectAnonym.setPath(COOLWSD::anonymizeUrl(uriObjectAnonym.getPath()));
+    const std::string uriAnonym = uriObjectAnonym.toString();
 
     const auto wopiLog = (lock == StorageBase::LockState::LOCK ? "WOPI::Lock" : "WOPI::Unlock");
     LOG_DBG(wopiLog << " requesting: " << uriAnonym);
 
     _lockHttpSession = StorageConnectionManager::getHttpSession(uriObject);
 
-    http::Request httpRequest = createLockRequest(uriObject, auth, lockCtx, lock, attribs);
+    http::Request httpRequest = StorageConnectionManager::createHttpRequest(uriObject, auth);
+    httpRequest.setVerb(http::Request::VERB_POST);
+
+    httpRequest.set("X-WOPI-Override", lock == StorageBase::LockState::LOCK ? "LOCK" : "UNLOCK");
+    httpRequest.set("X-WOPI-Lock", lockCtx.lockToken());
+    if (!attribs.getExtendedData().empty())
+    {
+        httpRequest.set("X-COOL-WOPI-ExtendedData", attribs.getExtendedData());
+        if (isLegacyServer())
+            httpRequest.set("X-LOOL-WOPI-ExtendedData", attribs.getExtendedData());
+    }
+
+    // IIS requires content-length for POST requests: see https://forums.iis.net/t/1119456.aspx
+    httpRequest.setContentLength(0);
 
     http::Session::FinishedCallback finishedCallback =
         [this, startTime, lock, wopiLog, asyncLockStateCallback,
@@ -497,7 +490,9 @@ void WopiStorage::updateLockStateAsync(const Authorization& auth, LockContext& l
         std::string failureReason = httpResponse->get("X-WOPI-LockFailureReason", "");
 
         const bool unauthorized =
-            http::isUnauthorizedStatusCode(httpResponse->statusLine().statusCode());
+            (httpResponse->statusLine().statusCode() == http::StatusCode::Unauthorized ||
+             httpResponse->statusLine().statusCode() == http::StatusCode::Forbidden ||
+             httpResponse->statusLine().statusCode() == http::StatusCode::NotFound);
 
         const StorageBase::LockUpdateResult::Status status =
             unauthorized ? LockUpdateResult::Status::UNAUTHORIZED
@@ -581,7 +576,9 @@ std::string WopiStorage::downloadStorageFileToLocal(const Authorization& auth,
     uriObject.setPath(uriObject.getPath() + "/contents");
     auth.authorizeURI(uriObject);
 
-    const std::string uriAnonym = getAnonymizedUri("/contents");
+    Poco::URI uriObjectAnonym(getUri());
+    uriObjectAnonym.setPath(COOLWSD::anonymizeUrl(uriObjectAnonym.getPath()) + "/contents");
+    const std::string uriAnonym = uriObjectAnonym.toString();
 
     try
     {
@@ -610,7 +607,13 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
 
     // Make sure the path is valid.
     const Poco::Path downloadPath = Poco::Path(getRootFilePath()).parent();
-    Poco::File(downloadPath).createDirectories();
+
+    std::string ext = Poco::Path(downloadPath).getExtension();
+    if (ext == "pdf" || ext == "epub" || ext == "odt" || ext == "ods" || ext == "odp" || ext == "docx" || ext == "xlsx" || ext == "pptx") {
+        Poco::File(Poco::Path(downloadPath).parent()).createDirectories();
+    } else {
+        Poco::File(downloadPath).createDirectories();
+    }
 
     // Check for available space.
     if (!FileUtil::checkDiskSpace(downloadPath.toString()))
@@ -643,7 +646,10 @@ std::string WopiStorage::downloadDocument(const Poco::URI& uriObject, const std:
         LOG_TRC("WOPI::GetFile response header for URI [" << uriAnonym << "]:\n"
                                                           << httpResponse->header());
     }
-    else if (http::isRedirectStatusCode(statusCode))
+    else if (statusCode == http::StatusCode::MovedPermanently ||
+             statusCode == http::StatusCode::Found ||
+             statusCode == http::StatusCode::TemporaryRedirect ||
+             statusCode == http::StatusCode::PermanentRedirect)
     {
         if (redirectLimit)
         {
@@ -723,10 +729,10 @@ std::size_t WopiStorage::uploadLocalFileToStorageAsync(
     //TODO: replace with state machine.
     if (_uploadHttpSession)
     {
-        LOG_INF("Upload is already in progress");
+        LOG_WRN("Upload is already in progress.");
         asyncUploadCallback(
-            AsyncUpload(AsyncUpload::State::Running,
-                        UploadResult(UploadResult::Result::OK, "Already in progress.")));
+            AsyncUpload(AsyncUpload::State::Error,
+                UploadResult(UploadResult::Result::FAILED, "Already in progress.")));
         return 0;
     }
 
@@ -775,23 +781,35 @@ std::size_t WopiStorage::uploadLocalFileToStorageAsync(
         {
             // normal save
             httpRequest.set("X-WOPI-Override", "PUT");
-            setWopiHeader(httpRequest, "IsModifiedByUser",
-                          attribs.isUserModified() ? "true" : "false");
-            setWopiHeader(httpRequest, "IsAutosave", attribs.isAutosave() ? "true" : "false");
-            setWopiHeader(httpRequest, "IsExitSave", attribs.isExitSave() ? "true" : "false");
-
-            if (attribs.isExitSave())
+            httpRequest.set("X-COOL-WOPI-IsModifiedByUser",
+                            attribs.isUserModified() ? "true" : "false");
+            httpRequest.set("X-COOL-WOPI-IsAutosave", attribs.isAutosave() ? "true" : "false");
+            httpRequest.set("X-COOL-WOPI-IsExitSave", attribs.isExitSave() ? "true" : "false");
+            if (isLegacyServer())
             {
+                httpRequest.set("X-LOOL-WOPI-IsModifiedByUser",
+                                attribs.isUserModified() ? "true" : "false");
+                httpRequest.set("X-LOOL-WOPI-IsAutosave", attribs.isAutosave() ? "true" : "false");
+                httpRequest.set("X-LOOL-WOPI-IsExitSave", attribs.isExitSave() ? "true" : "false");
+            }
+
+            if (attribs.isExitSave()) {
                 // Don't maintain the socket if we are exiting.
                 httpRequest.setConnectionToken(http::Header::ConnectionToken::Close);
             }
             if (!attribs.getExtendedData().empty())
-                setWopiHeader(httpRequest, "ExtendedData", attribs.getExtendedData());
+            {
+                httpRequest.set("X-COOL-WOPI-ExtendedData", attribs.getExtendedData());
+                if (isLegacyServer())
+                    httpRequest.set("X-LOOL-WOPI-ExtendedData", attribs.getExtendedData());
+            }
 
             if (!attribs.isForced() && isLastModifiedTimeSafe())
             {
                 // Request WOPI host to not overwrite if timestamps mismatch
-                setWopiHeader(httpRequest, "Timestamp", getLastModifiedTime());
+                httpRequest.set("X-COOL-WOPI-Timestamp", getLastModifiedTime());
+                if (isLegacyServer())
+                    httpRequest.set("X-LOOL-WOPI-Timestamp", getLastModifiedTime());
             }
         }
         else
@@ -989,7 +1007,9 @@ WopiStorage::handleUploadToStorageResponse(const WopiUploadDetails& details,
         {
             result.setResult(StorageBase::UploadResult::Result::TOO_LARGE);
         }
-        else if (http::isUnauthorizedStatusCode(details.httpResponseCode))
+        else if (details.httpResponseCode == http::StatusCode::Unauthorized ||
+                 details.httpResponseCode == http::StatusCode::Forbidden ||
+                 details.httpResponseCode == http::StatusCode::NotFound)
         {
             // The ms-wopi specs recognizes 401 and 404 for invalid token
             // and file unknown/user unauthorized, respectively.


### PR DESCRIPTION
**Description & Cause:**
This PR addresses critical failures when exporting documents (PDF, EPUB, etc.) in environments with strict User Namespaces enabled:

1. **`Is a directory` bug:** Several endpoints blindly called `Poco::File(path).createDirectories()` on absolute file paths, erroneously creating a directory with the file's exact name (e.g., `normal.pdf/`), which blocked further physical copies.
2. **0-byte truncated downloads:** `coolmount` silently fails to bind-mount individual files in certain restricted namespace conditions.
3. **Not found downloads:** `ClientRequestDispatcher` attempts to read the exported file from the jail's root `/tmp/` instead of the deeper isolated directory (`/tmp/user/docs/HASH/`) where the engine actually placed it.

**Fix:**
- Implemented a clean `getExtension()` check before directory creation to safely isolate file paths and only create `.parent()` directories.
- Added an automatic fallback to `copyTo()` in `JailUtil.cpp` specifically for files, bypassing `coolmount` failures gracefully.
- Introduced a fallback dynamic search in `ClientRequestDispatcher.cpp` to correctly locate the exported file deep inside the user's isolated `docs` folder if it's not found in the root.

- [x] I have run `make prettier-write` and formatted the code.
- [x] All commits have Change-Id
- [x] I have run tests with `make check` *(Delegated to CI run due to local LibreOfficeKit/COKit core headers mismatch).*
- [x] I have issued `make run` and manually verified that everything looks okay _ (Verified manually on a live deployment by compiling the modified objects, restarting coolwsd, and successfully downloading the exported PDFs)._
- [x] Documentation (manuals or wiki) has been updated or is not required

