### PR TITLE
online: Save icon remains unchanged after save in compact-view

### DIFF
--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -920,7 +920,7 @@ function processStateChangedCommand(commandName, state) {
 		}
 	}
 	else if (commandName === '.uno:ModifiedStatus') {
-		const saveIcon = document.querySelector('[id^="save"]');
+		const saveIcon = document.querySelector('[id^="save"].unotoolbutton');
 		if (saveIcon) {
 			if (state === 'true' && map.saveState)
 				map.saveState.showModifiedStatus();


### PR DESCRIPTION
This is a regression from 1db9edaa1da96899649589244ce222a0729b7c71 (https://github.com/CollaboraOnline/online/pull/13567).

In compact-view we are setting the saved status on `save-toptoolbar` overflowgroup instead of the actual save button.

Change-Id: I3d50719332e2fed314c05a63fcf36114c2184311

Reviewed-on: https://gerrit.collaboraoffice.com/c/online/+/3035
Tested-by: Jenkins CPCI <releng@collaboraoffice.com>
Reviewed-by: Darshan-Upadhyay <darshan.upadhyay@collabora.com>
Reviewed-by: Szymon Kłos <szymon.klos@collabora.com>
(cherry picked from commit f2100ec768d3b533ab836dabb1609c7f628bf6d6)


* Resolves: # <!-- related github issue -->
* Target version: main

### Summary


### TODO

- [ ] ...

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

