### PR TITLE
cypress-a11y: use sidebar.container instead of getContainer()

### DIFF
--- a/browser/src/app/A11yValidator.ts
+++ b/browser/src/app/A11yValidator.ts
@@ -357,6 +357,43 @@ class A11yValidator {
 		return 0;
 	}
 
+	private checkVisibleLabelsForFormControls(container: HTMLElement): number {
+		const elements = container.querySelectorAll('input, select');
+		const excludedInputTypes = new Set([
+			'hidden',
+			'button',
+			'submit',
+			'reset',
+			'image',
+		]);
+		let errorCount = 0;
+
+		elements.forEach((el) => {
+			const htmlEl = el as HTMLElement;
+
+			if (!this.isVisible(htmlEl)) return;
+
+			if (el.tagName === 'INPUT') {
+				const inputType = (el as HTMLInputElement).type?.toLowerCase();
+				if (excludedInputTypes.has(inputType)) return;
+			}
+
+			const hasLabelFor = !!document.querySelector(`label[for="${htmlEl.id}"]`);
+			const hasAriaLabelledBy = htmlEl.hasAttribute('aria-labelledby');
+
+			if (!hasLabelFor && !hasAriaLabelledBy) {
+				console.error(
+					new A11yValidatorException(
+						`In sidebar at '${this.getElementPath(htmlEl)}': ${el.tagName.toLowerCase()} element '${htmlEl.id}' is missing a visible label. Sidebar form controls should have a <label> or aria-labelledby association, not just aria-label.`,
+					),
+				);
+				errorCount++;
+			}
+		});
+
+		return errorCount;
+	}
+
 	private checkDuplicateButtonLabels(container: HTMLElement): number {
 		const buttons = container.querySelectorAll('button[aria-labelledby]');
 		const labelMap = new Map<string, HTMLElement[]>();
@@ -515,7 +552,10 @@ class A11yValidator {
 			return;
 		}
 
-		const errorCount = this.validateContainer(currentSidebar.container);
+		let errorCount = this.validateContainer(currentSidebar.container);
+		errorCount += this.checkVisibleLabelsForFormControls(
+			currentSidebar.container,
+		);
 
 		if (errorCount === 0) {
 			console.error('A11yValidator: sidebar passed all checks');

--- a/cypress_test/integration_tests/desktop/calc/a11y_sidebar_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/a11y_sidebar_spec.js
@@ -51,7 +51,7 @@ describe(['tagdesktop'], 'Accessibility Calc Sidebar Tests', { testIsolation: fa
 		helper.processToIdle(win);
 
 		cy.then(() => {
-			const container = win.app.map.sidebar.getContainer();
+			const container = win.app.map.sidebar.container;
 			const allInputs = container.querySelectorAll('input, select');
 			const target = Array.prototype.find.call(allInputs, function (el) {
 				if (!el.id) return false;


### PR DESCRIPTION
an issue since:

commit c612a11aefd99efcbe1e50f2f4927b94bb09c36e
Date:   Sun May 10 21:30:33 2026 +0530

    cypress-a11y: add negative test for missing visible label check

getContainer() isn't in co-25.04 (yet)


Change-Id: I9dbb57669ba551f69f6c69814bd2fe84a1d37ac2


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

