### PR TITLE
browser: derive page title from filename and doc type

### DIFF
--- a/browser/html/debug.html
+++ b/browser/html/debug.html
@@ -56,7 +56,12 @@
                     filename = decodedWopiSrc.substring(lastSlash + 1);
                 }
             }
-            document.getElementById("coolframe").title = filename + " - Collabora Online";
+            // Initial title carries the brand without a module suffix; the
+            // iframe will postMessage 'Doc_Title' once it knows the doc type
+            // and we refine to '<filename> - Collabora <Module>' then.
+            var initialTitle = filename + " - Collabora Online";
+            window.document.title = initialTitle;
+            document.getElementById("coolframe").title = initialTitle;
             if (req)
               localUrl += 'req=' + req + '&';
 
@@ -117,6 +122,12 @@
                 return;
               if (msg.Values.Status == 'Document_Loaded')
                 post({'MessageId': 'Host_PostmessageReady'});
+              break;
+            case 'Doc_Title':
+              if (msg.Values && msg.Values.Title) {
+                window.document.title = msg.Values.Title;
+                document.getElementById("coolframe").title = msg.Values.Title;
+              }
               break;
             case 'UI_Mention':
               if (!msg.Values)

--- a/browser/src/app/Socket.ts
+++ b/browser/src/app/Socket.ts
@@ -1613,6 +1613,8 @@ class Socket {
 
 			if (textMsg.startsWith('renamefile:')) {
 				this._map.uiManager.documentNameInput.showLoadingAnimation();
+				if (command.filename)
+					this._map['wopi'].onRenameFile(decodeURIComponent(command.filename));
 				this._map.fire('postMessage', {
 					msgId: 'File_Rename',
 					args: {

--- a/browser/src/app/Socket.ts
+++ b/browser/src/app/Socket.ts
@@ -2176,6 +2176,12 @@ class Socket {
 				if (this.ReconnectCount > 1) {
 					this._map.showBusy(errorMessages.docunloadingretry, false);
 				}
+			} else {
+				// Any other load error (io, network, etc.)
+				this._map._fatal = true;
+				this._map.fire('error', {
+					msg: errorMessages.faileddocloading,
+				});
 			}
 
 			if (passwordNeeded) {

--- a/browser/src/app/iface/Map.Interface.ts
+++ b/browser/src/app/iface/Map.Interface.ts
@@ -72,6 +72,7 @@ interface MapInterface extends Evented {
 
 	wopi: {
 		resetAppLoaded(): void;
+		onRenameFile(newName: string): void;
 		DisableInactiveMessages: boolean;
 		UserCanNotWriteRelative: boolean;
 		BaseFileName: string;

--- a/browser/src/control/Control.Notebookbar.js
+++ b/browser/src/control/Control.Notebookbar.js
@@ -479,6 +479,8 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 			if (tabs[tab].context) {
 				tabElement.hide();
 				var contexts = tabs[tab].context.split('|');
+				var tabMatched = false;
+
 				for (var context in contexts) {
 					// Check the tab isn't hidden.
 					if (!this.map.uiManager.isTabVisible(tabs[tab].name)) {
@@ -491,11 +493,18 @@ window.L.Control.Notebookbar = window.L.Control.extend({
 							contextTab = tabElement;
 						else
 							alreadySelected = tabElement;
+						tabMatched = true;
 					} else if (contexts[context] === 'default') {
 						tabElement.show();
+						tabElement.removeClass('hidden');
+						tabMatched = true;
+
 						if (!tabElement.hasClass('selected'))
 							defaultTab = tabElement;
 					}
+				}
+				if (!tabMatched) {
+					tabElement.addClass('hidden');
 				}
 			} else if (!this.map.uiManager.isTabVisible(tabs[tab].name)) {
 				// There is no context, but we check if the tab is hidden

--- a/browser/src/control/Control.Toolbar.js
+++ b/browser/src/control/Control.Toolbar.js
@@ -920,7 +920,7 @@ function processStateChangedCommand(commandName, state) {
 		}
 	}
 	else if (commandName === '.uno:ModifiedStatus') {
-		const saveIcon = document.querySelector('[id^="save"]');
+		const saveIcon = document.querySelector('[id^="save"].unotoolbutton');
 		if (saveIcon) {
 			if (state === 'true' && map.saveState)
 				map.saveState.showModifiedStatus();

--- a/browser/src/layer/tile/CalcTileLayer.js
+++ b/browser/src/layer/tile/CalcTileLayer.js
@@ -931,6 +931,8 @@ window.L.CalcTileLayer = window.L.CanvasTileLayer.extend({
 				var grid = document.getElementById('document-canvas');
 				grid.classList.add('spreadsheet-cursor');
 				grid.style.cursor = '';
+				// More of a workaround, clear displayed references outside insert mode
+				this._map._docLayer._clearReferences();
 			}
 		}
 		else if (e.commandName === '.uno:ToggleSheetGrid') {

--- a/browser/src/map/handler/Map.WOPI.js
+++ b/browser/src/map/handler/Map.WOPI.js
@@ -12,7 +12,7 @@
  * L.WOPI contains WOPI related logic
  */
 
-/* global _ app _UNO JSDialog errorMessages URLPopUpSection */
+/* global _ app _UNO JSDialog errorMessages URLPopUpSection brandProductName */
 window.L.Map.WOPI = window.L.Handler.extend({
 	// If the CheckFileInfo call fails on server side, we won't have any PostMessageOrigin.
 	// So use '*' because we still needs to send 'close' message to the parent frame which
@@ -142,6 +142,7 @@ window.L.Map.WOPI = window.L.Handler.extend({
 		this.BreadcrumbDocName = wopiInfo['BreadcrumbDocName'];
 		if (this.BreadcrumbDocName === undefined)
 			this.BreadcrumbDocName = this.BaseFileName;
+		this._updateDocumentTitle();
 		this.HidePrintOption = !!wopiInfo['HidePrintOption'];
 		this.HideSaveOption = !!wopiInfo['HideSaveOption'];
 		this.HideExportOption = !!wopiInfo['HideExportOption'];
@@ -183,6 +184,56 @@ window.L.Map.WOPI = window.L.Handler.extend({
 		}
 
 		this.setupImageInsertionMenu();
+	},
+
+	_updateDocumentTitle: function() {
+		var docName = this.BreadcrumbDocName || this.BaseFileName;
+		if (!docName)
+			return;
+
+		var moduleByDocType = {
+			'text': 'Writer',
+			'spreadsheet': 'Calc',
+			'presentation': 'Impress',
+			'drawing': 'Draw',
+		};
+		var docType = this._map.getDocType();
+		var moduleName = moduleByDocType[docType];
+
+		var brand = (typeof brandProductName !== 'undefined' && brandProductName) ? brandProductName : 'Collabora Online';
+		var product = moduleName ? brand.replace(/Online$/, moduleName).trim() : brand;
+		if (moduleName && product === brand)
+			product = brand + ' ' + moduleName;
+
+		var title = docName + ' - ' + product;
+		if (title === this._lastDocTitle)
+			return;
+		this._lastDocTitle = title;
+		document.title = title;
+
+		this._map.fire('postMessage', {
+			msgId: 'Doc_Title',
+			args: {
+				Title: title,
+				DocName: docName,
+				DocType: docType || '',
+				ProductName: product,
+			},
+		});
+	},
+
+	// Called after an in-place rename so cached WOPI props and the page title
+	// refresh without waiting for a fresh CheckFileInfo round trip. Only
+	// update BreadcrumbDocName if it was the default fallback (== BaseFileName);
+	// a host-customized breadcrumb (friendly title, path prefix, extension-less
+	// name) is left alone and will be refreshed by the next CheckFileInfo.
+	onRenameFile: function(newName) {
+		if (!newName)
+			return;
+		if (this.BreadcrumbDocName === this.BaseFileName)
+			this.BreadcrumbDocName = newName;
+		this.BaseFileName = newName;
+		this._updateDocumentTitle();
 	},
 
 	sendFrameReady: function() {
@@ -259,6 +310,7 @@ window.L.Map.WOPI = window.L.Handler.extend({
 			}
 
 			this.DocumentLoadedTime = Date.now();
+			this._updateDocumentTitle();
 		}
 		this._appLoadedConditions[e.type] = true;
 		for (var key in this._appLoadedConditions) {

--- a/cypress_test/integration_tests/common/helper.js
+++ b/cypress_test/integration_tests/common/helper.js
@@ -26,7 +26,10 @@ function setupDocument(filePath, copyCertificates = false) {
 	} else {
 		// Rename and copy file to use a clean test document for every test case.
 		var randomText = (Math.random() + 1).toString(36).substring(2,7);
-		var cypressTestName = Cypress.currentTest.title.replace(/[\/\\ \.]/g, '-'); // replace slashes and spaces and dots
+		// The filename is used in a URI query string where characters like
+		// '/' and '+' have special meaning, and spaces are invalid. Replace
+		// these with hyphens so the path survives URL parsing unchanged.
+		var cypressTestName = Cypress.currentTest.title.replace(/[\/\\ \.+]/g, '-');
 
 		// Check for extension. The '.' has to be in fileName specifically, not earlier in filePath
 		if (getFileName(filePath).includes('.')) {


### PR DESCRIPTION
- set document.title inside the COOL frame to "<filename> - Collabora <module>" once WOPI info arrives, refining the module suffix (Writer/Calc/Impress/Draw) when docloaded fires and again after an in-place rename.

- brand prefix comes from brandProductName: a trailing "Online" is swapped for the module name, or the module is appended if the brand doesn't end in "Online". A Doc_Title postMessage carries the same string to any host frame so it can mirror the tab title; debug.html consumes it.

Change-Id: If1773316446de51e81d0a80f54f98543b7ee0dfd

**backport of** : https://gerrit.collaboraoffice.com/c/online/+/3263

### Checklist

- [ ] I have run `make prettier-write` and formatted the code.
- [ ] All commits have Change-Id
- [ ] I have run tests with `make check`
- [ ] I have issued `make run` and manually verified that everything looks okay
- [ ] Documentation (manuals or wiki) has been updated or is not required

