### PR TITLE
feat(helm): make probe scheme configurable for SSL-terminating coolwsd

### DIFF
--- a/kubernetes/helm/collabora-online/Chart.yaml
+++ b/kubernetes/helm/collabora-online/Chart.yaml
@@ -4,7 +4,7 @@ type: "application"
 name: collabora-online
 description: Collabora Online helm chart
 
-version: 1.1.60
+version: 1.1.61
 appVersion: "25.04.9.4.1"
 
 home: "https://www.collaboraonline.com/code/"

--- a/kubernetes/helm/collabora-online/templates/deployment.yaml
+++ b/kubernetes/helm/collabora-online/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             httpGet:
               path: {{ .Values.probes.startup.path }}
               port: {{ .Values.deployment.containerPort }}
-              scheme: HTTP
+              scheme: {{ .Values.probes.scheme | default "HTTP" | upper }}
             failureThreshold: {{ .Values.probes.startup.failureThreshold }}
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
           {{- end }}
@@ -80,7 +80,7 @@ spec:
             httpGet:
               path: {{ .Values.probes.liveness.path }}
               port: {{ .Values.deployment.containerPort }}
-              scheme: HTTP
+              scheme: {{ .Values.probes.scheme | default "HTTP" | upper }}
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
@@ -92,7 +92,7 @@ spec:
             httpGet:
               path: {{ .Values.probes.readiness.path }}
               port: {{ .Values.deployment.containerPort }}
-              scheme: HTTP
+              scheme: {{ .Values.probes.scheme | default "HTTP" | upper }}
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}

--- a/kubernetes/helm/collabora-online/templates/dynamicConfig/deployment.yaml
+++ b/kubernetes/helm/collabora-online/templates/dynamicConfig/deployment.yaml
@@ -44,7 +44,7 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.dynamicConfig.containerPort }}
-              scheme: HTTP
+              scheme: {{ .Values.dynamicConfig.probes.scheme | default "HTTP" | upper }}
             failureThreshold: {{ .Values.dynamicConfig.probes.startup.failureThreshold }}
             periodSeconds: {{ .Values.dynamicConfig.probes.startup.periodSeconds }}
           {{- end }}
@@ -53,7 +53,7 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.dynamicConfig.containerPort }}
-              scheme: HTTP
+              scheme: {{ .Values.dynamicConfig.probes.scheme | default "HTTP" | upper }}
             initialDelaySeconds: {{ .Values.dynamicConfig.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.dynamicConfig.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.dynamicConfig.probes.liveness.timeoutSeconds }}
@@ -65,7 +65,7 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.dynamicConfig.containerPort }}
-              scheme: HTTP
+              scheme: {{ .Values.dynamicConfig.probes.scheme | default "HTTP" | upper }}
             initialDelaySeconds: {{ .Values.dynamicConfig.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.dynamicConfig.probes.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.dynamicConfig.probes.readiness.timeoutSeconds }}

--- a/kubernetes/helm/collabora-online/templates/dynamicConfig/statefulset.yaml
+++ b/kubernetes/helm/collabora-online/templates/dynamicConfig/statefulset.yaml
@@ -45,7 +45,7 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.dynamicConfig.containerPort }}
-              scheme: HTTP
+              scheme: {{ .Values.dynamicConfig.probes.scheme | default "HTTP" | upper }}
             failureThreshold: {{ .Values.dynamicConfig.probes.startup.failureThreshold }}
             periodSeconds: {{ .Values.dynamicConfig.probes.startup.periodSeconds }}
           {{- end }}
@@ -54,7 +54,7 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.dynamicConfig.containerPort }}
-              scheme: HTTP
+              scheme: {{ .Values.dynamicConfig.probes.scheme | default "HTTP" | upper }}
             initialDelaySeconds: {{ .Values.dynamicConfig.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.dynamicConfig.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.dynamicConfig.probes.liveness.timeoutSeconds }}
@@ -66,7 +66,7 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.dynamicConfig.containerPort }}
-              scheme: HTTP
+              scheme: {{ .Values.dynamicConfig.probes.scheme | default "HTTP" | upper }}
             initialDelaySeconds: {{ .Values.dynamicConfig.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.dynamicConfig.probes.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.dynamicConfig.probes.readiness.timeoutSeconds }}

--- a/kubernetes/helm/collabora-online/templates/statefulset.yaml
+++ b/kubernetes/helm/collabora-online/templates/statefulset.yaml
@@ -64,7 +64,7 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.deployment.containerPort }}
-              scheme: HTTP
+              scheme: {{ .Values.probes.scheme | default "HTTP" | upper }}
             failureThreshold: {{ .Values.probes.startup.failureThreshold }}
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
           {{- end }}
@@ -73,7 +73,7 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.deployment.containerPort }}
-              scheme: HTTP
+              scheme: {{ .Values.probes.scheme | default "HTTP" | upper }}
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
@@ -85,7 +85,7 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.deployment.containerPort }}
-              scheme: HTTP
+              scheme: {{ .Values.probes.scheme | default "HTTP" | upper }}
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -197,6 +197,10 @@ deployment:
     securityContext: {}
 
 probes:
+  # Scheme used by the kubelet to reach the probe endpoint.
+  # Set to HTTPS when SSL is terminated directly at coolwsd (e.g. via
+  # extra_params: --o:ssl.enable=true).
+  scheme: HTTP
   startup:
     enabled: true
     failureThreshold: 30
@@ -495,6 +499,9 @@ dynamicConfig:
   containerPort: 80
 
   probes:
+    # Scheme used by the kubelet to reach the dynamicConfig probe endpoint.
+    # Set to HTTPS when the dynamicConfig pod terminates SSL itself.
+    scheme: HTTP
     startup:
       enabled: true
       failureThreshold: 30


### PR DESCRIPTION
When SSL is enabled on coolwsd via extra_params, POCO binds a single TLS socket so the hardcoded HTTP probes always fail and the only workaround was disabling probes entirely. Surface the scheme as a values key (probes.scheme, dynamicConfig.probes.scheme), defaulting to HTTP so existing deployments are unaffected


Change-Id: I36314c52bc763c9bf0773f7ce948c52e21c80ff8
Reviewed-on: https://gerrit.collaboraoffice.com/c/online/+/2991
Tested-by: Jenkins CPCI <releng@collaboraoffice.com>


* Target version: main


