### PR TITLE
helm: Add an optional in-namespace reverse proxy to the chart

### DIFF
--- a/kubernetes/helm/collabora-online/Chart.yaml
+++ b/kubernetes/helm/collabora-online/Chart.yaml
@@ -4,7 +4,7 @@ type: "application"
 name: collabora-online
 description: Collabora Online helm chart
 
-version: 1.1.62
+version: 1.2.0
 appVersion: "25.04.9.4.1"
 
 home: "https://www.collaboraonline.com/code/"
@@ -40,3 +40,7 @@ annotations:
       image: docker.io/nginx:1.25
     - name: twostoryrobot/simple-file-upload
       image: docker.io/twostoryrobot/simple-file-upload@sha256:547fc4360b31d8604b7a26202914e87cd13609cc938fd83f412c77eb44aa1cc4
+    - name: nginx-unprivileged
+      image: docker.io/nginxinc/nginx-unprivileged:stable
+    - name: kubectl
+      image: docker.io/alpine/k8s:1.31.1

--- a/kubernetes/helm/collabora-online/README.md
+++ b/kubernetes/helm/collabora-online/README.md
@@ -356,6 +356,98 @@ In current state of COOL remoteconfigurl for [Remote/DynamicConfiguration](https
 
 ---
 
+## In-namespace reverse proxy (OpenShift or clusters without an ingress controller)
+
+Collabora Online needs session affinity: every request for one document must
+reach the same pod. The usual way to get this is an ingress controller that
+hashes on a request parameter. On clusters where you cannot install an ingress
+controller (for example OpenShift, where the cluster ingress is the built-in
+Router and you only have namespaced rights), the chart can instead deploy a
+small nginx reverse proxy inside your namespace. nginx hashes on a request
+parameter and load-balances across the Collabora replicas, and you front it
+with whatever entry point your cluster already gives you (an OpenShift Route,
+or a plain Service).
+
+Enable it with `reverseProxy.enabled=true`. It creates:
+
+- an nginx deployment (the unprivileged image, so it passes OpenShift
+  `restricted-v2` with no extra grants),
+- a `ClusterIP` Service for the proxy,
+- a headless Service that resolves to the individual Collabora pods (nginx
+  hashes across these),
+- a reloader sidecar that watches the Collabora EndpointSlices and reloads
+  nginx when the pod set changes, so the upstream tracks live pods after a
+  restart or scale. It uses a namespaced Role only. Disable it with
+  `reverseProxy.endpointReloader.enabled=false` on clusters that forbid a
+  shared process namespace, then reload nginx by hand after pod changes.
+
+`reverseProxy.hashParam` chooses what nginx hashes on. The default `WOPISrc`
+gives correct per-document affinity for a standalone multi-replica deployment
+with no extra components. Set it to `RouteToken` and turn on
+`reverseProxy.controller.enabled` (with `reverseProxy.controller.upstream`
+pointing at the COOL Controller service) when running with the COOL Controller.
+
+`reverseProxy.controller.enabled` only proxies the client-facing routeToken
+endpoint (`/controller`), so it can share the documents' external host. The
+controller's monitor WebSocket does not go through the proxy: point each COOL
+pod's `monitors.monitor` straight at the controller Service over cluster DNS.
+
+### OpenShift quickstart
+
+This serves Collabora through the default OpenShift Router, with the proxy
+doing the load balancing. The Collabora pods run under `restricted-v2`, so the
+per-document jail is turned off and its working paths move under `/tmp`.
+
+``` bash
+helm install collabora-online collabora/collabora-online -n collabora \
+  --set replicaCount=3 \
+  --set 'collabora.aliasgroups[0].host=https://your-wopi-host' \
+  --set 'securityContext.runAsNonRoot=true' \
+  --set 'securityContext.seccompProfile.type=RuntimeDefault' \
+  --set 'securityContext.capabilities.drop[0]=ALL' \
+  --set 'collabora.extra_params=--o:ssl.enable=false --o:ssl.termination=false --o:security.capabilities=false --o:child_root_path=/tmp/coolwsd-child-roots --o:cache_files.path=/tmp/coolwsd-cache' \
+  --set reverseProxy.enabled=true \
+  --set reverseProxy.route.enabled=true \
+  --set reverseProxy.route.host=cool.apps.example.com
+```
+
+The Collabora `child_root_path` and `cache_files.path` need writable emptyDir
+mounts under `/tmp`. Add them with `extraVolumes` and `extraVolumeMounts`.
+
+### Wiring with the COOL Controller
+
+With the controller, hash on `RouteToken`, enable the `/controller` proxy, and
+split the two controller URLs in the Collabora config. The client-facing
+`indirection_endpoint.url` goes through the proxy's `/controller` on the
+documents' host. The `monitors.monitor` WebSocket goes straight to the
+controller Service in-cluster, so it does not pass through nginx.
+
+``` yaml
+reverseProxy:
+  enabled: true
+  hashParam: RouteToken
+  controller:
+    enabled: true
+    upstream: cool-controller.collabora.svc.cluster.local:9000
+  route:
+    enabled: true
+    host: cool.apps.example.com
+
+collabora:
+  extra_params: >-
+    --o:ssl.enable=false
+    --o:ssl.termination=false
+    --o:indirection_endpoint.url=http://cool.apps.example.com/controller/routeToken
+    --o:monitors.monitor[0]=ws://cool-controller.collabora.svc.cluster.local:9000/controller/ws
+    --o:monitors.monitor[0][@retryInterval]=5
+```
+
+`indirection_endpoint.url` (client-facing) uses the external host and the
+proxy's `/controller`. `monitors.monitor` (in-cluster) uses the controller
+Service directly.
+
+---
+
 ## Useful commands to check what is happening
 
 Where is this pods, are they ready?

--- a/kubernetes/helm/collabora-online/templates/_helpers.tpl
+++ b/kubernetes/helm/collabora-online/templates/_helpers.tpl
@@ -100,3 +100,28 @@ HTTP
 HTTPS
 {{- end -}}
 {{- end }}
+
+{{/*
+Reverse proxy selector labels. The app.kubernetes.io/name here is distinct
+from the main one, so selectors that match the Collabora pods by
+app.kubernetes.io/name do not also match the reverse proxy. The COOL
+Controller watches deployments and pods by app.kubernetes.io/name set to its
+resourceName, so without a distinct name it would mistake the reverse proxy
+Deployment for a Collabora one.
+*/}}
+{{- define "collabora-online.reverseproxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "collabora-online.name" . }}-reverseproxy
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Reverse proxy common labels.
+*/}}
+{{- define "collabora-online.reverseproxy.labels" -}}
+helm.sh/chart: {{ include "collabora-online.chart" . }}
+{{ include "collabora-online.reverseproxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/reverse-proxy/configmap.yaml
+++ b/kubernetes/helm/collabora-online/templates/reverse-proxy/configmap.yaml
@@ -1,0 +1,87 @@
+{{- if .Values.reverseProxy.enabled -}}
+{{- $fullName := include "collabora-online.fullname" . -}}
+{{- $headless := printf "%s-reverseproxy-headless" $fullName -}}
+{{- $port := .Values.reverseProxy.upstreamPort | default .Values.deployment.containerPort -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}-reverseproxy
+  labels:
+    {{- include "collabora-online.reverseproxy.labels" . | nindent 4 }}
+data:
+  nginx.conf: |
+{{- if .Values.reverseProxy.nginxConfigOverride }}
+{{ .Values.reverseProxy.nginxConfigOverride | indent 4 }}
+{{- else }}
+    worker_processes auto;
+    pid /run/nginx/nginx.pid;
+
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+        client_body_temp_path /tmp/client_temp;
+        proxy_temp_path       /tmp/proxy_temp;
+        fastcgi_temp_path     /tmp/fastcgi_temp;
+        uwsgi_temp_path       /tmp/uwsgi_temp;
+        scgi_temp_path        /tmp/scgi_temp;
+
+        access_log /dev/stdout;
+        error_log  /dev/stderr;
+
+        # Send "Connection: upgrade" only for real WebSocket requests. Plain
+        # HTTP requests get "Connection: close", otherwise Collabora holds the
+        # connection open waiting for a WebSocket upgrade that never arrives.
+        map $http_upgrade $connection_upgrade {
+            default upgrade;
+            ''      close;
+        }
+
+        upstream coolwsd {
+            zone coolwsd 64k;
+            hash $arg_{{ .Values.reverseProxy.hashParam }};
+            server {{ $headless }}.{{ .Release.Namespace }}.svc.cluster.local:{{ $port }};
+        }
+        {{- if .Values.reverseProxy.controller.enabled }}
+
+        upstream controller {
+            server {{ required "reverseProxy.controller.upstream is required when reverseProxy.controller.enabled is true" .Values.reverseProxy.controller.upstream }};
+        }
+        {{- end }}
+
+        server {
+            listen {{ .Values.reverseProxy.containerPort }};
+            server_name _;
+
+            location = /nginx-health {
+                return 200 "ok\n";
+            }
+            {{- if .Values.reverseProxy.controller.enabled }}
+
+            location ~* ^/controller(/|$) {
+                proxy_pass               http://controller;
+                proxy_http_version       1.1;
+                proxy_set_header         Host $host;
+                proxy_set_header         Upgrade $http_upgrade;
+                proxy_set_header         Connection $connection_upgrade;
+                client_max_body_size     0;
+                proxy_read_timeout       {{ .Values.reverseProxy.proxyTimeout }};
+                proxy_send_timeout       {{ .Values.reverseProxy.proxyTimeout }};
+            }
+            {{- end }}
+
+            location / {
+                proxy_pass               http://coolwsd;
+                proxy_http_version       1.1;
+                proxy_set_header         Host $host;
+                proxy_set_header         Upgrade $http_upgrade;
+                proxy_set_header         Connection $connection_upgrade;
+                client_max_body_size     0;
+                proxy_read_timeout       {{ .Values.reverseProxy.proxyTimeout }};
+                proxy_send_timeout       {{ .Values.reverseProxy.proxyTimeout }};
+            }
+        }
+    }
+{{- end }}
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/reverse-proxy/deployment.yaml
+++ b/kubernetes/helm/collabora-online/templates/reverse-proxy/deployment.yaml
@@ -1,0 +1,114 @@
+{{- if .Values.reverseProxy.enabled -}}
+{{- $fullName := include "collabora-online.fullname" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $fullName }}-reverseproxy
+  labels:
+    {{- include "collabora-online.reverseproxy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.reverseProxy.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "collabora-online.reverseproxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.reverseProxy.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "collabora-online.reverseproxy.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.reverseProxy.endpointReloader.enabled }}
+      # The reloader sidecar signals the nginx master across containers.
+      serviceAccountName: {{ $fullName }}-reverseproxy
+      shareProcessNamespace: true
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.reverseProxy.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}-reverseproxy
+          securityContext:
+            {{- toYaml .Values.reverseProxy.securityContext | nindent 12 }}
+          image: "{{ .Values.reverseProxy.image.repository }}:{{ .Values.reverseProxy.image.tag }}"
+          imagePullPolicy: {{ .Values.reverseProxy.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.reverseProxy.containerPort }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /nginx-health
+              port: {{ .Values.reverseProxy.containerPort }}
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /nginx-health
+              port: {{ .Values.reverseProxy.containerPort }}
+            initialDelaySeconds: 5
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.reverseProxy.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+            - name: nginx-run
+              mountPath: /run/nginx
+        {{- if .Values.reverseProxy.endpointReloader.enabled }}
+        - name: reloader
+          securityContext:
+            {{- toYaml .Values.reverseProxy.securityContext | nindent 12 }}
+          image: "{{ .Values.reverseProxy.endpointReloader.image.repository }}:{{ .Values.reverseProxy.endpointReloader.image.tag }}"
+          imagePullPolicy: {{ .Values.reverseProxy.endpointReloader.image.pullPolicy }}
+          env:
+            - name: HOME
+              value: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -u
+              echo "reloader: waiting for nginx pid file"
+              while [ ! -s /run/nginx/nginx.pid ]; do sleep 1; done
+              echo "reloader: watching EndpointSlices for {{ $fullName }}-reverseproxy-headless"
+              while true; do
+                kubectl get endpointslices -n {{ .Release.Namespace }} \
+                  -l kubernetes.io/service-name={{ $fullName }}-reverseproxy-headless \
+                  --watch -o name 2>&1 | while read -r ev; do
+                    sleep 2
+                    pid="$(cat /run/nginx/nginx.pid 2>/dev/null || echo '')"
+                    if [ -n "$pid" ]; then
+                      echo "reloader: COOL endpoints changed ($ev), reloading nginx (pid $pid)"
+                      kill -HUP "$pid" 2>/dev/null || echo "reloader: HUP failed"
+                    fi
+                  done
+                echo "reloader: watch dropped, reconnecting in 3s"
+                sleep 3
+              done
+          volumeMounts:
+            - name: nginx-run
+              mountPath: /run/nginx
+        {{- end }}
+      {{- with .Values.reverseProxy.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.reverseProxy.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.reverseProxy.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $fullName }}-reverseproxy
+        - name: nginx-run
+          emptyDir: {}
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/reverse-proxy/headless-service.yaml
+++ b/kubernetes/helm/collabora-online/templates/reverse-proxy/headless-service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.reverseProxy.enabled -}}
+# Headless Service resolving to the individual Collabora pod IPs. The reverse
+# proxy hashes across these pods, so it needs them directly rather than the
+# round-robin ClusterIP main Service. publishNotReadyAddresses keeps the DNS
+# name returning pod IPs while a pod is briefly not ready, so nginx can still
+# resolve the upstream at startup.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "collabora-online.fullname" . }}-reverseproxy-headless
+  labels:
+    {{- include "collabora-online.reverseproxy.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - port: {{ .Values.reverseProxy.upstreamPort | default .Values.deployment.containerPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "collabora-online.selectorLabels" . | nindent 4 }}
+    type: main
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/reverse-proxy/ingress.yaml
+++ b/kubernetes/helm/collabora-online/templates/reverse-proxy/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.reverseProxy.enabled .Values.reverseProxy.ingress.enabled -}}
+{{- $fullName := include "collabora-online.fullname" . -}}
+{{- $svcPort := .Values.reverseProxy.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-reverseproxy
+  labels:
+    {{- include "collabora-online.reverseproxy.labels" . | nindent 4 }}
+  {{- with .Values.reverseProxy.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.reverseProxy.ingress.className }}
+  ingressClassName: {{ .Values.reverseProxy.ingress.className }}
+  {{- end }}
+  {{- if .Values.reverseProxy.ingress.tls }}
+  tls:
+    {{- range .Values.reverseProxy.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.reverseProxy.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}-reverseproxy
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/reverse-proxy/rbac.yaml
+++ b/kubernetes/helm/collabora-online/templates/reverse-proxy/rbac.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.reverseProxy.enabled .Values.reverseProxy.endpointReloader.enabled -}}
+{{- $fullName := include "collabora-online.fullname" . -}}
+# Namespaced RBAC for the reloader sidecar: read the Collabora EndpointSlices
+# in this namespace. No cluster-scoped rights, so it works on locked-down
+# clusters.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullName }}-reverseproxy
+  labels:
+    {{- include "collabora-online.reverseproxy.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullName }}-reverseproxy
+  labels:
+    {{- include "collabora-online.reverseproxy.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullName }}-reverseproxy
+  labels:
+    {{- include "collabora-online.reverseproxy.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullName }}-reverseproxy
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullName }}-reverseproxy
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/reverse-proxy/route.yaml
+++ b/kubernetes/helm/collabora-online/templates/reverse-proxy/route.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.reverseProxy.enabled .Values.reverseProxy.route.enabled -}}
+{{- $fullName := include "collabora-online.fullname" . -}}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ $fullName }}-reverseproxy
+  labels:
+    {{- include "collabora-online.reverseproxy.labels" . | nindent 4 }}
+  {{- with .Values.reverseProxy.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.reverseProxy.route.host }}
+  host: {{ . | quote }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ $fullName }}-reverseproxy
+    weight: 100
+  port:
+    targetPort: http
+  {{- with .Values.reverseProxy.route.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  wildcardPolicy: None
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/reverse-proxy/service.yaml
+++ b/kubernetes/helm/collabora-online/templates/reverse-proxy/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.reverseProxy.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "collabora-online.fullname" . }}-reverseproxy
+  labels:
+    {{- include "collabora-online.reverseproxy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.reverseProxy.service.type }}
+  ports:
+    - port: {{ .Values.reverseProxy.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "collabora-online.reverseproxy.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -436,6 +436,119 @@ nginxDeny:
     #    hosts:
     #      - chart-example.local
 
+# An in-namespace nginx reverse proxy that load-balances across the Collabora
+# Online replicas with per-document affinity. Use it where you cannot install a
+# cluster ingress controller (for example OpenShift, where you front this with
+# the default Router through an OpenShift Route). nginx hashes on a request
+# parameter so every request for one document reaches the same pod.
+reverseProxy:
+  enabled: false
+
+  # nginx-unprivileged listens on 8080 and runs as a non-root user, so it
+  # passes restrictive pod security such as OpenShift restricted-v2 unchanged.
+  image:
+    repository: nginxinc/nginx-unprivileged
+    tag: stable
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+  containerPort: 8080
+
+  # The request parameter nginx hashes on to pin a document to one pod. Use
+  # "WOPISrc" for a standalone multi-replica setup (affinity with no extra
+  # components), or "RouteToken" when running with the COOL Controller.
+  hashParam: WOPISrc
+
+  # Port the Collabora pods listen on. Defaults to deployment.containerPort.
+  upstreamPort: 9980
+
+  # How long nginx keeps a proxied connection open. Editing sessions are
+  # long-lived WebSockets, so this is large.
+  proxyTimeout: "3600s"
+
+  # COOL Controller integration. When enabled, nginx also proxies /controller
+  # to the controller service. This is for the client-facing routeToken
+  # endpoint (indirection_endpoint.url), so it can live under the same external
+  # host as the documents. It is useful on OpenShift, where the controller has
+  # no ingress controller to expose it otherwise. Set hashParam to RouteToken
+  # alongside this.
+  # The controller's monitor WebSocket does NOT need this: point each COOL
+  # pod's monitors.monitor straight at the controller Service over cluster DNS
+  # (ws://<controller-service>:9000/controller/ws), which avoids an extra hop.
+  controller:
+    enabled: false
+    # host:port of the cool-controller service, for example
+    # cool-controller.collabora.svc.cluster.local:9000
+    upstream: ""
+
+  # Replace the whole generated nginx.conf. Leave empty to use the generated
+  # one. Only needed for cases the knobs above do not cover.
+  nginxConfigOverride: ""
+
+  # Open-source nginx resolves the upstream pod IPs only when it starts or
+  # reloads. This sidecar watches the Collabora EndpointSlices (a namespaced
+  # Role) and reloads nginx only when the pod set changes, so the upstream
+  # tracks live pods after a restart, scale or reinstall. It needs a shared
+  # process namespace so it can signal the nginx master. Disable it on clusters
+  # that forbid shareProcessNamespace, then reload nginx by hand after pod
+  # changes with kubectl rollout restart.
+  endpointReloader:
+    enabled: true
+    # Needs kubectl, a shell and kill. alpine/k8s has all three.
+    image:
+      repository: alpine/k8s
+      tag: "1.31.1"
+      pullPolicy: IfNotPresent
+
+  podAnnotations: []
+
+  # No runAsUser is pinned, so OpenShift assigns one from the namespace range.
+  podSecurityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+  service:
+    type: ClusterIP
+    port: 8080
+
+  # OpenShift entry point: a route.openshift.io/v1 Route to the proxy Service.
+  # The timeout annotation keeps long-lived WebSockets from being cut.
+  route:
+    enabled: false
+    host: ""
+    annotations:
+      haproxy.router.openshift.io/timeout: "3600s"
+    tls: {}
+    #  termination: edge
+    #  insecureEdgeTerminationPolicy: Redirect
+
+  # Standard Ingress to the proxy Service, for non-OpenShift clusters.
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+
 dynamicConfig:
   enabled: false
   logging:


### PR DESCRIPTION
Collabora Online needs per-document session affinity, so every request for one document reaches the same pod. The usual way to get this is an ingress controller that hashes on a request parameter. On clusters where you cannot install an ingress controller, such as OpenShift where the only entry point is the built-in Router and you only have rights inside your own namespace, the chart could not provide that affinity on its own.

This adds an optional nginx reverse proxy that runs inside the namespace and load-balances across the Collabora replicas with per-document affinity. You front it with whatever entry point the cluster already gives you, for example an OpenShift Route. Turn it on with reverseProxy.enabled.

It creates an nginx deployment using the unprivileged image, so it passes the OpenShift restricted-v2 security context with no extra grants, a ClusterIP Service, a headless Service that resolves to the individual Collabora pods so nginx can hash across them, and a reloader sidecar that watches the Collabora EndpointSlices and reloads nginx when the pod set changes. The reloader needs only a namespaced Role and can be turned off.

reverseProxy.hashParam chooses the request parameter to hash on. The default WOPISrc gives affinity for a standalone multi-replica deployment with no extra components. Set it to RouteToken and enable reverseProxy.controller to also proxy the controller routeToken endpoint when running with the COOL Controller.

The option is off by default, so existing deployments are unchanged.