### PR TITLE
cool#15850 browser: clear reference marks when leaving cell edit mode

### DIFF
--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -931,6 +931,8 @@ window.L.CalcTileLayer = window.L.CanvasTileLayer.extend({
 				var grid = document.getElementById('document-canvas');
 				grid.classList.add('spreadsheet-cursor');
 				grid.style.cursor = '';
+				// More of a workaround, clear displayed references outside insert mode
+				this._map._docLayer._clearReferences();
 			}
 		}
 		else if (e.commandName === '.uno:ToggleSheetGrid') {


### PR DESCRIPTION
After these steps:
- Press = in cell,
- Select another cell or range,
- Press Enter.

But not when double-clicking cell first.

For now, make sure references are cleared.
TODO: eventually the source of the discrepancy
in behavior should be investigated.

Happened since c377673103b67dc3a021c89d744eea32684e19a6. (but the existing code was more of a workaround, too)


Change-Id: I12e637a8d9420291c3867d843bd4950fe48066d3 Reviewed-on: https://gerrit.collaboraoffice.com/c/online/+/3252
Reviewed-by: Mike Kaganski <mike.kaganski@collabora.com>
Tested-by: Jenkins CPCI <releng@collaboraoffice.com>
Reviewed-by: Gökay ŞATIR <gokay.satir@collabora.com>
(cherry picked from commit 3a78704c4a0028cf4eb4bb75b8ded4d0f61f3895)


* Resolves: #15850
* Target version: 25.04

### Checklist

- [X] I have run `make prettier-write` and formatted the code.
- [X] All commits have Change-Id
- [ ] I have run tests with `make check`
- [X] I have issued `make run` and manually verified that everything looks okay
- [X] Documentation (manuals or wiki) has been updated or is not required

