### PR TITLE
remove + from the file name derived from the test description

### DIFF
--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -26,7 +26,10 @@ function setupDocument(filePath, copyCertificates = false) {
 	} else {
 		// Rename and copy file to use a clean test document for every test case.
 		var randomText = (Math.random() + 1).toString(36).substring(2,7);
-		var cypressTestName = Cypress.currentTest.title.replace(/[\/\\ \.]/g, '-'); // replace slashes and spaces and dots
+		// The filename is used in a URI query string where characters like
+		// '/' and '+' have special meaning, and spaces are invalid. Replace
+		// these with hyphens so the path survives URL parsing unchanged.
+		var cypressTestName = Cypress.currentTest.title.replace(/[\/\\ \.+]/g, '-');
 
 		// Check for extension. The '.' has to be in fileName specifically, not earlier in filePath
 		if (getFileName(filePath).includes('.')) {


### PR DESCRIPTION
Otherwise the tempname doesn't work due to the reserved char in the uri and the test fails in a baffling way.


Change-Id: I1be52d64898fbc2c0c0444937e7d26262ff94a6a (cherry picked from commit 333ed5edff436ed680867440b0afa7ff801ef10b)


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

