### PR TITLE
Apply Hide_Command to comment-dialog actions too

### DIFF
--- a/browser/css/cool.css
+++ b/browser/css/cool.css
@@ -917,6 +917,13 @@ body {
 	box-sizing: border-box;
 }
 
+/* Marker added by UIManager.showCommand on elements the host has asked to
+   hide via Hide_Command. !important so it wins over any non-important
+   display rule on the element it is applied to. */
+.hidden-by-command {
+	display: none !important;
+}
+
 .cool-redline-accept-button {
 	background: url('images/lc_acceptchanges.svg') no-repeat center !important;
 }

--- a/browser/src/canvas/sections/CommentListSection.ts
+++ b/browser/src/canvas/sections/CommentListSection.ts
@@ -1624,46 +1624,54 @@ export class CommentSection extends CanvasSectionObject {
 			build: function ($trigger: any) {
 				const blockChangeFromDifferentAuthor = this.map.isReadOnlyMode() && docLayer._docType === 'text' && this.map.getViewName(docLayer._viewId) !== $trigger[0].annotation.sectionProperties.data.author;
 				const isShownBig = this.sectionProperties.showSelectedBigger && this.sectionProperties.selectedComment === this.sectionProperties.commentList[this.getRootIndexOf($trigger[0].annotation.sectionProperties.data.id)];
+				// Honor Hide_Command for entries that map to a UNO command, so a host
+				// can suppress comment-dialog actions the same way it suppresses
+				// menubar / toolbar items.
+				const isShown = (uno: string): boolean =>
+					app.map.uiManager.isCommandVisible(uno);
+				const removeUno = docLayer._docType === 'text' ? '.uno:DeleteComment'
+					: (docLayer._docType === 'spreadsheet' ? '.uno:DeleteNote'
+						: '.uno:DeleteAnnotation');
 				return {
 					autoHide: true,
 					items: {
-						modify: blockChangeFromDifferentAuthor ? undefined : {
+						modify: (blockChangeFromDifferentAuthor || !isShown('.uno:EditAnnotation')) ? undefined : {
 							name: _('Modify'),
 							callback: function (key: any, options: any) {
 								this.modify.call(this, options.$trigger[0].annotation);
 							}.bind(this)
 						},
-						reply: (docLayer._docType !== 'text') ? undefined : {
+						reply: (docLayer._docType !== 'text' || !isShown('.uno:ReplyComment')) ? undefined : {
 							name: _('Reply'),
 							callback: function (key: any, options: any) {
 								this.reply.call(this, options.$trigger[0].annotation);
 							}.bind(this)
 						},
-						remove: blockChangeFromDifferentAuthor ? undefined : {
+						remove: (blockChangeFromDifferentAuthor || !isShown(removeUno)) ? undefined : {
 							name: _('Remove'),
 							callback: function (key: any, options: any) {
 								this.remove.call(this, options.$trigger[0].annotation.sectionProperties.data.id);
 							}.bind(this)
 						},
-						removeThread: docLayer._docType !== 'text' || !$trigger[0].annotation.isRootComment() || blockChangeFromDifferentAuthor ? undefined : {
+						removeThread: (docLayer._docType !== 'text' || !$trigger[0].annotation.isRootComment() || blockChangeFromDifferentAuthor || !isShown('.uno:DeleteCommentThread')) ? undefined : {
 							name: _('Remove Thread'),
 							callback: function (key: any, options: any) {
 								this.removeThread.call(this, options.$trigger[0].annotation.sectionProperties.data.id);
 							}.bind(this)
 						},
-						resolve: docLayer._docType !== 'text' && !(['spreadsheet', 'drawing', 'presentation'].includes(docLayer._docType) && $trigger[0].annotation.sectionProperties.data.threaded) ? undefined : {
+						resolve: (docLayer._docType !== 'text' && !(['spreadsheet', 'drawing', 'presentation'].includes(docLayer._docType) && $trigger[0].annotation.sectionProperties.data.threaded)) || !isShown('.uno:ResolveComment') ? undefined : {
 							name: $trigger[0].annotation.sectionProperties.data.resolved === 'false' ? _('Resolve') : _('Unresolve'),
 							callback: function (key: any, options: any) {
 								this.resolve.call(this, options.$trigger[0].annotation);
 							}.bind(this)
 						},
-						resolveThread: docLayer._docType !== 'text' || !$trigger[0].annotation.isRootComment() ? undefined : {
+						resolveThread: (docLayer._docType !== 'text' || !$trigger[0].annotation.isRootComment() || !isShown('.uno:ResolveCommentThread')) ? undefined : {
 							name: this.isThreadResolved($trigger[0].annotation) ? _('Unresolve Thread') : _('Resolve Thread'),
 							callback: function (key: any, options: any) {
 								this.resolveThread.call(this, options.$trigger[0].annotation);
 							}.bind(this)
 						},
-						promote: docLayer._docType !== 'text' || $trigger[0].annotation.isRootComment() || blockChangeFromDifferentAuthor ? undefined : {
+						promote: (docLayer._docType !== 'text' || $trigger[0].annotation.isRootComment() || blockChangeFromDifferentAuthor || !isShown('.uno:PromoteComment')) ? undefined : {
 							name: _('Promote to top comment'),
 							callback: function (key: any, options: any) {
 								this.promote.call(this, options.$trigger[0].annotation);
@@ -1688,8 +1696,15 @@ export class CommentSection extends CanvasSectionObject {
 				show: function (options: any) {
 					options.$trigger[0].annotation.sectionProperties.contextMenu = true;
 					setTimeout(function() {
-						options.items.modify.$node[0].tabIndex = 0;
-						options.items.modify.$node[0].focus();
+						// modify may be absent when Hide_Command suppressed
+						// .uno:EditAnnotation; fall back to the first visible
+						// item so the menu still gets initial focus.
+						const target = options.items.modify
+							|| Object.values(options.items).find((it: any) => it && it.$node);
+						if (target) {
+							(target as any).$node[0].tabIndex = 0;
+							(target as any).$node[0].focus();
+						}
 					}.bind(this), 10);
 				},
 				hide: function (options: any) {

--- a/browser/src/canvas/sections/CommentSection.ts
+++ b/browser/src/canvas/sections/CommentSection.ts
@@ -368,6 +368,10 @@ export class Comment extends CanvasSectionObject {
 		this.sectionProperties.menuBarCell = tdMenu;
 		const edit = window.L.DomUtil.create('div', 'cool-annotation-menu-edit', tdMenu);
 		edit.id = 'comment-annotation-menu-edit-' + this.sectionProperties.data.id;
+		// Honor an earlier Hide_Command for .uno:EditAnnotation; the class
+		// is toggled symmetrically by UIManager.showCommand later.
+		if (!app.map.uiManager.isCommandVisible('.uno:EditAnnotation'))
+			edit.classList.add('hidden-by-command');
 		edit.tabIndex = 0;
 		edit.onclick = this.onEditComment.bind(this);
 		edit.onkeypress = this.editOnKeyPress.bind(this);

--- a/browser/src/control/Control.UIManager.ts
+++ b/browser/src/control/Control.UIManager.ts
@@ -1195,6 +1195,18 @@ class UIManager extends window.L.Control {
 			this.hiddenCommands[command] = true;
 
 		var found = false;
+
+		// The standalone edit affordance on the comment dialog is keyed to
+		// .uno:EditAnnotation. Toggle it for any comments already on screen;
+		// createMenu also consults isCommandVisible for ones built later.
+		// Done before the toolbar/menubar/notebookbar branches so a failure
+		// in one of them cannot skip the comment-dialog update.
+		if (command === '.uno:EditAnnotation') {
+			document.querySelectorAll<HTMLElement>('.cool-annotation-menu-edit')
+				.forEach(el => { el.classList.toggle('hidden-by-command', !show); });
+			found = true;
+		}
+
 		if (this.getCurrentMode() === 'classic') {
 			if (this.showCommandInClassicToolbar(command, show)) {
 				found = true;

--- a/cypress_test/integration_tests/desktop/calc/threaded_comment_spec.js
+++ b/cypress_test/integration_tests/desktop/calc/threaded_comment_spec.js
@@ -69,6 +69,61 @@ describe(['tagdesktop'], 'Threaded Comment', function() {
 		});
 	});
 
+	// Hide_Command should also suppress the standalone edit affordance on the
+	// comment dialog and entries inside its three-dot dropdown.
+	it('Hide_Command suppresses comment dialog edit and dropdown entries', function() {
+		// Insert via the toolbar so the current view is the author and the
+		// standalone edit affordance is present.
+		cy.cGet('#Insert-tab-label').click();
+		cy.cGet('#insert-insert-threaded-comment').click();
+		cy.cGet('#comment-container-new').should('exist');
+		cy.cGet('.cool-annotation').last().find('#annotation-modify-textarea-new')
+			.should('exist');
+		cy.getFrameWindow().then(function(win) { helper.processToIdle(win); });
+		cy.cGet('#comment-container-new').then(function(el) {
+			el[0].style.visibility = '';
+			el[0].style.display = '';
+		});
+		cy.cGet('.cool-annotation').last().find('.modify-annotation .cool-annotation-textarea')
+			.should('not.have.attr', 'disabled');
+		cy.cGet('.cool-annotation').last().find('.modify-annotation .cool-annotation-textarea')
+			.type('to be hidden', { force: true });
+		cy.cGet('.cool-annotation').last().find('[value="Save"]').click({ force: true });
+		cy.cGet('#comment-container-1').should('exist');
+		cy.getFrameWindow().then(function(win) { helper.processToIdle(win); });
+
+		// Standalone edit affordance is present initially (the Calc comment
+		// container is hidden until hover, so check the button's own display
+		// rather than be.visible).
+		cy.cGet('#comment-annotation-menu-edit-1').should('exist')
+			.should('not.have.css', 'display', 'none');
+
+		// Hide both commands.
+		cy.getFrameWindow().then(function(win) {
+			win.postMessage(JSON.stringify({
+				MessageId: 'Hide_Command', Values: { id: '.uno:ResolveComment' } }), '*');
+			win.postMessage(JSON.stringify({
+				MessageId: 'Hide_Command', Values: { id: '.uno:EditAnnotation' } }), '*');
+		});
+
+		// Standalone edit affordance is hidden (check inline display, since
+		// the Calc comment container is hidden until hover and that would
+		// confuse be.visible).
+		cy.cGet('#comment-annotation-menu-edit-1')
+			.should('have.css', 'display', 'none');
+
+		// Dropdown's Resolve entry is gone; Remove is still there (so we
+		// know the dropdown opened, not that it is empty).
+		cy.getFrameWindow().then(function(win) {
+			const section = win.app.sectionContainer.getSectionWithName(
+				win.app.CSections.CommentList.name);
+			section.sectionProperties.commentList[0].onMouseEnter();
+		});
+		cy.cGet('#comment-annotation-menu-1').click();
+		cy.cGet('body').contains('.context-menu-item', 'Remove').should('exist');
+		cy.cGet('body').contains('.context-menu-item', 'Resolve').should('not.exist');
+	});
+
 	it('Insert, resolve, unresolve, and remove threaded comment', function() {
 		// Click the "Insert Comment" button on the Insert tab.
 		cy.cGet('#Insert-tab-label').click();


### PR DESCRIPTION
Hide_Command was honored in the menubar, toolbar and notebookbar but not
inside the per-comment dialog, so a host that hid e.g. .uno:EditAnnotation
or .uno:ResolveComment still got those actions in the comment - the
standalone edit affordance and the three-dot dropdown entries respectively.

Toggle a generic .hidden-by-command marker class on the edit affordance
when .uno:EditAnnotation is hidden/shown, both for comments already on
screen (from UIManager.showCommand) and for ones built afterwards (from
createMenu). Filter the three-dot dropdown entries against
isCommandVisible, mapping each one to the UNO it would actually dispatch:
.uno:ReplyComment for Reply, the doc-type-specific
.uno:Delete{Comment,Note,Annotation} for Remove, .uno:DeleteCommentThread
for Remove Thread, .uno:Resolve{Comment,CommentThread},
.uno:PromoteComment, and .uno:EditAnnotation for Modify.

The new CSS rule needs !important because the base
.cool-annotation-menu-edit rule already uses display: inline-block
!important.

Signed-off-by: Mike Kaganski <mike.kaganski@collabora.com>
Change-Id: I96e179ee3dcbe3a2f08338603524a54a2f8694c5
Reviewed-on: https://gerrit.collaboraoffice.com/c/online/+/3400
Tested-by: Jenkins CPCI <releng@collaboraoffice.com>
Reviewed-by: Caolán McNamara <caolan.mcnamara@collabora.com>
(cherry picked from commit b5554f63b55cfa6d1e02581cfc6c61377645d0c2)

Conflicts:
	browser/src/canvas/sections/CommentSection.ts
