### PR TITLE
helm: add collabora.config and configFromSecrets values

### DIFF
--- a/kubernetes/helm/collabora-online/Chart.yaml
+++ b/kubernetes/helm/collabora-online/Chart.yaml
@@ -4,7 +4,7 @@ type: "application"
 name: collabora-online
 description: Collabora Online helm chart
 
-version: 1.1.61
+version: 1.2.0
 appVersion: "25.04.9.4.1"
 
 home: "https://www.collaboraonline.com/code/"

--- a/kubernetes/helm/collabora-online/README.md
+++ b/kubernetes/helm/collabora-online/README.md
@@ -56,6 +56,8 @@ In order for Collaborative Editing and copy/paste to function correctly on kuber
       aliasgroups:
          - host: "https://example.integrator.com:443"
       extra_params: --o:ssl.enable=false --o:ssl.termination=true
+      # with images 26.04 or later, prefer the structured `config` map over
+      # extra_params, see the "Structured configuration" section below
       # for production enviroment we recommend appending `extra_params` with `--o:num_prespawn_children=4`. It defines number of child processes to keep started in advance and waiting for new clients
 
    resources:
@@ -102,6 +104,8 @@ In order for Collaborative Editing and copy/paste to function correctly on kuber
       aliasgroups:
          - host: "https://example.integrator.com:443"
       extra_params: --o:ssl.enable=false --o:ssl.termination=true
+      # with images 26.04 or later, prefer the structured `config` map over
+      # extra_params, see the "Structured configuration" section below
       # for production enviroment we recommend appending `extra_params` with `--o:num_prespawn_children=4`. It defines number of child processes to keep started in advance and waiting for new clients
 
    resources:
@@ -145,7 +149,7 @@ In order for Collaborative Editing and copy/paste to function correctly on kuber
          server_name: <hostname>:<port>
       ```
 
-   - For production enviroment we recommended following resource values. We recommend appending `extra_params` with `--o:num_prespawn_children=4`. It defines number of child processes to keep started in advance and waiting for new clients
+   - For production enviroment we recommended following resource values. We recommend setting `num_prespawn_children` to 4 (through `extra_params`, or through `collabora.config` with images 26.04 or later). It defines number of child processes to keep started in advance and waiting for new clients
 
       ``` yaml
       resources:
@@ -236,6 +240,106 @@ In order for Collaborative Editing and copy/paste to function correctly on kuber
       content-length: 2
       content-type: text/plain
       ```
+
+## Structured configuration
+
+The `collabora.config` map configures coolwsd without editing coolwsd.xml or
+building long `--o:` option strings. Each key is a coolwsd setting path in
+the same syntax as the `--o:` command-line option, including `[n]` indices
+and `[@attr]` attributes. The chart renders the map into a ConfigMap that is
+mounted at `/etc/coolwsd/overrides.d` inside the pod, and coolwsd applies it
+at startup on top of coolwsd.xml. It needs an image of version 26.04 or
+later.
+
+``` yaml
+collabora:
+   # clear the deprecated default, it would override "ssl.enable" below
+   extra_params: ""
+   config:
+      "ssl.enable": false
+      "indirection_endpoint.url": "http://test.collabora.online:30080/controller/routeToken"
+      "monitors.monitor[0]": "ws://test.collabora.online:30080/controller/ws"
+      "monitors.monitor[0][@retryInterval]": "5"
+      "security.server_signature": true
+```
+
+Format rules:
+
+- Keys that contain brackets must be quoted in YAML.
+- Quote large numbers as strings, otherwise Helm may render them in
+  scientific notation.
+- Prefer a values file over `helm --set` for these keys, because the dots in
+  the key names collide with `--set` path syntax.
+- Key names are not validated against a schema. A typo creates an unknown
+  setting that coolwsd ignores. Each applied key is logged at INFO level at
+  startup, which helps spotting mistakes.
+
+To bind a setting to a value stored in a Kubernetes Secret, use
+`collabora.configFromSecrets`. It is a map keyed by the setting path, so an
+overlay values file can override a single entry. The secret value never
+enters the ConfigMap, the pod spec or the coolwsd logs. coolwsd reads it
+from the mounted secret file at startup.
+
+Each entry supports two modes:
+
+- `create: true` makes the chart create the Secret itself from the given
+  `value`. Convenient when your values files are protected anyway (SOPS,
+  helm-secrets) and for test setups. `name` defaults to
+  `<release fullname>-config-secrets` and `key` defaults to the setting
+  path.
+- `create: false` (the default) references a Secret that already exists in
+  the namespace, for example one managed by the external-secrets operator.
+  `name` is required.
+
+``` yaml
+collabora:
+   configFromSecrets:
+      # chart-created Secret, only the value is needed
+      "logging.anonymize.anonymization_salt":
+         create: true
+         value: "change-me"
+      # existing Secret managed outside the chart
+      "deepl.auth_key":
+         name: cool-config-secrets
+         key: deepl-key
+```
+
+For the `create: false` example the Secret could have been created with:
+
+``` bash
+kubectl create secret generic cool-config-secrets -n collabora \
+   --from-literal=deepl-key="..."
+```
+
+Setting paths with brackets are not valid Secret key names, so such entries
+need an explicit `key`.
+
+Precedence, strongest first: remote/dynamic configuration, `extra_params`
+(`--o:` command-line options), `config` and `configFromSecrets`, the
+coolwsd.xml base file, built-in defaults.
+
+Notes:
+
+- This feature needs an image that supports the overrides.d directory
+  (Collabora Online 26.04 or later). An older image silently ignores the
+  mounted overrides. The chart default therefore still uses `extra_params`
+  for `ssl.enable=false`.
+- `collabora.extra_params` is deprecated for images 26.04 and later, but it
+  keeps working and still overrides the `config` map. When you move a
+  setting to `config`, remove it from `extra_params` (including the chart
+  default `--o:ssl.enable=false`), otherwise the `extra_params` value wins
+  silently.
+- The admin console credentials cannot be set through `config` or
+  `configFromSecrets` (the chart rejects it): the chart always injects them
+  as environment variables, which rank higher. Use `collabora.username`,
+  `collabora.password` or `collabora.existingSecret`.
+- Changing `config` or `configFromSecrets` rolls the pods automatically (the
+  pod template carries a hash of the collabora values). This includes the
+  `value` of `create: true` entries, so rotating a chart-created secret is
+  just a `helm upgrade`. Changing only the VALUE inside an externally
+  managed Secret (`create: false`) does not roll the pods. Restart them
+  manually after rotating such a secret, for example with `kubectl rollout
+  restart`.
 
 ## Kubernetes cluster monitoring
 

--- a/kubernetes/helm/collabora-online/templates/_helpers.tpl
+++ b/kubernetes/helm/collabora-online/templates/_helpers.tpl
@@ -83,3 +83,153 @@ Create the name of the SeccompProfileDaemonSet service account to use
 {{- default "default" .Values.daemonSetServiceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Validate one coolwsd setting path destined for the overrides.d file.
+Context: dict with "key" (the setting path) and "root" (the chart root).
+Rejects characters that would corrupt the key=value file format, and
+settings that the chart already delivers through environment variables,
+which rank higher than overrides.d and would silently win.
+*/}}
+{{- define "collabora-online.validateConfigKey" -}}
+{{- $key := .key }}
+{{- if not (regexMatch "^[a-zA-Z0-9_.@\\[\\]-]+$" $key) }}
+{{- fail (printf "collabora config key %q is not a valid coolwsd setting path (allowed: letters, digits, '.', '_', '-', '[', ']', '@')" $key) }}
+{{- end }}
+{{- if or (eq $key "admin_console.username") (eq $key "admin_console.password") }}
+{{- fail (printf "%q cannot be set here: the chart always injects the admin credentials as environment variables, which override it. Use collabora.username/password or collabora.existingSecret instead" $key) }}
+{{- end }}
+{{- if and (eq $key "server_name") .root.Values.collabora.server_name }}
+{{- fail "server_name cannot be set here while collabora.server_name is also set: the environment variable overrides it. Use collabora.server_name only" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Render collabora.config as key=value lines for the coolwsd overrides.d file.
+Iterating a map in Helm yields the keys in sorted order, so the output is stable.
+*/}}
+{{- define "collabora-online.configOverrides" -}}
+{{- $root := . }}
+{{- range $key, $value := .Values.collabora.config }}
+{{- include "collabora-online.validateConfigKey" (dict "key" $key "root" $root) }}
+{{- if contains "\n" (toString $value) }}
+{{- fail (printf "collabora.config[%q]: the value must not contain newlines" $key) }}
+{{- end }}
+{{ $key }}={{ toString $value }}
+{{- end }}
+{{- end }}
+
+{{/*
+Normalize collabora.configFromSecrets: apply defaults and validate every
+entry. Returns a YAML map of configKey to {create, value, name, key} for use
+with fromYaml. All defaulting and validation lives here so the other
+templates can rely on complete entries.
+*/}}
+{{- define "collabora-online.configFromSecretsNormalized" -}}
+{{- $defaultName := printf "%s-config-secrets" (include "collabora-online.fullname" .) }}
+{{- $out := dict }}
+{{- range $configKey, $entry := .Values.collabora.configFromSecrets }}
+{{- if not (kindIs "map" $entry) }}
+{{- fail (printf "collabora.configFromSecrets[%q] must be a map with create/value/name/key" $configKey) }}
+{{- end }}
+{{- include "collabora-online.validateConfigKey" (dict "key" $configKey "root" $) }}
+{{- $create := default false $entry.create }}
+{{- $value := toString (default "" $entry.value) }}
+{{- $name := toString (default "" $entry.name) }}
+{{- $key := toString (default "" $entry.key) }}
+{{- if $create }}
+{{- if not $value }}
+{{- fail (printf "collabora.configFromSecrets[%q]: value is required when create is true" $configKey) }}
+{{- end }}
+{{- $name = default $defaultName $name }}
+{{- else }}
+{{- if $value }}
+{{- fail (printf "collabora.configFromSecrets[%q]: value is only allowed when create is true" $configKey) }}
+{{- end }}
+{{- if not $name }}
+{{- fail (printf "collabora.configFromSecrets[%q]: name of an existing Secret is required when create is false" $configKey) }}
+{{- end }}
+{{- end }}
+{{- if not (regexMatch "^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$" $name) }}
+{{- fail (printf "collabora.configFromSecrets[%q]: name %q is not a valid Secret name" $configKey $name) }}
+{{- end }}
+{{- if not $key }}
+{{- if regexMatch "^[-._a-zA-Z0-9]+$" $configKey }}
+{{- $key = $configKey }}
+{{- else }}
+{{- fail (printf "collabora.configFromSecrets[%q]: an explicit key is required because the setting path is not a valid Secret key name" $configKey) }}
+{{- end }}
+{{- end }}
+{{- if not (regexMatch "^[-._a-zA-Z0-9]+$" $key) }}
+{{- fail (printf "collabora.configFromSecrets[%q]: key %q is not a valid Secret key name" $configKey $key) }}
+{{- end }}
+{{- $_ := set $out $configKey (dict "create" $create "value" $value "name" $name "key" $key) }}
+{{- end }}
+{{- $out | toYaml }}
+{{- end }}
+
+{{/*
+Render collabora.configFromSecrets as key=@file: lines pointing at the
+mounted secret files. The secret values themselves never enter the ConfigMap.
+*/}}
+{{- define "collabora-online.secretConfigOverrides" -}}
+{{- $entries := include "collabora-online.configFromSecretsNormalized" . | fromYaml }}
+{{- range $configKey, $entry := $entries }}
+{{ $configKey }}=@file:/etc/coolwsd/secret-overrides/{{ $entry.name }}/{{ $entry.key }}
+{{- end }}
+{{- end }}
+
+{{/*
+The sorted, deduplicated Secret names referenced by configFromSecrets,
+as a YAML object {names: [...]} for use with fromYaml.
+*/}}
+{{- define "collabora-online.configSecretNames" -}}
+{{- $entries := include "collabora-online.configFromSecretsNormalized" . | fromYaml }}
+{{- $secretNames := dict }}
+{{- range $configKey, $entry := $entries }}
+{{- $_ := set $secretNames $entry.name true }}
+{{- end }}
+names: {{ keys $secretNames | sortAlpha | toJson }}
+{{- end }}
+
+{{/*
+Volume mounts for the coolwsd configuration overrides: the overrides.d
+directory from the ConfigMap, plus one mount per referenced Secret.
+*/}}
+{{- define "collabora-online.configOverridesVolumeMounts" -}}
+{{- if or .Values.collabora.config .Values.collabora.configFromSecrets }}
+- name: coolwsd-overrides
+  mountPath: /etc/coolwsd/overrides.d
+  readOnly: true
+{{- end }}
+{{- range $name := (include "collabora-online.configSecretNames" . | fromYaml).names }}
+- name: {{ printf "secret-override-%s" $name | trunc 63 | trimSuffix "-" }}
+  mountPath: /etc/coolwsd/secret-overrides/{{ $name }}
+  readOnly: true
+{{- end }}
+{{- end }}
+
+{{/*
+Volumes for the coolwsd configuration overrides.
+*/}}
+{{- define "collabora-online.configOverridesVolumes" -}}
+{{- if or .Values.collabora.config .Values.collabora.configFromSecrets }}
+- name: coolwsd-overrides
+  configMap:
+    name: {{ include "collabora-online.fullname" . }}
+    items:
+      {{- if .Values.collabora.config }}
+      - key: coolwsd-config-overrides
+        path: 10-config
+      {{- end }}
+      {{- if .Values.collabora.configFromSecrets }}
+      - key: coolwsd-secret-overrides
+        path: 20-secrets
+      {{- end }}
+{{- end }}
+{{- range $name := (include "collabora-online.configSecretNames" . | fromYaml).names }}
+- name: {{ printf "secret-override-%s" $name | trunc 63 | trimSuffix "-" }}
+  secret:
+    secretName: {{ $name | quote }}
+{{- end }}
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/config-secrets.yaml
+++ b/kubernetes/helm/collabora-online/templates/config-secrets.yaml
@@ -1,0 +1,31 @@
+{{- /*
+Secrets created by the chart for collabora.configFromSecrets entries with
+create: true, grouped into one Secret per name. Entries with create: false
+reference Secrets that already exist and render nothing here.
+*/ -}}
+{{- $entries := include "collabora-online.configFromSecretsNormalized" . | fromYaml }}
+{{- $byName := dict }}
+{{- range $configKey, $entry := $entries }}
+{{- if $entry.create }}
+{{- $secretKeys := default dict (get $byName $entry.name) }}
+{{- if hasKey $secretKeys $entry.key }}
+{{- fail (printf "collabora.configFromSecrets: Secret %q key %q is created by more than one entry" $entry.name $entry.key) }}
+{{- end }}
+{{- $_ := set $secretKeys $entry.key $entry.value }}
+{{- $_ := set $byName $entry.name $secretKeys }}
+{{- end }}
+{{- end }}
+{{- range $name := keys $byName | sortAlpha }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "collabora-online.labels" $ | nindent 4 }}
+type: Opaque
+data:
+  {{- range $key, $value := get $byName $name }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- end }}
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/configmap.yaml
+++ b/kubernetes/helm/collabora-online/templates/configmap.yaml
@@ -22,6 +22,14 @@ data:
   aliasgroup{{ add $k 1 }}: {{ $alias }}
   {{- end }}
   {{- end }}
+  {{- if .Values.collabora.config }}
+  coolwsd-config-overrides: |
+    {{- include "collabora-online.configOverrides" . | trim | nindent 4 }}
+  {{- end }}
+  {{- if .Values.collabora.configFromSecrets }}
+  coolwsd-secret-overrides: |
+    {{- include "collabora-online.secretConfigOverrides" . | trim | nindent 4 }}
+  {{- end }}
   {{- if .Values.collabora.coolkitconfig_xcu_content }}
   coolkitconfig.xcu: |
     {{ .Values.collabora.coolkitconfig_xcu_content | nindent 4 }}

--- a/kubernetes/helm/collabora-online/templates/deployment.yaml
+++ b/kubernetes/helm/collabora-online/templates/deployment.yaml
@@ -132,6 +132,7 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- include "collabora-online.configOverridesVolumeMounts" . | nindent 12 }}
             {{- if .Values.collabora.coolkitconfig_xcu_content }}
             - name: coolwsd-config
               mountPath: /etc/coolwsd/coolkitconfig.xcu
@@ -179,6 +180,7 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- include "collabora-online.configOverridesVolumes" . | nindent 8 }}
         {{- if or .Values.collabora.coolkitconfig_xcu_content .Values.collabora.coolwsd_xml_content }}
         - name: coolwsd-config
           configMap:

--- a/kubernetes/helm/collabora-online/templates/statefulset.yaml
+++ b/kubernetes/helm/collabora-online/templates/statefulset.yaml
@@ -125,6 +125,7 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- include "collabora-online.configOverridesVolumeMounts" . | nindent 12 }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
@@ -143,4 +144,5 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- include "collabora-online.configOverridesVolumes" . | nindent 8 }}
 {{- end }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -35,6 +35,62 @@ collabora:
   #   aliases: ["<protocol>://<its-first-alias>:<port>, <protocol>://<its-second-alias>:<port>"]
   aliasgroups: []
 
+  # Structured coolwsd configuration. Each key is a coolwsd setting path in
+  # the same syntax as the --o: command-line option, including [n] indices
+  # and [@attr] attributes. The map is rendered into a file that coolwsd
+  # reads at startup.
+  # IMPORTANT: requires an image with overrides.d support (Collabora Online
+  # 26.04 or later). Older images silently ignore these settings. With such
+  # images keep using extra_params.
+  # Note: extra_params ranks higher than this map. When you set a key here
+  # that is also in extra_params (the default extra_params sets ssl.enable),
+  # clear extra_params or the value here will not take effect.
+  # Keys that contain brackets must be quoted. Quote large numbers as
+  # strings, otherwise Helm may render them in scientific notation.
+  # Example:
+  # config:
+  #   "ssl.enable": false
+  #   "indirection_endpoint.url": "http://example.com/controller/routeToken"
+  #   "monitors.monitor[0]": "ws://example.com/controller/ws"
+  #   "monitors.monitor[0][@retryInterval]": "5"
+  config: {}
+
+  # Bind coolwsd settings to values stored in Kubernetes Secrets. Keyed by
+  # the coolwsd setting path, so single entries can be overridden from
+  # another values file. coolwsd reads the secret value from the mounted
+  # secret file at startup. The value never enters the ConfigMap or the pod
+  # spec.
+  #
+  # Each entry:
+  #   create: false  When true, the chart creates the Secret with the given
+  #                  value. The value then lives in your values file and in
+  #                  the Helm release storage, so protect those (for example
+  #                  with SOPS or helm-secrets). When false, the Secret must
+  #                  already exist in the namespace.
+  #   value: ""      The secret value. Only allowed with create: true.
+  #   name: ""       Secret name. When create is true it defaults to
+  #                  "<release fullname>-config-secrets". Required when
+  #                  create is false.
+  #   key: ""        Key inside the Secret. Defaults to the setting path when
+  #                  that is a valid Secret key name (letters, digits, "-",
+  #                  "_", "."). Setting paths with brackets need an explicit
+  #                  key.
+  #
+  # Example:
+  # configFromSecrets:
+  #   "logging.anonymize.anonymization_salt":
+  #     create: true
+  #     value: "change-me"
+  #   "deepl.auth_key":
+  #     name: existing-secret
+  #     key: deepl-key
+  configFromSecrets: {}
+
+  # Deprecated in favour of the structured "config" map above, but kept as
+  # the default because it also works with images older than 26.04. Values
+  # given here are passed as --o: command-line options and override the
+  # "config" map. Once your image is 26.04 or later, move these to "config"
+  # and set extra_params to "".
   extra_params: --o:ssl.enable=false
 
   # External hostname:port of the server running coolwsd.
@@ -198,8 +254,8 @@ deployment:
 
 probes:
   # Scheme used by the kubelet to reach the probe endpoint.
-  # Set to HTTPS when SSL is terminated directly at coolwsd (e.g. via
-  # extra_params: --o:ssl.enable=true).
+  # Set to HTTPS when SSL is terminated directly at coolwsd (ssl.enable set
+  # to true through extra_params or the config map).
   scheme: HTTP
   startup:
     enabled: true


### PR DESCRIPTION
A single unstructured extra_params string of --o: flags does not scale and cannot carry secrets. collabora.config is a flat map of coolwsd setting paths rendered into the ConfigMap and mounted at /etc/coolwsd/overrides.d, where coolwsd of version 26.04 or later picks it up. The map is flat because index and attribute syntax like monitors.monitor[0][@retryInterval] has no natural nested YAML form, and flat keys can be copied straight from an existing extra_params.

collabora.configFromSecrets binds setting paths to Kubernetes Secrets. It is a map keyed by the setting path, because helm merges maps per key across values files while lists are replaced wholesale. With create true the chart creates the Secret from the given value, and rotation rolls the pods through the confighash annotation. With create false an existing Secret is referenced. Either way coolwsd reads the value from the mounted file, so it never appears in the ConfigMap, the pod spec or the logs.

Entries are validated at template time: setting paths that would break the key=value file format, values with newlines, invalid Secret names and keys, and the admin_console credentials, which the chart always injects as environment variables that would override the new layer anyway.

extra_params keeps working and stays the default for ssl.enable=false because the current appVersion image does not read overrides.d yet. Flip the default to config once appVersion is on 26.04.

Change-Id: I2b1f12ec829519d1aa4f142e1e4ad14d4a702ff6

Depends on gerrit change: https://gerrit.collaboraoffice.com/c/online/+/4270/2