### PR TITLE
helm: Add an extraObjects section for arbitrary manifests

### DIFF
--- a/kubernetes/helm/collabora-online/Chart.yaml
+++ b/kubernetes/helm/collabora-online/Chart.yaml
@@ -4,7 +4,7 @@ type: "application"
 name: collabora-online
 description: Collabora Online helm chart
 
-version: 1.2.0
+version: 1.2.1
 appVersion: "25.04.9.4.1"
 
 home: "https://www.collaboraonline.com/code/"

--- a/kubernetes/helm/collabora-online/README.md
+++ b/kubernetes/helm/collabora-online/README.md
@@ -448,6 +448,42 @@ Service directly.
 
 ---
 
+## Extra objects
+
+The chart templates routing objects for the providers it supports directly: a
+standard `Ingress`, a Gateway API `HTTPRoute` (or an OpenShift `Route`), and
+the in-namespace reverse proxy. If your cluster uses a different gateway, you
+can deploy its objects through `extraObjects` instead of waiting for the chart
+to add explicit support for that gateway.
+
+`extraObjects` is a list of arbitrary Kubernetes manifests. The chart renders
+each one as-is into the release, so they are installed, upgraded and uninstalled
+along with everything else. Each entry is passed through `tpl`, so you can
+reference release values such as the release name or the service port.
+
+For example, to route Collabora through Apache APISIX, add its `ApisixRoute`
+custom resource:
+
+``` yaml
+extraObjects:
+  - apiVersion: apisix.apache.org/v2
+    kind: ApisixRoute
+    metadata:
+      name: '{{ include "collabora-online.fullname" . }}'
+    spec:
+      http:
+        - name: collabora
+          match:
+            hosts: ["office.example.com"]
+            paths: ["/*"]
+          backends:
+            - serviceName: '{{ include "collabora-online.fullname" . }}'
+              servicePort: '{{ .Values.service.port }}'
+```
+
+The same approach works for any other gateway (Traefik, Istio, Kong, ...): put
+its objects in `extraObjects` and they are deployed with the release.
+
 ## Useful commands to check what is happening
 
 Where is this pods, are they ready?

--- a/kubernetes/helm/collabora-online/templates/extra-objects.yaml
+++ b/kubernetes/helm/collabora-online/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -679,3 +679,10 @@ extraVolumes: []
 
 # Optionally specify an extra list of additional volumeMounts.
 extraVolumeMounts: []
+
+# Optionally specify a list of extra Kubernetes manifests to deploy with the
+# release. Each entry is rendered through tpl, so values may reference release
+# data. Use this to add provider-specific routing objects (for example an
+# APISIX ApisixRoute) without the chart needing explicit support for that
+# provider.
+extraObjects: []


### PR DESCRIPTION
The chart templates routing objects only for the providers it supports directly: a standard Ingress, a Gateway API HTTPRoute or an OpenShift Route, and the in-namespace reverse proxy. Users whose cluster uses a different gateway, for example Apache APISIX with its own ApisixRoute custom resource, had no way to attach their routing objects to the release, and the chart cannot grow bespoke templates for every gateway in existence.

This adds an extraObjects value, a list of arbitrary Kubernetes manifests that the chart renders as-is into the release, so they are installed, upgraded and uninstalled along with everything else. Each entry is passed through tpl, so it can reference release values such as the release name or the service port. Users put their gateway's objects in extraObjects instead of waiting for the chart to support that gateway.

The list is empty by default, so existing deployments are unchanged.


Change-Id: Ia4270921ef659a93ba0623c9d3c2b80d2efb4276