### PR TITLE
helm: render the extra volumes on the stateful set as well

### DIFF
--- a/kubernetes/helm/collabora-online/README.md
+++ b/kubernetes/helm/collabora-online/README.md
@@ -448,6 +448,46 @@ Service directly.
 
 ---
 
+## Extra volumes, mounts and environment variables
+
+`extraVolumes`, `extraVolumeMounts` and `extraEnvVars` put anything else the
+Collabora pod needs into it. Each one takes the plain Kubernetes form, and the
+chart appends the entries after the ones it renders itself. All three reach both
+workload kinds, so they apply whether `deployment.kind` is `Deployment` or
+`StatefulSet`.
+
+One case is a WOPI host served with a certificate signed by a private authority.
+Mount the certificate of that authority and name it in `SSL_CERT_FILE`, and
+Collabora reaches the host over a verified connection:
+
+``` yaml
+extraVolumes:
+  - name: internal-ca
+    secret:
+      secretName: internal-ca
+
+extraVolumeMounts:
+  - name: internal-ca
+    mountPath: /etc/ssl/internal-ca
+    readOnly: true
+
+extraEnvVars:
+  - name: SSL_CERT_FILE
+    value: /etc/ssl/internal-ca/ca.crt
+```
+
+`SSL_CERT_FILE` names the one file that is trusted, and the public authorities
+the system carries are left out once it is set. Put every certificate that has to
+be verified in that file. `SSL_CERT_DIR` names a directory of certificates and
+works the same way.
+
+The other common case is a writable directory. Collabora needs one wherever
+`child_root_path` and `cache_files.path` point when the root filesystem is read
+only, and an `emptyDir` volume mounted under `/tmp` covers it.
+
+Environment variables can also be given under `collabora.env`, which takes the
+same form.
+
 ## Extra objects
 
 The chart templates routing objects for the providers it supports directly: a

--- a/kubernetes/helm/collabora-online/templates/deployment.yaml
+++ b/kubernetes/helm/collabora-online/templates/deployment.yaml
@@ -125,7 +125,10 @@ spec:
                   key: password
                   {{- end }}
             {{- with .Values.collabora.env }}
-            {{ toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/kubernetes/helm/collabora-online/templates/statefulset.yaml
+++ b/kubernetes/helm/collabora-online/templates/statefulset.yaml
@@ -135,6 +135,9 @@ spec:
               subPath: proof_key.pub
             {{- end }}
             {{- end }}
+            {{- if .Values.extraVolumeMounts }}
+            {{- .Values.extraVolumeMounts | toYaml | nindent 12 }}
+            {{- end }}
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . | quote }}
       {{- end }}
@@ -157,5 +160,8 @@ spec:
         - name: wopi-proof
           secret:
             secretName: {{ include "collabora-online.proofKeysSecretName" . | quote }}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- .Values.extraVolumes | toYaml | nindent 8 }}
         {{- end }}
 {{- end }}

--- a/kubernetes/helm/collabora-online/templates/statefulset.yaml
+++ b/kubernetes/helm/collabora-online/templates/statefulset.yaml
@@ -118,7 +118,10 @@ spec:
                   key: password
                   {{- end }}
             {{- with .Values.collabora.env }}
-            {{ toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/kubernetes/helm/collabora-online/values.yaml
+++ b/kubernetes/helm/collabora-online/values.yaml
@@ -707,6 +707,11 @@ extraVolumes: []
 # Optionally specify an extra list of additional volumeMounts.
 extraVolumeMounts: []
 
+# Optionally specify an extra list of additional environment variables for the
+# Collabora container. Each entry takes the Kubernetes form, a name with a plain
+# value or a name with a valueFrom reference to a secret or a config map.
+extraEnvVars: []
+
 # Optionally specify a list of extra Kubernetes manifests to deploy with the
 # release. Each entry is rendered through tpl, so values may reference release
 # data. Use this to add provider-specific routing objects (for example an


### PR DESCRIPTION
extraVolumes and extraVolumeMounts reached the deployment template only. A
release that sets deployment.kind to StatefulSet had both values accepted and
neither rendered, so the volumes were dropped without a word in the output.