### PR TITLE
Let posted insert-comment commands pick the PDF anchor

### DIFF
--- a/browser/src/app/iface/Map.Interface.ts
+++ b/browser/src/app/iface/Map.Interface.ts
@@ -125,4 +125,5 @@ interface MapInterface extends Evented {
 	sidebar: Sidebar;
 	getViewColor(viewId: number): number;
 	insertThreadedComment(): void;
+	insertCommentInteractive(command: string, args: any): void;
 }

--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -47,7 +47,7 @@ window.L.Map.include({
 		if (author in this._viewInfoByUserName) {
 			avatar = this._viewInfoByUserName[author].userextrainfo.avatar;
 		}
-		const commentData = {
+		const commentData: any = {
 			text: '',
 			textrange: '',
 			author: author,
@@ -55,9 +55,21 @@ window.L.Map.include({
 			id: 'new', // 'new' only when added by us
 			avatar: avatar
 		};
-		// In PDF, enter a click-to-place mode and let the user pick the spot.
+		// In PDF, enter a click-to-place mode and let the user pick the spot,
+		// then open the in-place editor anchored there. Switching the active
+		// part keeps save()'s setPart wrapper consistent and lets newAnnotation
+		// pick up the correct parthash; yAddition lets save() back the per-page
+		// offset out before sending PositionY.
 		if (app.file.fileBasedView && commentSection) {
-			commentSection.startCommentPlacement(commentData);
+			commentSection.startCommentPlacement((pick: cool.CommentPlacementPick) => {
+				commentData.yAddition = pick.partIndex * pick.additionPerPart;
+				this.setPart(pick.partIndex, false);
+				commentData.position = [pick.docTL.x, pick.docTL.y];
+				if (pick.docBR)
+					commentData.size = [pick.docBR.x - pick.docTL.x,
+						pick.docBR.y - pick.docTL.y];
+				this._docLayer.newAnnotation(commentData);
+			});
 			return;
 		}
 		this._docLayer.newAnnotation(commentData);
@@ -91,6 +103,57 @@ window.L.Map.include({
 		});
 	},
 
+	// Host-driven insertion: the host has the comment text ready and asks the
+	// browser to pick the anchor interactively (PDF only). Args carries the
+	// final UNO payload plus an InteractiveAnchor sentinel; we strip the
+	// sentinel, run the click-to-place picker, then dispatch the command with
+	// PositionX/Y (and Width/Height when the user dragged a rectangle) merged
+	// in. Outside fileBasedView there is no picker, so we just strip and
+	// dispatch as-is.
+	insertCommentInteractive: function(command: string, args: any) {
+		if (this.stateChangeHandler.getItemValue('InsertAnnotation') === 'disabled')
+			return;
+
+		const editingComment = cool.Comment.isAnyEdit();
+		const commentSection = app.sectionContainer.getSectionWithName(
+			app.CSections.CommentList.name
+		) as cool.CommentSection;
+		if (commentSection && editingComment) {
+			commentSection.navigateAndFocusComment(editingComment);
+			return;
+		}
+
+		const cleanArgs: any = {};
+		for (const key in args) {
+			if (key !== 'InteractiveAnchor')
+				cleanArgs[key] = args[key];
+		}
+
+		if (!app.file.fileBasedView || !commentSection) {
+			this.sendUnoCommand(command, cleanArgs, true);
+			return;
+		}
+
+		commentSection.startCommentPlacement((pick: cool.CommentPlacementPick) => {
+			// docTL is stacked-document twips; the engine wants the page-local
+			// Y, so back out the per-page offset. Width/Height follow when the
+			// user dragged a rectangle.
+			const partTop = pick.partIndex * pick.additionPerPart;
+			const finalArgs: any = {
+				...cleanArgs,
+				PositionX: { type: 'int32', value: pick.docTL.x },
+				PositionY: { type: 'int32', value: pick.docTL.y - partTop },
+			};
+			if (pick.docBR) {
+				finalArgs.Width = { type: 'int32', value: pick.docBR.x - pick.docTL.x };
+				finalArgs.Height = { type: 'int32', value: pick.docBR.y - pick.docTL.y };
+			}
+			this.setPart(pick.partIndex, false);
+			this.sendUnoCommand(command, finalArgs, true);
+			this.setPart(0, false);
+		});
+	},
+
 	showResolvedComments: function(on: boolean = false) {
 		var unoCommand = '.uno:ShowResolvedAnnotations';
 		this.sendUnoCommand(unoCommand);
@@ -110,6 +173,17 @@ window.L.Map.include({
 declare var JSDialog: any;
 
 namespace cool {
+
+// Geometry a placement-mode pick hands back to its caller: the validated
+// anchor in stacked-document twips (docTL, plus docBR when a rectangle was
+// dragged), and the containing page so the caller can derive page-local
+// coordinates or switch the active part.
+export type CommentPlacementPick = {
+	partIndex: number;
+	additionPerPart: number;
+	docTL: { x: number; y: number };
+	docBR: { x: number; y: number } | null;
+};
 
 export class CommentSection extends CanvasSectionObject {
 	backgroundColor: string = app.sectionContainer.getClearColor();
@@ -166,10 +240,15 @@ export class CommentSection extends CanvasSectionObject {
 
 	// Active "click anywhere on the page to place a new comment" mode for PDF.
 	// When non-null, the next document mousedown is consumed to position a new
-	// comment at that point instead of being forwarded to core. A click+drag
-	// instead of a plain click captures an anchor area; if the drag stays
-	// below DRAG_THRESHOLD_PX the click is treated as a point placement.
-	private placementCommentData: any = null;
+	// comment at that point instead of being forwarded to the engine. A
+	// click+drag instead of a plain click captures an anchor area; if the drag
+	// stays below DRAG_THRESHOLD_PX the click is treated as a point placement.
+	//
+	// finishCommentPlacement reports the picked geometry (in stacked-document
+	// twips) here and stays out of what happens next: the caller's routine
+	// either opens the in-place editor (toolbar/menu Insert Comment) or
+	// dispatches a ready UNO command (host-driven insertCommentInteractive).
+	private placementOnPicked: ((pick: CommentPlacementPick) => void) | null = null;
 	private placementSavedCursor: string | null = null;
 	private placementStart: { cX: number; cY: number } | null = null;
 	private placementOverlay: HTMLDivElement | null = null;
@@ -810,17 +889,17 @@ export class CommentSection extends CanvasSectionObject {
 		app.map.fire('deleteannotation');
 	}
 
-	public startCommentPlacement(commentData: any): void {
+	public startCommentPlacement(onPicked: (pick: CommentPlacementPick) => void): void {
 		// An additional Insert Comment trigger while placement is already
 		// pending is a no-op.
-		if (this.placementCommentData)
+		if (this.placementOnPicked)
 			return;
 
 		const canvas = document.getElementById('document-canvas') as HTMLCanvasElement | null;
 		if (!canvas)
 			return;
 
-		this.placementCommentData = commentData;
+		this.placementOnPicked = onPicked;
 		this.placementSavedCursor = canvas.style.cursor;
 		canvas.style.cursor = 'crosshair';
 
@@ -841,7 +920,7 @@ export class CommentSection extends CanvasSectionObject {
 		}
 		document.removeEventListener('keydown', this.onPlacementKeyDown, true);
 		this.removePlacementOverlay();
-		this.placementCommentData = null;
+		this.placementOnPicked = null;
 		this.placementSavedCursor = null;
 		this.placementStart = null;
 	}
@@ -923,7 +1002,7 @@ export class CommentSection extends CanvasSectionObject {
 
 	private finishCommentPlacement(canvas: HTMLCanvasElement,
 		end: { cX: number; cY: number }): void {
-		const commentData = this.placementCommentData;
+		const onPicked = this.placementOnPicked;
 		const start = this.placementStart;
 		// Treat the gesture as a drag-to-area when the user moved past the
 		// threshold; otherwise it's a plain click and we anchor a 5x5 mm
@@ -974,17 +1053,12 @@ export class CommentSection extends CanvasSectionObject {
 			docBR.y = Math.min(docBR.y, partTop + docLayer._partHeightTwips);
 		}
 
-		// Switching the active part keeps save()'s setPart wrapper consistent
-		// and lets newAnnotation pick up the correct parthash; yAddition lets
-		// save() back the per-page offset out before sending PositionY.
-		commentData.yAddition = partIndex * additionPerPart;
-		this.map.setPart(partIndex, false);
-
-		commentData.position = [docTL.x, docTL.y];
-		if (docBR)
-			commentData.size = [docBR.x - docTL.x, docBR.y - docTL.y];
+		// Tear down placement mode, then hand the validated geometry to the
+		// caller's routine. docTL/docBR are stacked-document twips; partIndex
+		// and additionPerPart let the caller derive page-local coordinates or
+		// switch the active part as it needs.
 		this.exitCommentPlacement();
-		this.sectionProperties.docLayer.newAnnotation(commentData);
+		onPicked({ partIndex, additionPerPart, docTL, docBR });
 	}
 
 	public click (annotation: any): void {

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -513,6 +513,18 @@ window.L.Map.WOPI = window.L.Handler.extend({
 					return;
 				}
 			}
+			// Same commands shipped with full args plus an InteractiveAnchor
+			// sentinel: the host has the text ready and wants the browser to
+			// pick the anchor (PDF picker), then dispatch the command with the
+			// picked PositionX/Y (and Width/Height for a drag) substituted in.
+			// The sentinel is browser-directed (stripped before dispatch), not
+			// a UNO arg, so any truthy value enables it.
+			else if (msg.Values.Args.InteractiveAnchor
+				&& (msg.Values.Command === '.uno:InsertAnnotation'
+					|| msg.Values.Command === '.uno:InsertThreadedComment')) {
+				this._map.insertCommentInteractive(msg.Values.Command, msg.Values.Args);
+				return;
+			}
 			this._map.sendUnoCommand(msg.Values.Command, msg.Values.Args || '');
 			return;
 		}

--- a/cypress_test/integration_tests/desktop/calc/threaded_comment_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/threaded_comment_spec.js
@@ -33,6 +33,42 @@ describe(['tagdesktop'], 'Threaded Comment', function() {
 			.should('exist');
 	});
 
+	// Variant where the host ships full Args plus an InteractiveAnchor sentinel.
+	// Outside PDF there is no anchor picker, so the browser strips the sentinel
+	// and dispatches the command verbatim; engine inserts the threaded comment
+	// with the host-provided text and no in-place editor is opened.
+	it('Send_UNO_Command .uno:InsertThreadedComment with InteractiveAnchor inserts directly', function() {
+		const commentText = 'interactive-anchor-calc ' + Date.now();
+		cy.getFrameWindow().then(function(win) {
+			win.postMessage(JSON.stringify({
+				MessageId: 'Send_UNO_Command',
+				Values: {
+					Command: '.uno:InsertThreadedComment',
+					Args: {
+						Author: { type: 'string', value: 'PostMessageBot' },
+						Text: { type: 'string', value: commentText },
+						InteractiveAnchor: true,
+					},
+				},
+			}), '*');
+		});
+
+		// Engine acks a real (non-'new') comment carrying the host text -
+		// no #comment-container-new is ever created because newAnnotation
+		// is skipped.
+		cy.cGet('#comment-container-1').should('exist');
+		cy.cGet('#annotation-modify-textarea-new').should('not.exist');
+		cy.getFrameWindow().then(function(win) { return helper.processToIdle(win); });
+		cy.getFrameWindow().should(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			const comments = section.sectionProperties.commentList;
+			expect(comments.length).to.equal(1);
+			expect(comments[0].sectionProperties.data.text).to.contain(commentText);
+			expect(comments[0].sectionProperties.data.threaded).to.equal('true');
+		});
+	});
+
 	it('Insert, resolve, unresolve, and remove threaded comment', function() {
 		// Click the "Insert Comment" button on the Insert tab.
 		cy.cGet('#Insert-tab-label').click();

--- a/cypress_test/integration_tests/desktop/draw/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/annotation_spec.js
@@ -350,6 +350,201 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 		});
 	});
 
+	// Same Send_UNO_Command path, but the host also ships Text/Author plus
+	// an InteractiveAnchor sentinel. The browser must run the picker, then
+	// dispatch the command with the picked PositionX/Y substituted in - the
+	// in-place editor must not open because the text is already known.
+	it('Send_UNO_Command .uno:InsertAnnotation with InteractiveAnchor dispatches with picked point', { env: { 'pdf-view': true } }, function() {
+		const commentText = 'interactive-anchor-point ' + Date.now();
+		let initialCount = 0;
+
+		cy.getFrameWindow().then(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			initialCount = section.sectionProperties.commentList.length;
+
+			win.postMessage(JSON.stringify({
+				MessageId: 'Send_UNO_Command',
+				Values: {
+					Command: '.uno:InsertAnnotation',
+					Args: {
+						Author: { type: 'string', value: 'PostMessageBot' },
+						Text: { type: 'string', value: commentText },
+						InteractiveAnchor: true,
+					},
+				},
+			}), '*');
+		});
+
+		cy.getFrameWindow().should(function(win) {
+			expect(win.document.getElementById('document-canvas').style.cursor,
+				'placement mode must switch the canvas cursor to crosshair')
+				.to.equal('crosshair');
+		});
+
+		// Click at ~25%/25% of page 1 (CSS pixels computed from twips so the
+		// test is zoom-independent).
+		let expectedX = 0, expectedY = 0;
+		cy.getFrameWindow().then(function(win) {
+			const canvas = win.document.getElementById('document-canvas');
+			const rect = canvas.getBoundingClientRect();
+			const docLayer = win.app.map._docLayer;
+			const targetTwipsX = docLayer._partWidthTwips / 4;
+			const targetTwipsY = docLayer._partHeightTwips / 4;
+			const cssX = (targetTwipsX * win.app.twipsToPixels) / win.app.dpiScale;
+			const cssY = (targetTwipsY * win.app.twipsToPixels) / win.app.dpiScale;
+
+			const point = new win.cool.SimplePoint(0, 0);
+			point.cX = cssX;
+			point.cY = cssY;
+			const docPoint = win.app.activeDocument.activeLayout.canvasToDocumentPoint(point);
+			expectedX = docPoint.x;
+			expectedY = docPoint.y;
+
+			canvas.dispatchEvent(new win.MouseEvent('mousedown', {
+				clientX: rect.left + cssX, clientY: rect.top + cssY,
+				button: 0, bubbles: true,
+			}));
+			canvas.dispatchEvent(new win.MouseEvent('mouseup', {
+				clientX: rect.left + cssX, clientY: rect.top + cssY,
+				button: 0, bubbles: true,
+			}));
+		});
+
+		// The host-text path bypasses newAnnotation, so no local 'new'
+		// comment appears and no in-place editor is ever opened.
+		cy.getFrameWindow().should(function(win) {
+			expect(win.document.getElementById('document-canvas').style.cursor,
+				'cursor must be restored once the pick completes')
+				.to.not.equal('crosshair');
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			const stray = section.sectionProperties.commentList.find(
+				function(c) { return c.sectionProperties.data.id === 'new'; });
+			expect(stray,
+				'no editor-driven \'new\' comment should be created').to.not.exist;
+		});
+		cy.cGet('#annotation-modify-textarea-new').should('not.exist');
+
+		cy.getFrameWindow().then(function(win) { return helper.processToIdle(win); });
+
+		// After the engine ack: the comment lands in the list carrying the
+		// host text and an engine-assigned id, anchored at the picked point.
+		cy.getFrameWindow().should(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			expect(section.sectionProperties.commentList.length,
+				'commentList must grow by one after the engine ack')
+				.to.equal(initialCount + 1);
+			const acked = section.sectionProperties.commentList.find(function(c) {
+				return c.sectionProperties.data.text === commentText;
+			});
+			expect(acked, 'a comment with the host text must be present').to.exist;
+			expect(acked.sectionProperties.data.id,
+				'core must assign a real (non-\'new\') id').to.not.equal('new');
+			// Round-trip goes twips -> mm/100 (core) -> twips, so allow a few
+			// twips of rounding slack.
+			expect(acked.sectionProperties.data.anchorPos[0],
+				'anchor X must match the picked point').to.be.closeTo(expectedX, 5);
+			expect(acked.sectionProperties.data.anchorPos[1],
+				'anchor Y must match the picked point').to.be.closeTo(expectedY, 5);
+		});
+	});
+
+	// Drag variant of the InteractiveAnchor path: the gesture passes the
+	// drag threshold, so Width/Height reach engine alongside PositionX/Y and
+	// the resulting comment owns an anchor-area sub-section.
+	it('Send_UNO_Command .uno:InsertAnnotation with InteractiveAnchor dispatches with picked rectangle', { env: { 'pdf-view': true } }, function() {
+		const commentText = 'interactive-anchor-drag ' + Date.now();
+		let initialCount = 0;
+
+		cy.getFrameWindow().then(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			initialCount = section.sectionProperties.commentList.length;
+
+			win.postMessage(JSON.stringify({
+				MessageId: 'Send_UNO_Command',
+				Values: {
+					Command: '.uno:InsertAnnotation',
+					Args: {
+						Author: { type: 'string', value: 'PostMessageBot' },
+						Text: { type: 'string', value: commentText },
+						InteractiveAnchor: true,
+					},
+				},
+			}), '*');
+		});
+
+		cy.getFrameWindow().should(function(win) {
+			expect(win.document.getElementById('document-canvas').style.cursor)
+				.to.equal('crosshair');
+		});
+
+		let expectedW = 0, expectedH = 0;
+		cy.getFrameWindow().then(function(win) {
+			const canvas = win.document.getElementById('document-canvas');
+			const rect = canvas.getBoundingClientRect();
+			const docLayer = win.app.map._docLayer;
+			const startTwipsX = docLayer._partWidthTwips / 4;
+			const startTwipsY = docLayer._partHeightTwips / 4;
+			const endTwipsX = docLayer._partWidthTwips / 2;
+			const endTwipsY = docLayer._partHeightTwips * 0.4;
+			const startCssX = (startTwipsX * win.app.twipsToPixels) / win.app.dpiScale;
+			const startCssY = (startTwipsY * win.app.twipsToPixels) / win.app.dpiScale;
+			const endCssX = (endTwipsX * win.app.twipsToPixels) / win.app.dpiScale;
+			const endCssY = (endTwipsY * win.app.twipsToPixels) / win.app.dpiScale;
+
+			const tlPoint = new win.cool.SimplePoint(0, 0);
+			tlPoint.cX = Math.min(startCssX, endCssX);
+			tlPoint.cY = Math.min(startCssY, endCssY);
+			const docTL = win.app.activeDocument.activeLayout.canvasToDocumentPoint(tlPoint);
+			const brPoint = new win.cool.SimplePoint(0, 0);
+			brPoint.cX = Math.max(startCssX, endCssX);
+			brPoint.cY = Math.max(startCssY, endCssY);
+			const docBR = win.app.activeDocument.activeLayout.canvasToDocumentPoint(brPoint);
+			expectedW = docBR.x - docTL.x;
+			expectedH = docBR.y - docTL.y;
+
+			canvas.dispatchEvent(new win.MouseEvent('mousedown', {
+				clientX: rect.left + startCssX, clientY: rect.top + startCssY,
+				button: 0, bubbles: true,
+			}));
+			canvas.dispatchEvent(new win.MouseEvent('mousemove', {
+				clientX: rect.left + endCssX, clientY: rect.top + endCssY,
+				button: 0, bubbles: true,
+			}));
+			canvas.dispatchEvent(new win.MouseEvent('mouseup', {
+				clientX: rect.left + endCssX, clientY: rect.top + endCssY,
+				button: 0, bubbles: true,
+			}));
+		});
+
+		cy.cGet('#annotation-modify-textarea-new').should('not.exist');
+		cy.getFrameWindow().then(function(win) { return helper.processToIdle(win); });
+
+		cy.getFrameWindow().should(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			expect(section.sectionProperties.commentList.length,
+				'commentList must grow by one after the engine ack')
+				.to.equal(initialCount + 1);
+			const acked = section.sectionProperties.commentList.find(function(c) {
+				return c.sectionProperties.data.text === commentText;
+			});
+			expect(acked, 'a comment with the host text must be present').to.exist;
+			expect(acked.sectionProperties.data.id,
+				'core must assign a real id').to.not.equal('new');
+			const ackRect = acked.sectionProperties.data.rectangle;
+			expect(ackRect[2],
+				'round-tripped marker width must match the dragged area').to.be.closeTo(expectedW, 5);
+			expect(ackRect[3],
+				'round-tripped marker height must match the dragged area').to.be.closeTo(expectedH, 5);
+			expect(acked.sectionProperties.data.hasArea,
+				'core must report hasArea for an explicit-size comment').to.equal('true');
+		});
+	});
+
 	// Negative path through placement mode: enter placement, miss the page
 	// (no comment), then click on the page (anchor visible at the click
 	// point), then cancel the editor before saving (no comment ends up in


### PR DESCRIPTION
Building on 04525a6fc39afbfb71bf470bd00181c771e9d9f9 ("Handle no-arg
"insert comment" commands in browser", 2026-05-19), a WOPI host can now
post Send_UNO_Command with .uno:InsertAnnotation or
.uno:InsertThreadedComment carrying the full args (text, author) plus an
InteractiveAnchor flag, asking the browser to choose where the comment
is anchored. In PDF this enters the click-to-place picker; once the user
clicks a point or drags a rectangle, the picked PositionX/Y (and
Width/Height for a drag) are substituted into the args and the command
is dispatched, without showing the in-place editor since the text is
already known. The flag is browser-directed rather than a UNO arg, so it
is stripped before dispatch and any truthy value enables it. Outside PDF
there is no anchor picker, so the flag is dropped and the command
dispatched as-is, to be anchored at the cursor or selection.

The placement picker no longer decides what happens after a pick: it
reports the validated geometry (stacked-document twips, plus the page
index) to a callback, and the caller's routine either opens the in-place
editor (the toolbar/menu Insert Comment) or dispatches the ready command
(the host path). This unifies both insertion modes on one mechanism.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I49bf4c393a15019c876d5b704de731699aebe860
Reviewed-on: https://gerrit.collaboraoffice.com/c/online/+/3336
Tested-by: Jenkins CPCI <releng@collaboraoffice.com>
Reviewed-by: Miklos Vajna <vmiklos@collabora.com>
(cherry picked from commit f2034b06f19bd679bfb59428394073fd17000a75)

Conflicts:
	browser/src/app/iface/Map.Interface.ts
