### PR TITLE
docker: make every file of the engine tree readable in the image

### DIFF
--- a/docker/from-source-gh-action/README.md
+++ b/docker/from-source-gh-action/README.md
@@ -107,6 +107,20 @@ the switches the assets were built with, so the choices between system and
 bundled libraries agree with the archives in the tarball. Anything the tarball
 ships under that name is overwritten.
 
+## Why build.sh resets the file modes
+
+The tarball keeps the owner and the modes that the files had on the publishing
+machine. The zip tool there writes the archives it creates, such as the autotext
+`.bau` files, the autocorrect `.dat` files and the `.otp` and `.ott` templates,
+readable by their owner only. The image runs coolwsd as its own `cool` user, and
+each kit reads every file of the engine tree while it fills its jail, so one such
+file stops every document from loading.
+
+So `build.sh` extracts the tarball without keeping the owner, which leaves the
+files owned by root like a packaged installation, and makes every file of the
+copied engine tree readable by everyone. Directories and files that were already
+executable keep their execute bits.
+
 ## How the publishing job packs it
 
 That job is not in this repository. It builds the engine and then packs the

--- a/docker/from-source-gh-action/build.sh
+++ b/docker/from-source-gh-action/build.sh
@@ -154,7 +154,7 @@ if [ -z "$ENGINE_ASSETS" ]; then
   detect_engine_cxx_abi
 else
   # drop in prebuilt engine assets
-  ( cd "$engine_dir" && wget "$ENGINE_ASSETS" -O engine-assets.tar.gz && tar -xzf engine-assets.tar.gz && rm engine-assets.tar.gz ) || exit 1
+  ( cd "$engine_dir" && wget "$ENGINE_ASSETS" -O engine-assets.tar.gz && tar --no-same-owner -xzf engine-assets.tar.gz && rm engine-assets.tar.gz ) || exit 1
   check_engine_assets || exit 1
   # The assets come from another machine, so configure the tree here.  gbuild
   # compiles online's C++ with the compiler, the linker and the paths that
@@ -170,6 +170,12 @@ fi
 
 mkdir -p "$INSTDIR"/opt/
 cp -a "$engine_dir"/instdir "$INSTDIR"/opt/collaboraoffice
+# The engine tree keeps the file modes its build tools chose, and the zip tool that packs
+# the autotext, autocorrect and template archives leaves them readable by their owner
+# only.  The image runs coolwsd as a different user, which reads and copies every file of
+# this tree into each jail, so every file becomes readable by everyone.  Directories and
+# files that were already executable stay executable.
+chmod -R a+rX "$INSTDIR"/opt/collaboraoffice
 
 ##### coolwsd & cool #####
 


### PR DESCRIPTION
Fixes https://github.com/CollaboraOnline/online/issues/16175

The prebuilt engine assets keep the file modes of the machine that built them. The zip tool there leaves the archives it creates readable by their owner only: the autotext .bau files, the autocorrect .dat files and a few .otp and .ott templates, 62 files in the current tarball. The image runs coolwsd as the cool user, which is not the owner of those files. When a kit fills its jail it copies every file of the engine tree, so the first of these files it reaches makes it exit with

  Failed to copy or link [/opt/collaboraoffice/share/autotext/en-US/template.bau]
  to [.../lo/share/autotext/en-US/template.bau]. Exiting.

and coolwsd never gets a working kit.

Extract the tarball without keeping the owner, so the files belong to root like a packaged installation does, and make every file of the copied engine tree readable by everyone before it goes into the image. Directories and files that were already executable keep their execute bits.
