### PR TITLE
Show an err msg when failing to load a document

### DIFF
--- a/browser/src/app/Socket.ts
+++ b/browser/src/app/Socket.ts
@@ -2176,6 +2176,12 @@ class Socket {
 				if (this.ReconnectCount > 1) {
 					this._map.showBusy(errorMessages.docunloadingretry, false);
 				}
+			} else {
+				// Any other load error (io, network, etc.)
+				this._map._fatal = true;
+				this._map.fire('error', {
+					msg: errorMessages.faileddocloading,
+				});
 			}
 
 			if (passwordNeeded) {


### PR DESCRIPTION
Previously, load failures with an unhandled errors fell through silently and no error was shown to the user. Add a fallback that surfaces a generic "faileddocloading" message for any such case.

Signed-off-by: Karthik <karthik.godha@collabora.com>
Change-Id: I01125969355fef21c4826aac238403bc78797a46

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

