### PR TITLE
Keep the crosshair while picking a PDF comment anchor

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -614,6 +614,12 @@ body {
 	z-index: 11;
 }
 
+/* While picking a comment anchor, keep the crosshair regardless of the inline
+   cursor MouseControl writes on hover/enter; !important beats that inline style. */
+.comment-placement-cursor {
+	cursor: crosshair !important;
+}
+
 .cool-annotation.annotation-pop-up {
 	/* Make sure the comment card is not cropped if the window is narrow: */
 	max-width: 95%;

--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -249,7 +249,6 @@ export class CommentSection extends CanvasSectionObject {
 	// either opens the in-place editor (toolbar/menu Insert Comment) or
 	// dispatches a ready UNO command (host-driven insertCommentInteractive).
 	private placementOnPicked: ((pick: CommentPlacementPick) => void) | null = null;
-	private placementSavedCursor: string | null = null;
 	private placementStart: { cX: number; cY: number } | null = null;
 	private placementOverlay: HTMLDivElement | null = null;
 	private static readonly DRAG_THRESHOLD_PX = 5;
@@ -900,8 +899,7 @@ export class CommentSection extends CanvasSectionObject {
 			return;
 
 		this.placementOnPicked = onPicked;
-		this.placementSavedCursor = canvas.style.cursor;
-		canvas.style.cursor = 'crosshair';
+		canvas.classList.add('comment-placement-cursor');
 
 		// Capture phase, before CanvasSectionContainer's onmousedown property
 		// handler dispatches to MouseControl/etc.
@@ -915,13 +913,11 @@ export class CommentSection extends CanvasSectionObject {
 			canvas.removeEventListener('mousedown', this.onPlacementMouseDown, true);
 			canvas.removeEventListener('mousemove', this.onPlacementMouseMove, true);
 			canvas.removeEventListener('mouseup', this.onPlacementMouseUp, true);
-			if (this.placementSavedCursor !== null)
-				canvas.style.cursor = this.placementSavedCursor;
+			canvas.classList.remove('comment-placement-cursor');
 		}
 		document.removeEventListener('keydown', this.onPlacementKeyDown, true);
 		this.removePlacementOverlay();
 		this.placementOnPicked = null;
-		this.placementSavedCursor = null;
 		this.placementStart = null;
 	}
 

--- a/browser/src/control/Toolbar.js
+++ b/browser/src/control/Toolbar.js
@@ -387,7 +387,7 @@ window.L.Map.include({
 			allowedCommands.push('.uno:InsertAnnotation','.uno:DeleteCommentThread', '.uno:DeleteAnnotation', '.uno:DeleteNote',
 				'.uno:DeleteComment', '.uno:ReplyComment', '.uno:ReplyToAnnotation', '.uno:PromoteComment', '.uno:ResolveComment',
 				'.uno:ResolveCommentThread', '.uno:ResolveComment', '.uno:EditAnnotation', '.uno:ExportToEPUB', '.uno:ExportToPDF',
-				'.uno:ExportDirectToPDF');
+				'.uno:ExportDirectToPDF', '.uno:InsertThreadedComment');
 
 			const graphicInfo = GraphicSelection.extraInfo;
 			if (graphicInfo && graphicInfo.isSignature)

--- a/cypress_test/data/desktop/calc/focus.ods.wopi.json
+++ b/cypress_test/data/desktop/calc/focus.ods.wopi.json
@@ -1,0 +1,4 @@
+{
+  "_comment": "Only used when setupAndLoadDocument is called with copyCertificates=true. Opens the file comment-only (read-only, comment editing allowed).",
+  "UserCanOnlyComment": true
+}

--- a/cypress_test/integration_tests/desktop/calc/threaded_comment_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/threaded_comment_spec.js
@@ -196,3 +196,77 @@ describe(['tagdesktop'], 'Threaded Comment', function() {
 		cy.cGet('#comment-container-1').should('not.exist');
 	});
 });
+
+describe(['tagdesktop'], 'Comment-only Threaded Comment', function() {
+
+	beforeEach(function() {
+		// copyCertificates=true to copy focus.ods.wopi.json, which sets
+		// UserCanOnlyComment, so the session opens comment-only. Skip the
+		// standard load checks - they wait for the notebookbar, which a
+		// read-only session does not initialize - and wait on the canvas/map
+		// instead.
+		const file = helper.setupDocument('calc/focus.ods', true);
+		helper.loadDocument(file, true);
+		cy.cGet('#document-canvas').should('be.visible');
+		cy.cGet('#map').should('have.class', 'initialized');
+		cy.getFrameWindow().then((win) => {
+			helper.processToIdle(win);
+		});
+	});
+
+	// .uno:InsertThreadedComment must be allowed in the comment-only mode.
+	it('comment-only mode accepts a posted .uno:InsertThreadedComment', function() {
+		cy.getFrameWindow().should(function(win) {
+			expect(win.app.map.isEditMode(), 'session must be read-only').to.be.false;
+			expect(win.app.isCommentEditingAllowed(), 'comment editing must be allowed').to.be.true;
+		});
+
+		const commentText = 'comment-only-insert ' + Date.now();
+		cy.getFrameWindow().then(function(win) {
+			win.postMessage(JSON.stringify({
+				MessageId: 'Send_UNO_Command',
+				Values: {
+					Command: '.uno:InsertThreadedComment',
+					Args: { Text: { type: 'string', value: commentText } },
+				},
+			}), '*');
+		});
+
+		cy.getFrameWindow().then(function(win) { return helper.processToIdle(win); });
+		cy.getFrameWindow().should(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			const found = section.sectionProperties.commentList.find(function(c) {
+				return c.sectionProperties.data.text === commentText;
+			});
+			expect(found, 'the posted comment must be inserted').to.exist;
+			expect(found.sectionProperties.data.resolved,
+				'the new comment must start unresolved').to.not.equal('true');
+		});
+
+		// Resolving must work in comment-only mode too.
+		cy.getFrameWindow().then(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			const found = section.sectionProperties.commentList.find(function(c) {
+				return c.sectionProperties.data.text === commentText;
+			});
+			win.postMessage(JSON.stringify({
+				MessageId: 'Action_ResolveComment',
+				Values: { Id: found.sectionProperties.data.id },
+			}), '*');
+		});
+
+		cy.getFrameWindow().then(function(win) { return helper.processToIdle(win); });
+		cy.getFrameWindow().should(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			const found = section.sectionProperties.commentList.find(function(c) {
+				return c.sectionProperties.data.text === commentText;
+			});
+			expect(found, 'the comment must still be present').to.exist;
+			expect(found.sectionProperties.data.resolved,
+				'the comment must be resolved').to.equal('true');
+		});
+	});
+});

--- a/cypress_test/integration_tests/desktop/draw/annotation_spec.js
+++ b/cypress_test/integration_tests/desktop/draw/annotation_spec.js
@@ -204,9 +204,9 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 		});
 
 		cy.getFrameWindow().should(function(win) {
-			expect(win.document.getElementById('document-canvas').style.cursor,
+			expect(win.document.getElementById('document-canvas').classList.contains('comment-placement-cursor'),
 				'placement mode must switch the canvas cursor to crosshair')
-				.to.equal('crosshair');
+				.to.be.true;
 
 			const section = win.app.sectionContainer.getSectionWithName(
 				win.app.CSections.CommentList.name);
@@ -260,9 +260,9 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 
 		// Local 'new' comment exists with the expected on-screen anchor.
 		cy.getFrameWindow().should(function(win) {
-			expect(win.document.getElementById('document-canvas').style.cursor,
+			expect(win.document.getElementById('document-canvas').classList.contains('comment-placement-cursor'),
 				'cursor must be restored after placement finishes')
-				.to.not.equal('crosshair');
+				.to.be.false;
 
 			const section = win.app.sectionContainer.getSectionWithName(
 				win.app.CSections.CommentList.name);
@@ -338,15 +338,52 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 		});
 
 		cy.getFrameWindow().should(function(win) {
-			expect(win.document.getElementById('document-canvas').style.cursor,
+			expect(win.document.getElementById('document-canvas').classList.contains('comment-placement-cursor'),
 				'placement mode must switch the canvas cursor to crosshair')
-				.to.equal('crosshair');
+				.to.be.true;
 
 			const section = win.app.sectionContainer.getSectionWithName(
 				win.app.CSections.CommentList.name);
 			expect(section.sectionProperties.commentList.length,
 				'no comment should be created until the user picks a position')
 				.to.equal(initialCount);
+		});
+	});
+
+	// The crosshair must survive pointer movement. MouseControl rewrites the
+	// inline canvas cursor on hover/enter, which used to drop the crosshair
+	// on the first move.
+	it('Insert Comment placement keeps the crosshair while the pointer moves', { env: { 'pdf-view': true } }, function() {
+		cy.getFrameWindow().then(function(win) {
+			win.app.map.insertComment();
+		});
+
+		cy.getFrameWindow().should(function(win) {
+			const canvas = win.document.getElementById('document-canvas');
+			expect(canvas.classList.contains('comment-placement-cursor'),
+				'placement mode must add the crosshair class').to.be.true;
+			expect(win.getComputedStyle(canvas).cursor,
+				'effective cursor must be crosshair').to.equal('crosshair');
+		});
+
+		// Emulate MouseControl writing an inline cursor on hover, plus a real
+		// pointer move, then confirm the crosshair still wins.
+		cy.getFrameWindow().then(function(win) {
+			const canvas = win.document.getElementById('document-canvas');
+			canvas.style.cursor = 'text';
+			const rect = canvas.getBoundingClientRect();
+			canvas.dispatchEvent(new win.MouseEvent('mousemove', {
+				clientX: rect.left + 40, clientY: rect.top + 40, bubbles: true,
+			}));
+		});
+
+		cy.getFrameWindow().should(function(win) {
+			const canvas = win.document.getElementById('document-canvas');
+			expect(canvas.classList.contains('comment-placement-cursor'),
+				'crosshair class must persist through pointer movement').to.be.true;
+			expect(win.getComputedStyle(canvas).cursor,
+				'effective cursor must remain crosshair despite the inline cursor')
+				.to.equal('crosshair');
 		});
 	});
 
@@ -377,9 +414,9 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 		});
 
 		cy.getFrameWindow().should(function(win) {
-			expect(win.document.getElementById('document-canvas').style.cursor,
+			expect(win.document.getElementById('document-canvas').classList.contains('comment-placement-cursor'),
 				'placement mode must switch the canvas cursor to crosshair')
-				.to.equal('crosshair');
+				.to.be.true;
 		});
 
 		// Click at ~25%/25% of page 1 (CSS pixels computed from twips so the
@@ -414,9 +451,9 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 		// The host-text path bypasses newAnnotation, so no local 'new'
 		// comment appears and no in-place editor is ever opened.
 		cy.getFrameWindow().should(function(win) {
-			expect(win.document.getElementById('document-canvas').style.cursor,
+			expect(win.document.getElementById('document-canvas').classList.contains('comment-placement-cursor'),
 				'cursor must be restored once the pick completes')
-				.to.not.equal('crosshair');
+				.to.be.false;
 			const section = win.app.sectionContainer.getSectionWithName(
 				win.app.CSections.CommentList.name);
 			const stray = section.sectionProperties.commentList.find(
@@ -477,8 +514,8 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 		});
 
 		cy.getFrameWindow().should(function(win) {
-			expect(win.document.getElementById('document-canvas').style.cursor)
-				.to.equal('crosshair');
+			expect(win.document.getElementById('document-canvas').classList.contains('comment-placement-cursor'))
+				.to.be.true;
 		});
 
 		let expectedW = 0, expectedH = 0;
@@ -560,8 +597,8 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 		});
 
 		cy.getFrameWindow().should(function(win) {
-			expect(win.document.getElementById('document-canvas').style.cursor)
-				.to.equal('crosshair');
+			expect(win.document.getElementById('document-canvas').classList.contains('comment-placement-cursor'))
+				.to.be.true;
 		});
 
 		// Off-page click. Compute an X past the page's right edge from
@@ -593,9 +630,9 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 
 		cy.getFrameWindow().then(function(win) { return helper.processToIdle(win); });
 		cy.getFrameWindow().should(function(win) {
-			expect(win.document.getElementById('document-canvas').style.cursor,
+			expect(win.document.getElementById('document-canvas').classList.contains('comment-placement-cursor'),
 				'placement mode should remain active after an off-page click')
-				.to.equal('crosshair');
+				.to.be.true;
 
 			const section = win.app.sectionContainer.getSectionWithName(
 				win.app.CSections.CommentList.name);
@@ -643,9 +680,9 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 		});
 
 		cy.getFrameWindow().should(function(win) {
-			expect(win.document.getElementById('document-canvas').style.cursor,
+			expect(win.document.getElementById('document-canvas').classList.contains('comment-placement-cursor'),
 				'cursor must be restored after the on-page click')
-				.to.not.equal('crosshair');
+				.to.be.false;
 
 			const section = win.app.sectionContainer.getSectionWithName(
 				win.app.CSections.CommentList.name);
@@ -692,9 +729,9 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 		});
 
 		cy.getFrameWindow().should(function(win) {
-			expect(win.document.getElementById('document-canvas').style.cursor,
+			expect(win.document.getElementById('document-canvas').classList.contains('comment-placement-cursor'),
 				'placement mode must switch the canvas cursor to crosshair')
-				.to.equal('crosshair');
+				.to.be.true;
 		});
 
 		// Drag a rectangle from ~25%/25% to ~50%/40% of page 1. Compute the
@@ -757,9 +794,9 @@ describe(['tagdesktop'], 'PDF Threaded Comments', function() {
 		// Local 'new' comment exists with anchor at the rectangle's top-left
 		// and a marker rectangle that reflects the dragged size.
 		cy.getFrameWindow().should(function(win) {
-			expect(win.document.getElementById('document-canvas').style.cursor,
+			expect(win.document.getElementById('document-canvas').classList.contains('comment-placement-cursor'),
 				'cursor must be restored after placement finishes')
-				.to.not.equal('crosshair');
+				.to.be.false;
 
 			const section = win.app.sectionContainer.getSectionWithName(
 				win.app.CSections.CommentList.name);


### PR DESCRIPTION
Comment-anchor placement set the canvas cursor with an inline style.
MouseControl rewrites that inline cursor on pointer enter/move (e.g. it
clears it on enter and sets a text cursor over text), so the crosshair
was lost as soon as the pointer moved into the document - the very time
the user is aiming at an anchor. Drive the placement cursor from a
"cursor: crosshair !important" class instead, which wins over whatever
inline cursor MouseControl writes; the saved/restored inline cursor is
no longer needed. A plain class is not enough here: the #document-canvas
id selector and the inline cursor both outrank it, so !important is
required.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: Ibd3286616bf6358a810ed7443c06f0e77878289c
Reviewed-on: https://gerrit.collaboraoffice.com/c/online/+/3349
Tested-by: Jenkins CPCI <releng@collaboraoffice.com>
Reviewed-by: Miklos Vajna <vmiklos@collabora.com>
(cherry picked from commit 5525f4bdddde7639744ddb6b866711534f465de0)

Conflicts:
	cypress_test/integration_tests/desktop/draw/annotation_spec.js
