### PR TITLE
feat(helm): derive the probe scheme from coolwsd's ssl.enable

### DIFF
--- a/kubernetes/helm/collabora-online/Chart.yaml
+++ b/kubernetes/helm/collabora-online/Chart.yaml
@@ -4,7 +4,7 @@ type: "application"
 name: collabora-online
 description: Collabora Online helm chart
 
-version: 1.1.61
+version: 1.1.62
 appVersion: "25.04.9.4.1"
 
 home: "https://www.collaboraonline.com/code/"

--- a/kubernetes/helm/collabora-online/templates/_helpers.tpl
+++ b/kubernetes/helm/collabora-online/templates/_helpers.tpl
@@ -83,3 +83,20 @@ Create the name of the SeccompProfileDaemonSet service account to use
 {{- default "default" .Values.daemonSetServiceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Probe scheme (HTTP or HTTPS) for the coolwsd pods.
+An explicit probes.scheme wins. Otherwise the scheme is derived from coolwsd's
+ssl.enable in collabora.extra_params: ssl.enable=false means coolwsd serves
+plain HTTP, while anything else - an explicit ssl.enable=true, or no flag at
+all so coolwsd's built-in default of true applies - means it serves HTTPS.
+*/}}
+{{- define "collabora-online.probeScheme" -}}
+{{- if .Values.probes.scheme -}}
+{{- .Values.probes.scheme | upper -}}
+{{- else if .Values.collabora.extra_params | default "" | lower | contains "ssl.enable=false" -}}
+HTTP
+{{- else -}}
+HTTPS
+{{- end -}}
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/deployment.yaml
+++ b/kubernetes/helm/collabora-online/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             httpGet:
               path: {{ .Values.probes.startup.path }}
               port: {{ .Values.deployment.containerPort }}
-              scheme: {{ .Values.probes.scheme | default "HTTP" | upper }}
+              scheme: {{ include "collabora-online.probeScheme" . }}
             failureThreshold: {{ .Values.probes.startup.failureThreshold }}
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
           {{- end }}
@@ -80,7 +80,7 @@ spec:
             httpGet:
               path: {{ .Values.probes.liveness.path }}
               port: {{ .Values.deployment.containerPort }}
-              scheme: {{ .Values.probes.scheme | default "HTTP" | upper }}
+              scheme: {{ include "collabora-online.probeScheme" . }}
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
@@ -92,7 +92,7 @@ spec:
             httpGet:
               path: {{ .Values.probes.readiness.path }}
               port: {{ .Values.deployment.containerPort }}
-              scheme: {{ .Values.probes.scheme | default "HTTP" | upper }}
+              scheme: {{ include "collabora-online.probeScheme" . }}
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}

--- a/kubernetes/helm/collabora-online/templates/statefulset.yaml
+++ b/kubernetes/helm/collabora-online/templates/statefulset.yaml
@@ -64,7 +64,7 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.deployment.containerPort }}
-              scheme: {{ .Values.probes.scheme | default "HTTP" | upper }}
+              scheme: {{ include "collabora-online.probeScheme" . }}
             failureThreshold: {{ .Values.probes.startup.failureThreshold }}
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
           {{- end }}
@@ -73,7 +73,7 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.deployment.containerPort }}
-              scheme: {{ .Values.probes.scheme | default "HTTP" | upper }}
+              scheme: {{ include "collabora-online.probeScheme" . }}
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
@@ -85,7 +85,7 @@ spec:
             httpGet:
               path: /
               port: {{ .Values.deployment.containerPort }}
-              scheme: {{ .Values.probes.scheme | default "HTTP" | upper }}
+              scheme: {{ include "collabora-online.probeScheme" . }}
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -197,10 +197,12 @@ deployment:
     securityContext: {}
 
 probes:
-  # Scheme used by the kubelet to reach the probe endpoint.
-  # Set to HTTPS when SSL is terminated directly at coolwsd (e.g. via
-  # extra_params: --o:ssl.enable=true).
-  scheme: HTTP
+  # Scheme the kubelet uses to reach the coolwsd probe endpoint.
+  # Leave blank to derive it automatically from collabora.extra_params:
+  # ssl.enable=false serves plain HTTP, anything else (ssl.enable=true, or the
+  # flag absent so coolwsd's built-in default of true applies) serves HTTPS.
+  # Set this to HTTP or HTTPS only to override the derived value.
+  scheme: ""
   startup:
     enabled: true
     failureThreshold: 30


### PR DESCRIPTION
Release 1.1.61 exposed the kubelet probe scheme as a manual probes.scheme value defaulting to HTTP. Operators had to remember to flip it to HTTPS whenever they turned on SSL at coolwsd, and a forgotten flip brought back the original failure where an HTTP probe hits coolwsd's single TLS socket and the pod never goes ready.

Derive the scheme automatically from the ssl.enable flag in collabora.extra_params instead. An explicit ssl.enable=false serves plain HTTP. Anything else serves HTTPS, covering both an explicit ssl.enable=true and the flag being absent, in which case coolwsd falls back to its own built-in default of true. The manual probes.scheme is kept as an optional override for cases the chart cannot see, such as a TLS sidecar or ssl.enable set through a mounted coolwsd.xml.


Change-Id: Ic4ae6d6e1f233b7d73818dd8bef64797cfa17143