### PR TITLE
feat(helm): add support for additional labels in Ingress resource

### DIFF
--- a/kubernetes/helm/collabora-online/templates/ingress.yaml
+++ b/kubernetes/helm/collabora-online/templates/ingress.yaml
@@ -7,6 +7,9 @@ metadata:
   name: {{ $fullName }}
   labels:
     {{- include "collabora-online.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -296,6 +296,8 @@ route:
 ingress:
   enabled: false
   className: ""
+  # Additional labels to add to the Ingress resource. These are merged with the default labels.
+  labels: {}
   annotations: {}
   # # nginx
   #  nginx.ingress.kubernetes.io/upstream-hash-by: "$arg_WOPISrc"


### PR DESCRIPTION
Adds an `ingress.labels` value (default: `{}`) that is merged with the chart's default labels on the Ingress resource, mirroring the existing pattern for custom deployment labels.