### PR TITLE
helm: generate the WOPI proof key inside the chart

### DIFF
--- a/kubernetes/helm/collabora-online/Chart.yaml
+++ b/kubernetes/helm/collabora-online/Chart.yaml
@@ -4,7 +4,7 @@ type: "application"
 name: collabora-online
 description: Collabora Online helm chart
 
-version: 1.2.2
+version: 1.3.0
 appVersion: "26.04.2.1.1"
 
 home: "https://www.collaboraonline.com/code/"

--- a/kubernetes/helm/collabora-online/templates/_helpers.tpl
+++ b/kubernetes/helm/collabora-online/templates/_helpers.tpl
@@ -125,3 +125,16 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+
+{{/*
+Name of the secret holding the WOPI proof key. Returns the generated secret
+name when automatic generation is on, otherwise the user-supplied
+proofKeysSecretRef. An empty result means no proof key is configured.
+*/}}
+{{- define "collabora-online.proofKeysSecretName" -}}
+{{- if .Values.collabora.proofKeyGeneration.enabled -}}
+{{- default (printf "%s-wopi-proof" (include "collabora-online.fullname" .)) .Values.collabora.proofKeyGeneration.secretName -}}
+{{- else -}}
+{{- .Values.collabora.proofKeysSecretRef -}}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/helm/collabora-online/templates/deployment.yaml
+++ b/kubernetes/helm/collabora-online/templates/deployment.yaml
@@ -142,13 +142,15 @@ spec:
               mountPath: /etc/coolwsd/coolwsd.xml
               subPath: coolwsd.xml
             {{- end }}
-            {{- if .Values.collabora.proofKeysSecretRef }}
+            {{- if (include "collabora-online.proofKeysSecretName" .) }}
             - name: wopi-proof
               mountPath: /etc/coolwsd/proof_key
               subPath: proof_key
+            {{- if not .Values.collabora.proofKeyGeneration.enabled }}
             - name: wopi-proof
               mountPath: /etc/coolwsd/proof_key.pub
               subPath: proof_key.pub
+            {{- end }}
             {{- end }}
             {{- if .Values.deployment.customFonts.enabled }}
             - name: custom-fonts
@@ -193,10 +195,10 @@ spec:
                 path: coolwsd.xml
               {{- end }}
         {{- end }}
-        {{- if .Values.collabora.proofKeysSecretRef }}
+        {{- if (include "collabora-online.proofKeysSecretName" .) }}
         - name: wopi-proof
           secret:
-            secretName: {{ .Values.collabora.proofKeysSecretRef | quote }}
+            secretName: {{ include "collabora-online.proofKeysSecretName" . | quote }}
         {{- end }}
         {{- if .Values.deployment.customFonts.enabled }}
         - name: custom-fonts

--- a/kubernetes/helm/collabora-online/templates/proof_key_secret.yaml
+++ b/kubernetes/helm/collabora-online/templates/proof_key_secret.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.collabora.proofKeyGeneration.enabled }}
+{{- /*
+Generate the WOPI proof key on first install and keep it stable afterwards.
+lookup reads the secret that already exists in the cluster; when it is present
+its proof_key is reused unchanged, so upgrades never rotate the key and every
+replica shares the same one. On the first install lookup finds nothing and a
+fresh RSA private key is generated. coolwsd reads only this private key and
+derives the public modulus and exponent from it in memory, so no public key
+file is stored here.
+
+lookup only returns data during a real install or upgrade against a live
+cluster. When the chart is rendered with helm template (as Argo CD and Flux
+do), lookup is empty and a new key is generated on every render, so this path
+is meant for installs driven by the helm command line. GitOps setups should
+create the secret themselves and use proofKeysSecretRef.
+*/}}
+{{- $secretName := include "collabora-online.proofKeysSecretName" . }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "collabora-online.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if and $existing (hasKey ($existing.data | default dict) "proof_key") }}
+  proof_key: {{ index $existing.data "proof_key" }}
+  {{- else }}
+  proof_key: {{ genPrivateKey "rsa" | b64enc }}
+  {{- end }}
+{{- end }}

--- a/kubernetes/helm/collabora-online/templates/statefulset.yaml
+++ b/kubernetes/helm/collabora-online/templates/statefulset.yaml
@@ -125,6 +125,16 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if (include "collabora-online.proofKeysSecretName" .) }}
+            - name: wopi-proof
+              mountPath: /etc/coolwsd/proof_key
+              subPath: proof_key
+            {{- if not .Values.collabora.proofKeyGeneration.enabled }}
+            - name: wopi-proof
+              mountPath: /etc/coolwsd/proof_key.pub
+              subPath: proof_key.pub
+            {{- end }}
+            {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
@@ -143,4 +153,9 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if (include "collabora-online.proofKeysSecretName" .) }}
+        - name: wopi-proof
+          secret:
+            secretName: {{ include "collabora-online.proofKeysSecretName" . | quote }}
+        {{- end }}
 {{- end }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -51,12 +51,39 @@ collabora:
   username: admin
   env: []
 
-  # name of a secret that holds the WOPI proof keys for Collabora
-  # How to generate this secret:
-  # 1. ssh-keygen -t rsa -N "" -m PEM -f proof_key
-  # 2. kubectl create secret generic <name-of-the-secret> --from-file=proof_key --from-file=proof_key.pub
-  # finally set proofKeysSecretRef to the name of the secret
+  # Name of a pre-existing secret holding the WOPI proof key. Used only when
+  # proofKeyGeneration.enabled is false. The secret must contain the private
+  # key under "proof_key" (a PEM RSA key) and may also contain "proof_key.pub".
+  # coolwsd reads only the private "proof_key"; the public file is mounted for
+  # completeness but is not read by the server.
+  # To create it by hand:
+  #   openssl genrsa -out proof_key 4096
+  #   openssl rsa -in proof_key -pubout -out proof_key.pub
+  #   kubectl create secret generic <name> --from-file=proof_key --from-file=proof_key.pub
   proofKeysSecretRef: ""
+
+  # Let the chart generate and manage the WOPI proof key. On first install a
+  # 4096-bit RSA private key is created and stored in a secret that Helm owns;
+  # on later upgrades the existing key is read back and kept unchanged, so it
+  # stays stable across all replicas. When enabled, proofKeysSecretRef is
+  # ignored.
+  #
+  # Because the secret belongs to the release, "helm uninstall" deletes it. A
+  # secret you create yourself and point to through proofKeysSecretRef is left
+  # in place instead.
+  #
+  # This is meant for installs driven by the helm command line. Keeping the key
+  # stable relies on reading the existing secret back from the live cluster.
+  # Tools that render the chart with "helm template" without live cluster
+  # access, such as Argo CD and Flux, do not perform that read, so every render
+  # generates a fresh key. That shows up as a permanent difference on the
+  # secret and can rotate the key on each sync, which breaks WOPI proof
+  # validation. In a GitOps setup, create the secret yourself and set
+  # proofKeysSecretRef instead of enabling generation here.
+  proofKeyGeneration:
+    enabled: false
+    # Name of the secret to create. Defaults to "<release>-wopi-proof".
+    secretName: ""
 
   # Provide custom coolwsd configuration files here.
   # Note: Content provided will override the default files (coolkitconfig.xcu, coolwsd.xml)


### PR DESCRIPTION
Until now the chart could only mount a WOPI proof key from a secret the operator had to create by hand before installing, named through collabora.proofKeysSecretRef. Add an opt-in that lets the chart create and keep that key itself.

Setting collabora.proofKeyGeneration.enabled makes the chart render a secret holding an RSA private key. The key is generated on first install and, on later upgrades, read back from the existing secret and left unchanged, so it stays the same for every replica across upgrades. coolwsd reads only the private key and derives the public modulus and exponent from it, so no public key file is stored.

A new helper, collabora-online.proofKeysSecretName, returns the generated name when generation is on and the value of proofKeysSecretRef otherwise. Both the Deployment and the StatefulSet mount the key through this helper. When generation is off the helper returns proofKeysSecretRef unchanged, so existing installs behave exactly as before: an empty value mounts nothing, and a set value mounts both proof_key and proof_key.pub as it did before.

This also mounts the proof key in the StatefulSet, which previously ignored proofKeysSecretRef and never mounted it.